### PR TITLE
chore: promote develop batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,6 @@ jobs:
           {
             swift --version 2>&1
             shasum -a 256 container-compose/Package.swift container-compose/Package.resolved
-            git -C container rev-parse HEAD
             shasum -a 256 container/Package.swift container/Package.resolved
           } | shasum -a 256 | awk '{ printf "fingerprint=%s\n", $1 }' >> "$GITHUB_OUTPUT"
 
@@ -197,7 +196,6 @@ jobs:
           {
             swift --version 2>&1
             shasum -a 256 container-compose/Package.swift container-compose/Package.resolved
-            git -C container rev-parse HEAD
             shasum -a 256 container/Package.swift container/Package.resolved
           } | shasum -a 256 | awk '{ printf "fingerprint=%s\n", $1 }' >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
 
   package:
     name: Package Plugin
+    if: github.event_name != 'pull_request'
     runs-on: macos-26
     steps:
       - name: Checkout container-compose

--- a/BUILD.md
+++ b/BUILD.md
@@ -140,6 +140,8 @@ Build the plugin archive consumed by the install guide:
 make package
 ```
 
+GitHub Actions builds and uploads this archive for `main` branch pushes and manual workflow runs. Pull requests run validation and SonarQube analysis without producing a package artifact, which keeps review feedback faster and avoids unnecessary release builds.
+
 The package target writes the archive and staging directory:
 
 ```text

--- a/BUILD.md
+++ b/BUILD.md
@@ -109,7 +109,7 @@ Run the same validation used by GitHub Actions:
 make ci
 ```
 
-`make ci` resolves Swift packages, runs required Markdown linting and Go formatting checks, runs Swift and Go coverage, checks the coverage threshold, builds the Go helper, and runs the CLI smoke test. The smoke test builds the debug `compose` executable before exercising representative commands.
+`make ci` runs required Markdown linting and Go formatting checks, runs Swift and Go coverage, checks the coverage threshold, builds the Go helper, and runs the CLI smoke test. Swift build and test targets use the checked-in `Package.resolved` by default so CI fails quickly if dependency versions need an intentional lockfile refresh. The smoke test builds the debug `compose` executable before exercising representative commands.
 
 The default minimum coverage is 85 percent for both Swift and Go:
 

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -36,14 +36,14 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Compose v2 surface | Supported subset | [`apple/container`][apple-container] primitive used | Example |
 | --- | --- | --- | --- |
 | Config normalization | File discovery, repeated `-f`, `.env`, `--env-file`, interpolation, merge, profiles, `--project-directory`, `-p/--project-name`, and canonical `config` JSON | No runtime primitive; `compose-go` normalizes the Compose model | [S1](#s1-supported-local-web-stack), [O1](#o1-config-only-metadata) |
-| Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, runtime-scoped `images`, `images --format table/json`, `images --quiet/-q`, global `up --pull always/missing/never`, one-off `run --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never`, image removal through `down --rmi local/all` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container list --format json`, `container image delete` | [S1](#s1-supported-local-web-stack) |
-| Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `rm --force/-f`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, `down --rmi local/all`, `stop/restart/down --timeout`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container delete --force`, `container kill`, `container inspect`, `container list`, `container image delete` | [S1](#s1-supported-local-web-stack) |
+| Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, runtime-scoped `images`, `images --format table/json`, `images --quiet/-q`, global `up --pull always/missing/if_not_present/never`, `create --pull always/missing/if_not_present/never/build`, `create --build`, `create --no-build`, one-off `run --pull always/missing/if_not_present/never`, service `pull_policy: always/missing/if_not_present/never`, image removal through `down --rmi local/all` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container list --format json`, `container image delete` | [S1](#s1-supported-local-web-stack) |
+| Container lifecycle | `create`, `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `rm --force/-f`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, `down --rmi local/all`, `stop/restart/down --timeout`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container create`, `container run`, `container start`, `container stop`, `container delete`, `container delete --force`, `container kill`, `container inspect`, `container list`, `container image delete` | [S1](#s1-supported-local-web-stack) |
 | Project discovery | `ls`, `ls --all/-a`, `ls --format table/json`, `ls --quiet/-q`, and `ls --filter name=...` from project labels on created containers | `container list --format json` and Compose project/config-hash labels | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `ps --quiet`, `ps --services`, `ps --status running/exited`, `ps --filter status=...`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
-| Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
-| Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `rm --volumes/-v` for anonymous volumes, `down --volumes` for named project volumes | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
-| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, one-off `run -T/--no-tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container run` and `container stop` flags | [S1](#s1-supported-local-web-stack) |
-| Environment and labels | Service `environment`, `env_file`, one-off `run --env/-e`, one-off `run --env-from-file`, one-off `run --label/-l`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
+| Default networking | One service network, default project networks, external networks, service ports for `create` and `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container create --network`, `container create --publish`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
+| Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `rm --volumes/-v` for anonymous volumes, `down --volumes` for named project volumes | `container volume create`, `container volume delete`, `container create --volume`, `container create --tmpfs`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
+| Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, one-off `run -T/--no-tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container create`, `container run`, and `container stop` flags | [S1](#s1-supported-local-web-stack) |
+| Environment and labels | Service `environment`, `env_file`, one-off `run --env/-e`, one-off `run --env-from-file`, one-off `run --label/-l`, service labels, network labels, volume labels, Compose project/service/config-hash labels | `container create --env`, `container create --env-file`, `container run --env`, `container run --env-file`, resource/container labels | [S1](#s1-supported-local-web-stack) |
 | Simple ordering | `depends_on` with no condition or `condition: service_started` | Plugin dependency ordering before `container run` | [S1](#s1-supported-local-web-stack) |
 
 ### Blocked By apple/container
@@ -70,7 +70,7 @@ These are valid Docker Compose v2 surfaces where [`apple/container`][apple-conta
 | Develop, providers, models, hooks | `develop`, watch settings, service `provider`, service `models`, `post_start`, `pre_stop` | Watch/sync/rebuild orchestration, provider/model wiring, lifecycle hook safety and ordering | [C3](#c3-plugin-gap-develop-providers-models-and-hooks) |
 | Metadata, logging, storage shortcuts | `annotations`, `attach`, `label_file`, `logging`, `log_driver`, `log_opt`, `storage_opt`, `volumes_from`, service-level `volume_driver` | Runtime mapping, inherited mount behavior, label-file loading, logging behavior, storage option policy | [C4](#c4-plugin-gap-metadata-storage-api-socket-and-pull-windows) |
 | API socket, block I/O, pull windows | `use_api_socket`, `blkio_config`, service `pull_policy: build/daily/weekly/<duration>` | Security review, resource-control mapping, and time-window/build-trigger pull semantics | [C4](#c4-plugin-gap-metadata-storage-api-socket-and-pull-windows) |
-| Additional CLI commands | `create`, `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` | Command design, output compatibility, and runtime mapping | [C5](#c5-plugin-gap-additional-cli-commands) |
+| Additional CLI commands | `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` | Command design, output compatibility, and runtime mapping | [C5](#c5-plugin-gap-additional-cli-commands) |
 
 ### Config-Only Today
 
@@ -87,9 +87,9 @@ These Compose surfaces are useful in normalized output, but they do not currentl
 
 | Status | Commands |
 | --- | --- |
-| Supported | `config`, `up`, `down`, `build`, `pull`, `push`, `ls`, `ps`, `logs`, `exec`, `run`, `start`, `stop`, `restart`, `rm`, `images`, `cp`, `kill`, `version` |
+| Supported | `config`, `create`, `up`, `down`, `build`, `pull`, `push`, `ls`, `ps`, `logs`, `exec`, `run`, `start`, `stop`, `restart`, `rm`, `images`, `cp`, `kill`, `version` |
 | Present but blocked by [`apple/container`][apple-container] runtime gaps | `top`, `events`, `port`, `pause`, `unpause`, `wait` |
-| Not implemented by `container-compose` yet | `create`, `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` |
+| Not implemented by `container-compose` yet | `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` |
 
 ## References
 
@@ -105,7 +105,7 @@ Every example includes a Compose file or commands plus the matching Dockerfile s
 
 | Example | Status bucket | What it demonstrates |
 | --- | --- | --- |
-| [S1: Supported Local Web Stack](#s1-supported-local-web-stack) | Supported | Build, images, ports, environment, one network, volumes, labels, lifecycle, logs, exec, copy, and `down --volumes` |
+| [S1: Supported Local Web Stack](#s1-supported-local-web-stack) | Supported | Build, images, `create`, ports, environment, one network, volumes, labels, lifecycle, logs, exec, copy, and `down --volumes` |
 | [A1: Apple Gap, Networking](#a1-apple-gap-networking) | [`apple/container`][apple-container] gap | Multiple networks, aliases, fixed IP attachment options, and network namespace modes |
 | [A2: Apple Gap, Host Identity And Links](#a2-apple-gap-host-identity-and-links) | [`apple/container`][apple-container] gap | Hostname, domain name, explicit host entries, MAC address, and legacy links |
 | [A3: Apple Gap, Runtime Controls](#a3-apple-gap-runtime-controls) | [`apple/container`][apple-container] gap | Namespace controls, privileged/device access, advanced resources, DNS options, and sysctls |
@@ -122,7 +122,7 @@ Every example includes a Compose file or commands plus the matching Dockerfile s
 
 ### S1: Supported Local Web Stack
 
-Expected result: `container compose config`, `build`, `up`, `ps`, `logs`, `exec`, `cp`, `rm --force --volumes` for anonymous volumes, and `down --volumes` run through [`apple/container`][apple-container].
+Expected result: `container compose config`, `build`, `create`, `up`, `ps`, `logs`, `exec`, `cp`, `rm --force --volumes` for anonymous volumes, and `down --volumes` run through [`apple/container`][apple-container].
 
 Status path:
 
@@ -216,6 +216,9 @@ Useful supported commands against this project:
 ```sh
 container compose config
 container compose build
+container compose create --build
+container compose create --pull build api
+container compose create --no-build worker
 container compose up --pull missing
 container compose ls
 container compose ls --all
@@ -735,7 +738,6 @@ services:
 Compare the missing command behavior:
 
 ```sh
-docker compose create
 docker compose watch
 docker compose stats
 docker compose scale worker=3

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -39,7 +39,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, runtime-scoped `images`, `images --format table/json`, `images --quiet/-q`, global `up --pull always/missing/if_not_present/never`, `create --pull always/missing/if_not_present/never/build`, `create --build`, `create --no-build`, one-off `run --pull always/missing/if_not_present/never`, service `pull_policy: always/missing/if_not_present/never`, image removal through `down --rmi local/all` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container list --format json`, `container image delete` | [S1](#s1-supported-local-web-stack) |
 | Container lifecycle | `create`, `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `rm --force/-f`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, `down --rmi local/all`, `stop/restart/down --timeout`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container create`, `container run`, `container start`, `container stop`, `container delete`, `container delete --force`, `container kill`, `container inspect`, `container list`, `container image delete` | [S1](#s1-supported-local-web-stack) |
 | Project discovery | `ls`, `ls --all/-a`, `ls --format table/json`, `ls --quiet/-q`, and `ls --filter name=...` from project labels on created containers | `container list --format json` and Compose project/config-hash labels | [S1](#s1-supported-local-web-stack) |
-| Container interaction | `ps`, `ps --quiet`, `ps --services`, `ps --status running/exited`, `ps --filter status=...`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
+| Container interaction | `ps`, `ps --quiet`, `ps --services`, `ps --status running/exited`, `ps --filter status=...`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `stats`, `stats --format table/json`, `stats --no-stream`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, `container stats`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `create` and `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container create --network`, `container create --publish`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `rm --volumes/-v` for anonymous volumes, `down --volumes` for named project volumes | `container volume create`, `container volume delete`, `container create --volume`, `container create --tmpfs`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
 | Common runtime options | `command`, `entrypoint`, one-off `run --entrypoint`, `container_name`, `working_dir`, one-off `run --workdir`, `user`, one-off `run --user`, `tty`, one-off `run -T/--no-tty`, `stdin_open`, `read_only`, `init`, `platform`, `runtime`, `dns`, `dns_search`, `cap_add`, `cap_drop`, `cpus`, `mem_limit`, `shm_size`, `ulimits`, `stop_signal`, `stop_grace_period` | `container create`, `container run`, and `container stop` flags | [S1](#s1-supported-local-web-stack) |
@@ -57,7 +57,7 @@ These are valid Docker Compose v2 surfaces. `container-compose` recognizes them,
 | Namespace and resource controls | `cgroup`, `cgroup_parent`, `ipc`, `pid`, `userns_mode`, `uts`, `isolation`, advanced CPU controls, advanced memory/OOM/PID controls | Namespace selection, parent cgroups, CPU scheduler controls beyond `cpus`, memory controls beyond `mem_limit`, swap/OOM/PID controls | [A3](#a3-apple-gap-runtime-controls) |
 | User, security, devices, DNS, kernel tuning | `group_add`, `security_opt`, `privileged`, `credential_spec`, `device_cgroup_rules`, `devices`, `gpus`, `dns_opt`, `sysctls` | Supplemental groups, security profiles, privileged mode, host devices, GPUs, DNS resolver options, per-container sysctls | [A3](#a3-apple-gap-runtime-controls) |
 | Health, completion, configs, secrets, restart | `healthcheck`, `depends_on.condition: service_healthy`, `depends_on.condition: service_completed_successfully`, service-level `configs`, service-level `secrets`, service `restart` | Health status, exit code/completion-time metadata, config/secret mount primitives, restart policy support | [A4](#a4-apple-gap-health-secrets-and-restart) |
-| Runtime data and state commands | `top`, `events`, `port`, `pause`, `unpause`, `wait` | Process listing, event stream, published-port inspect, pause/unpause, wait/exit metadata | [A5](#a5-apple-gap-runtime-data-commands) |
+| Runtime data and state commands | `top`, `events`, `port`, `pause`, `unpause`, `wait`, `stats --all`, `stats --no-trunc` | Process listing, event stream, published-port inspect, pause/unpause, wait/exit metadata, stats all-container/truncation controls | [A5](#a5-apple-gap-runtime-data-commands) |
 
 ### Blocked By `container-compose`
 
@@ -70,7 +70,7 @@ These are valid Docker Compose v2 surfaces where [`apple/container`][apple-conta
 | Develop, providers, models, hooks | `develop`, watch settings, service `provider`, service `models`, `post_start`, `pre_stop` | Watch/sync/rebuild orchestration, provider/model wiring, lifecycle hook safety and ordering | [C3](#c3-plugin-gap-develop-providers-models-and-hooks) |
 | Metadata, logging, storage shortcuts | `annotations`, `attach`, `label_file`, `logging`, `log_driver`, `log_opt`, `storage_opt`, `volumes_from`, service-level `volume_driver` | Runtime mapping, inherited mount behavior, label-file loading, logging behavior, storage option policy | [C4](#c4-plugin-gap-metadata-storage-api-socket-and-pull-windows) |
 | API socket, block I/O, pull windows | `use_api_socket`, `blkio_config`, service `pull_policy: build/daily/weekly/<duration>` | Security review, resource-control mapping, and time-window/build-trigger pull semantics | [C4](#c4-plugin-gap-metadata-storage-api-socket-and-pull-windows) |
-| Additional CLI commands | `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` | Command design, output compatibility, and runtime mapping | [C5](#c5-plugin-gap-additional-cli-commands) |
+| Additional CLI commands | `watch`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` | Command design, output compatibility, and runtime mapping | [C5](#c5-plugin-gap-additional-cli-commands) |
 
 ### Config-Only Today
 
@@ -87,9 +87,9 @@ These Compose surfaces are useful in normalized output, but they do not currentl
 
 | Status | Commands |
 | --- | --- |
-| Supported | `config`, `create`, `up`, `down`, `build`, `pull`, `push`, `ls`, `ps`, `logs`, `exec`, `run`, `start`, `stop`, `restart`, `rm`, `images`, `cp`, `kill`, `version` |
-| Present but blocked by [`apple/container`][apple-container] runtime gaps | `top`, `events`, `port`, `pause`, `unpause`, `wait` |
-| Not implemented by `container-compose` yet | `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` |
+| Supported | `config`, `create`, `up`, `down`, `build`, `pull`, `push`, `ls`, `ps`, `logs`, `exec`, `run`, `start`, `stop`, `restart`, `rm`, `images`, `stats`, `cp`, `kill`, `version` |
+| Present but blocked by [`apple/container`][apple-container] runtime gaps | `top`, `events`, `port`, `pause`, `unpause`, `wait`, `stats --all`, `stats --no-trunc` |
+| Not implemented by `container-compose` yet | `watch`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` |
 
 ## References
 
@@ -105,7 +105,7 @@ Every example includes a Compose file or commands plus the matching Dockerfile s
 
 | Example | Status bucket | What it demonstrates |
 | --- | --- | --- |
-| [S1: Supported Local Web Stack](#s1-supported-local-web-stack) | Supported | Build, images, `create`, ports, environment, one network, volumes, labels, lifecycle, logs, exec, copy, and `down --volumes` |
+| [S1: Supported Local Web Stack](#s1-supported-local-web-stack) | Supported | Build, images, `create`, ports, environment, one network, volumes, labels, lifecycle, logs, exec, stats, copy, and `down --volumes` |
 | [A1: Apple Gap, Networking](#a1-apple-gap-networking) | [`apple/container`][apple-container] gap | Multiple networks, aliases, fixed IP attachment options, and network namespace modes |
 | [A2: Apple Gap, Host Identity And Links](#a2-apple-gap-host-identity-and-links) | [`apple/container`][apple-container] gap | Hostname, domain name, explicit host entries, MAC address, and legacy links |
 | [A3: Apple Gap, Runtime Controls](#a3-apple-gap-runtime-controls) | [`apple/container`][apple-container] gap | Namespace controls, privileged/device access, advanced resources, DNS options, and sysctls |
@@ -122,7 +122,7 @@ Every example includes a Compose file or commands plus the matching Dockerfile s
 
 ### S1: Supported Local Web Stack
 
-Expected result: `container compose config`, `build`, `create`, `up`, `ps`, `logs`, `exec`, `cp`, `rm --force --volumes` for anonymous volumes, and `down --volumes` run through [`apple/container`][apple-container].
+Expected result: `container compose config`, `build`, `create`, `up`, `ps`, `logs`, `exec`, `stats`, `cp`, `rm --force --volumes` for anonymous volumes, and `down --volumes` run through [`apple/container`][apple-container].
 
 Status path:
 
@@ -249,6 +249,8 @@ container compose logs api
 container compose exec api sh
 container compose exec -T api echo ok
 container compose exec --interactive=false -T api echo ok
+container compose stats
+container compose stats --no-stream --format json api
 container compose cp api:/app/env.txt ./env.txt
 container compose stop --timeout 12 api
 container compose restart -t 12 api
@@ -484,12 +486,12 @@ CMD ["sh", "-c", "echo worker-ready && sleep 3600"]
 
 ### A5: Apple Gap, Runtime Data Commands
 
-Expected result: these commands reject because [`apple/container`][apple-container] needs richer runtime data and state controls.
+Expected result: these commands and options reject because [`apple/container`][apple-container] needs richer runtime data and state controls.
 
 Status path:
 
 - Docker Compose v2: supports these commands.
-- [`apple/container`][apple-container]: missing process listing, event streaming, published-port lookup, pause/unpause, and wait/exit metadata primitives.
+- [`apple/container`][apple-container]: missing process listing, event streaming, published-port lookup, pause/unpause, wait/exit metadata, and stats all-container/truncation primitives.
 - `container-compose`: exposes the command names but reports the Apple runtime gap.
 
 ```yaml
@@ -517,6 +519,8 @@ container compose port api 8080
 container compose pause api
 container compose unpause api
 container compose wait api
+container compose stats --all
+container compose stats --no-trunc api
 ```
 
 Dockerfile: `api/Dockerfile`
@@ -739,7 +743,6 @@ Compare the missing command behavior:
 
 ```sh
 docker compose watch
-docker compose stats
 docker compose scale worker=3
 docker compose attach api
 docker compose commit api example/api:snapshot

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -36,7 +36,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Compose v2 surface | Supported subset | [`apple/container`][apple-container] primitive used | Example |
 | --- | --- | --- | --- |
 | Config normalization | File discovery, repeated `-f`, `.env`, `--env-file`, interpolation, merge, profiles, `--project-directory`, `-p/--project-name`, and canonical `config` JSON | No runtime primitive; `compose-go` normalizes the Compose model | [S1](#s1-supported-local-web-stack), [O1](#o1-config-only-metadata) |
-| Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, `images`, global `up --pull always/missing/never`, one-off `run --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never`, image removal through `down --rmi local/all` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container image list`, `container image delete` | [S1](#s1-supported-local-web-stack) |
+| Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, runtime-scoped `images`, `images --format table/json`, `images --quiet/-q`, global `up --pull always/missing/never`, one-off `run --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never`, image removal through `down --rmi local/all` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container list --format json`, `container image delete` | [S1](#s1-supported-local-web-stack) |
 | Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `rm --force/-f`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, `down --rmi local/all`, `stop/restart/down --timeout`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container delete --force`, `container kill`, `container inspect`, `container list`, `container image delete` | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `ps --quiet`, `ps --services`, `ps --status running/exited`, `ps --filter status=...`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
@@ -216,6 +216,8 @@ Useful supported commands against this project:
 container compose config
 container compose build
 container compose up --pull missing
+container compose images --format json
+container compose images -q
 container compose run --pull missing api true
 container compose run --rm api printf ok
 container compose run --detach api sleep 60

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -38,6 +38,7 @@ These surfaces have all three pieces: Docker Compose v2 model support, [`apple/c
 | Config normalization | File discovery, repeated `-f`, `.env`, `--env-file`, interpolation, merge, profiles, `--project-directory`, `-p/--project-name`, and canonical `config` JSON | No runtime primitive; `compose-go` normalizes the Compose model | [S1](#s1-supported-local-web-stack), [O1](#o1-config-only-metadata) |
 | Build and images | `build.context`, `build.dockerfile`, `build.args`, `build.target`, `build.no_cache`, CLI `build --no-cache`, `pull`, `push`, runtime-scoped `images`, `images --format table/json`, `images --quiet/-q`, global `up --pull always/missing/never`, one-off `run --pull always/missing/never`, service `pull_policy: always/missing/if_not_present/never`, image removal through `down --rmi local/all` | `container build`, `container image pull`, `container image push`, `container image inspect`, `container list --format json`, `container image delete` | [S1](#s1-supported-local-web-stack) |
 | Container lifecycle | `up`, `down`, `run`, `start`, `stop`, `restart`, `rm`, `rm --force/-f`, `kill`, deterministic names, one-off names, config-hash recreate, `--force-recreate`, `--no-recreate`, `--remove-orphans`, `down --rmi local/all`, `stop/restart/down --timeout`, one-off `run --rm`, one-off `run --detach/-d`, one-off `run --name` | `container run`, `container start`, `container stop`, `container delete`, `container delete --force`, `container kill`, `container inspect`, `container list`, `container image delete` | [S1](#s1-supported-local-web-stack) |
+| Project discovery | `ls`, `ls --all/-a`, `ls --format table/json`, `ls --quiet/-q`, and `ls --filter name=...` from project labels on created containers | `container list --format json` and Compose project/config-hash labels | [S1](#s1-supported-local-web-stack) |
 | Container interaction | `ps`, `ps --quiet`, `ps --services`, `ps --status running/exited`, `ps --filter status=...`, `logs`, `exec` with Compose-default stdin/TTY, `-T/--no-tty`, and `--interactive=false`, service-aware `cp`, `version` | `container list`, `container logs`, `container exec --interactive --tty`, `container cp`, plugin version output | [S1](#s1-supported-local-web-stack) |
 | Default networking | One service network, default project networks, external networks, service ports for `up`, one-off `run --service-ports/-P`, one-off `run --publish/-p` | `container network create`, `container network delete`, `container run --network`, `container run --publish` | [S1](#s1-supported-local-web-stack) |
 | Default storage | Named volumes, external volumes, bind mounts, anonymous volumes, read-only mounts, tmpfs mounts, one-off `run --volume/-v`, `rm --volumes/-v` for anonymous volumes, `down --volumes` for named project volumes | `container volume create`, `container volume delete`, `container run --volume`, `container run --tmpfs` | [S1](#s1-supported-local-web-stack) |
@@ -69,7 +70,7 @@ These are valid Docker Compose v2 surfaces where [`apple/container`][apple-conta
 | Develop, providers, models, hooks | `develop`, watch settings, service `provider`, service `models`, `post_start`, `pre_stop` | Watch/sync/rebuild orchestration, provider/model wiring, lifecycle hook safety and ordering | [C3](#c3-plugin-gap-develop-providers-models-and-hooks) |
 | Metadata, logging, storage shortcuts | `annotations`, `attach`, `label_file`, `logging`, `log_driver`, `log_opt`, `storage_opt`, `volumes_from`, service-level `volume_driver` | Runtime mapping, inherited mount behavior, label-file loading, logging behavior, storage option policy | [C4](#c4-plugin-gap-metadata-storage-api-socket-and-pull-windows) |
 | API socket, block I/O, pull windows | `use_api_socket`, `blkio_config`, service `pull_policy: build/daily/weekly/<duration>` | Security review, resource-control mapping, and time-window/build-trigger pull semantics | [C4](#c4-plugin-gap-metadata-storage-api-socket-and-pull-windows) |
-| Additional CLI commands | `create`, `ls`, `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` | Command design, output compatibility, and runtime mapping | [C5](#c5-plugin-gap-additional-cli-commands) |
+| Additional CLI commands | `create`, `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` | Command design, output compatibility, and runtime mapping | [C5](#c5-plugin-gap-additional-cli-commands) |
 
 ### Config-Only Today
 
@@ -86,9 +87,9 @@ These Compose surfaces are useful in normalized output, but they do not currentl
 
 | Status | Commands |
 | --- | --- |
-| Supported | `config`, `up`, `down`, `build`, `pull`, `push`, `ps`, `logs`, `exec`, `run`, `start`, `stop`, `restart`, `rm`, `images`, `cp`, `kill`, `version` |
+| Supported | `config`, `up`, `down`, `build`, `pull`, `push`, `ls`, `ps`, `logs`, `exec`, `run`, `start`, `stop`, `restart`, `rm`, `images`, `cp`, `kill`, `version` |
 | Present but blocked by [`apple/container`][apple-container] runtime gaps | `top`, `events`, `port`, `pause`, `unpause`, `wait` |
-| Not implemented by `container-compose` yet | `create`, `ls`, `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` |
+| Not implemented by `container-compose` yet | `create`, `watch`, `stats`, `scale`, `attach`, `commit`, `convert`, `export`, `publish`, `volumes` |
 
 ## References
 
@@ -216,6 +217,11 @@ Useful supported commands against this project:
 container compose config
 container compose build
 container compose up --pull missing
+container compose ls
+container compose ls --all
+container compose ls --filter name=supported-demo
+container compose ls --format json
+container compose ls --quiet
 container compose images --format json
 container compose images -q
 container compose run --pull missing api true
@@ -730,7 +736,6 @@ Compare the missing command behavior:
 
 ```sh
 docker compose create
-docker compose ls
 docker compose watch
 docker compose stats
 docker compose scale worker=3

--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -110,7 +110,7 @@ Every example includes a Compose file or commands plus the matching Dockerfile s
 | [A2: Apple Gap, Host Identity And Links](#a2-apple-gap-host-identity-and-links) | [`apple/container`][apple-container] gap | Hostname, domain name, explicit host entries, MAC address, and legacy links |
 | [A3: Apple Gap, Runtime Controls](#a3-apple-gap-runtime-controls) | [`apple/container`][apple-container] gap | Namespace controls, privileged/device access, advanced resources, DNS options, and sysctls |
 | [A4: Apple Gap, Health, Secrets, And Restart](#a4-apple-gap-health-secrets-and-restart) | [`apple/container`][apple-container] gap | Healthchecks, healthy/completed dependency gates, service secrets/configs, and restart policies |
-| [A5: Apple Gap, Runtime Data Commands](#a5-apple-gap-runtime-data-commands) | [`apple/container`][apple-container] gap | Process listing, event streams, port lookup, pause/unpause, and wait metadata |
+| [A5: Apple Gap, Runtime Data Commands](#a5-apple-gap-runtime-data-commands) | [`apple/container`][apple-container] gap | Process listing, event streams, port lookup, pause/unpause, wait metadata, and stats output controls |
 | [C1: Plugin Gap, Replica Scaling And Deploy](#c1-plugin-gap-replica-scaling-and-deploy) | `container-compose` gap | Replica naming, lifecycle, logs, `ps`, `rm`, DNS, and deploy semantics |
 | [C2: Plugin Gap, Advanced Build Fields](#c2-plugin-gap-advanced-build-fields) | `container-compose` gap | Additional contexts, cache, inline Dockerfile, secrets, SSH, tags, and provenance/SBOM fields |
 | [C3: Plugin Gap, Develop, Providers, Models, And Hooks](#c3-plugin-gap-develop-providers-models-and-hooks) | `container-compose` gap | Watch/develop, providers, model bindings, and lifecycle hooks |

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := all
 
 SWIFT ?= swift
+SWIFT_RESOLVED_FLAGS ?= --disable-automatic-resolution
 GO ?= go
 PYTHON ?= python3
 MARKDOWNLINT ?= markdownlint
@@ -46,24 +47,24 @@ all: workflow
 
 workflow: ci package
 
-ci: resolve lint coverage-check go-build cli-smoke
+ci: lint coverage-check go-build cli-smoke
 
 resolve:
 	$(SWIFT) package resolve
 
 build:
-	$(SWIFT) build --product compose
+	$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) --product compose
 
 build-release:
-	$(SWIFT) build -c release --product compose
+	$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) -c release --product compose
 
 run:
-	$(SWIFT) run compose version
+	$(SWIFT) run $(SWIFT_RESOLVED_FLAGS) compose version
 
 test: swift-test go-test
 
 swift-test:
-	$(SWIFT) test --enable-code-coverage $(SWIFT_TEST_FLAGS)
+	$(SWIFT) test $(SWIFT_RESOLVED_FLAGS) --enable-code-coverage $(SWIFT_TEST_FLAGS)
 
 swift-coverage: swift-test
 	test_binary="$$(find .build -path '*.xctest/Contents/MacOS/*' -type f | head -n 1)"; \

--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,11 @@ cli-smoke: build
 	[[ "$$images_json_output" == *"container list --format json --all"* ]]; \
 	images_quiet_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo images -q api)"; \
 	[[ "$$images_quiet_output" == *"container list --format json --all"* ]]; \
+	ls_json_output="$$(".build/debug/compose" --dry-run ls --format json)"; \
+	[[ "$$ls_json_output" == *"container list --format json"* ]]; \
+	[[ "$$ls_json_output" != *"--all"* ]]; \
+	ls_all_output="$$(".build/debug/compose" --dry-run ls --all --filter name=demo)"; \
+	[[ "$$ls_all_output" == *"container list --format json --all"* ]]; \
 	top_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" top api 2>&1 || true)"; \
 	[[ "$$top_output" == *"unsupported compose feature: top:"* ]]; \
 	[[ "$$top_output" == *"apple/container does not expose a process-list command yet"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ cli-smoke: build
 	[[ "$$up_output" == *"container run"* ]]; \
 	[[ "$$up_output" == *"--publish 8080:80"* ]]; \
 	[[ "$$up_output" != *"--detach"* ]]; \
+	create_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" create --build api)"; \
+	[[ "$$create_output" == *"container create"* ]]; \
+	[[ "$$create_output" == *"--publish 8080:80"* ]]; \
+	[[ "$$create_output" != *"--detach"* ]]; \
 	detached_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" up --detach api)"; \
 	[[ "$$detached_output" == *"container run"* ]]; \
 	[[ "$$detached_output" == *"--detach"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -178,6 +178,10 @@ cli-smoke: build
 	[[ "$$ps_status_output" == *"container list --format json --all"* ]]; \
 	ps_filter_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo ps --filter status=exited)"; \
 	[[ "$$ps_filter_output" == *"container list --format json --all"* ]]; \
+	images_json_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo images --format json api)"; \
+	[[ "$$images_json_output" == *"container list --format json --all"* ]]; \
+	images_quiet_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo images -q api)"; \
+	[[ "$$images_quiet_output" == *"container list --format json --all"* ]]; \
 	top_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" top api 2>&1 || true)"; \
 	[[ "$$top_output" == *"unsupported compose feature: top:"* ]]; \
 	[[ "$$top_output" == *"apple/container does not expose a process-list command yet"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,9 @@ cli-smoke: build
 	events_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" events --json 2>&1 || true)"; \
 	[[ "$$events_output" == *"unsupported compose feature: events:"* ]]; \
 	[[ "$$events_output" == *"apple/container does not expose an event stream yet"* ]]; \
+	port_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" port api 8080 2>&1 || true)"; \
+	[[ "$$port_output" == *"unsupported compose feature: port:"* ]]; \
+	[[ "$$port_output" == *"published port lookup needs richer inspect output"* ]]; \
 	pause_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" pause api 2>&1 || true)"; \
 	[[ "$$pause_output" == *"unsupported compose feature: pause:"* ]]; \
 	[[ "$$pause_output" == *"apple/container does not expose pause yet"* ]]; \

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,8 @@ cli-smoke: build
 	[[ "$$images_json_output" == *"container list --format json --all"* ]]; \
 	images_quiet_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo images -q api)"; \
 	[[ "$$images_quiet_output" == *"container list --format json --all"* ]]; \
+	stats_output="$$(".build/debug/compose" --dry-run -f "$$tmpdir/compose.yml" -p demo stats --no-stream --format json api)"; \
+	[[ "$$stats_output" == *"container stats --format json --no-stream demo-api-1"* ]]; \
 	ls_json_output="$$(".build/debug/compose" --dry-run ls --format json)"; \
 	[[ "$$ls_json_output" == *"container list --format json"* ]]; \
 	[[ "$$ls_json_output" != *"--all"* ]]; \

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -27,6 +27,7 @@ public enum ComposeArgumentRewriter {
         "build",
         "config",
         "cp",
+        "create",
         "down",
         "events",
         "exec",

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -32,6 +32,7 @@ public enum ComposeArgumentRewriter {
         "exec",
         "images",
         "kill",
+        "ls",
         "logs",
         "pause",
         "port",

--- a/Sources/ComposeCore/ComposeArgumentRewriter.swift
+++ b/Sources/ComposeCore/ComposeArgumentRewriter.swift
@@ -44,6 +44,7 @@ public enum ComposeArgumentRewriter {
         "rm",
         "run",
         "start",
+        "stats",
         "stop",
         "top",
         "unpause",

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -90,6 +90,17 @@ public struct ComposeDownOptions {
     }
 }
 
+/// Options for `compose images`.
+public struct ComposeImagesOptions {
+    public var quiet: Bool
+    public var format: String
+
+    public init(quiet: Bool = false, format: String = "table") {
+        self.quiet = quiet
+        self.format = format
+    }
+}
+
 /// Options for `compose run` one-off containers.
 public struct ComposeRunOptions {
     public var command: [String] = []
@@ -138,6 +149,11 @@ private enum DownImageRemovalPolicy {
     case none
     case local
     case all
+}
+
+private enum ComposeImagesFormat {
+    case table
+    case json
 }
 
 /// Converts a normalized Compose project into deterministic `container`
@@ -458,9 +474,36 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
     }
 
-    /// Returns image names referenced by selected services.
-    public func images(project: ComposeProject, services selected: [String]) throws -> [String] {
-        try selectedServices(project: project, selected: selected).compactMap(\.image).sorted()
+    /// Lists images used by created project containers.
+    public func images(project: ComposeProject, services selected: [String], options images: ComposeImagesOptions) async throws {
+        let services = try selectedServices(project: project, selected: selected)
+        let selectedServiceNames = selected.isEmpty ? nil : Set(services.map(\.name))
+        let format = try composeImagesFormat(images.format)
+        let args = ["list", "--format", "json", "--all"]
+        if options.dryRun {
+            try await runContainer(args)
+            return
+        }
+
+        let result = try await runContainer(args, emitOutput: false)
+        let records = try composeImageRecords(projectName: project.name, output: result.stdout, selectedServices: selectedServiceNames)
+        if images.quiet {
+            let identifiers = records.map(\.imageID).filter { !$0.isEmpty }
+            if !identifiers.isEmpty {
+                options.emit(identifiers.joined(separator: "\n"))
+            }
+            return
+        }
+
+        switch format {
+        case .table:
+            let table = renderComposeImageTable(records)
+            if !table.isEmpty {
+                options.emit(table)
+            }
+        case .json:
+            options.emit(try renderComposeImageJSON(records))
+        }
     }
 
     /// Sends a signal to selected service containers.
@@ -1723,6 +1766,185 @@ private func containerServiceNames(_ containers: [Any]) -> [String] {
         }
     }
     return services
+}
+
+/// Validates the `compose images --format` value.
+private func composeImagesFormat(_ value: String) throws -> ComposeImagesFormat {
+    switch value.lowercased() {
+    case "table":
+        return .table
+    case "json":
+        return .json
+    default:
+        throw ComposeError.unsupported("images --format '\(value)'; supported formats are table and json")
+    }
+}
+
+/// One Docker Compose-style image row derived from a created project container.
+private struct ComposeImageRecord: Encodable, Equatable {
+    let container: String
+    let service: String
+    let repository: String
+    let tag: String
+    let platform: String
+    let imageID: String
+}
+
+/// Returns image rows from `container list --format json` scoped by Compose labels.
+private func composeImageRecords(projectName: String, output: String, selectedServices: Set<String>?) throws -> [ComposeImageRecord] {
+    try projectContainers(projectName: projectName, output: output).compactMap { container in
+        guard let service = inspectLabel(serviceLabel, in: container), !service.isEmpty else {
+            return nil
+        }
+        if let selectedServices, !selectedServices.contains(service) {
+            return nil
+        }
+        guard let imageReference = containerImageReference(container), !imageReference.isEmpty else {
+            return nil
+        }
+        let reference = splitImageReference(imageReference)
+        return ComposeImageRecord(
+            container: containerIdentifier(container) ?? service,
+            service: service,
+            repository: reference.repository,
+            tag: reference.tag,
+            platform: containerPlatform(container),
+            imageID: shortImageID(containerImageDigest(container))
+        )
+    }
+    .sorted { lhs, rhs in
+        if lhs.container == rhs.container {
+            return lhs.service < rhs.service
+        }
+        return lhs.container < rhs.container
+    }
+}
+
+/// Renders image rows as a compact table.
+private func renderComposeImageTable(_ records: [ComposeImageRecord]) -> String {
+    guard !records.isEmpty else {
+        return ""
+    }
+    let rows = [
+        ["CONTAINER", "REPOSITORY", "TAG", "IMAGE ID", "PLATFORM"],
+    ] + records.map { record in
+        [record.container, record.repository, record.tag, record.imageID.isEmpty ? "<none>" : record.imageID, record.platform]
+    }
+    let widths = rows.reduce(Array(repeating: 0, count: rows[0].count)) { current, row in
+        zip(current, row).map { max($0, $1.count) }
+    }
+    return rows.map { row in
+        row.enumerated().map { index, value in
+            index == row.count - 1 ? value : value.padding(toLength: widths[index], withPad: " ", startingAt: 0)
+        }.joined(separator: "  ")
+    }.joined(separator: "\n")
+}
+
+/// Renders image rows as deterministic JSON.
+private func renderComposeImageJSON(_ records: [ComposeImageRecord]) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(records)
+    return String(decoding: data, as: UTF8.self)
+}
+
+/// Extracts a container image reference from common `container list` JSON shapes.
+private func containerImageReference(_ value: Any) -> String? {
+    for path in [
+        ["configuration", "image", "reference"],
+        ["configuration", "image", "name"],
+        ["Config", "Image"],
+        ["config", "image"],
+        ["Image"],
+        ["image"],
+    ] {
+        if let value = stringValue(at: path, in: value), !value.isEmpty {
+            return value
+        }
+    }
+    return nil
+}
+
+/// Extracts an image digest from common `container list` JSON shapes.
+private func containerImageDigest(_ value: Any) -> String? {
+    for path in [
+        ["configuration", "image", "descriptor", "digest"],
+        ["configuration", "image", "digest"],
+        ["Config", "ImageID"],
+        ["ImageID"],
+        ["imageID"],
+        ["imageId"],
+    ] {
+        if let value = stringValue(at: path, in: value), !value.isEmpty {
+            return value
+        }
+    }
+    return nil
+}
+
+/// Extracts a platform string from common `container list` JSON shapes.
+private func containerPlatform(_ value: Any) -> String {
+    for path in [
+        ["configuration", "platform"],
+        ["Config", "Platform"],
+        ["Platform"],
+        ["platform"],
+    ] {
+        guard let platform = nestedValue(at: path, in: value) as? [String: Any] else {
+            continue
+        }
+        let os = platform["os"] as? String ?? platform["OS"] as? String
+        let architecture = platform["architecture"] as? String ?? platform["Architecture"] as? String
+        let variant = platform["variant"] as? String ?? platform["Variant"] as? String
+        guard let os, let architecture, !os.isEmpty, !architecture.isEmpty else {
+            continue
+        }
+        if let variant, !variant.isEmpty {
+            return "\(os)/\(architecture)/\(variant)"
+        }
+        return "\(os)/\(architecture)"
+    }
+    return ""
+}
+
+/// Splits a container image reference into repository and tag display fields.
+private func splitImageReference(_ reference: String) -> (repository: String, tag: String) {
+    let withoutDigest = reference.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false).first.map(String.init) ?? reference
+    guard let lastColon = withoutDigest.lastIndex(of: ":") else {
+        return (withoutDigest, "<none>")
+    }
+    if let lastSlash = withoutDigest.lastIndex(of: "/"), lastColon < lastSlash {
+        return (withoutDigest, "<none>")
+    }
+    return (String(withoutDigest[..<lastColon]), String(withoutDigest[withoutDigest.index(after: lastColon)...]))
+}
+
+/// Returns the short Docker-style image ID without an algorithm prefix.
+private func shortImageID(_ digest: String?) -> String {
+    guard var digest, !digest.isEmpty else {
+        return ""
+    }
+    if let colonIndex = digest.firstIndex(of: ":") {
+        digest = String(digest[digest.index(after: colonIndex)...])
+    }
+    return String(digest.prefix(12))
+}
+
+/// Reads a string from a nested JSON object path.
+private func stringValue(at path: [String], in value: Any) -> String? {
+    nestedValue(at: path, in: value) as? String
+}
+
+/// Reads a value from a nested JSON object path.
+private func nestedValue(at path: [String], in value: Any) -> Any? {
+    var current = value
+    for key in path {
+        guard let object = current as? [String: Any], let next = object[key] else {
+            return nil
+        }
+        current = next
+    }
+    return current
 }
 
 /// Combines `ps --status` and `ps --filter status=...` into runtime state values.

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -75,6 +75,38 @@ public struct ComposeUpOptions {
     }
 }
 
+/// Options for `compose create`.
+public struct ComposeCreateOptions {
+    public var services: [String]
+    public var build: Bool
+    public var noBuild: Bool
+    public var forceRecreate: Bool
+    public var noRecreate: Bool
+    public var removeOrphans: Bool
+    public var pullPolicy: String?
+    public var scales: [String]
+
+    public init(
+        services: [String] = [],
+        build: Bool = false,
+        noBuild: Bool = false,
+        forceRecreate: Bool = false,
+        noRecreate: Bool = false,
+        removeOrphans: Bool = false,
+        pullPolicy: String? = nil,
+        scales: [String] = []
+    ) {
+        self.services = services
+        self.build = build
+        self.noBuild = noBuild
+        self.forceRecreate = forceRecreate
+        self.noRecreate = noRecreate
+        self.removeOrphans = removeOrphans
+        self.pullPolicy = pullPolicy
+        self.scales = scales
+    }
+}
+
 /// Options for `compose down`.
 public struct ComposeDownOptions {
     public var volumes: Bool
@@ -144,6 +176,7 @@ public struct ComposeRunOptions {
 }
 
 private struct RunArgumentOptions {
+    var command = "run"
     var detach = false
     var remove = false
     var oneOff = false
@@ -240,6 +273,55 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
 
         if up.removeOrphans {
+            let declaredContainers = Set(project.services.values.map { containerName(project: project, service: $0, oneOff: false) })
+            try await removeRemainingProjectContainers(project: project, excluding: declaredContainers)
+        }
+    }
+
+    /// Creates project resources and selected service containers without starting them.
+    public func create(project: ComposeProject, options create: ComposeCreateOptions) async throws {
+        try validate(project: project)
+        try validateCreateOptions(create)
+        let services = try orderedServices(project: project, selected: create.services)
+        try validateCreatePullPolicy(create.pullPolicy)
+        try validateRuntimeSupport(services: services)
+
+        try await ensureResources(project: project)
+
+        try await applyCreateImagePolicy(create, project: project, services: services)
+
+        for service in services {
+            if shouldBuildServiceForCreate(create, service: service) {
+                try await build(project: project, services: [service.name], noCache: false)
+            }
+
+            let name = containerName(project: project, service: service, oneOff: false)
+            let existing = try await inspectContainer(name)
+            if let existing {
+                if create.noRecreate {
+                    options.emit("compose: reusing existing container \(name)")
+                    continue
+                }
+                if !create.forceRecreate, existing.configHash == configHash(project: project, service: service) {
+                    options.emit("compose: reusing existing container \(name)")
+                    continue
+                }
+                try await runContainer(stopArguments(service: service, containerName: name), check: false)
+                try await runContainer(["delete", name], check: false)
+            }
+
+            try await runContainer(
+                runArguments(
+                    project: project,
+                    service: service,
+                    options: RunArgumentOptions {
+                        $0.command = "create"
+                    }
+                )
+            )
+        }
+
+        if create.removeOrphans {
             let declaredContainers = Set(project.services.values.map { containerName(project: project, service: $0, oneOff: false) })
             try await removeRemainingProjectContainers(project: project, excluding: declaredContainers)
         }
@@ -976,7 +1058,30 @@ private extension ComposeOrchestrator {
         guard let policy, !policy.isEmpty else {
             return
         }
-        if !["always", "missing", "never"].contains(policy) {
+        if !["always", "missing", "if_not_present", "never"].contains(policy) {
+            throw ComposeError.invalidProject("unsupported pull policy '\(policy)'")
+        }
+    }
+
+    /// Validates command-level `compose create` option combinations before runtime side effects.
+    func validateCreateOptions(_ options: ComposeCreateOptions) throws {
+        if options.build, options.noBuild {
+            throw ComposeError.invalidProject("--build and --no-build are incompatible")
+        }
+        if options.forceRecreate, options.noRecreate {
+            throw ComposeError.invalidProject("--force-recreate and --no-recreate are incompatible")
+        }
+        if !options.scales.isEmpty {
+            throw ComposeError.unsupported("create --scale: service replica scaling is not implemented by container-compose yet")
+        }
+    }
+
+    /// Validates `create --pull`, including Docker Compose's build policy.
+    func validateCreatePullPolicy(_ policy: String?) throws {
+        guard let policy, !policy.isEmpty else {
+            return
+        }
+        if !["always", "missing", "if_not_present", "never", "build"].contains(policy) {
             throw ComposeError.invalidProject("unsupported pull policy '\(policy)'")
         }
     }
@@ -1079,13 +1184,36 @@ private extension ComposeOrchestrator {
         switch policy {
         case "always":
             try await pull(project: project, services: services.map(\.name))
-        case "missing":
+        case "missing", "if_not_present":
             try await pullMissingImages(services: services)
         case "never":
             return
         default:
             throw ComposeError.invalidProject("unsupported pull policy '\(policy)'")
         }
+    }
+
+    /// Applies `compose create` image preparation before creating containers.
+    func applyCreateImagePolicy(_ create: ComposeCreateOptions, project: ComposeProject, services: [ComposeService]) async throws {
+        if create.pullPolicy == "build" {
+            guard !create.noBuild else {
+                return
+            }
+            try await build(project: project, services: services.map(\.name), noCache: false)
+            return
+        }
+
+        try await applyPullPolicy(create.pullPolicy, project: project, services: services)
+
+        guard create.build, !create.noBuild else {
+            return
+        }
+        try await build(project: project, services: services.map(\.name), noCache: false)
+    }
+
+    /// Returns whether `create` should auto-build a service before container creation.
+    func shouldBuildServiceForCreate(_ create: ComposeCreateOptions, service: ComposeService) -> Bool {
+        !create.noBuild && !create.build && create.pullPolicy != "build" && service.image == nil && service.build != nil
     }
 
     /// Applies service-level `pull_policy` when no global pull override is set.
@@ -1260,7 +1388,7 @@ private extension ComposeOrchestrator {
         service: ComposeService,
         options run: RunArgumentOptions = RunArgumentOptions()
     ) throws -> [String] {
-        var args = ["run"]
+        var args = [run.command]
         let runtimeName = run.containerNameOverride.map(slug) ?? containerName(project: project, service: service, oneOff: run.oneOff)
         args.append(contentsOf: ["--name", runtimeName])
         if run.detach {

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -133,6 +133,23 @@ public struct ComposeImagesOptions {
     }
 }
 
+/// Options for `compose stats`.
+public struct ComposeStatsOptions {
+    public var services: [String]
+    public var all: Bool
+    public var format: String
+    public var noStream: Bool
+    public var noTrunc: Bool
+
+    public init(services: [String] = [], all: Bool = false, format: String = "table", noStream: Bool = false, noTrunc: Bool = false) {
+        self.services = services
+        self.all = all
+        self.format = format
+        self.noStream = noStream
+        self.noTrunc = noTrunc
+    }
+}
+
 /// Options for `compose ls`.
 public struct ComposeLsOptions {
     public var all: Bool
@@ -637,6 +654,22 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         }
     }
 
+    /// Displays resource usage statistics for selected service containers.
+    public func stats(project: ComposeProject, options stats: ComposeStatsOptions) async throws {
+        try validate(project: project)
+        try validateStatsOptions(stats)
+        let services = try selectedServices(project: project, selected: stats.services)
+        var args = ["stats"]
+        if stats.format != "table" {
+            args.append(contentsOf: ["--format", stats.format])
+        }
+        if stats.noStream {
+            args.append("--no-stream")
+        }
+        args.append(contentsOf: services.map { containerName(project: project, service: $0, oneOff: false) })
+        try await runContainer(args)
+    }
+
     /// Sends a signal to selected service containers.
     public func kill(project: ComposeProject, services selected: [String], signal: String?) async throws {
         for service in try selectedServices(project: project, selected: selected) {
@@ -1083,6 +1116,22 @@ private extension ComposeOrchestrator {
         }
         if !["always", "missing", "if_not_present", "never", "build"].contains(policy) {
             throw ComposeError.invalidProject("unsupported pull policy '\(policy)'")
+        }
+    }
+
+    /// Validates `compose stats` options before invoking runtime stats.
+    func validateStatsOptions(_ options: ComposeStatsOptions) throws {
+        if options.services.count > 1 {
+            throw ComposeError.invalidProject("stats accepts at most one service")
+        }
+        if options.all {
+            throw ComposeError.unsupported("stats --all: apple/container stats only reports running containers")
+        }
+        if options.noTrunc {
+            throw ComposeError.unsupported("stats --no-trunc: apple/container stats does not expose truncation control")
+        }
+        if !["table", "json"].contains(options.format) {
+            throw ComposeError.unsupported("stats --format '\(options.format)': apple/container stats supports table and json output")
         }
     }
 

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -101,6 +101,21 @@ public struct ComposeImagesOptions {
     }
 }
 
+/// Options for `compose ls`.
+public struct ComposeLsOptions {
+    public var all: Bool
+    public var quiet: Bool
+    public var format: String
+    public var filters: [String]
+
+    public init(all: Bool = false, quiet: Bool = false, format: String = "table", filters: [String] = []) {
+        self.all = all
+        self.quiet = quiet
+        self.format = format
+        self.filters = filters
+    }
+}
+
 /// Options for `compose run` one-off containers.
 public struct ComposeRunOptions {
     public var command: [String] = []
@@ -281,6 +296,40 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         for service in services {
             guard let image = service.image else { continue }
             try await runContainer(["image", "push", image])
+        }
+    }
+
+    /// Lists Compose projects discovered through project-scoped container labels.
+    public func ls(options list: ComposeLsOptions = ComposeLsOptions()) async throws {
+        let nameFilters = try lsNameFilters(list.filters)
+        let format = try composeLsFormat(list.format)
+        var args = ["list", "--format", "json"]
+        if list.all {
+            args.append("--all")
+        }
+        if options.dryRun {
+            try await runContainer(args)
+            return
+        }
+
+        let result = try await runContainer(args, emitOutput: false)
+        let records = try composeProjectRecords(output: result.stdout, nameFilters: nameFilters)
+        if list.quiet {
+            let names = records.map(\.name)
+            if !names.isEmpty {
+                options.emit(names.joined(separator: "\n"))
+            }
+            return
+        }
+
+        switch format {
+        case .table:
+            let table = renderComposeProjectTable(records)
+            if !table.isEmpty {
+                options.emit(table)
+            }
+        case .json:
+            options.emit(try renderComposeProjectJSON(records))
         }
     }
 
@@ -1565,6 +1614,7 @@ private let projectLabel = "com.apple.container.compose.project"
 private let serviceLabel = "com.apple.container.compose.service"
 private let configHashLabel = "com.apple.container.compose.config-hash"
 private let workingDirectoryLabel = "com.apple.container.compose.project.working-directory"
+private let configFilesLabel = "com.apple.container.compose.project.config-files"
 private let configFilesHashLabel = "com.apple.container.compose.project.config-files-hash"
 private let reservedComposeLabelPrefix = "com.apple.container.compose."
 
@@ -1630,6 +1680,7 @@ private func resourceLabels(project: ComposeProject) -> [String] {
         "\(projectLabel)=\(project.name)",
         "com.apple.container.compose.version=1",
         "\(workingDirectoryLabel)=\(project.workingDirectory)",
+        "\(configFilesLabel)=\(project.composeFiles.joined(separator: ","))",
         "\(configFilesHashLabel)=\(composeFilesHash(project.composeFiles))",
     ]
 }
@@ -1766,6 +1817,157 @@ private func containerServiceNames(_ containers: [Any]) -> [String] {
         }
     }
     return services
+}
+
+/// Validates the `compose ls --format` value.
+private func composeLsFormat(_ value: String) throws -> ComposeLsFormat {
+    switch value.lowercased() {
+    case "table":
+        return .table
+    case "json":
+        return .json
+    default:
+        throw ComposeError.unsupported("ls --format '\(value)'; supported formats are table and json")
+    }
+}
+
+/// Output modes supported by `compose ls`.
+private enum ComposeLsFormat {
+    case table
+    case json
+}
+
+/// One Docker Compose-style project row derived from labeled containers.
+private struct ComposeProjectRecord: Encodable, Equatable {
+    let name: String
+    let status: String
+    let configFiles: String
+}
+
+/// Returns project rows from `container list --format json`, optionally filtered by project name.
+private func composeProjectRecords(output: String, nameFilters: [String]) throws -> [ComposeProjectRecord] {
+    let containers = try composeLabeledContainers(output: output)
+    let grouped = Dictionary(grouping: containers) { inspectLabel(projectLabel, in: $0) ?? "" }
+    return grouped.keys.sorted().compactMap { projectName in
+        guard !projectName.isEmpty, lsProjectNameMatches(projectName, filters: nameFilters) else {
+            return nil
+        }
+        let projectContainers = grouped[projectName] ?? []
+        return ComposeProjectRecord(
+            name: projectName,
+            status: combinedProjectStatus(projectContainers),
+            configFiles: combinedProjectConfigFiles(projectContainers)
+        )
+    }
+}
+
+/// Returns all containers carrying the labels needed to identify Compose projects.
+private func composeLabeledContainers(output: String) throws -> [Any] {
+    try listedContainers(output: output).filter {
+        inspectLabel(projectLabel, in: $0) != nil && inspectLabel(configHashLabel, in: $0) != nil
+    }
+}
+
+/// Parses raw `container list --format json` output into container JSON objects.
+private func listedContainers(output: String) throws -> [Any] {
+    guard let data = output.data(using: .utf8),
+          let json = try? JSONSerialization.jsonObject(with: data)
+    else {
+        throw ComposeError.invalidProject("container list returned invalid JSON")
+    }
+
+    let containers: [Any]
+    if let values = json as? [Any] {
+        containers = values
+    } else if let value = json as? [String: Any] {
+        containers = [value]
+    } else {
+        throw ComposeError.invalidProject("container list returned invalid JSON")
+    }
+    return containers
+}
+
+/// Parses `compose ls --filter` values. Docker Compose currently accepts only `name`.
+private func lsNameFilters(_ filters: [String]) throws -> [String] {
+    try filters.map { filter in
+        let parts = filter.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        guard parts.count == 2, !parts[0].isEmpty else {
+            throw ComposeError.invalidProject("ls --filter must be in KEY=VALUE form")
+        }
+        let key = String(parts[0])
+        let value = String(parts[1])
+        guard key == "name" else {
+            throw ComposeError.unsupported("ls --filter \(key); supported filter is name")
+        }
+        guard !value.isEmpty else {
+            throw ComposeError.invalidProject("ls --filter name requires a value")
+        }
+        return value
+    }
+}
+
+/// Applies Docker Compose's exact-name or regular-expression project name matching.
+private func lsProjectNameMatches(_ name: String, filters: [String]) -> Bool {
+    guard !filters.isEmpty else {
+        return true
+    }
+    return filters.contains { filter in
+        if name == filter {
+            return true
+        }
+        return name.range(of: filter, options: .regularExpression) != nil
+    }
+}
+
+/// Combines per-container states into the `state(count)` form used by Docker Compose.
+private func combinedProjectStatus(_ containers: [Any]) -> String {
+    let statuses = containers.map { (containerRuntimeState($0) ?? "unknown").lowercased() }
+    let counts = Dictionary(grouping: statuses, by: { $0 }).mapValues(\.count)
+    return counts.keys.sorted().map { "\($0)(\(counts[$0] ?? 0))" }.joined(separator: ", ")
+}
+
+/// Combines config-file labels across project containers while preserving first-seen order.
+private func combinedProjectConfigFiles(_ containers: [Any]) -> String {
+    var seen: Set<String> = []
+    var files: [String] = []
+    for container in containers {
+        let values = [
+            inspectLabel(configFilesLabel, in: container),
+            inspectLabel("com.apple.container.compose.project.config-file", in: container),
+        ].compactMap { $0 }
+        for value in values {
+            for file in value.split(separator: ",").map(String.init) where !file.isEmpty && seen.insert(file).inserted {
+                files.append(file)
+            }
+        }
+    }
+    return files.isEmpty ? "N/A" : files.joined(separator: ",")
+}
+
+/// Renders project rows as a compact table.
+private func renderComposeProjectTable(_ records: [ComposeProjectRecord]) -> String {
+    guard !records.isEmpty else {
+        return ""
+    }
+    let rows = [
+        ["NAME", "STATUS", "CONFIG FILES"],
+    ] + records.map { [$0.name, $0.status, $0.configFiles] }
+    let widths = rows.reduce(Array(repeating: 0, count: rows[0].count)) { current, row in
+        zip(current, row).map { max($0, $1.count) }
+    }
+    return rows.map { row in
+        row.enumerated().map { index, value in
+            index == row.count - 1 ? value : value.padding(toLength: widths[index], withPad: " ", startingAt: 0)
+        }.joined(separator: "  ")
+    }.joined(separator: "\n")
+}
+
+/// Renders project rows as deterministic JSON.
+private func renderComposeProjectJSON(_ records: [ComposeProjectRecord]) throws -> String {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(records)
+    return String(decoding: data, as: UTF8.self)
 }
 
 /// Validates the `compose images --format` value.
@@ -1995,24 +2197,9 @@ private func filterContainersByStatus(_ containers: [Any], statuses: Set<String>
 
 /// Filters raw `container list --format json` output by Compose project label.
 private func projectContainers(projectName: String, output: String) throws -> [Any] {
-    guard let data = output.data(using: .utf8),
-          let json = try? JSONSerialization.jsonObject(with: data)
-    else {
-        throw ComposeError.invalidProject("container list returned invalid JSON")
-    }
-
-    let containers: [Any]
-    if let values = json as? [Any] {
-        containers = values
-    } else if let value = json as? [String: Any] {
-        containers = [value]
-    } else {
-        throw ComposeError.invalidProject("container list returned invalid JSON")
-    }
-
     // `container list` does not currently expose a label filter in the CLI, so
     // Compose project scoping is applied client-side after requesting JSON.
-    return containers.filter { inspectLabel(projectLabel, in: $0) == projectName }
+    return try listedContainers(output: output).filter { inspectLabel(projectLabel, in: $0) == projectName }
 }
 
 /// Extracts the runtime state from common `container list --format json` shapes.

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -684,8 +684,8 @@ public final class ComposeOrchestrator: @unchecked Sendable {
 
     /// Copies files between a Compose service container and the local host.
     public func copy(project: ComposeProject, arguments: [String]) async throws {
-        guard !arguments.isEmpty else {
-            throw ComposeError.invalidProject("cp requires source and destination")
+        guard arguments.count == 2 else {
+            throw ComposeError.invalidProject("cp requires exactly source and destination")
         }
         let mappedArguments = try arguments.map { try copyArgument($0, project: project) }
         try await runContainer(["cp"] + mappedArguments)

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -467,15 +467,17 @@ struct Rm: AsyncParsableCommand, ComposeProjectCommand {
 
 /// Implements `compose images`.
 struct Images: AsyncParsableCommand, ComposeProjectCommand {
-    static let configuration = CommandConfiguration(commandName: "images", abstract: "List images used by services.")
+    static let configuration = CommandConfiguration(commandName: "images", abstract: "List images used by created service containers.")
     @OptionGroup var global: GlobalOptions
+    @Option(name: .customLong("format"), help: "Output format: table or json.")
+    var format = "table"
+    @Flag(name: .shortAndLong, help: "Only display image IDs.")
+    var quiet = false
     @Argument var services: [String] = []
-    /// Prints image names referenced by selected services.
+    /// Lists images used by project containers.
     func run() async throws {
         let loadedProject = try await project()
-        for image in try orchestrator().images(project: loadedProject, services: services) {
-            print(image)
-        }
+        try await orchestrator().images(project: loadedProject, services: services, options: ComposeImagesOptions(quiet: quiet, format: format))
     }
 }
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -33,6 +33,7 @@ struct ComposePlugin: AsyncParsableCommand {
             Build.self,
             Pull.self,
             Push.self,
+            Ls.self,
             Ps.self,
             Logs.self,
             Exec.self,
@@ -253,6 +254,26 @@ struct Push: AsyncParsableCommand, ComposeProjectCommand {
     func run() async throws {
         let loadedProject = try await project()
         try await orchestrator().push(project: loadedProject, services: services)
+    }
+}
+
+/// Implements `compose ls`.
+struct Ls: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "ls", abstract: "List Compose projects.")
+
+    @OptionGroup var global: GlobalOptions
+    @Flag(name: .shortAndLong, help: "Show stopped Compose projects.")
+    var all = false
+    @Flag(name: [.customShort("q"), .customLong("quiet")], help: "Only display project names.")
+    var quiet = false
+    @Option(name: .customLong("format"), help: "Output format: table or json.")
+    var format = "table"
+    @Option(name: .customLong("filter"), help: "Filter projects. Supported filter: name.")
+    var filters: [String] = []
+
+    /// Lists project names and status without loading a Compose file.
+    func run() async throws {
+        try await global.orchestrator().ls(options: ComposeLsOptions(all: all, quiet: quiet, format: format, filters: filters))
     }
 }
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -44,6 +44,7 @@ struct ComposePlugin: AsyncParsableCommand {
             Restart.self,
             Rm.self,
             Images.self,
+            Stats.self,
             Top.self,
             Events.self,
             Port.self,
@@ -545,6 +546,37 @@ struct Images: AsyncParsableCommand, ComposeProjectCommand {
     func run() async throws {
         let loadedProject = try await project()
         try await orchestrator().images(project: loadedProject, services: services, options: ComposeImagesOptions(quiet: quiet, format: format))
+    }
+}
+
+/// Implements `compose stats`.
+struct Stats: AsyncParsableCommand, ComposeProjectCommand {
+    static let configuration = CommandConfiguration(commandName: "stats", abstract: "Display service container resource usage statistics.")
+    @OptionGroup var global: GlobalOptions
+    @Flag(name: [.customShort("a"), .customLong("all")], help: "Show all containers. Not supported by apple/container stats yet.")
+    var all = false
+    @Option(name: .customLong("format"), help: "Output format: table or json.")
+    var format = "table"
+    @Flag(name: .customLong("no-stream"), help: "Disable streaming stats and only pull the first result.")
+    var noStream = false
+    @Flag(name: .customLong("no-trunc"), help: "Do not truncate output. Not supported by apple/container stats yet.")
+    var noTrunc = false
+    @Argument(help: "Optional service name.")
+    var services: [String] = []
+
+    /// Displays resource usage statistics for the project or one selected service.
+    func run() async throws {
+        let loadedProject = try await project()
+        try await orchestrator().stats(
+            project: loadedProject,
+            options: ComposeStatsOptions(
+                services: services,
+                all: all,
+                format: format,
+                noStream: noStream,
+                noTrunc: noTrunc
+            )
+        )
     }
 }
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -28,6 +28,7 @@ struct ComposePlugin: AsyncParsableCommand {
         version: "container-compose 0.1.0",
         subcommands: [
             Config.self,
+            Create.self,
             Up.self,
             Down.self,
             Build.self,
@@ -148,6 +149,51 @@ struct Config: AsyncParsableCommand, ComposeProjectCommand {
     }
 }
 
+/// Implements `compose create`.
+struct Create: AsyncParsableCommand, ComposeProjectCommand {
+    static let configuration = CommandConfiguration(commandName: "create", abstract: "Create service containers without starting them.")
+
+    @OptionGroup var global: GlobalOptions
+    @Flag(name: .customLong("build"), help: "Build images before creating containers.")
+    var build = false
+    @Flag(name: .customLong("no-build"), help: "Do not build images before creating containers.")
+    var noBuild = false
+    @Flag(name: .customLong("force-recreate"), help: "Recreate containers even if they already exist.")
+    var forceRecreate = false
+    @Flag(name: .customLong("no-recreate"), help: "Reuse existing containers.")
+    var noRecreate = false
+    @Option(name: .customLong("pull"), help: "Image pull policy: always, missing, if_not_present, never, or build.")
+    var pull: String?
+    @Flag(name: .customLong("quiet-pull"), help: "Accepted for Docker Compose compatibility.")
+    var quietPull = false
+    @Flag(name: .customLong("remove-orphans"), help: "Remove project containers for services not declared by the Compose file.")
+    var removeOrphans = false
+    @Option(name: .customLong("scale"), help: "Scale SERVICE to NUM. Replica scaling is not supported yet.")
+    var scales: [String] = []
+    @Flag(name: [.customShort("y"), .customLong("yes")], help: "Accepted for Docker Compose compatibility.")
+    var yes = false
+    @Argument(help: "Optional service names to create.")
+    var services: [String] = []
+
+    /// Creates selected service containers without starting them.
+    func run() async throws {
+        let loadedProject = try await project()
+        try await orchestrator().create(
+            project: loadedProject,
+            options: ComposeCreateOptions(
+                services: services,
+                build: build,
+                noBuild: noBuild,
+                forceRecreate: forceRecreate,
+                noRecreate: noRecreate,
+                removeOrphans: removeOrphans,
+                pullPolicy: pull,
+                scales: scales
+            )
+        )
+    }
+}
+
 /// Implements `compose up`.
 struct Up: AsyncParsableCommand, ComposeProjectCommand {
     static let configuration = CommandConfiguration(commandName: "up", abstract: "Create and start services.")
@@ -163,7 +209,7 @@ struct Up: AsyncParsableCommand, ComposeProjectCommand {
     var noRecreate = false
     @Flag(name: .customLong("remove-orphans"), help: "Remove project containers for services not declared by the Compose file.")
     var removeOrphans = false
-    @Option(name: .customLong("pull"), help: "Image pull policy: always, missing, or never.")
+    @Option(name: .customLong("pull"), help: "Image pull policy: always, missing, if_not_present, or never.")
     var pull: String?
     @Argument(help: "Optional service names to start.")
     var services: [String] = []
@@ -378,7 +424,7 @@ struct Run: AsyncParsableCommand, ComposeProjectCommand {
     var servicePorts = false
     @Option(name: .customLong("publish"), help: "Publish a container port to the host. May be repeated.")
     var publish: [String] = []
-    @Option(name: .customLong("pull"), help: "Image pull policy before running: always, missing, or never.")
+    @Option(name: .customLong("pull"), help: "Image pull policy before running: always, missing, if_not_present, or never.")
     var pull: String?
     @Option(name: .customLong("name"), help: "Assign a name to the one-off container.")
     var name: String?

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -61,6 +61,23 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("recognizes ls as a compose subcommand")
+    func recognizesLsAsComposeSubcommand() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "--dry-run",
+            "ls",
+            "--format",
+            "json",
+        ])
+
+        #expect(rewritten == [
+            "ls",
+            "--dry-run",
+            "--format",
+            "json",
+        ])
+    }
+
     @Test("normalizes logs follow shorthand after subcommand")
     func normalizesLogsFollowShorthandAfterSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -97,6 +97,25 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("recognizes stats as a compose subcommand")
+    func recognizesStatsAsComposeSubcommand() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "--project-name",
+            "demo",
+            "stats",
+            "--no-stream",
+            "api",
+        ])
+
+        #expect(rewritten == [
+            "stats",
+            "--project-name",
+            "demo",
+            "--no-stream",
+            "api",
+        ])
+    }
+
     @Test("normalizes logs follow shorthand after subcommand")
     func normalizesLogsFollowShorthandAfterSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeArgumentRewriterTests.swift
@@ -78,6 +78,25 @@ struct ComposeArgumentRewriterTests {
         ])
     }
 
+    @Test("recognizes create as a compose subcommand")
+    func recognizesCreateAsComposeSubcommand() {
+        let rewritten = ComposeArgumentRewriter.rewrite([
+            "--file",
+            "compose.yml",
+            "create",
+            "--build",
+            "api",
+        ])
+
+        #expect(rewritten == [
+            "create",
+            "--file",
+            "compose.yml",
+            "--build",
+            "api",
+        ])
+    }
+
     @Test("normalizes logs follow shorthand after subcommand")
     func normalizesLogsFollowShorthandAfterSubcommand() {
         let rewritten = ComposeArgumentRewriter.rewrite([

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -4238,7 +4238,27 @@ struct ComposeOrchestratorTests {
             try await ComposeOrchestrator().copy(project: ComposeProject(name: "demo", services: [:]), arguments: [])
             Issue.record("Expected cp argument failure")
         } catch let error as ComposeError {
-            #expect(error == .invalidProject("cp requires source and destination"))
+            #expect(error == .invalidProject("cp requires exactly source and destination"))
+        }
+
+        do {
+            try await ComposeOrchestrator().copy(
+                project: ComposeProject(name: "demo", services: ["api": ComposeService(name: "api", image: "example/api")]),
+                arguments: ["api:/tmp/file"]
+            )
+            Issue.record("Expected cp single-operand failure")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("cp requires exactly source and destination"))
+        }
+
+        do {
+            try await ComposeOrchestrator().copy(
+                project: ComposeProject(name: "demo", services: ["api": ComposeService(name: "api", image: "example/api")]),
+                arguments: ["api:/tmp/file", ".", "extra"]
+            )
+            Issue.record("Expected cp extra-operand failure")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("cp requires exactly source and destination"))
         }
 
         do {

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -1670,6 +1670,74 @@ struct ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
+    @Test("stats targets project service containers")
+    func statsTargetsProjectServiceContainers() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api"),
+                "db": composeService(name: "db", image: "postgres") {
+                    $0.containerName = "custom-db"
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).stats(project: project, options: ComposeStatsOptions())
+        try await ComposeOrchestrator(runner: runner).stats(
+            project: project,
+            options: ComposeStatsOptions(services: ["db"], format: "json", noStream: true)
+        )
+
+        #expect(runner.commands.map(\.arguments) == [
+            ["container", "stats", "demo-api-1", "custom-db"],
+            ["container", "stats", "--format", "json", "--no-stream", "custom-db"],
+        ])
+    }
+
+    @Test("stats rejects unsupported options before runtime commands")
+    func statsRejectsUnsupportedOptionsBeforeRuntimeCommands() async throws {
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api"),
+                "db": ComposeService(name: "db", image: "postgres"),
+            ]
+        )
+
+        let cases: [(ComposeStatsOptions, ComposeError)] = [
+            (
+                ComposeStatsOptions(services: ["api", "db"]),
+                .invalidProject("stats accepts at most one service")
+            ),
+            (
+                ComposeStatsOptions(all: true),
+                .unsupported("stats --all: apple/container stats only reports running containers")
+            ),
+            (
+                ComposeStatsOptions(format: "yaml"),
+                .unsupported("stats --format 'yaml': apple/container stats supports table and json output")
+            ),
+            (
+                ComposeStatsOptions(noTrunc: true),
+                .unsupported("stats --no-trunc: apple/container stats does not expose truncation control")
+            ),
+        ]
+
+        for (options, expectedError) in cases {
+            let runner = RecordingRunner()
+            do {
+                try await ComposeOrchestrator(runner: runner).stats(project: project, options: options)
+                Issue.record("Expected unsupported stats option failure")
+            } catch let error as ComposeError {
+                #expect(error == expectedError)
+            } catch {
+                Issue.record("Unexpected error: \(error)")
+            }
+            #expect(runner.commands.isEmpty)
+        }
+    }
+
     @Test("ls lists compose projects with grouped status")
     func lsListsComposeProjectsWithGroupedStatus() async throws {
         let emitted = MessageRecorder()

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -1295,22 +1295,100 @@ struct ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
-    @Test("lists selected service images")
-    func listsSelectedServiceImages() throws {
+    @Test("images lists selected created container image records")
+    func imagesListsSelectedCreatedContainerImageRecords() async throws {
+        let emitted = MessageRecorder()
+        let runner = RecordingRunner(responses: [containerListResult()])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
         let project = ComposeProject(
             name: "demo",
             services: [
                 "api": ComposeService(name: "api", image: "example/api:latest"),
-                "builder": composeService(name: "builder") {
-                    $0.build = ComposeBuild(context: ".")
-                },
+                "worker": ComposeService(name: "worker", image: "example/worker:debug"),
                 "web": ComposeService(name: "web", image: "nginx:latest"),
             ]
         )
 
-        let images = try ComposeOrchestrator().images(project: project, services: ["web", "builder", "api"])
+        try await orchestrator.images(project: project, services: ["api"], options: ComposeImagesOptions())
 
-        #expect(images == ["example/api:latest", "nginx:latest"])
+        #expect(runner.commands.map(\.arguments) == [["container", "list", "--format", "json", "--all"]])
+        let output = try #require(emitted.messages.first)
+        #expect(output.contains("CONTAINER"))
+        #expect(output.contains("REPOSITORY"))
+        #expect(output.contains("demo-api-1"))
+        #expect(output.contains("localhost:5000/example/api"))
+        #expect(output.contains("latest"))
+        #expect(output.contains("aaaaaaaaaaaa"))
+        #expect(output.contains("linux/arm64"))
+        #expect(!output.contains("demo-worker-1"))
+    }
+
+    @Test("images quiet prints created image IDs")
+    func imagesQuietPrintsCreatedImageIDs() async throws {
+        let emitted = MessageRecorder()
+        let runner = RecordingRunner(responses: [containerListResult()])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api:latest"),
+                "worker": ComposeService(name: "worker", image: "example/worker:debug"),
+            ]
+        )
+
+        try await orchestrator.images(project: project, services: [], options: ComposeImagesOptions(quiet: true))
+
+        #expect(runner.commands.map(\.arguments) == [["container", "list", "--format", "json", "--all"]])
+        #expect(emitted.messages == ["aaaaaaaaaaaa\nbbbbbbbbbbbb"])
+    }
+
+    @Test("images json renders created image records")
+    func imagesJSONRendersCreatedImageRecords() async throws {
+        let emitted = MessageRecorder()
+        let runner = RecordingRunner(responses: [containerListResult()])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api:latest"),
+                "worker": ComposeService(name: "worker", image: "example/worker:debug"),
+            ]
+        )
+
+        try await orchestrator.images(project: project, services: [], options: ComposeImagesOptions(format: "json"))
+
+        let data = Data(try #require(emitted.messages.first).utf8)
+        let records = try #require(JSONSerialization.jsonObject(with: data) as? [[String: String]])
+        #expect(records.map { $0["container"] } == ["demo-api-1", "demo-worker-1"])
+        #expect(records.map { $0["repository"] } == ["localhost:5000/example/api", "example/worker"])
+        #expect(records.map { $0["tag"] } == ["latest", "debug"])
+        #expect(records.map { $0["imageID"] } == ["aaaaaaaaaaaa", "bbbbbbbbbbbb"])
+    }
+
+    @Test("images rejects unsupported output formats")
+    func imagesRejectsUnsupportedOutputFormats() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(name: "demo", services: ["api": ComposeService(name: "api", image: "example/api")])
+
+        do {
+            try await ComposeOrchestrator(runner: runner).images(project: project, services: [], options: ComposeImagesOptions(format: "yaml"))
+            Issue.record("Expected unsupported images format error")
+        } catch let error as ComposeError {
+            #expect(error == .unsupported("images --format 'yaml'; supported formats are table and json"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(runner.commands.isEmpty)
     }
 
     @Test("ps filters containers by project label")
@@ -4125,9 +4203,19 @@ private func containerListResult() -> CommandResult {
           {
             "id": "demo-api-1",
             "configuration": {
+              "image": {
+                "reference": "localhost:5000/example/api:latest",
+                "descriptor": {
+                  "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+              },
               "labels": {
                 "\(composeProjectLabel)": "demo",
                 "\(composeServiceLabel)": "api"
+              },
+              "platform": {
+                "os": "linux",
+                "architecture": "arm64"
               }
             },
             "status": {
@@ -4137,9 +4225,19 @@ private func containerListResult() -> CommandResult {
           {
             "id": "other-api-1",
             "configuration": {
+              "image": {
+                "reference": "other/api:latest",
+                "descriptor": {
+                  "digest": "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                }
+              },
               "labels": {
                 "\(composeProjectLabel)": "other",
                 "\(composeServiceLabel)": "api"
+              },
+              "platform": {
+                "os": "linux",
+                "architecture": "arm64"
               }
             },
             "status": {
@@ -4149,6 +4247,12 @@ private func containerListResult() -> CommandResult {
           {
             "id": "demo-worker-1",
             "Config": {
+              "Image": "example/worker:debug",
+              "ImageID": "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+              "Platform": {
+                "OS": "linux",
+                "Architecture": "amd64"
+              },
               "Labels": {
                 "\(composeProjectLabel)": "demo",
                 "\(composeServiceLabel)": "worker"

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -1391,6 +1391,131 @@ struct ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
+    @Test("ls lists compose projects with grouped status")
+    func lsListsComposeProjectsWithGroupedStatus() async throws {
+        let emitted = MessageRecorder()
+        let runner = RecordingRunner(responses: [containerListResult()])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
+
+        try await orchestrator.ls(options: ComposeLsOptions(all: true))
+
+        #expect(runner.commands.map(\.arguments) == [["container", "list", "--format", "json", "--all"]])
+        let output = try #require(emitted.messages.first)
+        #expect(output.contains("NAME"))
+        #expect(output.contains("STATUS"))
+        #expect(output.contains("CONFIG FILES"))
+        #expect(output.contains("demo"))
+        #expect(output.contains("running(1), stopped(1)"))
+        #expect(output.contains("/tmp/demo/compose.yml,/tmp/demo/compose.override.yml"))
+        #expect(output.contains("other"))
+        #expect(output.contains("/tmp/other/compose.yml"))
+    }
+
+    @Test("ls defaults to running projects only")
+    func lsDefaultsToRunningProjectsOnly() async throws {
+        let emitted = MessageRecorder()
+        let runner = RecordingRunner(responses: [containerListResult()])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
+
+        try await orchestrator.ls()
+
+        #expect(runner.commands.map(\.arguments) == [["container", "list", "--format", "json"]])
+        #expect(try #require(emitted.messages.first).contains("demo"))
+    }
+
+    @Test("ls quiet prints filtered project names")
+    func lsQuietPrintsFilteredProjectNames() async throws {
+        let emitted = MessageRecorder()
+        let runner = RecordingRunner(responses: [containerListResult()])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
+
+        try await orchestrator.ls(options: ComposeLsOptions(all: true, quiet: true, filters: ["name=^dem"]))
+
+        #expect(runner.commands.map(\.arguments) == [["container", "list", "--format", "json", "--all"]])
+        #expect(emitted.messages == ["demo"])
+    }
+
+    @Test("ls json renders compose projects")
+    func lsJSONRendersComposeProjects() async throws {
+        let emitted = MessageRecorder()
+        let runner = RecordingRunner(responses: [containerListResult()])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
+
+        try await orchestrator.ls(options: ComposeLsOptions(all: true, format: "json"))
+
+        let data = Data(try #require(emitted.messages.first).utf8)
+        let records = try #require(JSONSerialization.jsonObject(with: data) as? [[String: String]])
+        #expect(records.map { $0["name"] } == ["demo", "other"])
+        #expect(records.map { $0["status"] } == ["running(1), stopped(1)", "running(1)"])
+        #expect(records.map { $0["configFiles"] } == [
+            "/tmp/demo/compose.yml,/tmp/demo/compose.override.yml",
+            "/tmp/other/compose.yml",
+        ])
+    }
+
+    @Test("ls rejects malformed filters before runtime commands")
+    func lsRejectsMalformedFiltersBeforeRuntimeCommands() async throws {
+        let runner = RecordingRunner()
+        let orchestrator = ComposeOrchestrator(runner: runner)
+
+        do {
+            try await orchestrator.ls(options: ComposeLsOptions(filters: ["name"]))
+            Issue.record("Expected invalid filter error")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("ls --filter must be in KEY=VALUE form"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(runner.commands.isEmpty)
+    }
+
+    @Test("ls rejects unsupported filter keys before runtime commands")
+    func lsRejectsUnsupportedFilterKeysBeforeRuntimeCommands() async throws {
+        let runner = RecordingRunner()
+        let orchestrator = ComposeOrchestrator(runner: runner)
+
+        do {
+            try await orchestrator.ls(options: ComposeLsOptions(filters: ["status=running"]))
+            Issue.record("Expected unsupported filter error")
+        } catch let error as ComposeError {
+            #expect(error == .unsupported("ls --filter status; supported filter is name"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(runner.commands.isEmpty)
+    }
+
+    @Test("ls rejects unsupported output formats")
+    func lsRejectsUnsupportedOutputFormats() async throws {
+        let runner = RecordingRunner()
+        let orchestrator = ComposeOrchestrator(runner: runner)
+
+        do {
+            try await orchestrator.ls(options: ComposeLsOptions(format: "yaml"))
+            Issue.record("Expected unsupported ls format error")
+        } catch let error as ComposeError {
+            #expect(error == .unsupported("ls --format 'yaml'; supported formats are table and json"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+
+        #expect(runner.commands.isEmpty)
+    }
+
     @Test("ps filters containers by project label")
     func psFiltersContainersByProjectLabel() async throws {
         let emitted = MessageRecorder()
@@ -3809,6 +3934,7 @@ private extension CommandResult {
 private let composeConfigHashLabel = "com.apple.container.compose.config-hash"
 private let composeProjectLabel = "com.apple.container.compose.project"
 private let composeServiceLabel = "com.apple.container.compose.service"
+private let composeProjectConfigFilesLabel = "com.apple.container.compose.project.config-files"
 
 private struct UnsupportedRuntimeStringFieldCase: Sendable {
     let composeName: String
@@ -4211,7 +4337,9 @@ private func containerListResult() -> CommandResult {
               },
               "labels": {
                 "\(composeProjectLabel)": "demo",
-                "\(composeServiceLabel)": "api"
+                "\(composeServiceLabel)": "api",
+                "\(composeConfigHashLabel)": "api-hash",
+                "\(composeProjectConfigFilesLabel)": "/tmp/demo/compose.yml,/tmp/demo/compose.override.yml"
               },
               "platform": {
                 "os": "linux",
@@ -4233,7 +4361,9 @@ private func containerListResult() -> CommandResult {
               },
               "labels": {
                 "\(composeProjectLabel)": "other",
-                "\(composeServiceLabel)": "api"
+                "\(composeServiceLabel)": "api",
+                "\(composeConfigHashLabel)": "other-hash",
+                "\(composeProjectConfigFilesLabel)": "/tmp/other/compose.yml"
               },
               "platform": {
                 "os": "linux",
@@ -4255,7 +4385,9 @@ private func containerListResult() -> CommandResult {
               },
               "Labels": {
                 "\(composeProjectLabel)": "demo",
-                "\(composeServiceLabel)": "worker"
+                "\(composeServiceLabel)": "worker",
+                "\(composeConfigHashLabel)": "worker-hash",
+                "\(composeProjectConfigFilesLabel)": "/tmp/demo/compose.yml"
               }
             },
             "Status": {

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -169,6 +169,260 @@ struct ComposeOrchestratorTests {
         #expect(Array(run.suffix(2)) == ["example/api:latest", "serve"])
     }
 
+    @Test("create creates resources and service containers without starting them")
+    func createCreatesResourcesAndServiceContainersWithoutStartingThem() async throws {
+        let runner = RecordingRunner(responses: [
+            .success,
+            .success,
+            .failure,
+            .success,
+        ])
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api:latest") {
+                    $0.command = ["serve"]
+                    $0.environment = ["LOG_LEVEL": "debug"]
+                    $0.ports = ["8080:80"]
+                    $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
+                    $0.networks = ["default"]
+                    $0.platform = "linux/amd64"
+                },
+            ]
+        ) {
+            $0.networks = ["default": ComposeNetwork(name: "default")]
+            $0.volumes = ["cache": ComposeVolume(name: "cache")]
+        }
+
+        try await ComposeOrchestrator(runner: runner).create(project: project, options: ComposeCreateOptions())
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands[0].containsSequence(["container", "network", "create"]))
+        #expect(commands[1].containsSequence(["container", "volume", "create"]))
+        #expect(commands[2] == ["container", "inspect", "demo-api-1"])
+
+        let create = commands[3]
+        #expect(create.starts(with: ["container", "create", "--name", "demo-api-1"]))
+        #expect(!create.contains("--detach"))
+        #expect(create.containsSequence(["--label", "com.apple.container.compose.project=demo"]))
+        #expect(create.containsSequence(["--label", "com.apple.container.compose.service=api"]))
+        #expect(create.containsSequence(["--label", "com.apple.container.compose.oneoff=false"]))
+        #expect(create.containsSequence(["--env", "LOG_LEVEL=debug"]))
+        #expect(create.containsSequence(["--publish", "8080:80"]))
+        #expect(create.containsSequence(["--volume", "demo_cache:/cache"]))
+        #expect(create.containsSequence(["--network", "demo_default"]))
+        #expect(create.containsSequence(["--platform", "linux/amd64"]))
+        #expect(Array(create.suffix(2)) == ["example/api:latest", "serve"])
+    }
+
+    @Test("create applies build pull policy before creating containers")
+    func createAppliesBuildPullPolicyBeforeCreatingContainers() async throws {
+        let runner = RecordingRunner(responses: [
+            .success,
+            .success,
+            .failure,
+            .success,
+            .failure,
+            .success,
+        ])
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.build = ComposeBuild(context: "api")
+                },
+                "worker": composeService(name: "worker") {
+                    $0.build = ComposeBuild(context: "worker")
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).create(
+            project: project,
+            options: ComposeCreateOptions(pullPolicy: "build")
+        )
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands[0].containsSequence(["container", "build", "--tag", "example/api"]))
+        #expect(commands[0].last == "api")
+        #expect(commands[1].containsSequence(["container", "build", "--tag", "demo_worker:latest"]))
+        #expect(commands[1].last == "worker")
+        #expect(commands[2] == ["container", "inspect", "demo-api-1"])
+        #expect(commands[3].starts(with: ["container", "create", "--name", "demo-api-1"]))
+        #expect(commands[4] == ["container", "inspect", "demo-worker-1"])
+        #expect(commands[5].starts(with: ["container", "create", "--name", "demo-worker-1"]))
+    }
+
+    @Test("create pull if not present pulls only absent images")
+    func createPullIfNotPresentPullsOnlyAbsentImages() async throws {
+        let runner = RecordingRunner(responses: [
+            .success,
+            .failure,
+            .success,
+            .failure,
+            .success,
+            .failure,
+            .success,
+        ])
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api"),
+                "db": ComposeService(name: "db", image: "postgres"),
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).create(
+            project: project,
+            options: ComposeCreateOptions(pullPolicy: "if_not_present")
+        )
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands[0] == ["container", "image", "inspect", "example/api"])
+        #expect(commands[1] == ["container", "image", "inspect", "postgres"])
+        #expect(commands[2] == ["container", "image", "pull", "postgres"])
+        #expect(commands[3] == ["container", "inspect", "demo-api-1"])
+        #expect(commands[4].starts(with: ["container", "create", "--name", "demo-api-1"]))
+        #expect(commands[5] == ["container", "inspect", "demo-db-1"])
+        #expect(commands[6].starts(with: ["container", "create", "--name", "demo-db-1"]))
+    }
+
+    @Test("create auto builds build-only services by default")
+    func createAutoBuildsBuildOnlyServicesByDefault() async throws {
+        let runner = RecordingRunner(responses: [
+            .success,
+            .failure,
+            .success,
+        ])
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "worker": composeService(name: "worker") {
+                    $0.build = ComposeBuild(context: "worker")
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).create(project: project, options: ComposeCreateOptions())
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands[0].containsSequence(["container", "build", "--tag", "demo_worker:latest"]))
+        #expect(commands[0].last == "worker")
+        #expect(commands[1] == ["container", "inspect", "demo-worker-1"])
+        #expect(commands[2].starts(with: ["container", "create", "--name", "demo-worker-1"]))
+    }
+
+    @Test("create no-build skips auto build for build-only service")
+    func createNoBuildSkipsAutoBuildForBuildOnlyService() async throws {
+        let runner = RecordingRunner(responses: [
+            .failure,
+            .success,
+        ])
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "worker": composeService(name: "worker") {
+                    $0.build = ComposeBuild(context: "worker")
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).create(
+            project: project,
+            options: ComposeCreateOptions(noBuild: true)
+        )
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands.count == 2)
+        #expect(!commands.contains { $0.containsSequence(["container", "build"]) })
+        #expect(commands[0] == ["container", "inspect", "demo-worker-1"])
+        #expect(commands[1].starts(with: ["container", "create", "--name", "demo-worker-1"]))
+        #expect(commands[1].last == "demo_worker:latest")
+    }
+
+    @Test("create reuses or recreates existing containers according to policy")
+    func createReusesOrRecreatesExistingContainersAccordingToPolicy() async throws {
+        let emitted = MessageRecorder()
+        let reuseRunner = RecordingRunner(responses: [.success])
+        try await ComposeOrchestrator(
+            runner: reuseRunner,
+            options: ComposeExecutionOptions(emit: { emitted.append($0) })
+        )
+        .create(
+            project: ComposeProject(name: "demo", services: ["api": ComposeService(name: "api", image: "example/api")]),
+            options: ComposeCreateOptions(noRecreate: true)
+        )
+
+        #expect(reuseRunner.commands.map(\.arguments) == [["container", "inspect", "demo-api-1"]])
+        #expect(emitted.messages == ["compose: reusing existing container demo-api-1"])
+
+        let recreateRunner = RecordingRunner(responses: [
+            inspectResult(configHash: "stale"),
+            .success,
+            .success,
+            .success,
+        ])
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.stopSignal = "SIGUSR1"
+                    $0.stopGracePeriodSeconds = 9
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: recreateRunner).create(project: project, options: ComposeCreateOptions())
+
+        #expect(recreateRunner.commands[0].arguments == ["container", "inspect", "demo-api-1"])
+        #expect(recreateRunner.commands[1].arguments == ["container", "stop", "--signal", "SIGUSR1", "--time", "9", "demo-api-1"])
+        #expect(recreateRunner.commands[2].arguments == ["container", "delete", "demo-api-1"])
+        #expect(recreateRunner.commands[3].arguments.starts(with: ["container", "create", "--name", "demo-api-1"]))
+    }
+
+    @Test("create validates incompatible options and unsupported scale before side effects")
+    func createValidatesIncompatibleOptionsAndUnsupportedScaleBeforeSideEffects() async throws {
+        let project = ComposeProject(name: "demo", services: ["api": ComposeService(name: "api", image: "example/api")])
+
+        for options in [
+            ComposeCreateOptions(build: true, noBuild: true),
+            ComposeCreateOptions(forceRecreate: true, noRecreate: true),
+        ] {
+            let runner = RecordingRunner()
+            do {
+                try await ComposeOrchestrator(runner: runner).create(project: project, options: options)
+                Issue.record("Expected invalid create option combination")
+            } catch let error as ComposeError {
+                #expect(error == .invalidProject(options.build ? "--build and --no-build are incompatible" : "--force-recreate and --no-recreate are incompatible"))
+            }
+            #expect(runner.commands.isEmpty)
+        }
+
+        let scaleRunner = RecordingRunner()
+        do {
+            try await ComposeOrchestrator(runner: scaleRunner).create(
+                project: project,
+                options: ComposeCreateOptions(scales: ["api=2"])
+            )
+            Issue.record("Expected unsupported create scale failure")
+        } catch let error as ComposeError {
+            #expect(error == .unsupported("create --scale: service replica scaling is not implemented by container-compose yet"))
+        }
+        #expect(scaleRunner.commands.isEmpty)
+
+        let pullRunner = RecordingRunner()
+        do {
+            try await ComposeOrchestrator(runner: pullRunner).create(
+                project: project,
+                options: ComposeCreateOptions(pullPolicy: "daily")
+            )
+            Issue.record("Expected unsupported create pull policy failure")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("unsupported pull policy 'daily'"))
+        }
+        #expect(pullRunner.commands.isEmpty)
+    }
+
     @Test("up uses external resource names without creating project resources")
     func upUsesExternalResourceNamesWithoutCreatingProjectResources() async throws {
         let runner = RecordingRunner(responses: [
@@ -361,6 +615,31 @@ struct ComposeOrchestratorTests {
         #expect(commands[2] == ["container", "image", "pull", "postgres"])
         #expect(commands[3] == ["container", "inspect", "demo-api-1"])
         #expect(commands[5] == ["container", "inspect", "demo-db-1"])
+    }
+
+    @Test("up pull if not present uses the missing-image flow")
+    func upPullIfNotPresentUsesMissingImageFlow() async throws {
+        let runner = RecordingRunner(responses: [
+            .failure,
+            .success,
+            .failure,
+            .success,
+        ])
+        let project = ComposeProject(
+            name: "demo",
+            services: ["api": ComposeService(name: "api", image: "example/api")]
+        )
+
+        try await ComposeOrchestrator(runner: runner).up(
+            project: project,
+            options: ComposeUpOptions(pullPolicy: "if_not_present")
+        )
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands[0] == ["container", "image", "inspect", "example/api"])
+        #expect(commands[1] == ["container", "image", "pull", "example/api"])
+        #expect(commands[2] == ["container", "inspect", "demo-api-1"])
+        #expect(commands[3].starts(with: ["container", "run", "--name", "demo-api-1"]))
     }
 
     @Test("up applies service pull policies when no global pull policy is set")
@@ -3238,6 +3517,29 @@ struct ComposeOrchestratorTests {
         #expect(absentCommands[0] == ["container", "image", "inspect", "alpine"])
         #expect(absentCommands[1] == ["container", "image", "pull", "alpine"])
         #expect(absentCommands[2].starts(with: ["container", "run"]))
+    }
+
+    @Test("run pull if not present uses the missing-image flow")
+    func runPullIfNotPresentUsesMissingImageFlow() async throws {
+        let runner = RecordingRunner(responses: [.failure, .success])
+        let project = ComposeProject(
+            name: "demo",
+            services: ["job": ComposeService(name: "job", image: "alpine")]
+        )
+
+        try await ComposeOrchestrator(runner: runner).run(
+            project: project,
+            serviceName: "job",
+            options: composeRunOptions(command: ["true"]) {
+                $0.pullPolicy = "if_not_present"
+            }
+        )
+
+        let commands = runner.commands.map(\.arguments)
+        #expect(commands[0] == ["container", "image", "inspect", "alpine"])
+        #expect(commands[1] == ["container", "image", "pull", "alpine"])
+        #expect(commands[2].starts(with: ["container", "run"]))
+        #expect(Array(commands[2].suffix(2)) == ["alpine", "true"])
     }
 
     @Test("run rejects unsupported explicit pull policy")


### PR DESCRIPTION
## Summary

- Promote the latest 10 validated develop-cycle commits to main.
- Add compose `images`, `ls`, `create`, and `stats` support.
- Improve CI cache behavior, smoke coverage, `cp` operand validation, and compatibility documentation consistency.

## Local validation

- `make swift-test`
- `make ci`
- `make package` for the stats slice
- `actionlint .github/workflows/ci.yml`
- `make lint`
- `git diff --check`
- Coverage gate: Swift 94.01%, Go 94.55%
- Local Sonar scan: `SONAR_TOKEN= SONAR_BRANCH=develop make sonar-scan`
