### PR TITLE
feat(run): batch one-off terminal controls

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -37,7 +37,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | --- | --- | --- | --- |
 | Config normalization | File discovery, repeated `-f`, `.env`, `--env-file`, interpolation, merge, profiles, `--project-directory`, `-p/--project-name`, and canonical `config` JSON | No runtime primitive; `compose-go` normalizes the Compose model | [S1](#s1-supported-local-web-stack), [O1](#o1-config-only-metadata) |
 | Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, `images`, global `up --pull always/missing/never`, one-off `run --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container image list` | [S1](#s1-supported-local-web-stack) |
-| Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, one-off `run --rm`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
+| Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
@@ -218,6 +218,7 @@ container compose build
 container compose up --pull missing
 container compose run --pull missing api true
 container compose run --rm api printf ok
+container compose run --detach api sleep 60
 container compose run --name api-shell api sh
 container compose run --service-ports api printf ok
 container compose run -p 9090:8080 api printf ok

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -41,7 +41,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Container interaction | `ps`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
-| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
+| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, one-off `run -T/--no-tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
 | Environment and labels | Service `environment`, `env_file`, one-off `run --env/-e`, one-off `run --env-from-file`, one-off `run --label/-l`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
 
@@ -225,6 +225,7 @@ container compose run -p 9090:8080 api printf ok
 container compose run --entrypoint "/bin/sh -c" api "printf ok"
 container compose run --workdir /app api pwd
 container compose run --user 1000:1000 api id
+container compose run -T api sh
 container compose run -e LOG_LEVEL=debug --env-from-file .env.local api env
 container compose run -l com.example.role=job api true
 container compose run -v ./scratch:/scratch:ro api ls /scratch

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,9 @@ cli-smoke: build
 	run_volume_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -v /host:/container:ro api ls)"; \
 	[[ "$$run_volume_output" == *"--volume /host:/container:ro"* ]]; \
 	[[ "$$run_volume_output" == *" alpine ls"* ]]; \
+	run_detached_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -d api sleep 60)"; \
+	[[ "$$run_detached_output" == *"--detach"* ]]; \
+	[[ "$$run_detached_output" == *" alpine sleep 60"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ cli-smoke: build
 	.build/debug/compose version --dry-run >/dev/null
 	tmpdir="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmpdir"' EXIT; \
-	printf 'services:\n  api:\n    image: alpine\n    ports:\n      - "8080:80"\n' > "$$tmpdir/compose.yml"; \
+	printf 'services:\n  api:\n    image: alpine\n    ports:\n      - "8080:80"\n  shell:\n    image: alpine\n    tty: true\n    stdin_open: true\n' > "$$tmpdir/compose.yml"; \
 	run_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run api echo hello)"; \
 	[[ "$$run_output" == *"container run"* ]]; \
 	[[ "$$run_output" == *" alpine echo hello"* ]]; \
@@ -126,6 +126,12 @@ cli-smoke: build
 	run_detached_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -d api sleep 60)"; \
 	[[ "$$run_detached_output" == *"--detach"* ]]; \
 	[[ "$$run_detached_output" == *" alpine sleep 60"* ]]; \
+	run_tty_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run shell sh)"; \
+	[[ "$$run_tty_output" == *"--tty"* ]]; \
+	[[ "$$run_tty_output" == *"--interactive"* ]]; \
+	run_no_tty_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" run -T shell sh)"; \
+	[[ "$$run_no_tty_output" != *"--tty"* ]]; \
+	[[ "$$run_no_tty_output" == *"--interactive"* ]]; \
 	up_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up api)"; \
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -91,6 +91,7 @@ public struct ComposeRunOptions {
     public var command: [String]
     public var remove: Bool
     public var detach: Bool
+    public var noTty: Bool
     public var servicePorts: Bool
     public var publish: [String]
     public var pullPolicy: String?
@@ -107,6 +108,7 @@ public struct ComposeRunOptions {
         command: [String] = [],
         remove: Bool = false,
         detach: Bool = false,
+        noTty: Bool = false,
         servicePorts: Bool = false,
         publish: [String] = [],
         pullPolicy: String? = nil,
@@ -122,6 +124,7 @@ public struct ComposeRunOptions {
         self.command = command
         self.remove = remove
         self.detach = detach
+        self.noTty = noTty
         self.servicePorts = servicePorts
         self.publish = publish
         self.pullPolicy = pullPolicy
@@ -335,6 +338,9 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
         if let user = run.user {
             service.user = user
+        }
+        if run.noTty {
+            service.tty = false
         }
         try applyRunEnvironmentOverrides(run, service: &service)
         try applyRunVolumeOverrides(run, project: &runProject, service: &service)

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -90,6 +90,7 @@ public struct ComposeDownOptions {
 public struct ComposeRunOptions {
     public var command: [String]
     public var remove: Bool
+    public var detach: Bool
     public var servicePorts: Bool
     public var publish: [String]
     public var pullPolicy: String?
@@ -105,6 +106,7 @@ public struct ComposeRunOptions {
     public init(
         command: [String] = [],
         remove: Bool = false,
+        detach: Bool = false,
         servicePorts: Bool = false,
         publish: [String] = [],
         pullPolicy: String? = nil,
@@ -119,6 +121,7 @@ public struct ComposeRunOptions {
     ) {
         self.command = command
         self.remove = remove
+        self.detach = detach
         self.servicePorts = servicePorts
         self.publish = publish
         self.pullPolicy = pullPolicy
@@ -345,14 +348,14 @@ public final class ComposeOrchestrator: @unchecked Sendable {
             runArguments(
                 project: runProject,
                 service: service,
-                detach: false,
+                detach: run.detach,
                 remove: run.remove,
                 oneOff: true,
                 publishedPorts: publishedPorts,
                 containerNameOverride: run.containerName,
                 labelOverrides: labelOverrides
             ),
-            inheritedIO: service.tty == true || service.stdinOpen == true
+            inheritedIO: !run.detach && (service.tty == true || service.stdinOpen == true)
         )
     }
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -327,6 +327,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     @OptionGroup var global: GlobalOptions
     @Flag(name: .customLong("rm"), help: "Remove the one-off container after exit.")
     var remove = false
+    @Flag(name: .shortAndLong, help: "Run the one-off container in the background.")
+    var detach = false
     @Flag(name: [.customShort("P"), .customLong("service-ports")], help: "Publish all ports declared by the service.")
     var servicePorts = false
     @Option(name: .customLong("publish"), help: "Publish a container port to the host. May be repeated.")
@@ -363,6 +365,7 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
             options: ComposeRunOptions(
                 command: command,
                 remove: remove,
+                detach: detach,
                 servicePorts: servicePorts,
                 publish: publish,
                 pullPolicy: pull,

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -329,6 +329,8 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var remove = false
     @Flag(name: .shortAndLong, help: "Run the one-off container in the background.")
     var detach = false
+    @Flag(name: [.customShort("T"), .customLong("no-tty")], help: "Disable pseudo-TTY allocation.")
+    var noTty = false
     @Flag(name: [.customShort("P"), .customLong("service-ports")], help: "Publish all ports declared by the service.")
     var servicePorts = false
     @Option(name: .customLong("publish"), help: "Publish a container port to the host. May be repeated.")
@@ -366,6 +368,7 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
                 command: command,
                 remove: remove,
                 detach: detach,
+                noTty: noTty,
                 servicePorts: servicePorts,
                 publish: publish,
                 pullPolicy: pull,

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -184,6 +184,7 @@ struct ComposeArgumentRewriterTests {
         let rewritten = ComposeArgumentRewriter.rewrite([
             "run",
             "-d",
+            "-T",
             "--rm",
             "--service-ports",
             "api",
@@ -194,6 +195,7 @@ struct ComposeArgumentRewriterTests {
         #expect(rewritten == [
             "run",
             "-d",
+            "-T",
             "--rm",
             "--service-ports",
             "api",

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -183,6 +183,7 @@ struct ComposeArgumentRewriterTests {
     func keepsRunFlagsBeforeServiceNameWhilePreservingCommandArguments() {
         let rewritten = ComposeArgumentRewriter.rewrite([
             "run",
+            "-d",
             "--rm",
             "--service-ports",
             "api",
@@ -192,6 +193,7 @@ struct ComposeArgumentRewriterTests {
 
         #expect(rewritten == [
             "run",
+            "-d",
             "--rm",
             "--service-ports",
             "api",

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2840,6 +2840,32 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(3)) == ["alpine", "sleep", "60"])
     }
 
+    @Test("run disables pseudo tty while preserving interactive stdin")
+    func runDisablesPseudoTtyWhilePreservingInteractiveStdin() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.tty = true
+                    $0.stdinOpen = true
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["sh"], noTty: true)
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(runner.commands.first?.io == .inherited)
+        #expect(!command.contains("--tty"))
+        #expect(command.contains("--interactive"))
+        #expect(Array(command.suffix(2)) == ["alpine", "sh"])
+    }
+
     @Test("run overrides service entrypoint for one-off containers")
     func runOverridesServiceEntrypointForOneOffContainers() async throws {
         let runner = RecordingRunner()

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2813,6 +2813,33 @@ struct ComposeOrchestratorTests {
         #expect(Array(command.suffix(2)) == ["alpine", "true"])
     }
 
+    @Test("run detaches one-off containers without inheriting terminal IO")
+    func runDetachesOneOffContainersWithoutInheritingTerminalIO() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.tty = true
+                    $0.stdinOpen = true
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: ComposeRunOptions(command: ["sleep", "60"], detach: true)
+        )
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(runner.commands.first?.io == .captured(input: nil))
+        #expect(command.contains("--detach"))
+        #expect(command.contains("--tty"))
+        #expect(command.contains("--interactive"))
+        #expect(Array(command.suffix(3)) == ["alpine", "sleep", "60"])
+    }
+
     @Test("run overrides service entrypoint for one-off containers")
     func runOverridesServiceEntrypointForOneOffContainers() async throws {
         let runner = RecordingRunner()


### PR DESCRIPTION
## Summary

Batch-promotes the current validated develop commits to main so the one-off run improvements land together in a single main CI/SonarQube run.

Included commits:
- feat(run): support detached one-off containers
- feat(run): support no-tty one-off containers

## Validation

- make lint
- git diff --check
- make cli-smoke
- make coverage-check
- SONAR_BRANCH=develop make sonar-scan, with CE task success on the develop branch

## Merge intent

Use a normal merge commit, not a squash merge, so main keeps the individual issue commits from develop while triggering one batched main build.