### PR TITLE
ci: batch Sonar remediation build speedups

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -109,7 +109,7 @@ Run the same validation used by GitHub Actions:
 make ci
 ```
 
-`make ci` resolves Swift packages, runs required Markdown linting and Go formatting checks, builds the Swift package, runs Swift and Go coverage, checks the coverage threshold, and builds the Go helper.
+`make ci` resolves Swift packages, runs required Markdown linting and Go formatting checks, runs Swift and Go coverage, checks the coverage threshold, builds the Go helper, and runs the CLI smoke test. The smoke test builds the debug `compose` executable before exercising representative commands.
 
 The default minimum coverage is 85 percent for both Swift and Go:
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ all: workflow
 
 workflow: ci package
 
-ci: resolve lint build coverage-check go-build cli-smoke
+ci: resolve lint coverage-check go-build cli-smoke
 
 resolve:
 	$(SWIFT) package resolve


### PR DESCRIPTION
## Summary

- batch the current develop CI/Sonar remediation commits into one pull request
- remove the redundant Swift product build from the local validation target
- align the build documentation with the faster Makefile validation graph

## Validation

- `make lint`
- `git diff --check`
- `make ci`
- `SONAR_BRANCH=develop make sonar-scan`

## Merge intent

Use a non-squash merge into `main` so `main` receives the already-squashed issue commits from `develop` in one CI/Sonar run.
