### PR TITLE
refactor(run): batch Sonar parameter cleanup

### DIFF
--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -109,6 +109,19 @@ public struct ComposeRunOptions {
     }
 }
 
+private struct RunArgumentOptions {
+    var detach = false
+    var remove = false
+    var oneOff = false
+    var publishedPorts: [String]?
+    var containerNameOverride: String?
+    var labelOverrides: [ComposeLabelOverride] = []
+
+    init(_ configure: (inout RunArgumentOptions) -> Void = { _ in }) {
+        configure(&self)
+    }
+}
+
 /// Converts a normalized Compose project into deterministic `container`
 /// commands.
 public final class ComposeOrchestrator: @unchecked Sendable {
@@ -166,7 +179,15 @@ public final class ComposeOrchestrator: @unchecked Sendable {
                 try await runContainer(["delete", name], check: false)
             }
 
-            try await runContainer(runArguments(project: project, service: service, detach: up.detach, remove: false, oneOff: false))
+            try await runContainer(
+                runArguments(
+                    project: project,
+                    service: service,
+                    options: RunArgumentOptions {
+                        $0.detach = up.detach
+                    }
+                )
+            )
         }
 
         if up.removeOrphans {
@@ -327,12 +348,14 @@ public final class ComposeOrchestrator: @unchecked Sendable {
             runArguments(
                 project: runProject,
                 service: service,
-                detach: run.detach,
-                remove: run.remove,
-                oneOff: true,
-                publishedPorts: publishedPorts,
-                containerNameOverride: run.containerName,
-                labelOverrides: labelOverrides
+                options: RunArgumentOptions {
+                    $0.detach = run.detach
+                    $0.remove = run.remove
+                    $0.oneOff = true
+                    $0.publishedPorts = publishedPorts
+                    $0.containerNameOverride = run.containerName
+                    $0.labelOverrides = labelOverrides
+                }
             ),
             inheritedIO: !run.detach && (service.tty == true || service.stdinOpen == true)
         )
@@ -1050,34 +1073,29 @@ private extension ComposeOrchestrator {
     }
 
     /// Builds the `container run` argument vector for a service.
-    func runArguments(
+    private func runArguments(
         project: ComposeProject,
         service: ComposeService,
-        detach: Bool,
-        remove: Bool,
-        oneOff: Bool,
-        publishedPorts: [String]? = nil,
-        containerNameOverride: String? = nil,
-        labelOverrides: [ComposeLabelOverride] = []
+        options run: RunArgumentOptions = RunArgumentOptions()
     ) throws -> [String] {
         var args = ["run"]
-        let runtimeName = containerNameOverride.map(slug) ?? containerName(project: project, service: service, oneOff: oneOff)
+        let runtimeName = run.containerNameOverride.map(slug) ?? containerName(project: project, service: service, oneOff: run.oneOff)
         args.append(contentsOf: ["--name", runtimeName])
-        if detach {
+        if run.detach {
             args.append("--detach")
         }
-        if remove {
+        if run.remove {
             args.append("--rm")
         }
 
-        for label in serviceLabels(project: project, service: service, oneOff: oneOff) {
+        for label in serviceLabels(project: project, service: service, oneOff: run.oneOff) {
             args.append(contentsOf: ["--label", label])
         }
-        let overriddenLabelKeys = Set(labelOverrides.map(\.key))
+        let overriddenLabelKeys = Set(run.labelOverrides.map(\.key))
         for (key, value) in (service.labels ?? [:]).sorted(by: { $0.key < $1.key }) where !overriddenLabelKeys.contains(key) {
             args.append(contentsOf: ["--label", "\(key)=\(value)"])
         }
-        for label in labelOverrides {
+        for label in run.labelOverrides {
             args.append(contentsOf: ["--label", label.rawValue])
         }
         for (key, value) in (service.environment ?? [:]).sorted(by: { $0.key < $1.key }) {
@@ -1090,7 +1108,7 @@ private extension ComposeOrchestrator {
         for envFile in service.envFiles ?? [] {
             args.append(contentsOf: ["--env-file", envFile])
         }
-        for port in publishedPorts ?? service.ports ?? [] {
+        for port in run.publishedPorts ?? service.ports ?? [] {
             args.append(contentsOf: ["--publish", port])
         }
         for mount in service.volumes ?? [] {

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -88,54 +88,24 @@ public struct ComposeDownOptions {
 
 /// Options for `compose run` one-off containers.
 public struct ComposeRunOptions {
-    public var command: [String]
-    public var remove: Bool
-    public var detach: Bool
-    public var noTty: Bool
-    public var servicePorts: Bool
-    public var publish: [String]
+    public var command: [String] = []
+    public var remove = false
+    public var detach = false
+    public var noTty = false
+    public var servicePorts = false
+    public var publish: [String] = []
     public var pullPolicy: String?
     public var containerName: String?
     public var entrypoint: String?
     public var workingDirectory: String?
     public var user: String?
-    public var environment: [String]
-    public var envFiles: [String]
-    public var labels: [String]
-    public var volumes: [String]
+    public var environment: [String] = []
+    public var envFiles: [String] = []
+    public var labels: [String] = []
+    public var volumes: [String] = []
 
-    public init(
-        command: [String] = [],
-        remove: Bool = false,
-        detach: Bool = false,
-        noTty: Bool = false,
-        servicePorts: Bool = false,
-        publish: [String] = [],
-        pullPolicy: String? = nil,
-        containerName: String? = nil,
-        entrypoint: String? = nil,
-        workingDirectory: String? = nil,
-        user: String? = nil,
-        environment: [String] = [],
-        envFiles: [String] = [],
-        labels: [String] = [],
-        volumes: [String] = []
-    ) {
-        self.command = command
-        self.remove = remove
-        self.detach = detach
-        self.noTty = noTty
-        self.servicePorts = servicePorts
-        self.publish = publish
-        self.pullPolicy = pullPolicy
-        self.containerName = containerName
-        self.entrypoint = entrypoint
-        self.workingDirectory = workingDirectory
-        self.user = user
-        self.environment = environment
-        self.envFiles = envFiles
-        self.labels = labels
-        self.volumes = volumes
+    public init(_ configure: (inout ComposeRunOptions) -> Void = { _ in }) {
+        configure(&self)
     }
 }
 
@@ -317,7 +287,10 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         try await run(
             project: project,
             serviceName: serviceName,
-            options: ComposeRunOptions(command: command, remove: remove)
+            options: ComposeRunOptions {
+                $0.command = command
+                $0.remove = remove
+            }
         )
     }
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -364,23 +364,23 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
         try await orchestrator().run(
             project: loadedProject,
             serviceName: service,
-            options: ComposeRunOptions(
-                command: command,
-                remove: remove,
-                detach: detach,
-                noTty: noTty,
-                servicePorts: servicePorts,
-                publish: publish,
-                pullPolicy: pull,
-                containerName: name,
-                entrypoint: entrypoint,
-                workingDirectory: workdir,
-                user: user,
-                environment: environment,
-                envFiles: envFiles,
-                labels: labels,
-                volumes: volumes
-            )
+            options: ComposeRunOptions {
+                $0.command = command
+                $0.remove = remove
+                $0.detach = detach
+                $0.noTty = noTty
+                $0.servicePorts = servicePorts
+                $0.publish = publish
+                $0.pullPolicy = pull
+                $0.containerName = name
+                $0.entrypoint = entrypoint
+                $0.workingDirectory = workdir
+                $0.user = user
+                $0.environment = environment
+                $0.envFiles = envFiles
+                $0.labels = labels
+                $0.volumes = volumes
+            }
         )
     }
 }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -38,6 +38,16 @@ private func composeProject(
     return project
 }
 
+private func composeRunOptions(
+    command: [String] = [],
+    configure: (inout ComposeRunOptions) -> Void = { _ in }
+) -> ComposeRunOptions {
+    var options = ComposeRunOptions()
+    options.command = command
+    configure(&options)
+    return options
+}
+
 private func projectWithRuntimeResources(networkName: String, volumeName: String) -> ComposeProject {
     composeProject(
         name: "demo",
@@ -1794,12 +1804,14 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: defaultRunner).run(
             project: project,
             serviceName: "api",
-            options: ComposeRunOptions(command: ["true"])
+            options: composeRunOptions(command: ["true"])
         )
         try await ComposeOrchestrator(runner: servicePortsRunner).run(
             project: project,
             serviceName: "api",
-            options: ComposeRunOptions(command: ["true"], servicePorts: true)
+            options: composeRunOptions(command: ["true"]) {
+                $0.servicePorts = true
+            }
         )
 
         let defaultCommand = try #require(defaultRunner.commands.first?.arguments)
@@ -1823,10 +1835,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "api",
-            options: ComposeRunOptions(
-                command: ["true"],
-                publish: ["127.0.0.1:9090:90"]
-            )
+            options: composeRunOptions(command: ["true"]) {
+                $0.publish = ["127.0.0.1:9090:90"]
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2685,7 +2696,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["true"], pullPolicy: "always")
+            options: composeRunOptions(command: ["true"]) {
+                $0.pullPolicy = "always"
+            }
         )
 
         let commands = runner.commands.map(\.arguments)
@@ -2706,12 +2719,16 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: presentRunner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["true"], pullPolicy: "missing")
+            options: composeRunOptions(command: ["true"]) {
+                $0.pullPolicy = "missing"
+            }
         )
         try await ComposeOrchestrator(runner: absentRunner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["true"], pullPolicy: "missing")
+            options: composeRunOptions(command: ["true"]) {
+                $0.pullPolicy = "missing"
+            }
         )
 
         let presentCommands = presentRunner.commands.map(\.arguments)
@@ -2735,7 +2752,9 @@ struct ComposeOrchestratorTests {
             try await ComposeOrchestrator(runner: runner).run(
                 project: project,
                 serviceName: "job",
-                options: ComposeRunOptions(command: ["true"], pullPolicy: "daily")
+                options: composeRunOptions(command: ["true"]) {
+                    $0.pullPolicy = "daily"
+                }
             )
             Issue.record("Expected unsupported run pull policy to fail")
         } catch let error as ComposeError {
@@ -2805,7 +2824,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["true"], containerName: "custom-job")
+            options: composeRunOptions(command: ["true"]) {
+                $0.containerName = "custom-job"
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2829,7 +2850,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["sleep", "60"], detach: true)
+            options: composeRunOptions(command: ["sleep", "60"]) {
+                $0.detach = true
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2856,7 +2879,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["sh"], noTty: true)
+            options: composeRunOptions(command: ["sh"]) {
+                $0.noTty = true
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2881,7 +2906,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["echo", "ok"], entrypoint: "/bin/sh -c")
+            options: composeRunOptions(command: ["echo", "ok"]) {
+                $0.entrypoint = "/bin/sh -c"
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2905,7 +2932,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["pwd"], workingDirectory: "/workspace")
+            options: composeRunOptions(command: ["pwd"]) {
+                $0.workingDirectory = "/workspace"
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2929,7 +2958,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(command: ["id"], user: "2000:2000")
+            options: composeRunOptions(command: ["id"]) {
+                $0.user = "2000:2000"
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2954,11 +2985,10 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(
-                command: ["env"],
-                environment: ["LOG_LEVEL=debug", "NEW=value", "PASSTHROUGH", "EMPTY="],
-                envFiles: [".env.local"]
-            )
+            options: composeRunOptions(command: ["env"]) {
+                $0.environment = ["LOG_LEVEL=debug", "NEW=value", "PASSTHROUGH", "EMPTY="]
+                $0.envFiles = [".env.local"]
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -2988,10 +3018,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(
-                command: ["true"],
-                labels: ["com.example.role=job", "com.example.flag"]
-            )
+            options: composeRunOptions(command: ["true"]) {
+                $0.labels = ["com.example.role=job", "com.example.flag"]
+            }
         )
 
         let command = try #require(runner.commands.first?.arguments)
@@ -3014,7 +3043,9 @@ struct ComposeOrchestratorTests {
             try await ComposeOrchestrator().run(
                 project: project,
                 serviceName: "job",
-                options: ComposeRunOptions(command: ["true"], labels: [""])
+                options: composeRunOptions(command: ["true"]) {
+                    $0.labels = [""]
+                }
             )
             Issue.record("Expected empty run label override to fail")
         } catch let error as ComposeError {
@@ -3033,10 +3064,9 @@ struct ComposeOrchestratorTests {
             try await ComposeOrchestrator().run(
                 project: project,
                 serviceName: "job",
-                options: ComposeRunOptions(
-                    command: ["true"],
-                    labels: ["com.apple.container.compose.project=evil"]
-                )
+                options: composeRunOptions(command: ["true"]) {
+                    $0.labels = ["com.apple.container.compose.project=evil"]
+                }
             )
             Issue.record("Expected reserved run label override to fail")
         } catch let error as ComposeError {
@@ -3059,10 +3089,9 @@ struct ComposeOrchestratorTests {
         try await ComposeOrchestrator(runner: runner).run(
             project: project,
             serviceName: "job",
-            options: ComposeRunOptions(
-                command: ["ls"],
-                volumes: ["/host:/container:ro", "cache:/cache", "/scratch"]
-            )
+            options: composeRunOptions(command: ["ls"]) {
+                $0.volumes = ["/host:/container:ro", "cache:/cache", "/scratch"]
+            }
         )
 
         let volumeCreate = try #require(runner.commands.first?.arguments)
@@ -3087,7 +3116,9 @@ struct ComposeOrchestratorTests {
             try await ComposeOrchestrator().run(
                 project: project,
                 serviceName: "job",
-                options: ComposeRunOptions(command: ["ls"], volumes: ["/host:/container:delegated"])
+                options: composeRunOptions(command: ["ls"]) {
+                    $0.volumes = ["/host:/container:delegated"]
+                }
             )
             Issue.record("Expected unsupported run volume mode to fail")
         } catch let error as ComposeError {
@@ -3106,7 +3137,9 @@ struct ComposeOrchestratorTests {
             try await ComposeOrchestrator().run(
                 project: project,
                 serviceName: "job",
-                options: ComposeRunOptions(command: ["env"], environment: [""])
+                options: composeRunOptions(command: ["env"]) {
+                    $0.environment = [""]
+                }
             )
             Issue.record("Expected empty run environment override to fail")
         } catch let error as ComposeError {


### PR DESCRIPTION
## Summary

Batch-promotes the current develop Sonar remediation commits to main so both parameter-count fixes land in a single main CI/SonarQube run.

Included commits:
- refactor(run): simplify run option construction
- refactor(run): group run argument options

## Validation

For each develop fix:
- focused ComposeOrchestratorTests
- make lint
- git diff --check
- make cli-smoke
- make coverage-check, with Swift 94.04% and Go 94.55%
- SONAR_BRANCH=develop make sonar-scan, with CE task success

## Merge intent

Use a normal merge commit, not a squash merge, so main keeps the individual develop remediation commits while still using one batched main build.