### PR TITLE
feat(run): batch one-off override support

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -41,7 +41,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
-| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
+| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
 | Environment and labels | Service `environment`, `env_file`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
 
@@ -222,6 +222,7 @@ container compose run --service-ports api printf ok
 container compose run -p 9090:8080 api printf ok
 container compose run --entrypoint "/bin/sh -c" api "printf ok"
 container compose run --workdir /app api pwd
+container compose run --user 1000:1000 api id
 container compose ps
 container compose logs api
 container compose exec api sh

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -42,7 +42,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
 | Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
-| Environment and labels | Service `environment`, `env_file`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
+| Environment and labels | Service `environment`, `env_file`, one-off `run --env/-e`, one-off `run --env-from-file`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
 
 ### Blocked By apple/container
@@ -223,6 +223,7 @@ container compose run -p 9090:8080 api printf ok
 container compose run --entrypoint "/bin/sh -c" api "printf ok"
 container compose run --workdir /app api pwd
 container compose run --user 1000:1000 api id
+container compose run -e LOG_LEVEL=debug --env-from-file .env.local api env
 container compose ps
 container compose logs api
 container compose exec api sh

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,9 @@ cli-smoke: build
 	run_workdir_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --workdir /workspace api pwd)"; \
 	[[ "$$run_workdir_output" == *"--workdir /workspace"* ]]; \
 	[[ "$$run_workdir_output" == *" alpine pwd"* ]]; \
+	run_user_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -u 1000:1000 api id)"; \
+	[[ "$$run_user_output" == *"--user 1000:1000"* ]]; \
+	[[ "$$run_user_output" == *" alpine id"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ cli-smoke: build
 	run_user_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -u 1000:1000 api id)"; \
 	[[ "$$run_user_output" == *"--user 1000:1000"* ]]; \
 	[[ "$$run_user_output" == *" alpine id"* ]]; \
+	run_env_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -e LOG_LEVEL=debug --env-from-file .env.local api env)"; \
+	[[ "$$run_env_output" == *"--env LOG_LEVEL=debug"* ]]; \
+	[[ "$$run_env_output" == *"--env-file .env.local"* ]]; \
+	[[ "$$run_env_output" == *" alpine env"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -258,6 +258,7 @@ public enum ComposeArgumentRewriter {
             "--user",
             "--volume",
             "--workdir",
+            "-e",
             "-u",
             "-w",
         ].contains(argument)

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -258,6 +258,7 @@ public enum ComposeArgumentRewriter {
             "--user",
             "--volume",
             "--workdir",
+            "-u",
             "-w",
         ].contains(argument)
     }

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -95,6 +95,7 @@ public struct ComposeRunOptions {
     public var containerName: String?
     public var entrypoint: String?
     public var workingDirectory: String?
+    public var user: String?
 
     public init(
         command: [String] = [],
@@ -103,7 +104,8 @@ public struct ComposeRunOptions {
         publish: [String] = [],
         containerName: String? = nil,
         entrypoint: String? = nil,
-        workingDirectory: String? = nil
+        workingDirectory: String? = nil,
+        user: String? = nil
     ) {
         self.command = command
         self.remove = remove
@@ -112,6 +114,7 @@ public struct ComposeRunOptions {
         self.containerName = containerName
         self.entrypoint = entrypoint
         self.workingDirectory = workingDirectory
+        self.user = user
     }
 }
 
@@ -310,6 +313,9 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
         if let workingDirectory = run.workingDirectory {
             service.workingDir = workingDirectory
+        }
+        if let user = run.user {
+            service.user = user
         }
         try validateRuntimeSupport(service: service)
         try await applyServicePullPolicies(services: [service])

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -96,6 +96,8 @@ public struct ComposeRunOptions {
     public var entrypoint: String?
     public var workingDirectory: String?
     public var user: String?
+    public var environment: [String]
+    public var envFiles: [String]
 
     public init(
         command: [String] = [],
@@ -105,7 +107,9 @@ public struct ComposeRunOptions {
         containerName: String? = nil,
         entrypoint: String? = nil,
         workingDirectory: String? = nil,
-        user: String? = nil
+        user: String? = nil,
+        environment: [String] = [],
+        envFiles: [String] = []
     ) {
         self.command = command
         self.remove = remove
@@ -115,6 +119,8 @@ public struct ComposeRunOptions {
         self.entrypoint = entrypoint
         self.workingDirectory = workingDirectory
         self.user = user
+        self.environment = environment
+        self.envFiles = envFiles
     }
 }
 
@@ -317,6 +323,7 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         if let user = run.user {
             service.user = user
         }
+        try applyRunEnvironmentOverrides(run, service: &service)
         try validateRuntimeSupport(service: service)
         try await applyServicePullPolicies(services: [service])
         try await ensureResources(project: project)
@@ -905,6 +912,39 @@ private extension ComposeOrchestrator {
         default:
             throw ComposeError.invalidProject("unsupported pull policy '\(policy)' for service '\(service.name)'")
         }
+    }
+
+    /// Applies `compose run` environment overrides to the copied service model.
+    func applyRunEnvironmentOverrides(_ run: ComposeRunOptions, service: inout ComposeService) throws {
+        if !run.environment.isEmpty {
+            var environment = service.environment ?? [:]
+            for override in run.environment {
+                let parsed = try parseEnvironmentOverride(override)
+                environment[parsed.key] = parsed.value
+            }
+            service.environment = environment
+        }
+
+        if !run.envFiles.isEmpty {
+            service.envFiles = (service.envFiles ?? []) + run.envFiles
+        }
+    }
+
+    /// Parses a Compose CLI environment override as `NAME` or `NAME=VALUE`.
+    func parseEnvironmentOverride(_ override: String) throws -> (key: String, value: String?) {
+        if let equalsIndex = override.firstIndex(of: "=") {
+            let key = String(override[..<equalsIndex])
+            guard !key.isEmpty else {
+                throw ComposeError.invalidProject("run --env requires NAME or NAME=VALUE")
+            }
+            let value = String(override[override.index(after: equalsIndex)...])
+            return (key, value)
+        }
+
+        guard !override.isEmpty else {
+            throw ComposeError.invalidProject("run --env requires NAME or NAME=VALUE")
+        }
+        return (override, nil)
     }
 
     /// Pulls only service images not already present in the local image store.

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -339,6 +339,10 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var workdir: String?
     @Option(name: [.customShort("u"), .customLong("user")], help: "Override the user for the one-off container.")
     var user: String?
+    @Option(name: [.customShort("e"), .customLong("env")], help: "Set an environment variable for the one-off container. May be repeated.")
+    var environment: [String] = []
+    @Option(name: .customLong("env-from-file"), help: "Read environment variables for the one-off container from a file. May be repeated.")
+    var envFiles: [String] = []
     @Argument(help: "Service name.")
     var service: String
     @Argument(parsing: .allUnrecognized, help: "Optional replacement command.")
@@ -358,7 +362,9 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 containerName: name,
                 entrypoint: entrypoint,
                 workingDirectory: workdir,
-                user: user
+                user: user,
+                environment: environment,
+                envFiles: envFiles
             )
         )
     }

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -337,6 +337,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var entrypoint: String?
     @Option(name: [.customShort("w"), .customLong("workdir")], help: "Override the working directory for the one-off container.")
     var workdir: String?
+    @Option(name: [.customShort("u"), .customLong("user")], help: "Override the user for the one-off container.")
+    var user: String?
     @Argument(help: "Service name.")
     var service: String
     @Argument(parsing: .allUnrecognized, help: "Optional replacement command.")
@@ -355,7 +357,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 publish: publish,
                 containerName: name,
                 entrypoint: entrypoint,
-                workingDirectory: workdir
+                workingDirectory: workdir,
+                user: user
             )
         )
     }

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -265,6 +265,25 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run user shorthand value before service name")
+    func keepsRunUserShorthandValueBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "-u",
+            "1000:1000",
+            "api",
+            "id",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "-u",
+            "1000:1000",
+            "api",
+            "id",
+        ])
+    }
+
     @Test("keeps unknown root options before the subcommand")
     func keepsUnknownRootOptionsBeforeSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -284,6 +284,29 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run env shorthand value before service name")
+    func keepsRunEnvShorthandValueBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "-e",
+            "LOG_LEVEL=debug",
+            "--env-from-file",
+            ".env.local",
+            "api",
+            "env",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "-e",
+            "LOG_LEVEL=debug",
+            "--env-from-file",
+            ".env.local",
+            "api",
+            "env",
+        ])
+    }
+
     @Test("keeps unknown root options before the subcommand")
     func keepsUnknownRootOptionsBeforeSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2786,6 +2786,30 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(2)) == ["alpine", "pwd"])
     }
 
+    @Test("run overrides service user for one-off containers")
+    func runOverridesServiceUserForOneOffContainers() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.user = "1000"
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["id"], user: "2000:2000")
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.containsSequence(["--user", "2000:2000"]))
+        #expect(!command.containsSequence(["--user", "1000"]))
+        #expect(Array(command.suffix(2)) == ["alpine", "id"])
+    }
+
     @Test("up reuses existing containers when no recreate is requested")
     func upReusesExistingContainersWhenNoRecreateIsRequested() async throws {
         let emitted = MessageRecorder()

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2810,6 +2810,60 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(2)) == ["alpine", "id"])
     }
 
+    @Test("run applies one-off environment overrides")
+    func runAppliesOneOffEnvironmentOverrides() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.environment = ["EMPTY": nil, "KEEP": "yes", "LOG_LEVEL": "info"]
+                    $0.envFiles = [".env"]
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(
+                command: ["env"],
+                environment: ["LOG_LEVEL=debug", "NEW=value", "PASSTHROUGH", "EMPTY="],
+                envFiles: [".env.local"]
+            )
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.containsSequence(["--env", "EMPTY="]))
+        #expect(command.containsSequence(["--env", "KEEP=yes"]))
+        #expect(command.containsSequence(["--env", "LOG_LEVEL=debug"]))
+        #expect(command.containsSequence(["--env", "NEW=value"]))
+        #expect(command.containsSequence(["--env", "PASSTHROUGH"]))
+        #expect(!command.containsSequence(["--env", "LOG_LEVEL=info"]))
+        #expect(command.containsSequence(["--env-file", ".env"]))
+        #expect(command.containsSequence(["--env-file", ".env.local"]))
+        #expect(Array(command.suffix(2)) == ["alpine", "env"])
+    }
+
+    @Test("run rejects empty environment override")
+    func runRejectsEmptyEnvironmentOverride() async throws {
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        do {
+            try await ComposeOrchestrator().run(
+                project: project,
+                serviceName: "job",
+                options: ComposeRunOptions(command: ["env"], environment: [""])
+            )
+            Issue.record("Expected empty run environment override to fail")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("run --env requires NAME or NAME=VALUE"))
+        }
+    }
+
     @Test("up reuses existing containers when no recreate is requested")
     func upReusesExistingContainersWhenNoRecreateIsRequested() async throws {
         let emitted = MessageRecorder()


### PR DESCRIPTION
## Summary
- batch the current develop commits into main through a PR so CI/SonarQube validates the SQ remediation set together
- preserve the individual squashed develop commits on main via a normal merge commit
- keep the local .vscode/ directory out of the PR

## Batch commits
- feat(run): support one-off user override
- feat(run): support one-off environment overrides

## Validation
- prior develop cycle validation covered each commit with local Makefile checks and local Sonar scans
- this PR is intended to trigger the formal main/PR CI and SonarCloud checks together
