### PR TITLE
fix(model): reduce normalized initializer parameters

### DIFF
--- a/Sources/ComposeCore/NormalizedProject.swift
+++ b/Sources/ComposeCore/NormalizedProject.swift
@@ -384,6 +384,54 @@ public struct ComposeNetworkOptions: Codable, Equatable {
 
 /// Build configuration for a Compose service.
 public struct ComposeBuild: Codable, Equatable {
+    /// Build cache sources and destinations.
+    public struct Cache: Equatable {
+        public var from: [String]?
+        public var to: [String]?
+
+        public init(from: [String]? = nil, to: [String]? = nil) {
+            self.from = from
+            self.to = to
+        }
+    }
+
+    /// Build labels and secrets that become build-time metadata.
+    public struct Metadata: Equatable {
+        public var labels: [String: String]?
+        public var secrets: [ComposeBuildSecret]?
+
+        public init(labels: [String: String]? = nil, secrets: [ComposeBuildSecret]? = nil) {
+            self.labels = labels
+            self.secrets = secrets
+        }
+    }
+
+    /// Optional build behavior that is not required for every service.
+    public struct Options: Equatable {
+        public var target: String?
+        public var noCache: Bool?
+        public var pull: Bool?
+        public var platforms: [String]?
+        public var tags: [String]?
+        public var unsupportedFields: [String]?
+
+        public init(
+            target: String? = nil,
+            noCache: Bool? = nil,
+            pull: Bool? = nil,
+            platforms: [String]? = nil,
+            tags: [String]? = nil,
+            unsupportedFields: [String]? = nil
+        ) {
+            self.target = target
+            self.noCache = noCache
+            self.pull = pull
+            self.platforms = platforms
+            self.tags = tags
+            self.unsupportedFields = unsupportedFields
+        }
+    }
+
     public var context: String?
     public var dockerfile: String?
     public var args: [String: String]?
@@ -402,30 +450,23 @@ public struct ComposeBuild: Codable, Equatable {
         context: String? = nil,
         dockerfile: String? = nil,
         args: [String: String]? = nil,
-        cacheFrom: [String]? = nil,
-        cacheTo: [String]? = nil,
-        labels: [String: String]? = nil,
-        secrets: [ComposeBuildSecret]? = nil,
-        target: String? = nil,
-        noCache: Bool? = nil,
-        pull: Bool? = nil,
-        platforms: [String]? = nil,
-        tags: [String]? = nil,
-        unsupportedFields: [String]? = nil
+        cache: Cache = Cache(),
+        metadata: Metadata = Metadata(),
+        options: Options = Options()
     ) {
         self.context = context
         self.dockerfile = dockerfile
         self.args = args
-        self.cacheFrom = cacheFrom
-        self.cacheTo = cacheTo
-        self.labels = labels
-        self.secrets = secrets
-        self.target = target
-        self.noCache = noCache
-        self.pull = pull
-        self.platforms = platforms
-        self.tags = tags
-        self.unsupportedFields = unsupportedFields
+        self.cacheFrom = cache.from
+        self.cacheTo = cache.to
+        self.labels = metadata.labels
+        self.secrets = metadata.secrets
+        self.target = options.target
+        self.noCache = options.noCache
+        self.pull = options.pull
+        self.platforms = options.platforms
+        self.tags = options.tags
+        self.unsupportedFields = options.unsupportedFields
     }
 }
 
@@ -461,6 +502,17 @@ public struct ComposeMount: Codable, Equatable {
 
 /// Network definition normalized from the Compose project.
 public struct ComposeNetwork: Codable, Equatable {
+    /// IPAM subnets supported by Apple `container` network creation.
+    public struct Subnets: Equatable {
+        public var ipv4Subnet: String?
+        public var ipv6Subnet: String?
+
+        public init(ipv4Subnet: String? = nil, ipv6Subnet: String? = nil) {
+            self.ipv4Subnet = ipv4Subnet
+            self.ipv6Subnet = ipv6Subnet
+        }
+    }
+
     public var name: String
     public var external: Bool?
     public var driver: String?
@@ -476,8 +528,7 @@ public struct ComposeNetwork: Codable, Equatable {
         driver: String? = nil,
         isInternal: Bool? = nil,
         labels: [String: String]? = nil,
-        ipv4Subnet: String? = nil,
-        ipv6Subnet: String? = nil,
+        subnets: Subnets = Subnets(),
         unsupportedFields: [String]? = nil
     ) {
         self.name = name
@@ -485,8 +536,8 @@ public struct ComposeNetwork: Codable, Equatable {
         self.driver = driver
         self.isInternal = isInternal
         self.labels = labels
-        self.ipv4Subnet = ipv4Subnet
-        self.ipv6Subnet = ipv6Subnet
+        self.ipv4Subnet = subnets.ipv4Subnet
+        self.ipv6Subnet = subnets.ipv6Subnet
         self.unsupportedFields = unsupportedFields
     }
 

--- a/Tests/ComposeCoreTests/ComposeNormalizerTests.swift
+++ b/Tests/ComposeCoreTests/ComposeNormalizerTests.swift
@@ -168,8 +168,10 @@ struct ComposeNormalizerTests {
         #expect(project.networks["default"] == ComposeNetwork(
             name: "sample_default",
             isInternal: true,
-            ipv4Subnet: "10.10.0.0/24",
-            ipv6Subnet: "fd00:10::/64"
+            subnets: ComposeNetwork.Subnets(
+                ipv4Subnet: "10.10.0.0/24",
+                ipv6Subnet: "fd00:10::/64"
+            )
         ))
         #expect(project.volumes["data"] != nil)
     }
@@ -227,6 +229,57 @@ struct ComposeNormalizerTests {
         ])
         #expect(project.services["api"]?.build?.unsupportedFields == nil)
         #expect(project.services["worker"]?.build?.unsupportedFields == ["secrets"])
+    }
+
+    @Test("grouped model initializers preserve flat normalized fields")
+    func groupedModelInitializersPreserveFlatNormalizedFields() throws {
+        let build = ComposeBuild(
+            context: "api",
+            dockerfile: "Containerfile",
+            args: ["VERSION": "1"],
+            cache: ComposeBuild.Cache(
+                from: ["type=registry,ref=example/api:cache"],
+                to: ["type=local,dest=.cache"]
+            ),
+            metadata: ComposeBuild.Metadata(
+                labels: ["org.opencontainers.image.title": "api"],
+                secrets: [ComposeBuildSecret(id: "token", environment: "TOKEN")]
+            ),
+            options: ComposeBuild.Options(
+                target: "runtime",
+                noCache: true,
+                pull: true,
+                platforms: ["linux/arm64"],
+                tags: ["example/api:latest"],
+                unsupportedFields: ["ssh"]
+            )
+        )
+        let network = ComposeNetwork(
+            name: "backend",
+            isInternal: true,
+            subnets: ComposeNetwork.Subnets(
+                ipv4Subnet: "10.10.0.0/24",
+                ipv6Subnet: "fd00:10::/64"
+            )
+        )
+
+        #expect(build.cacheFrom == ["type=registry,ref=example/api:cache"])
+        #expect(build.cacheTo == ["type=local,dest=.cache"])
+        #expect(build.labels == ["org.opencontainers.image.title": "api"])
+        #expect(build.secrets == [ComposeBuildSecret(id: "token", environment: "TOKEN")])
+        #expect(build.target == "runtime")
+        #expect(build.noCache == true)
+        #expect(build.pull == true)
+        #expect(build.platforms == ["linux/arm64"])
+        #expect(build.tags == ["example/api:latest"])
+        #expect(build.unsupportedFields == ["ssh"])
+        #expect(network.ipv4Subnet == "10.10.0.0/24")
+        #expect(network.ipv6Subnet == "fd00:10::/64")
+
+        let encodedNetwork = String(data: try JSONEncoder().encode(network), encoding: .utf8) ?? ""
+        #expect(encodedNetwork.contains("\"ipv4Subnet\""))
+        #expect(encodedNetwork.contains("\"ipv6Subnet\""))
+        #expect(!encodedNetwork.contains("\"subnets\""))
     }
 
     @Test("normalizes network mode through compose-go")

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -541,8 +541,10 @@ struct ComposeOrchestratorTests {
                     name: "backend",
                     isInternal: true,
                     labels: ["com.example.network": "backend"],
-                    ipv4Subnet: "10.77.0.0/24",
-                    ipv6Subnet: "fd77::/64"
+                    subnets: ComposeNetwork.Subnets(
+                        ipv4Subnet: "10.77.0.0/24",
+                        ipv6Subnet: "fd77::/64"
+                    )
                 ),
             ]
         }
@@ -584,8 +586,10 @@ struct ComposeOrchestratorTests {
                 "backend": ComposeNetwork(
                     name: "backend",
                     isInternal: true,
-                    ipv4Subnet: "10.77.0.0/24",
-                    ipv6Subnet: "fd77::/64"
+                    subnets: ComposeNetwork.Subnets(
+                        ipv4Subnet: "10.77.0.0/24",
+                        ipv6Subnet: "fd77::/64"
+                    )
                 ),
             ]
         }
@@ -2208,7 +2212,10 @@ struct ComposeOrchestratorTests {
             name: "demo",
             services: [
                 "api": composeService(name: "api", image: "example/api") {
-                    $0.build = ComposeBuild(context: "api", unsupportedFields: ["additional_contexts", "ssh"])
+                    $0.build = ComposeBuild(
+                        context: "api",
+                        options: ComposeBuild.Options(unsupportedFields: ["additional_contexts", "ssh"])
+                    )
                     $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
                 },
             ]
@@ -3531,18 +3538,24 @@ struct ComposeOrchestratorTests {
                         context: "api",
                         dockerfile: "Containerfile",
                         args: ["VERSION": "1"],
-                        cacheFrom: ["type=registry,ref=example/api:cache"],
-                        cacheTo: ["type=local,dest=.cache"],
-                        labels: ["org.opencontainers.image.title": "api", "build.label": "true"],
-                        secrets: [
-                            ComposeBuildSecret(id: "file_token", file: "./token.txt"),
-                            ComposeBuildSecret(id: "npm_token", environment: "NPM_TOKEN"),
-                        ],
-                        target: "runtime",
-                        noCache: true,
-                        pull: true,
-                        platforms: ["linux/amd64", "linux/arm64"],
-                        tags: ["example/api:latest", "example/api:dev", "example/api:test"]
+                        cache: ComposeBuild.Cache(
+                            from: ["type=registry,ref=example/api:cache"],
+                            to: ["type=local,dest=.cache"]
+                        ),
+                        metadata: ComposeBuild.Metadata(
+                            labels: ["org.opencontainers.image.title": "api", "build.label": "true"],
+                            secrets: [
+                                ComposeBuildSecret(id: "file_token", file: "./token.txt"),
+                                ComposeBuildSecret(id: "npm_token", environment: "NPM_TOKEN"),
+                            ]
+                        ),
+                        options: ComposeBuild.Options(
+                            target: "runtime",
+                            noCache: true,
+                            pull: true,
+                            platforms: ["linux/amd64", "linux/arm64"],
+                            tags: ["example/api:latest", "example/api:dev", "example/api:test"]
+                        )
                     )
                 },
                 "worker": composeService(name: "worker") {
@@ -3589,7 +3602,10 @@ struct ComposeOrchestratorTests {
             name: "demo",
             services: [
                 "api": composeService(name: "api", image: "example/api:latest") {
-                    $0.build = ComposeBuild(context: "api", noCache: true)
+                    $0.build = ComposeBuild(
+                        context: "api",
+                        options: ComposeBuild.Options(noCache: true)
+                    )
                 },
             ]
         )
@@ -3607,7 +3623,10 @@ struct ComposeOrchestratorTests {
             name: "demo",
             services: [
                 "api": composeService(name: "api", image: "example/api:latest") {
-                    $0.build = ComposeBuild(context: "api", unsupportedFields: ["dockerfile_inline", "secrets"])
+                    $0.build = ComposeBuild(
+                        context: "api",
+                        options: ComposeBuild.Options(unsupportedFields: ["dockerfile_inline", "secrets"])
+                    )
                 },
             ]
         )
@@ -3632,7 +3651,9 @@ struct ComposeOrchestratorTests {
                 "api": composeService(name: "api", image: "example/api:latest") {
                     $0.build = ComposeBuild(
                         context: "api",
-                        secrets: [ComposeBuildSecret(id: "both", file: "./token.txt", environment: "TOKEN")]
+                        metadata: ComposeBuild.Metadata(
+                            secrets: [ComposeBuildSecret(id: "both", file: "./token.txt", environment: "TOKEN")]
+                        )
                     )
                 },
             ]
@@ -7405,7 +7426,10 @@ struct ComposeOrchestratorTests {
             name: "demo",
             services: [
                 "job": composeService(name: "job", image: "alpine") {
-                    $0.build = ComposeBuild(context: "job", unsupportedFields: ["entitlements", "ssh"])
+                    $0.build = ComposeBuild(
+                        context: "job",
+                        options: ComposeBuild.Options(unsupportedFields: ["entitlements", "ssh"])
+                    )
                     $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
                 },
             ]


### PR DESCRIPTION
## Summary
- Reduces `ComposeBuild` and `ComposeNetwork` initializer parameter counts under the Sonar Swift S107 threshold.
- Groups related initializer input into `Cache`, `Metadata`, `Options`, and `Subnets` helper values while preserving the flat normalized model fields.
- Adds a regression test proving grouped model initializers still populate flat fields and encode network subnets without a nested `subnets` key.

## Validation
- `swift test --filter ComposeNormalizerTests`
- `swift test --filter ComposeOrchestratorTests`
- `make ci` (Swift 91.76%, Go 92.43%)
- `SONAR_BRANCH=develop SONAR_QUALITYGATE_WAIT=false make sonar-scan`

## Notes
- Local Sonar quality-gate waiting remains blocked by token permissions; no-wait analysis submitted and processed successfully.