### PR TITLE
feat(lifecycle): batch Compose lifecycle compatibility

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -37,7 +37,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | --- | --- | --- | --- |
 | Config normalization | File discovery, repeated `-f`, `.env`, `--env-file`, interpolation, merge, profiles, `--project-directory`, `-p/--project-name`, and canonical `config` JSON | No runtime primitive; `compose-go` normalizes the Compose model | [S1](#s1-supported-local-web-stack), [O1](#o1-config-only-metadata) |
 | Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, `images`, global `up --pull always/missing/never`, one-off `run --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container image list` | [S1](#s1-supported-local-web-stack) |
-| Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
+| Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, `stop/restart/down --timeout`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container kill`, `container inspect`, `container list` | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `ps --quiet`, `ps --services`, `ps --status running/exited`, `ps --filter status=...`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `down --volumes` | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
@@ -239,8 +239,10 @@ container compose exec api sh
 container compose exec -T api echo ok
 container compose exec --interactive=false -T api echo ok
 container compose cp api:/app/env.txt ./env.txt
+container compose stop --timeout 12 api
+container compose restart -t 12 api
 container compose kill worker
-container compose down --volumes
+container compose down --timeout 12 --volumes
 ```
 
 ### A1: Apple Gap, Networking

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,10 @@ cli-smoke: build
 	[[ "$$exec_non_interactive_output" != *"--tty"* ]]; \
 	cp_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo cp api:/tmp/file .)"; \
 	[[ "$$cp_output" == *"container cp demo-api-1:/tmp/file ."* ]]; \
+	stop_timeout_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo stop --timeout 12 api)"; \
+	[[ "$$stop_timeout_output" == *"container stop --time 12 demo-api-1"* ]]; \
+	restart_timeout_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo restart -t 13 api)"; \
+	[[ "$$restart_timeout_output" == *"container stop --time 13 demo-api-1"* ]]; \
 	ps_quiet_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo ps -q)"; \
 	[[ "$$ps_quiet_output" == *"container list --format json"* ]]; \
 	ps_services_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo ps --services)"; \

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -79,10 +79,12 @@ public struct ComposeUpOptions {
 public struct ComposeDownOptions {
     public var volumes: Bool
     public var removeOrphans: Bool
+    public var timeout: Int?
 
-    public init(volumes: Bool = false, removeOrphans: Bool = false) {
+    public init(volumes: Bool = false, removeOrphans: Bool = false, timeout: Int? = nil) {
         self.volumes = volumes
         self.removeOrphans = removeOrphans
+        self.timeout = timeout
     }
 }
 
@@ -206,11 +208,12 @@ public final class ComposeOrchestrator: @unchecked Sendable {
 
     /// Stops and removes project-scoped resources.
     public func down(project: ComposeProject, options down: ComposeDownOptions) async throws {
+        try validateTimeoutSeconds(down.timeout, command: "down")
         let services = try orderedServices(project: project, selected: [])
         let declaredContainers = Set(services.map { containerName(project: project, service: $0, oneOff: false) })
         for service in services.reversed() {
             let name = containerName(project: project, service: service, oneOff: false)
-            try await runContainer(stopArguments(service: service, containerName: name), check: false)
+            try await runContainer(stopArguments(service: service, containerName: name, timeout: down.timeout), check: false)
             try await runContainer(["delete", name], check: false)
         }
         if down.removeOrphans {
@@ -401,18 +404,19 @@ public final class ComposeOrchestrator: @unchecked Sendable {
     }
 
     /// Stops selected service containers.
-    public func stop(project: ComposeProject, services selected: [String]) async throws {
+    public func stop(project: ComposeProject, services selected: [String], timeout: Int? = nil) async throws {
+        try validateTimeoutSeconds(timeout, command: "stop")
         for service in try selectedServices(project: project, selected: selected) {
             try await runContainer(
-                stopArguments(service: service, containerName: containerName(project: project, service: service, oneOff: false)),
+                stopArguments(service: service, containerName: containerName(project: project, service: service, oneOff: false), timeout: timeout),
                 check: false
             )
         }
     }
 
     /// Restarts selected service containers.
-    public func restart(project: ComposeProject, services selected: [String]) async throws {
-        try await stop(project: project, services: selected)
+    public func restart(project: ComposeProject, services selected: [String], timeout: Int? = nil) async throws {
+        try await stop(project: project, services: selected, timeout: timeout)
         try await start(project: project, services: selected)
     }
 
@@ -858,6 +862,16 @@ private extension ComposeOrchestrator {
         }
     }
 
+    /// Validates a Compose CLI shutdown timeout before runtime side effects.
+    func validateTimeoutSeconds(_ timeout: Int?, command: String) throws {
+        guard let timeout else {
+            return
+        }
+        guard timeout >= 0, timeout <= Int(Int32.max) else {
+            throw ComposeError.invalidProject("\(command) --timeout must be between 0 and \(Int32.max) seconds")
+        }
+    }
+
     /// Creates project networks and volumes required before containers start.
     func ensureResources(project: ComposeProject) async throws {
         for (name, network) in project.networks.sorted(by: { $0.key < $1.key }) where network.external != true {
@@ -1278,12 +1292,12 @@ private extension ComposeOrchestrator {
     }
 
     /// Returns the stop command arguments for a service container.
-    func stopArguments(service: ComposeService, containerName: String) -> [String] {
+    func stopArguments(service: ComposeService, containerName: String, timeout: Int? = nil) -> [String] {
         var args = ["stop"]
         if let signal = service.stopSignal, !signal.isEmpty {
             args.append(contentsOf: ["--signal", signal])
         }
-        if let seconds = service.stopGracePeriodSeconds {
+        if let seconds = timeout ?? service.stopGracePeriodSeconds {
             args.append(contentsOf: ["--time", "\(seconds)"])
         }
         args.append(containerName)

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -194,11 +194,16 @@ struct Down: AsyncParsableCommand, ComposeProjectCommand {
     var volumes = false
     @Flag(name: .customLong("remove-orphans"), help: "Remove project containers for services not declared by the Compose file.")
     var removeOrphans = false
+    @Option(name: [.customShort("t"), .customLong("timeout")], help: "Seconds to wait before killing containers.")
+    var timeout: Int?
 
     /// Stops containers and removes project-scoped resources.
     func run() async throws {
         let loadedProject = try await project()
-        try await orchestrator().down(project: loadedProject, options: ComposeDownOptions(volumes: volumes, removeOrphans: removeOrphans))
+        try await orchestrator().down(
+            project: loadedProject,
+            options: ComposeDownOptions(volumes: volumes, removeOrphans: removeOrphans, timeout: timeout)
+        )
     }
 }
 
@@ -416,11 +421,13 @@ struct Start: AsyncParsableCommand, ComposeProjectCommand {
 struct Stop: AsyncParsableCommand, ComposeProjectCommand {
     static let configuration = CommandConfiguration(commandName: "stop", abstract: "Stop service containers.")
     @OptionGroup var global: GlobalOptions
+    @Option(name: [.customShort("t"), .customLong("timeout")], help: "Seconds to wait before killing containers.")
+    var timeout: Int?
     @Argument var services: [String] = []
     /// Stops selected service containers.
     func run() async throws {
         let loadedProject = try await project()
-        try await orchestrator().stop(project: loadedProject, services: services)
+        try await orchestrator().stop(project: loadedProject, services: services, timeout: timeout)
     }
 }
 
@@ -428,11 +435,13 @@ struct Stop: AsyncParsableCommand, ComposeProjectCommand {
 struct Restart: AsyncParsableCommand, ComposeProjectCommand {
     static let configuration = CommandConfiguration(commandName: "restart", abstract: "Restart service containers.")
     @OptionGroup var global: GlobalOptions
+    @Option(name: [.customShort("t"), .customLong("timeout")], help: "Seconds to wait before killing containers.")
+    var timeout: Int?
     @Argument var services: [String] = []
     /// Restarts selected service containers.
     func run() async throws {
         let loadedProject = try await project()
-        try await orchestrator().restart(project: loadedProject, services: services)
+        try await orchestrator().restart(project: loadedProject, services: services, timeout: timeout)
     }
 }
 

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -1770,6 +1770,54 @@ struct ComposeOrchestratorTests {
         #expect(commands[9] == ["container", "cp", "demo-api-1:/tmp/file", "."])
     }
 
+    @Test("lifecycle timeout overrides service stop grace period")
+    func lifecycleTimeoutOverridesServiceStopGracePeriod() async throws {
+        let runner = RecordingRunner()
+        let orchestrator = ComposeOrchestrator(runner: runner)
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.stopSignal = "SIGUSR1"
+                    $0.stopGracePeriodSeconds = 9
+                },
+            ]
+        )
+
+        try await orchestrator.stop(project: project, services: ["api"], timeout: 12)
+        try await orchestrator.restart(project: project, services: ["api"], timeout: 13)
+        try await orchestrator.down(project: project, options: ComposeDownOptions(timeout: 14))
+
+        #expect(runner.commands.map(\.arguments) == [
+            ["container", "stop", "--signal", "SIGUSR1", "--time", "12", "demo-api-1"],
+            ["container", "stop", "--signal", "SIGUSR1", "--time", "13", "demo-api-1"],
+            ["container", "start", "demo-api-1"],
+            ["container", "stop", "--signal", "SIGUSR1", "--time", "14", "demo-api-1"],
+            ["container", "delete", "demo-api-1"],
+        ])
+    }
+
+    @Test("lifecycle rejects invalid timeout before runtime commands")
+    func lifecycleRejectsInvalidTimeoutBeforeRuntimeCommands() async throws {
+        let runner = RecordingRunner()
+        let orchestrator = ComposeOrchestrator(runner: runner)
+        let project = ComposeProject(
+            name: "demo",
+            services: ["api": ComposeService(name: "api", image: "example/api")]
+        )
+
+        do {
+            try await orchestrator.stop(project: project, services: ["api"], timeout: -1)
+            Issue.record("Expected invalid timeout error")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("stop --timeout must be between 0 and 2147483647 seconds"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(runner.commands.isEmpty)
+    }
+
     @Test("exec disables TTY while keeping stdin inherited")
     func execDisablesTTYWhileKeepingStdinInherited() async throws {
         let runner = RecordingRunner()


### PR DESCRIPTION
## Summary\n- Batch the queued develop lifecycle compatibility commit into main.\n- Preserve the individual develop commit history with a normal merge-commit PR path.\n- Let CI/SonarQube validate the remediation set on main in one build.\n\n## Validation\n- Prior develop slice validation passed locally before push.\n- Formal CI/SonarQube will run on this PR and main after merge.