### PR TITLE
feat(run): batch one-off run option support

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -36,7 +36,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Compose v2 surface | Supported subset | [`apple/container`][apple-container] primitive used | Example |
 | --- | --- | --- | --- |
 | Config normalization | File discovery, repeated `-f`, `.env`, `--env-file`, interpolation, merge, profiles, `--project-directory`, `-p/--project-name`, and canonical `config` JSON | No runtime primitive; `compose-go` normalizes the Compose model | [S1](#s1-supported-local-web-stack), [O1](#o1-config-only-metadata) |
-| Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, `images`, global `up --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container image list` | [S1](#s1-supported-local-web-stack) |
+| Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, `images`, global `up --pull always/missing/never`, one-off `run --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container image list` | [S1](#s1-supported-local-web-stack) |
 | Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, one-off `run --rm`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
@@ -216,6 +216,7 @@ Useful supported commands against this project:
 container compose config
 container compose build
 container compose up --pull missing
+container compose run --pull missing api true
 container compose run --rm api printf ok
 container compose run --name api-shell api sh
 container compose run --service-ports api printf ok

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -42,7 +42,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
 | Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
-| Environment and labels | Service `environment`, `env_file`, one-off `run --env/-e`, one-off `run --env-from-file`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
+| Environment and labels | Service `environment`, `env_file`, one-off `run --env/-e`, one-off `run --env-from-file`, one-off `run --label/-l`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
 
 ### Blocked By apple/container
@@ -224,6 +224,7 @@ container compose run --entrypoint "/bin/sh -c" api "printf ok"
 container compose run --workdir /app api pwd
 container compose run --user 1000:1000 api id
 container compose run -e LOG_LEVEL=debug --env-from-file .env.local api env
+container compose run -l com.example.role=job api true
 container compose run -v ./scratch:/scratch:ro api ls /scratch
 container compose ps
 container compose logs api

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,10 @@ cli-smoke: build
 	run_publish_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -p 9090:90 api echo hello)"; \
 	[[ "$$run_publish_output" == *"--publish 9090:90"* ]]; \
 	[[ "$$run_publish_output" != *"--publish 8080:80"* ]]; \
+	run_pull_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --pull missing api true)"; \
+	[[ "$$run_pull_output" == *"container image inspect alpine"* ]]; \
+	[[ "$$run_pull_output" == *"container image pull alpine"* ]]; \
+	[[ "$$run_pull_output" == *" alpine true"* ]]; \
 	run_named_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run --name custom-api api echo hello)"; \
 	[[ "$$run_named_output" == *"--name custom-api"* ]]; \
 	[[ "$$run_named_output" == *" alpine echo hello"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,9 @@ cli-smoke: build
 	[[ "$$run_env_output" == *"--env LOG_LEVEL=debug"* ]]; \
 	[[ "$$run_env_output" == *"--env-file .env.local"* ]]; \
 	[[ "$$run_env_output" == *" alpine env"* ]]; \
+	run_label_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -l com.example.role=job api true)"; \
+	[[ "$$run_label_output" == *"--label com.example.role=job"* ]]; \
+	[[ "$$run_label_output" == *" alpine true"* ]]; \
 	run_volume_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -v /host:/container:ro api ls)"; \
 	[[ "$$run_volume_output" == *"--volume /host:/container:ro"* ]]; \
 	[[ "$$run_volume_output" == *" alpine ls"* ]]; \

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -259,6 +259,7 @@ public enum ComposeArgumentRewriter {
             "--volume",
             "--workdir",
             "-e",
+            "-l",
             "-u",
             "-v",
             "-w",

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -92,6 +92,7 @@ public struct ComposeRunOptions {
     public var remove: Bool
     public var servicePorts: Bool
     public var publish: [String]
+    public var pullPolicy: String?
     public var containerName: String?
     public var entrypoint: String?
     public var workingDirectory: String?
@@ -106,6 +107,7 @@ public struct ComposeRunOptions {
         remove: Bool = false,
         servicePorts: Bool = false,
         publish: [String] = [],
+        pullPolicy: String? = nil,
         containerName: String? = nil,
         entrypoint: String? = nil,
         workingDirectory: String? = nil,
@@ -119,6 +121,7 @@ public struct ComposeRunOptions {
         self.remove = remove
         self.servicePorts = servicePorts
         self.publish = publish
+        self.pullPolicy = pullPolicy
         self.containerName = containerName
         self.entrypoint = entrypoint
         self.workingDirectory = workingDirectory
@@ -333,8 +336,9 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         try applyRunEnvironmentOverrides(run, service: &service)
         try applyRunVolumeOverrides(run, project: &runProject, service: &service)
         let labelOverrides = try parseRunLabelOverrides(run.labels)
+        try validatePullPolicy(run.pullPolicy)
         try validateRuntimeSupport(service: service)
-        try await applyServicePullPolicies(services: [service])
+        try await applyPullPolicy(run.pullPolicy, project: runProject, services: [service])
         try await ensureResources(project: runProject)
         let publishedPorts = (run.servicePorts ? service.ports ?? [] : []) + run.publish
         try await runContainer(

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -98,6 +98,7 @@ public struct ComposeRunOptions {
     public var user: String?
     public var environment: [String]
     public var envFiles: [String]
+    public var labels: [String]
     public var volumes: [String]
 
     public init(
@@ -111,6 +112,7 @@ public struct ComposeRunOptions {
         user: String? = nil,
         environment: [String] = [],
         envFiles: [String] = [],
+        labels: [String] = [],
         volumes: [String] = []
     ) {
         self.command = command
@@ -123,6 +125,7 @@ public struct ComposeRunOptions {
         self.user = user
         self.environment = environment
         self.envFiles = envFiles
+        self.labels = labels
         self.volumes = volumes
     }
 }
@@ -329,6 +332,7 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
         try applyRunEnvironmentOverrides(run, service: &service)
         try applyRunVolumeOverrides(run, project: &runProject, service: &service)
+        let labelOverrides = try parseRunLabelOverrides(run.labels)
         try validateRuntimeSupport(service: service)
         try await applyServicePullPolicies(services: [service])
         try await ensureResources(project: runProject)
@@ -341,7 +345,8 @@ public final class ComposeOrchestrator: @unchecked Sendable {
                 remove: run.remove,
                 oneOff: true,
                 publishedPorts: publishedPorts,
-                containerNameOverride: run.containerName
+                containerNameOverride: run.containerName,
+                labelOverrides: labelOverrides
             ),
             inheritedIO: service.tty == true || service.stdinOpen == true
         )
@@ -1015,6 +1020,31 @@ private extension ComposeOrchestrator {
         return (override, nil)
     }
 
+    /// Parses `compose run --label` overrides while preserving CLI order.
+    func parseRunLabelOverrides(_ overrides: [String]) throws -> [ComposeLabelOverride] {
+        try overrides.map { override in
+            let parsed: ComposeLabelOverride
+            if let equalsIndex = override.firstIndex(of: "=") {
+                let key = String(override[..<equalsIndex])
+                guard !key.isEmpty else {
+                    throw ComposeError.invalidProject("run --label requires KEY or KEY=VALUE")
+                }
+                let value = String(override[override.index(after: equalsIndex)...])
+                parsed = ComposeLabelOverride(key: key, value: value)
+            } else {
+                guard !override.isEmpty else {
+                    throw ComposeError.invalidProject("run --label requires KEY or KEY=VALUE")
+                }
+                parsed = ComposeLabelOverride(key: override, value: nil)
+            }
+
+            guard !parsed.key.hasPrefix(reservedComposeLabelPrefix) else {
+                throw ComposeError.invalidProject("run --label cannot override reserved Compose tracking label '\(parsed.key)'")
+            }
+            return parsed
+        }
+    }
+
     /// Pulls only service images not already present in the local image store.
     func pullMissingImages(services: [ComposeService]) async throws {
         for service in services {
@@ -1041,7 +1071,8 @@ private extension ComposeOrchestrator {
         remove: Bool,
         oneOff: Bool,
         publishedPorts: [String]? = nil,
-        containerNameOverride: String? = nil
+        containerNameOverride: String? = nil,
+        labelOverrides: [ComposeLabelOverride] = []
     ) throws -> [String] {
         var args = ["run"]
         let runtimeName = containerNameOverride.map(slug) ?? containerName(project: project, service: service, oneOff: oneOff)
@@ -1056,8 +1087,12 @@ private extension ComposeOrchestrator {
         for label in serviceLabels(project: project, service: service, oneOff: oneOff) {
             args.append(contentsOf: ["--label", label])
         }
-        for (key, value) in (service.labels ?? [:]).sorted(by: { $0.key < $1.key }) {
+        let overriddenLabelKeys = Set(labelOverrides.map(\.key))
+        for (key, value) in (service.labels ?? [:]).sorted(by: { $0.key < $1.key }) where !overriddenLabelKeys.contains(key) {
             args.append(contentsOf: ["--label", "\(key)=\(value)"])
+        }
+        for label in labelOverrides {
+            args.append(contentsOf: ["--label", label.rawValue])
         }
         for (key, value) in (service.environment ?? [:]).sorted(by: { $0.key < $1.key }) {
             if let value {
@@ -1325,10 +1360,23 @@ private struct ServiceConfigFingerprint: Encodable {
     var volumes: [String: String]
 }
 
+private struct ComposeLabelOverride {
+    var key: String
+    var value: String?
+
+    var rawValue: String {
+        guard let value else {
+            return key
+        }
+        return "\(key)=\(value)"
+    }
+}
+
 private let projectLabel = "com.apple.container.compose.project"
 private let configHashLabel = "com.apple.container.compose.config-hash"
 private let workingDirectoryLabel = "com.apple.container.compose.project.working-directory"
 private let configFilesHashLabel = "com.apple.container.compose.project.config-files-hash"
+private let reservedComposeLabelPrefix = "com.apple.container.compose."
 
 /// Returns whether a service pull policy can be implemented with local runtime primitives.
 private func isSupportedServicePullPolicy(_ policy: String) -> Bool {

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -331,6 +331,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var servicePorts = false
     @Option(name: .customLong("publish"), help: "Publish a container port to the host. May be repeated.")
     var publish: [String] = []
+    @Option(name: .customLong("pull"), help: "Image pull policy before running: always, missing, or never.")
+    var pull: String?
     @Option(name: .customLong("name"), help: "Assign a name to the one-off container.")
     var name: String?
     @Option(name: .customLong("entrypoint"), help: "Override the service entrypoint for the one-off container.")
@@ -363,6 +365,7 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 remove: remove,
                 servicePorts: servicePorts,
                 publish: publish,
+                pullPolicy: pull,
                 containerName: name,
                 entrypoint: entrypoint,
                 workingDirectory: workdir,

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -343,6 +343,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var environment: [String] = []
     @Option(name: .customLong("env-from-file"), help: "Read environment variables for the one-off container from a file. May be repeated.")
     var envFiles: [String] = []
+    @Option(name: [.customShort("l"), .customLong("label")], help: "Add or override a label for the one-off container. May be repeated.")
+    var labels: [String] = []
     @Option(name: [.customShort("v"), .customLong("volume")], help: "Bind mount a volume for the one-off container. May be repeated.")
     var volumes: [String] = []
     @Argument(help: "Service name.")
@@ -367,6 +369,7 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 user: user,
                 environment: environment,
                 envFiles: envFiles,
+                labels: labels,
                 volumes: volumes
             )
         )

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -307,6 +307,25 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run label shorthand value before service name")
+    func keepsRunLabelShorthandValueBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "-l",
+            "com.example.role=job",
+            "api",
+            "true",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "-l",
+            "com.example.role=job",
+            "api",
+            "true",
+        ])
+    }
+
     @Test("keeps run volume shorthand value before service name")
     func keepsRunVolumeShorthandValueBeforeServiceName() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -326,6 +326,25 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("keeps run pull policy before service name")
+    func keepsRunPullPolicyBeforeServiceName() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "run",
+            "--pull",
+            "missing",
+            "api",
+            "true",
+        ])
+
+        #expect(rewritten == [
+            "run",
+            "--pull",
+            "missing",
+            "api",
+            "true",
+        ])
+    }
+
     @Test("keeps run volume shorthand value before service name")
     func keepsRunVolumeShorthandValueBeforeServiceName() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2845,6 +2845,77 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(2)) == ["alpine", "env"])
     }
 
+    @Test("run applies one-off label overrides")
+    func runAppliesOneOffLabelOverrides() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.labels = ["com.example.keep": "yes", "com.example.role": "api"]
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(
+                command: ["true"],
+                labels: ["com.example.role=job", "com.example.flag"]
+            )
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.containsSequence(["--label", "com.apple.container.compose.oneoff=true"]))
+        #expect(command.containsSequence(["--label", "com.example.keep=yes"]))
+        #expect(command.containsSequence(["--label", "com.example.role=job"]))
+        #expect(command.containsSequence(["--label", "com.example.flag"]))
+        #expect(!command.containsSequence(["--label", "com.example.role=api"]))
+        #expect(Array(command.suffix(2)) == ["alpine", "true"])
+    }
+
+    @Test("run rejects empty label override")
+    func runRejectsEmptyLabelOverride() async throws {
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        do {
+            try await ComposeOrchestrator().run(
+                project: project,
+                serviceName: "job",
+                options: ComposeRunOptions(command: ["true"], labels: [""])
+            )
+            Issue.record("Expected empty run label override to fail")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("run --label requires KEY or KEY=VALUE"))
+        }
+    }
+
+    @Test("run rejects reserved Compose label overrides")
+    func runRejectsReservedComposeLabelOverrides() async throws {
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        do {
+            try await ComposeOrchestrator().run(
+                project: project,
+                serviceName: "job",
+                options: ComposeRunOptions(
+                    command: ["true"],
+                    labels: ["com.apple.container.compose.project=evil"]
+                )
+            )
+            Issue.record("Expected reserved run label override to fail")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("run --label cannot override reserved Compose tracking label 'com.apple.container.compose.project'"))
+        }
+    }
+
     @Test("run applies one-off volume overrides")
     func runAppliesOneOffVolumeOverrides() async throws {
         let runner = RecordingRunner()

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2670,6 +2670,81 @@ struct ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
+    @Test("run applies explicit pull policy before one-off container")
+    func runAppliesExplicitPullPolicyBeforeOneOffContainer() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.pullPolicy = "never"
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["true"], pullPolicy: "always")
+        )
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands[0] == ["container", "image", "pull", "alpine"])
+        #expect(commands[1].starts(with: ["container", "run"]))
+        #expect(Array(commands[1].suffix(2)) == ["alpine", "true"])
+    }
+
+    @Test("run pull missing only pulls absent images")
+    func runPullMissingOnlyPullsAbsentImages() async throws {
+        let presentRunner = RecordingRunner(responses: [.success])
+        let absentRunner = RecordingRunner(responses: [.failure, .success])
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        try await ComposeOrchestrator(runner: presentRunner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["true"], pullPolicy: "missing")
+        )
+        try await ComposeOrchestrator(runner: absentRunner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["true"], pullPolicy: "missing")
+        )
+
+        let presentCommands = presentRunner.commands.map(\.arguments)
+        #expect(presentCommands[0] == ["container", "image", "inspect", "alpine"])
+        #expect(presentCommands[1].starts(with: ["container", "run"]))
+        let absentCommands = absentRunner.commands.map(\.arguments)
+        #expect(absentCommands[0] == ["container", "image", "inspect", "alpine"])
+        #expect(absentCommands[1] == ["container", "image", "pull", "alpine"])
+        #expect(absentCommands[2].starts(with: ["container", "run"]))
+    }
+
+    @Test("run rejects unsupported explicit pull policy")
+    func runRejectsUnsupportedExplicitPullPolicy() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        do {
+            try await ComposeOrchestrator(runner: runner).run(
+                project: project,
+                serviceName: "job",
+                options: ComposeRunOptions(command: ["true"], pullPolicy: "daily")
+            )
+            Issue.record("Expected unsupported run pull policy to fail")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("unsupported pull policy 'daily'"))
+        }
+
+        #expect(runner.commands.isEmpty)
+    }
+
     @Test("run rejects unsupported restart policies before creating resources")
     func runRejectsUnsupportedRestartPoliciesBeforeCreatingResources() async throws {
         let runner = RecordingRunner()


### PR DESCRIPTION
## Summary

Batch the current `develop` commits into `main` so the main-branch CI/SonarQube run validates the fixes together.

Included commits:

- `c08c009 feat(run): support one-off label overrides`
- `f6d324d feat(run): support one-off pull policy`

## Validation

- `make lint`
- `git diff --check`
- `make cli-smoke`
- `make coverage-check` (Swift 94.03%, Go 94.55%)
- `SONAR_BRANCH=develop make sonar-scan` with CE task success

## Merge Plan

Use a normal PR merge commit, not squash or rebase, so the per-issue commits from `develop` remain ancestors of `main` while main CI/Sonar only runs once for the batch.
