### PR TITLE
refactor(run): batch Sonar initializer comments

### DIFF
--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -104,7 +104,9 @@ public struct ComposeRunOptions {
     public var labels: [String] = []
     public var volumes: [String] = []
 
-    public init() {}
+    public init() {
+        // Stored property defaults represent Docker Compose's default run behavior.
+    }
 
     public init(_ configure: (inout ComposeRunOptions) -> Void) {
         configure(&self)

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -121,7 +121,9 @@ private struct RunArgumentOptions {
     var containerNameOverride: String?
     var labelOverrides: [ComposeLabelOverride] = []
 
-    init() {}
+    init() {
+        // Stored property defaults represent unmodified service run arguments.
+    }
 
     init(_ configure: (inout RunArgumentOptions) -> Void) {
         configure(&self)


### PR DESCRIPTION
## Summary

Batch the remaining Sonar S1186 initializer-comment fixes from `develop` into `main` so formal main CI/Sonar processes them together.

## Changes

- Document why `ComposeRunOptions.init()` intentionally relies on stored property defaults.
- Document why `RunArgumentOptions.init()` intentionally relies on stored property defaults.
- Preserve runtime behavior while satisfying Sonar's empty-function guidance.

## Validation

- `swift test --enable-code-coverage ... --filter ComposeOrchestratorTests/runPublishesServicePortsOnlyWhenRequested`
- `make cli-smoke`
- `make coverage-check`
- `make lint`
- `git diff --check`
- `SONAR_BRANCH=develop make sonar-scan` for each develop commit

Coverage after the second follow-up fix: Swift 93.96%, Go 94.55%.