### PR TITLE
feat(run): batch one-off volume override support

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -40,7 +40,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, one-off `run --rm`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
-| Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
+| Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
 | Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
 | Environment and labels | Service `environment`, `env_file`, one-off `run --env/-e`, one-off `run --env-from-file`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
@@ -224,6 +224,7 @@ container compose run --entrypoint "/bin/sh -c" api "printf ok"
 container compose run --workdir /app api pwd
 container compose run --user 1000:1000 api id
 container compose run -e LOG_LEVEL=debug --env-from-file .env.local api env
+container compose run -v ./scratch:/scratch:ro api ls /scratch
 container compose ps
 container compose logs api
 container compose exec api sh

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,9 @@ cli-smoke: build
 	[[ "$$run_env_output" == *"--env LOG_LEVEL=debug"* ]]; \
 	[[ "$$run_env_output" == *"--env-file .env.local"* ]]; \
 	[[ "$$run_env_output" == *" alpine env"* ]]; \
+	run_volume_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -v /host:/container:ro api ls)"; \
+	[[ "$$run_volume_output" == *"--volume /host:/container:ro"* ]]; \
+	[[ "$$run_volume_output" == *" alpine ls"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -260,6 +260,7 @@ public enum ComposeArgumentRewriter {
             "--workdir",
             "-e",
             "-u",
+            "-v",
             "-w",
         ].contains(argument)
     }

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -98,6 +98,7 @@ public struct ComposeRunOptions {
     public var user: String?
     public var environment: [String]
     public var envFiles: [String]
+    public var volumes: [String]
 
     public init(
         command: [String] = [],
@@ -109,7 +110,8 @@ public struct ComposeRunOptions {
         workingDirectory: String? = nil,
         user: String? = nil,
         environment: [String] = [],
-        envFiles: [String] = []
+        envFiles: [String] = [],
+        volumes: [String] = []
     ) {
         self.command = command
         self.remove = remove
@@ -121,6 +123,7 @@ public struct ComposeRunOptions {
         self.user = user
         self.environment = environment
         self.envFiles = envFiles
+        self.volumes = volumes
     }
 }
 
@@ -308,7 +311,8 @@ public final class ComposeOrchestrator: @unchecked Sendable {
 
     /// Runs a one-off container for a service with Docker Compose compatible options.
     public func run(project: ComposeProject, serviceName: String, options run: ComposeRunOptions) async throws {
-        guard var service = project.services[serviceName] else {
+        var runProject = project
+        guard var service = runProject.services[serviceName] else {
             throw ComposeError.invalidProject("unknown service '\(serviceName)'")
         }
         if !run.command.isEmpty {
@@ -324,13 +328,14 @@ public final class ComposeOrchestrator: @unchecked Sendable {
             service.user = user
         }
         try applyRunEnvironmentOverrides(run, service: &service)
+        try applyRunVolumeOverrides(run, project: &runProject, service: &service)
         try validateRuntimeSupport(service: service)
         try await applyServicePullPolicies(services: [service])
-        try await ensureResources(project: project)
+        try await ensureResources(project: runProject)
         let publishedPorts = (run.servicePorts ? service.ports ?? [] : []) + run.publish
         try await runContainer(
             runArguments(
-                project: project,
+                project: runProject,
                 service: service,
                 detach: false,
                 remove: run.remove,
@@ -928,6 +933,69 @@ private extension ComposeOrchestrator {
         if !run.envFiles.isEmpty {
             service.envFiles = (service.envFiles ?? []) + run.envFiles
         }
+    }
+
+    /// Applies `compose run` volume overrides to the copied service model.
+    func applyRunVolumeOverrides(_ run: ComposeRunOptions, project: inout ComposeProject, service: inout ComposeService) throws {
+        guard !run.volumes.isEmpty else {
+            return
+        }
+
+        var volumes = service.volumes ?? []
+        for override in run.volumes {
+            let parsed = try parseRunVolumeOverride(override)
+            volumes.append(parsed.mount)
+            if let name = parsed.namedVolume, project.volumes[name] == nil {
+                project.volumes[name] = ComposeVolume(name: name)
+            }
+        }
+        service.volumes = volumes
+    }
+
+    /// Parses Docker Compose `run --volume` short syntax.
+    func parseRunVolumeOverride(_ override: String) throws -> (mount: ComposeMount, namedVolume: String?) {
+        let parts = override.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        switch parts.count {
+        case 1:
+            let target = parts[0]
+            guard !target.isEmpty else {
+                throw ComposeError.invalidProject("run --volume requires SOURCE:TARGET[:ro|rw] or TARGET")
+            }
+            return (ComposeMount(type: "volume", target: target), nil)
+        case 2, 3:
+            let source = parts[0]
+            let target = parts[1]
+            guard !source.isEmpty, !target.isEmpty else {
+                throw ComposeError.invalidProject("run --volume requires SOURCE:TARGET[:ro|rw] or TARGET")
+            }
+            let readOnly = try parseRunVolumeMode(parts.count == 3 ? parts[2] : nil)
+            if isBindVolumeSource(source) {
+                return (ComposeMount(type: "bind", source: source, target: target, readOnly: readOnly), nil)
+            }
+            return (ComposeMount(type: "volume", source: source, target: target, readOnly: readOnly), source)
+        default:
+            throw ComposeError.invalidProject("run --volume requires SOURCE:TARGET[:ro|rw] or TARGET")
+        }
+    }
+
+    /// Parses the optional access mode from `compose run --volume`.
+    func parseRunVolumeMode(_ mode: String?) throws -> Bool {
+        guard let mode, !mode.isEmpty else {
+            return false
+        }
+        switch mode {
+        case "ro", "readonly":
+            return true
+        case "rw":
+            return false
+        default:
+            throw ComposeError.invalidProject("run --volume mode '\(mode)' is not supported; use ro or rw")
+        }
+    }
+
+    /// Returns whether a `run --volume` source is a host bind path.
+    func isBindVolumeSource(_ source: String) -> Bool {
+        source.hasPrefix("/") || source.hasPrefix(".") || source.hasPrefix("~")
     }
 
     /// Parses a Compose CLI environment override as `NAME` or `NAME=VALUE`.

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -343,6 +343,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var environment: [String] = []
     @Option(name: .customLong("env-from-file"), help: "Read environment variables for the one-off container from a file. May be repeated.")
     var envFiles: [String] = []
+    @Option(name: [.customShort("v"), .customLong("volume")], help: "Bind mount a volume for the one-off container. May be repeated.")
+    var volumes: [String] = []
     @Argument(help: "Service name.")
     var service: String
     @Argument(parsing: .allUnrecognized, help: "Optional replacement command.")
@@ -364,7 +366,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 workingDirectory: workdir,
                 user: user,
                 environment: environment,
-                envFiles: envFiles
+                envFiles: envFiles,
+                volumes: volumes
             )
         )
     }

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -307,6 +307,25 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run volume shorthand value before service name")
+    func keepsRunVolumeShorthandValueBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "-v",
+            "/host:/container:ro",
+            "api",
+            "ls",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "-v",
+            "/host:/container:ro",
+            "api",
+            "ls",
+        ])
+    }
+
     @Test("keeps unknown root options before the subcommand")
     func keepsUnknownRootOptionsBeforeSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2845,6 +2845,57 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(2)) == ["alpine", "env"])
     }
 
+    @Test("run applies one-off volume overrides")
+    func runAppliesOneOffVolumeOverrides() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.volumes = [ComposeMount(type: "bind", source: "/default", target: "/default")]
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(
+                command: ["ls"],
+                volumes: ["/host:/container:ro", "cache:/cache", "/scratch"]
+            )
+        )
+
+        let volumeCreate = try #require(runner.commands.first?.arguments)
+        #expect(volumeCreate.containsSequence(["container", "volume", "create"]))
+        #expect(volumeCreate.last == "demo_cache")
+        let command = try #require(runner.commands.last?.arguments)
+        #expect(command.containsSequence(["--volume", "/default:/default"]))
+        #expect(command.containsSequence(["--volume", "/host:/container:ro"]))
+        #expect(command.containsSequence(["--volume", "demo_cache:/cache"]))
+        #expect(command.contains { $0.hasPrefix("demo_anon-") && $0.hasSuffix(":/scratch") })
+        #expect(Array(command.suffix(2)) == ["alpine", "ls"])
+    }
+
+    @Test("run rejects unsupported one-off volume mode")
+    func runRejectsUnsupportedOneOffVolumeMode() async throws {
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        do {
+            try await ComposeOrchestrator().run(
+                project: project,
+                serviceName: "job",
+                options: ComposeRunOptions(command: ["ls"], volumes: ["/host:/container:delegated"])
+            )
+            Issue.record("Expected unsupported run volume mode to fail")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("run --volume mode 'delegated' is not supported; use ro or rw"))
+        }
+    }
+
     @Test("run rejects empty environment override")
     func runRejectsEmptyEnvironmentOverride() async throws {
         let project = ComposeProject(


### PR DESCRIPTION
## Summary
- Batch the current develop remediation commit into main through a PR
- Preserve the squashed issue commit from develop without squash-merging to main
- Trigger formal CI/SonarQube on the PR/main path instead of pushing individual fixes to main

## Validation
- Previous local validation completed on develop for the included commit
- PR checks will provide the formal CI/SonarQube signal before merge