### PR TITLE
ci: batch Sonar remediation workflow speedups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
         with:
           repository: apple/container
           path: container
-          fetch-depth: 0
 
       - name: Compute SwiftPM cache fingerprint
         id: swiftpm-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ on:
   push:
     branches:
       - main
-      - develop
   pull_request:
     branches:
       - main
@@ -36,7 +35,7 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ resolve:
 	$(SWIFT) package resolve
 
 build:
-	$(SWIFT) build
+	$(SWIFT) build --product compose
 
 build-release:
 	$(SWIFT) build -c release --product compose


### PR DESCRIPTION
## Summary
- batch the queued `develop` CI/Sonar remediation commits into `main` through one PR
- reduce redundant develop push builds while keeping PR and main checks active
- build the `compose` product in local/CI validation
- shallow-checkout the external apple/container dependency to reduce CI setup time

## Commits
- `bbbb118` ci: reduce redundant develop builds
- `bc06dcd` ci: build compose product in validation
- `ddcbadf` ci: shallow checkout container dependency

## Validation
- Each commit was validated locally before pushing to `develop`.
- This PR is intended to run the formal GitHub Actions and SonarCloud checks once for the full remediation batch.

## Merge Plan
Use a normal merge commit, not squash or rebase, so `main` receives the squashed issue commits from `develop` without rewriting them.