### PR TITLE
feat(run): support named one-off containers

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -37,7 +37,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | --- | --- | --- | --- |
 | Config normalization | File discovery, repeated `-f`, `.env`, `--env-file`, interpolation, merge, profiles, `--project-directory`, `-p/--project-name`, and canonical `config` JSON | No runtime primitive; `compose-go` normalizes the Compose model | [S1](#s1-supported-local-web-stack), [O1](#o1-config-only-metadata) |
 | Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, `images`, global `up --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container image list` | [S1](#s1-supported-local-web-stack) |
-| Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, one-off `run --rm` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
+| Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, one-off `run --rm`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
@@ -217,6 +217,7 @@ container compose config
 container compose build
 container compose up --pull missing
 container compose run --rm api printf ok
+container compose run --name api-shell api sh
 container compose run --service-ports api printf ok
 container compose run -p 9090:8080 api printf ok
 container compose ps

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ cli-smoke: build
 	run_publish_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -p 9090:90 api echo hello)"; \
 	[[ "$$run_publish_output" == *"--publish 9090:90"* ]]; \
 	[[ "$$run_publish_output" != *"--publish 8080:80"* ]]; \
+	run_named_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --name custom-api api echo hello)"; \
+	[[ "$$run_named_output" == *"--name custom-api"* ]]; \
+	[[ "$$run_named_output" == *" alpine echo hello"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -92,12 +92,20 @@ public struct ComposeRunOptions {
     public var remove: Bool
     public var servicePorts: Bool
     public var publish: [String]
+    public var containerName: String?
 
-    public init(command: [String] = [], remove: Bool = false, servicePorts: Bool = false, publish: [String] = []) {
+    public init(
+        command: [String] = [],
+        remove: Bool = false,
+        servicePorts: Bool = false,
+        publish: [String] = [],
+        containerName: String? = nil
+    ) {
         self.command = command
         self.remove = remove
         self.servicePorts = servicePorts
         self.publish = publish
+        self.containerName = containerName
     }
 }
 
@@ -302,7 +310,8 @@ public final class ComposeOrchestrator: @unchecked Sendable {
                 detach: false,
                 remove: run.remove,
                 oneOff: true,
-                publishedPorts: publishedPorts
+                publishedPorts: publishedPorts,
+                containerNameOverride: run.containerName
             ),
             inheritedIO: service.tty == true || service.stdinOpen == true
         )
@@ -905,10 +914,12 @@ private extension ComposeOrchestrator {
         detach: Bool,
         remove: Bool,
         oneOff: Bool,
-        publishedPorts: [String]? = nil
+        publishedPorts: [String]? = nil,
+        containerNameOverride: String? = nil
     ) throws -> [String] {
         var args = ["run"]
-        args.append(contentsOf: ["--name", containerName(project: project, service: service, oneOff: oneOff)])
+        let runtimeName = containerNameOverride.map(slug) ?? containerName(project: project, service: service, oneOff: oneOff)
+        args.append(contentsOf: ["--name", runtimeName])
         if detach {
             args.append("--detach")
         }

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -331,6 +331,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var servicePorts = false
     @Option(name: .customLong("publish"), help: "Publish a container port to the host. May be repeated.")
     var publish: [String] = []
+    @Option(name: .customLong("name"), help: "Assign a name to the one-off container.")
+    var name: String?
     @Argument(help: "Service name.")
     var service: String
     @Argument(parsing: .allUnrecognized, help: "Optional replacement command.")
@@ -346,7 +348,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 command: command,
                 remove: remove,
                 servicePorts: servicePorts,
-                publish: publish
+                publish: publish,
+                containerName: name
             )
         )
     }

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -200,6 +200,31 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run name value before service name")
+    func keepsRunNameValueBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "--name",
+            "one-off-api",
+            "-p",
+            "9090:90",
+            "api",
+            "echo",
+            "ok",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "--name",
+            "one-off-api",
+            "--publish",
+            "9090:90",
+            "api",
+            "echo",
+            "ok",
+        ])
+    }
+
     @Test("keeps unknown root options before the subcommand")
     func keepsUnknownRootOptionsBeforeSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2719,6 +2719,25 @@ struct ComposeOrchestratorTests {
         #expect(names == ["demo-job-run-first", "demo-job-run-second"])
     }
 
+    @Test("run uses explicit one-off container name when provided")
+    func runUsesExplicitOneOffContainerNameWhenProvided() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["true"], containerName: "custom-job")
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.starts(with: ["container", "run", "--name", "custom-job"]))
+        #expect(Array(command.suffix(2)) == ["alpine", "true"])
+    }
+
     @Test("up reuses existing containers when no recreate is requested")
     func upReusesExistingContainersWhenNoRecreateIsRequested() async throws {
         let emitted = MessageRecorder()


### PR DESCRIPTION
## Summary
- add Compose `run --name` support for one-off containers
- pass the explicit name through the plugin and orchestrator to `container run --name`
- update compatibility docs and CLI smoke coverage

## Validation
- `make coverage-check` (Swift 93.83%, Go 94.55%)
- `make cli-smoke`
- `markdownlint COMPATIBILITY.md`
- `git diff --check`

## Main/Sonar flow
This batches the current develop fix into one PR so main CI and SonarCloud evaluate the group together.