### PR TITLE
feat(run): batch compose run one-off overrides

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -41,7 +41,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
-| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, `user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
+| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
 | Environment and labels | Service `environment`, `env_file`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
 
@@ -221,6 +221,7 @@ container compose run --name api-shell api sh
 container compose run --service-ports api printf ok
 container compose run -p 9090:8080 api printf ok
 container compose run --entrypoint "/bin/sh -c" api "printf ok"
+container compose run --workdir /app api pwd
 container compose ps
 container compose logs api
 container compose exec api sh

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -41,7 +41,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
-| Common runtime options | `command`, `entrypoint`, `container_name`, `working_dir`, `user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
+| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, `user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
 | Environment and labels | Service `environment`, `env_file`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
 
@@ -220,6 +220,7 @@ container compose run --rm api printf ok
 container compose run --name api-shell api sh
 container compose run --service-ports api printf ok
 container compose run -p 9090:8080 api printf ok
+container compose run --entrypoint "/bin/sh -c" api "printf ok"
 container compose ps
 container compose logs api
 container compose exec api sh

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ cli-smoke: build
 	run_named_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --name custom-api api echo hello)"; \
 	[[ "$$run_named_output" == *"--name custom-api"* ]]; \
 	[[ "$$run_named_output" == *" alpine echo hello"* ]]; \
+	run_entrypoint_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --entrypoint "/bin/sh -c" api echo hello)"; \
+	[[ "$$run_entrypoint_output" == *"--entrypoint '/bin/sh -c'"* ]]; \
+	[[ "$$run_entrypoint_output" == *" alpine echo hello"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ cli-smoke: build
 	run_entrypoint_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --entrypoint "/bin/sh -c" api echo hello)"; \
 	[[ "$$run_entrypoint_output" == *"--entrypoint '/bin/sh -c'"* ]]; \
 	[[ "$$run_entrypoint_output" == *" alpine echo hello"* ]]; \
+	run_workdir_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --workdir /workspace api pwd)"; \
+	[[ "$$run_workdir_output" == *"--workdir /workspace"* ]]; \
+	[[ "$$run_workdir_output" == *" alpine pwd"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -258,6 +258,7 @@ public enum ComposeArgumentRewriter {
             "--user",
             "--volume",
             "--workdir",
+            "-w",
         ].contains(argument)
     }
 

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -94,6 +94,7 @@ public struct ComposeRunOptions {
     public var publish: [String]
     public var containerName: String?
     public var entrypoint: String?
+    public var workingDirectory: String?
 
     public init(
         command: [String] = [],
@@ -101,7 +102,8 @@ public struct ComposeRunOptions {
         servicePorts: Bool = false,
         publish: [String] = [],
         containerName: String? = nil,
-        entrypoint: String? = nil
+        entrypoint: String? = nil,
+        workingDirectory: String? = nil
     ) {
         self.command = command
         self.remove = remove
@@ -109,6 +111,7 @@ public struct ComposeRunOptions {
         self.publish = publish
         self.containerName = containerName
         self.entrypoint = entrypoint
+        self.workingDirectory = workingDirectory
     }
 }
 
@@ -304,6 +307,9 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
         if let entrypoint = run.entrypoint {
             service.entrypoint = [entrypoint]
+        }
+        if let workingDirectory = run.workingDirectory {
+            service.workingDir = workingDirectory
         }
         try validateRuntimeSupport(service: service)
         try await applyServicePullPolicies(services: [service])

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -93,19 +93,22 @@ public struct ComposeRunOptions {
     public var servicePorts: Bool
     public var publish: [String]
     public var containerName: String?
+    public var entrypoint: String?
 
     public init(
         command: [String] = [],
         remove: Bool = false,
         servicePorts: Bool = false,
         publish: [String] = [],
-        containerName: String? = nil
+        containerName: String? = nil,
+        entrypoint: String? = nil
     ) {
         self.command = command
         self.remove = remove
         self.servicePorts = servicePorts
         self.publish = publish
         self.containerName = containerName
+        self.entrypoint = entrypoint
     }
 }
 
@@ -298,6 +301,9 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
         if !run.command.isEmpty {
             service.command = run.command
+        }
+        if let entrypoint = run.entrypoint {
+            service.entrypoint = [entrypoint]
         }
         try validateRuntimeSupport(service: service)
         try await applyServicePullPolicies(services: [service])

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -333,6 +333,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var publish: [String] = []
     @Option(name: .customLong("name"), help: "Assign a name to the one-off container.")
     var name: String?
+    @Option(name: .customLong("entrypoint"), help: "Override the service entrypoint for the one-off container.")
+    var entrypoint: String?
     @Argument(help: "Service name.")
     var service: String
     @Argument(parsing: .allUnrecognized, help: "Optional replacement command.")
@@ -349,7 +351,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 remove: remove,
                 servicePorts: servicePorts,
                 publish: publish,
-                containerName: name
+                containerName: name,
+                entrypoint: entrypoint
             )
         )
     }

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -335,6 +335,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var name: String?
     @Option(name: .customLong("entrypoint"), help: "Override the service entrypoint for the one-off container.")
     var entrypoint: String?
+    @Option(name: [.customShort("w"), .customLong("workdir")], help: "Override the working directory for the one-off container.")
+    var workdir: String?
     @Argument(help: "Service name.")
     var service: String
     @Argument(parsing: .allUnrecognized, help: "Optional replacement command.")
@@ -352,7 +354,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 servicePorts: servicePorts,
                 publish: publish,
                 containerName: name,
-                entrypoint: entrypoint
+                entrypoint: entrypoint,
+                workingDirectory: workdir
             )
         )
     }

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -225,6 +225,27 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run entrypoint value before service name")
+    func keepsRunEntrypointValueBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "--entrypoint",
+            "/bin/sh -c",
+            "api",
+            "echo",
+            "ok",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "--entrypoint",
+            "/bin/sh -c",
+            "api",
+            "echo",
+            "ok",
+        ])
+    }
+
     @Test("keeps unknown root options before the subcommand")
     func keepsUnknownRootOptionsBeforeSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -246,6 +246,25 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run workdir shorthand value before service name")
+    func keepsRunWorkdirShorthandValueBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "-w",
+            "/workspace",
+            "api",
+            "pwd",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "-w",
+            "/workspace",
+            "api",
+            "pwd",
+        ])
+    }
+
     @Test("keeps unknown root options before the subcommand")
     func keepsUnknownRootOptionsBeforeSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2738,6 +2738,30 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(2)) == ["alpine", "true"])
     }
 
+    @Test("run overrides service entrypoint for one-off containers")
+    func runOverridesServiceEntrypointForOneOffContainers() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.entrypoint = ["/usr/bin/default"]
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["echo", "ok"], entrypoint: "/bin/sh -c")
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.containsSequence(["--entrypoint", "/bin/sh -c"]))
+        #expect(!command.containsSequence(["--entrypoint", "/usr/bin/default"]))
+        #expect(Array(command.suffix(3)) == ["alpine", "echo", "ok"])
+    }
+
     @Test("up reuses existing containers when no recreate is requested")
     func upReusesExistingContainersWhenNoRecreateIsRequested() async throws {
         let emitted = MessageRecorder()

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2762,6 +2762,30 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(3)) == ["alpine", "echo", "ok"])
     }
 
+    @Test("run overrides service workdir for one-off containers")
+    func runOverridesServiceWorkdirForOneOffContainers() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.workingDir = "/default"
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["pwd"], workingDirectory: "/workspace")
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.containsSequence(["--workdir", "/workspace"]))
+        #expect(!command.containsSequence(["--workdir", "/default"]))
+        #expect(Array(command.suffix(2)) == ["alpine", "pwd"])
+    }
+
     @Test("up reuses existing containers when no recreate is requested")
     func upReusesExistingContainersWhenNoRecreateIsRequested() async throws {
         let emitted = MessageRecorder()


### PR DESCRIPTION
## Summary

Batch the current `develop` commits into one PR so the `main` promotion can be validated by a single PR CI/SonarQube run.

Included commits:

- `4f9e5f8 feat(run): support one-off entrypoint override`
- `722d13e feat(run): support one-off workdir override`

## Validation

- `make lint`
- `make coverage-check` (Swift 93.86%, Go 94.55%)
- `make cli-smoke`

## Main build behavior

This PR keeps the SonarQube remediation/main promotion model batched: merge `develop` to `main` via PR so the queued fixes land together and trigger one formal main CI/Sonar run after merge.