### PR TITLE
refactor(create): reduce create options initializer

### DIFF
--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -77,33 +77,21 @@ public struct ComposeUpOptions {
 
 /// Options for `compose create`.
 public struct ComposeCreateOptions {
-    public var services: [String]
-    public var build: Bool
-    public var noBuild: Bool
-    public var forceRecreate: Bool
-    public var noRecreate: Bool
-    public var removeOrphans: Bool
+    public var services: [String] = []
+    public var build = false
+    public var noBuild = false
+    public var forceRecreate = false
+    public var noRecreate = false
+    public var removeOrphans = false
     public var pullPolicy: String?
-    public var scales: [String]
+    public var scales: [String] = []
 
-    public init(
-        services: [String] = [],
-        build: Bool = false,
-        noBuild: Bool = false,
-        forceRecreate: Bool = false,
-        noRecreate: Bool = false,
-        removeOrphans: Bool = false,
-        pullPolicy: String? = nil,
-        scales: [String] = []
-    ) {
-        self.services = services
-        self.build = build
-        self.noBuild = noBuild
-        self.forceRecreate = forceRecreate
-        self.noRecreate = noRecreate
-        self.removeOrphans = removeOrphans
-        self.pullPolicy = pullPolicy
-        self.scales = scales
+    public init() {
+        // Stored property defaults represent Docker Compose's default create behavior.
+    }
+
+    public init(_ configure: (inout ComposeCreateOptions) -> Void) {
+        configure(&self)
     }
 }
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -181,16 +181,16 @@ struct Create: AsyncParsableCommand, ComposeProjectCommand {
         let loadedProject = try await project()
         try await orchestrator().create(
             project: loadedProject,
-            options: ComposeCreateOptions(
-                services: services,
-                build: build,
-                noBuild: noBuild,
-                forceRecreate: forceRecreate,
-                noRecreate: noRecreate,
-                removeOrphans: removeOrphans,
-                pullPolicy: pull,
-                scales: scales
-            )
+            options: ComposeCreateOptions {
+                $0.services = services
+                $0.build = build
+                $0.noBuild = noBuild
+                $0.forceRecreate = forceRecreate
+                $0.noRecreate = noRecreate
+                $0.removeOrphans = removeOrphans
+                $0.pullPolicy = pull
+                $0.scales = scales
+            }
         )
     }
 }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -239,7 +239,9 @@ struct ComposeOrchestratorTests {
 
         try await ComposeOrchestrator(runner: runner).create(
             project: project,
-            options: ComposeCreateOptions(pullPolicy: "build")
+            options: ComposeCreateOptions {
+                $0.pullPolicy = "build"
+            }
         )
 
         let commands = runner.commands.map(\.arguments)
@@ -274,7 +276,9 @@ struct ComposeOrchestratorTests {
 
         try await ComposeOrchestrator(runner: runner).create(
             project: project,
-            options: ComposeCreateOptions(pullPolicy: "if_not_present")
+            options: ComposeCreateOptions {
+                $0.pullPolicy = "if_not_present"
+            }
         )
 
         let commands = runner.commands.map(\.arguments)
@@ -329,7 +333,9 @@ struct ComposeOrchestratorTests {
 
         try await ComposeOrchestrator(runner: runner).create(
             project: project,
-            options: ComposeCreateOptions(noBuild: true)
+            options: ComposeCreateOptions {
+                $0.noBuild = true
+            }
         )
 
         let commands = runner.commands.map(\.arguments)
@@ -350,7 +356,9 @@ struct ComposeOrchestratorTests {
         )
         .create(
             project: ComposeProject(name: "demo", services: ["api": ComposeService(name: "api", image: "example/api")]),
-            options: ComposeCreateOptions(noRecreate: true)
+            options: ComposeCreateOptions {
+                $0.noRecreate = true
+            }
         )
 
         #expect(reuseRunner.commands.map(\.arguments) == [["container", "inspect", "demo-api-1"]])
@@ -385,8 +393,14 @@ struct ComposeOrchestratorTests {
         let project = ComposeProject(name: "demo", services: ["api": ComposeService(name: "api", image: "example/api")])
 
         for options in [
-            ComposeCreateOptions(build: true, noBuild: true),
-            ComposeCreateOptions(forceRecreate: true, noRecreate: true),
+            ComposeCreateOptions {
+                $0.build = true
+                $0.noBuild = true
+            },
+            ComposeCreateOptions {
+                $0.forceRecreate = true
+                $0.noRecreate = true
+            },
         ] {
             let runner = RecordingRunner()
             do {
@@ -402,7 +416,9 @@ struct ComposeOrchestratorTests {
         do {
             try await ComposeOrchestrator(runner: scaleRunner).create(
                 project: project,
-                options: ComposeCreateOptions(scales: ["api=2"])
+                options: ComposeCreateOptions {
+                    $0.scales = ["api=2"]
+                }
             )
             Issue.record("Expected unsupported create scale failure")
         } catch let error as ComposeError {
@@ -414,7 +430,9 @@ struct ComposeOrchestratorTests {
         do {
             try await ComposeOrchestrator(runner: pullRunner).create(
                 project: project,
-                options: ComposeCreateOptions(pullPolicy: "daily")
+                options: ComposeCreateOptions {
+                    $0.pullPolicy = "daily"
+                }
             )
             Issue.record("Expected unsupported create pull policy failure")
         } catch let error as ComposeError {


### PR DESCRIPTION
## Summary

- Resolve SonarCloud `swift:S107` by replacing the long `ComposeCreateOptions` initializer with defaulted properties and a closure-style initializer.
- Update create command wiring and existing create-option tests to use the new options API.

## Validation

- `make swift-test`
- `make ci`
- `git diff --check`
- `actionlint .github/workflows/ci.yml`
- Coverage gate: Swift 94.02%, Go 94.55%
- `SONAR_TOKEN= SONAR_BRANCH=develop make sonar-scan`
