### PR TITLE
refactor(run): batch Sonar closure cleanup

### DIFF
--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -119,7 +119,9 @@ private struct RunArgumentOptions {
     var containerNameOverride: String?
     var labelOverrides: [ComposeLabelOverride] = []
 
-    init(_ configure: (inout RunArgumentOptions) -> Void = { _ in }) {
+    init() {}
+
+    init(_ configure: (inout RunArgumentOptions) -> Void) {
         configure(&self)
     }
 }

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -104,7 +104,9 @@ public struct ComposeRunOptions {
     public var labels: [String] = []
     public var volumes: [String] = []
 
-    public init(_ configure: (inout ComposeRunOptions) -> Void = { _ in }) {
+    public init() {}
+
+    public init(_ configure: (inout ComposeRunOptions) -> Void) {
         configure(&self)
     }
 }


### PR DESCRIPTION
## Summary

Batch the two Sonar S1186 remediation commits from `develop` into `main` so the formal main CI/Sonar scan runs once for the full closure cleanup.

## Changes

- Split `ComposeRunOptions` into explicit empty and configuring initializers.
- Split `RunArgumentOptions` into explicit empty and configuring initializers.
- Preserve existing builder-style call sites without changing runtime behavior.

## Validation

- `swift test --enable-code-coverage ... --filter ComposeOrchestratorTests/runPublishesServicePortsOnlyWhenRequested`
- `make cli-smoke`
- `make coverage-check`
- `make lint`
- `git diff --check`
- `SONAR_BRANCH=develop make sonar-scan` for each develop commit

Coverage after the second fix: Swift 94.05%, Go 94.55%.