### PR TITLE
ci: batch workflow speedups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,6 @@ jobs:
   package:
     name: Package Plugin
     runs-on: macos-26
-    needs: validate
     steps:
       - name: Checkout container-compose
         uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,30 @@ jobs:
           path: container
           fetch-depth: 0
 
+      - name: Compute SwiftPM cache fingerprint
+        id: swiftpm-cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            swift --version 2>&1
+            shasum -a 256 container-compose/Package.swift container-compose/Package.resolved
+            git -C container rev-parse HEAD
+            shasum -a 256 container/Package.swift container/Package.resolved
+          } | shasum -a 256 | awk '{ printf "fingerprint=%s\n", $1 }' >> "$GITHUB_OUTPUT"
+
+      - name: Cache SwiftPM build artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            container-compose/.build
+            container-compose/.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-${{ runner.arch }}-macos26-swiftpm-v1-${{ steps.swiftpm-cache.outputs.fingerprint }}-${{ github.job }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-macos26-swiftpm-v1-${{ steps.swiftpm-cache.outputs.fingerprint }}-
+            ${{ runner.os }}-${{ runner.arch }}-macos26-swiftpm-v1-
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -165,6 +189,30 @@ jobs:
         with:
           repository: apple/container
           path: container
+
+      - name: Compute SwiftPM cache fingerprint
+        id: swiftpm-cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            swift --version 2>&1
+            shasum -a 256 container-compose/Package.swift container-compose/Package.resolved
+            git -C container rev-parse HEAD
+            shasum -a 256 container/Package.swift container/Package.resolved
+          } | shasum -a 256 | awk '{ printf "fingerprint=%s\n", $1 }' >> "$GITHUB_OUTPUT"
+
+      - name: Cache SwiftPM build artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            container-compose/.build
+            container-compose/.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+          key: ${{ runner.os }}-${{ runner.arch }}-macos26-swiftpm-v1-${{ steps.swiftpm-cache.outputs.fingerprint }}-${{ github.job }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-macos26-swiftpm-v1-${{ steps.swiftpm-cache.outputs.fingerprint }}-
+            ${{ runner.os }}-${{ runner.arch }}-macos26-swiftpm-v1-
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
## Summary

- Run the package job in parallel with validation so the workflow critical path is not `validate + package`.
- Cache SwiftPM build artifacts in both macOS jobs using a fingerprint built from the Swift toolchain, container-compose package files, and the checked-out apple/container revision/package files.

## Validation

- `actionlint .github/workflows/ci.yml`
- workflow YAML parse with PyYAML
- `git diff --check -- .github/workflows/ci.yml`
- `make workflow`

Local `make workflow` completed `make ci`, 133 Swift tests, Swift coverage `93.82%`, Go coverage `94.55%`, smoke checks, and release package archive creation.

## Notes

This PR follows the updated develop-first batching rule: keep individual commits on `develop`, then merge the batch to `main` via PR so formal CI/Sonar validates the set together.
