### PR TITLE
fix(sonar): remediate Swift static analysis findings

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -121,7 +121,7 @@ Run the same validation used by GitHub Actions:
 make ci
 ```
 
-`make ci` runs required Markdown linting, Python coverage-tool tests, Go formatting checks, Hawkeye license-header checks, Swift and Go coverage, the coverage threshold gate, the Go helper build, and the CLI smoke test. Swift build and test targets use the checked-in `Package.resolved` by default so CI fails quickly if dependency versions need an intentional lockfile refresh. The smoke test builds the debug `compose` executable before exercising representative commands.
+`make ci` runs required Markdown linting, Python coverage-tool tests, Go formatting checks, Hawkeye license-header checks, Swift and Go coverage, the coverage threshold gate, the Go helper build, and the CLI smoke test. Swift build and test targets use the checked-in `Package.resolved` by default so CI fails quickly if dependency versions need an intentional lockfile refresh. The CI smoke test reuses the debug `compose` executable emitted by the Swift coverage test build, while standalone `make cli-smoke` still builds the debug executable before exercising representative commands.
 
 Run the faster non-coverage source checks with:
 

--- a/Makefile
+++ b/Makefile
@@ -67,13 +67,13 @@ else
 SWIFT_TEST_FLAGS ?=
 endif
 
-.PHONY: all workflow ci clean run build build-release test resolve swift-test-build swift-test swift-coverage go-test go-build cli-smoke coverage coverage-check sonar sonar-scan package coverage-tools-test lint format fmt check check-licenses update-licenses pre-commit
+.PHONY: all workflow ci clean run build build-release test resolve swift-test-build swift-test swift-coverage go-test go-build cli-smoke cli-smoke-built coverage coverage-check sonar sonar-scan package coverage-tools-test lint format fmt check check-licenses update-licenses pre-commit
 
 all: workflow
 
 workflow: ci package
 
-ci: check coverage-check go-build cli-smoke
+ci: check coverage-check go-build cli-smoke-built
 
 resolve:
 	$(SWIFT) package resolve
@@ -121,7 +121,13 @@ go-test:
 go-build:
 	cd Tools/compose-normalizer && $(GO) build -o compose-normalizer .
 
-cli-smoke: build
+cli-smoke: build cli-smoke-built
+
+cli-smoke-built:
+	@test -x .build/debug/compose || { \
+		printf '.build/debug/compose is missing; run make build or make swift-test-build before make cli-smoke-built\n' >&2; \
+		exit 2; \
+	}
 	.build/debug/compose --ansi never version >/dev/null
 	.build/debug/compose version --dry-run >/dev/null
 	version_short_output="$$(".build/debug/compose" version --short)"; \

--- a/PLAN.md
+++ b/PLAN.md
@@ -497,6 +497,15 @@ is blocked upstream, and gray is not started.
     <tr>
       <td colspan="4"><strong>Notes:</strong> Removed the unused <code>project</code> parameter from replica support validation and its call sites so the helper signature reflects the data it actually needs.</td>
     </tr>
+    <tr>
+      <td>Sonar container summary initializer grouping</td>
+      <td>2026-06-18 19:28:33 BST</td>
+      <td>2026-06-18 19:28:33 BST</td>
+      <td>2026-06-18 19:28:33 BST</td>
+    </tr>
+    <tr>
+      <td colspan="4"><strong>Notes:</strong> Grouped discovered image metadata behind a typed <code>ComposeContainerSummary.Image</code> constructor value so the public summary initializer stays under the Sonar parameter threshold while preserving flat stored discovery fields.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -488,6 +488,15 @@ is blocked upstream, and gray is not started.
     <tr>
       <td colspan="4"><strong>Notes:</strong> Documented the intentionally empty <code>push --quiet</code> emission closure so the Swift source makes the quiet-mode behavior clear to reviewers and static analysis.</td>
     </tr>
+    <tr>
+      <td>Sonar unused replica validation parameter cleanup</td>
+      <td>2026-06-18 19:22:19 BST</td>
+      <td>2026-06-18 19:22:19 BST</td>
+      <td>2026-06-18 19:22:19 BST</td>
+    </tr>
+    <tr>
+      <td colspan="4"><strong>Notes:</strong> Removed the unused <code>project</code> parameter from replica support validation and its call sites so the helper signature reflects the data it actually needs.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -479,6 +479,15 @@ is blocked upstream, and gray is not started.
     <tr>
       <td colspan="4"><strong>Notes:</strong> Reused the debug <code>compose</code> executable emitted by the Swift coverage test build for <code>make ci</code> smoke tests, avoiding a second non-coverage SwiftPM product build on the CI path while keeping standalone <code>make cli-smoke</code> build-first behavior.</td>
     </tr>
+    <tr>
+      <td>Sonar empty closure cleanup</td>
+      <td>2026-06-18 19:20:02 BST</td>
+      <td>2026-06-18 19:20:02 BST</td>
+      <td>2026-06-18 19:20:02 BST</td>
+    </tr>
+    <tr>
+      <td colspan="4"><strong>Notes:</strong> Documented the intentionally empty <code>push --quiet</code> emission closure so the Swift source makes the quiet-mode behavior clear to reviewers and static analysis.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -506,6 +506,15 @@ is blocked upstream, and gray is not started.
     <tr>
       <td colspan="4"><strong>Notes:</strong> Grouped discovered image metadata behind a typed <code>ComposeContainerSummary.Image</code> constructor value so the public summary initializer stays under the Sonar parameter threshold while preserving flat stored discovery fields.</td>
     </tr>
+    <tr>
+      <td>Sonar mount initializer tmpfs grouping</td>
+      <td>2026-06-18 19:31:44 BST</td>
+      <td>2026-06-18 19:31:44 BST</td>
+      <td>2026-06-18 19:31:44 BST</td>
+    </tr>
+    <tr>
+      <td colspan="4"><strong>Notes:</strong> Grouped tmpfs constructor fields behind <code>ComposeMount.TmpfsOptions</code> so normalized mount construction stays under the Sonar parameter threshold while keeping flat decoded mount fields for orchestration.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -515,6 +515,15 @@ is blocked upstream, and gray is not started.
     <tr>
       <td colspan="4"><strong>Notes:</strong> Grouped tmpfs constructor fields behind <code>ComposeMount.TmpfsOptions</code> so normalized mount construction stays under the Sonar parameter threshold while keeping flat decoded mount fields for orchestration.</td>
     </tr>
+    <tr>
+      <td>Sonar execution options runtime hook grouping</td>
+      <td>2026-06-18 19:37:47 BST</td>
+      <td>2026-06-18 19:37:47 BST</td>
+      <td>2026-06-18 19:37:47 BST</td>
+    </tr>
+    <tr>
+      <td colspan="4"><strong>Notes:</strong> Grouped runtime injection callbacks behind <code>ComposeExecutionOptions.RuntimeHooks</code> and retained small convenience initializers for existing CLI and test configuration paths.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -470,6 +470,15 @@ is blocked upstream, and gray is not started.
     <tr>
       <td colspan="4"><strong>Notes:</strong> Added Hawkeye license-header tooling, adopted apple/container&#x27;s build-once Swift coverage pattern, cached repo-local tools in CI, documented apple/container upstream Compose parity gaps, and reformatted planning and compatibility docs for readability.</td>
     </tr>
+    <tr>
+      <td>CI smoke build reuse</td>
+      <td>2026-06-18 19:16:00 BST</td>
+      <td>2026-06-18 19:16:00 BST</td>
+      <td>2026-06-18 19:16:00 BST</td>
+    </tr>
+    <tr>
+      <td colspan="4"><strong>Notes:</strong> Reused the debug <code>compose</code> executable emitted by the Swift coverage test build for <code>make ci</code> smoke tests, avoiding a second non-coverage SwiftPM product build on the CI path while keeping standalone <code>make cli-smoke</code> build-first behavior.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -875,7 +875,7 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         try validateRuntimeSupport(services: services, project: project, validateDependencies: validateDependencies)
         let externalVolumeMounts = try await resolveExternalVolumeMounts(project: project, services: services)
         try validatePublishedPorts(services: services)
-        try validateReplicaSupport(project: project, services: services, scaleOverrides: scaleOverrides)
+        try validateReplicaSupport(services: services, scaleOverrides: scaleOverrides)
         let attachedForegroundService = try foregroundServiceTarget(project: project, services: services, scaleOverrides: scaleOverrides, detach: up.detach)
         try validateAttachedPostStartSupport(target: attachedForegroundService)
 
@@ -1075,7 +1075,7 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         try validateRuntimeSupport(services: services, project: project, validateDependencies: validateDependencies)
         let externalVolumeMounts = try await resolveExternalVolumeMounts(project: project, services: services)
         try validatePublishedPorts(services: services)
-        try validateReplicaSupport(project: project, services: services, scaleOverrides: scaleOverrides)
+        try validateReplicaSupport(services: services, scaleOverrides: scaleOverrides)
 
         try await ensureResources(project: project)
 
@@ -3408,7 +3408,6 @@ private extension ComposeOrchestrator {
 
     /// Validates scaled services that would collide under current local runtime primitives.
     func validateReplicaSupport(
-        project: ComposeProject,
         services: [ComposeService],
         scaleOverrides: [String: Int]
     ) throws {

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -26,6 +26,29 @@ import Foundation
 public struct ComposeExecutionOptions {
     public static let defaultEnvironmentLauncher = ["", "usr", "bin", "env"].joined(separator: "/")
 
+    /// Runtime hooks that make orchestration deterministic and testable.
+    public struct RuntimeHooks {
+        public var oneOffIdentifier: @Sendable () -> String
+        public var currentDate: @Sendable () -> Date
+        public var hostPortAllocator: @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16
+        public var sleep: @Sendable (Duration) async throws -> Void
+        public var emit: @Sendable (String) -> Void
+
+        public init(
+            oneOffIdentifier: @escaping @Sendable () -> String = ComposeExecutionOptions.defaultOneOffIdentifier,
+            currentDate: @escaping @Sendable () -> Date = Date.init,
+            hostPortAllocator: @escaping @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16 = ComposeExecutionOptions.defaultHostPortAllocator,
+            sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
+            emit: @escaping @Sendable (String) -> Void = { print($0) }
+        ) {
+            self.oneOffIdentifier = oneOffIdentifier
+            self.currentDate = currentDate
+            self.hostPortAllocator = hostPortAllocator
+            self.sleep = sleep
+            self.emit = emit
+        }
+    }
+
     public var dryRun: Bool
     public var containerBinary: String
     public var environmentLauncher: String
@@ -40,22 +63,75 @@ public struct ComposeExecutionOptions {
         dryRun: Bool = false,
         containerBinary: String = ProcessInfo.processInfo.environment["CONTAINER_BIN"] ?? "container",
         environmentLauncher: String = ComposeExecutionOptions.defaultEnvironmentLauncher,
-        oneOffIdentifier: @escaping @Sendable () -> String = ComposeExecutionOptions.defaultOneOffIdentifier,
-        currentDate: @escaping @Sendable () -> Date = Date.init,
-        hostPortAllocator: @escaping @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16 = ComposeExecutionOptions.defaultHostPortAllocator,
         watchPollInterval: Duration = .seconds(1),
-        sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
-        emit: @escaping @Sendable (String) -> Void = { print($0) }
+        runtimeHooks: RuntimeHooks = RuntimeHooks()
     ) {
         self.dryRun = dryRun
         self.containerBinary = containerBinary
         self.environmentLauncher = environmentLauncher
-        self.oneOffIdentifier = oneOffIdentifier
-        self.currentDate = currentDate
-        self.hostPortAllocator = hostPortAllocator
+        self.oneOffIdentifier = runtimeHooks.oneOffIdentifier
+        self.currentDate = runtimeHooks.currentDate
+        self.hostPortAllocator = runtimeHooks.hostPortAllocator
         self.watchPollInterval = watchPollInterval
-        self.sleep = sleep
-        self.emit = emit
+        self.sleep = runtimeHooks.sleep
+        self.emit = runtimeHooks.emit
+    }
+
+    public init(dryRun: Bool = false, emit: @escaping @Sendable (String) -> Void) {
+        self.init(dryRun: dryRun, runtimeHooks: RuntimeHooks(emit: emit))
+    }
+
+    public init(hostPortAllocator: @escaping @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16) {
+        self.init(runtimeHooks: RuntimeHooks(hostPortAllocator: hostPortAllocator))
+    }
+
+    public init(currentDate: @escaping @Sendable () -> Date) {
+        self.init(runtimeHooks: RuntimeHooks(currentDate: currentDate))
+    }
+
+    public init(environmentLauncher: String) {
+        self.init(environmentLauncher: environmentLauncher, runtimeHooks: RuntimeHooks())
+    }
+
+    public init(oneOffIdentifier: @escaping @Sendable () -> String) {
+        self.init(runtimeHooks: RuntimeHooks(oneOffIdentifier: oneOffIdentifier))
+    }
+
+    public init(sleep: @escaping @Sendable (Duration) async throws -> Void) {
+        self.init(runtimeHooks: RuntimeHooks(sleep: sleep))
+    }
+
+    public init(
+        watchPollInterval: Duration,
+        sleep: @escaping @Sendable (Duration) async throws -> Void
+    ) {
+        self.init(
+            watchPollInterval: watchPollInterval,
+            runtimeHooks: RuntimeHooks(sleep: sleep)
+        )
+    }
+
+    public init(
+        dryRun: Bool,
+        containerBinary: String,
+        emit: @escaping @Sendable (String) -> Void
+    ) {
+        self.init(
+            dryRun: dryRun,
+            containerBinary: containerBinary,
+            runtimeHooks: RuntimeHooks(emit: emit)
+        )
+    }
+
+    public init(
+        dryRun: Bool,
+        hostPortAllocator: @escaping @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16,
+        emit: @escaping @Sendable (String) -> Void
+    ) {
+        self.init(
+            dryRun: dryRun,
+            runtimeHooks: RuntimeHooks(hostPortAllocator: hostPortAllocator, emit: emit)
+        )
     }
 
     public static func defaultOneOffIdentifier() -> String {

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -1283,7 +1283,9 @@ public final class ComposeOrchestrator: @unchecked Sendable {
             : selectedServices(project: project, selected: push.services)
         let emit: @Sendable (String) -> Void
         if push.quiet {
-            emit = { _ in }
+            emit = { _ in
+                // `push --quiet` intentionally suppresses per-image status lines.
+            }
         } else {
             emit = options.emit
         }

--- a/Sources/ComposeCore/ContainerDiscoveryAdapter.swift
+++ b/Sources/ComposeCore/ContainerDiscoveryAdapter.swift
@@ -20,6 +20,19 @@ import ContainerizationError
 
 /// Stable container data used by Compose project discovery and projections.
 public struct ComposeContainerSummary: Sendable, Equatable, Codable {
+    /// Image metadata discovered from the runtime snapshot.
+    public struct Image: Sendable, Equatable, Codable {
+        public var reference: String
+        public var digest: String?
+        public var platform: String
+
+        public init(reference: String = "", digest: String? = nil, platform: String = "") {
+            self.reference = reference
+            self.digest = digest
+            self.platform = platform
+        }
+    }
+
     public var id: String
     public var status: String
     public var labels: [String: String]
@@ -33,18 +46,16 @@ public struct ComposeContainerSummary: Sendable, Equatable, Codable {
         id: String,
         status: String,
         labels: [String: String] = [:],
-        imageReference: String = "",
-        imageDigest: String? = nil,
-        platform: String = "",
+        image: Image = Image(),
         publishedPorts: [ComposeContainerPublishedPort] = [],
         mounts: [ComposeMount] = []
     ) {
         self.id = id
         self.status = status
         self.labels = labels
-        self.imageReference = imageReference
-        self.imageDigest = imageDigest
-        self.platform = platform
+        self.imageReference = image.reference
+        self.imageDigest = image.digest
+        self.platform = image.platform
         self.publishedPorts = publishedPorts
         self.mounts = mounts
     }
@@ -152,9 +163,11 @@ public struct ContainerClientDiscoveryManager: ContainerDiscoveryManaging {
             id: snapshot.id,
             status: snapshot.status.rawValue,
             labels: snapshot.configuration.labels,
-            imageReference: snapshot.configuration.image.reference,
-            imageDigest: snapshot.configuration.image.digest,
-            platform: snapshot.platform.description,
+            image: ComposeContainerSummary.Image(
+                reference: snapshot.configuration.image.reference,
+                digest: snapshot.configuration.image.digest,
+                platform: snapshot.platform.description
+            ),
             publishedPorts: snapshot.configuration.publishedPorts.map {
                 ComposeContainerPublishedPort(
                     hostAddress: String(describing: $0.hostAddress),

--- a/Sources/ComposeCore/NormalizedProject.swift
+++ b/Sources/ComposeCore/NormalizedProject.swift
@@ -598,6 +598,17 @@ public struct ComposeBuildSecret: Codable, Equatable {
 
 /// Mount definition normalized from Compose volume and bind syntax.
 public struct ComposeMount: Codable, Equatable, Sendable {
+    /// Tmpfs options grouped for construction while preserving flat storage.
+    public struct TmpfsOptions: Codable, Equatable, Sendable {
+        public var size: String?
+        public var mode: String?
+
+        public init(size: String? = nil, mode: String? = nil) {
+            self.size = size
+            self.mode = mode
+        }
+    }
+
     public var type: String?
     public var source: String?
     public var target: String?
@@ -612,8 +623,7 @@ public struct ComposeMount: Codable, Equatable, Sendable {
         source: String? = nil,
         target: String? = nil,
         readOnly: Bool? = nil,
-        tmpfsSize: String? = nil,
-        tmpfsMode: String? = nil,
+        tmpfs: TmpfsOptions = TmpfsOptions(),
         raw: String? = nil,
         unsupportedFields: [String]? = nil
     ) {
@@ -621,8 +631,8 @@ public struct ComposeMount: Codable, Equatable, Sendable {
         self.source = source
         self.target = target
         self.readOnly = readOnly
-        self.tmpfsSize = tmpfsSize
-        self.tmpfsMode = tmpfsMode
+        self.tmpfsSize = tmpfs.size
+        self.tmpfsMode = tmpfs.mode
         self.raw = raw
         self.unsupportedFields = unsupportedFields
     }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -7326,9 +7326,11 @@ struct ComposeOrchestratorTests {
                 composeServiceLabel: "api",
                 composeConfigHashLabel: "api-hash",
             ],
-            imageReference: "example/api:latest",
-            imageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            platform: "linux/arm64",
+            image: .init(
+                reference: "example/api:latest",
+                digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                platform: "linux/arm64"
+            ),
             publishedPorts: [
                 ComposeContainerPublishedPort(hostAddress: "127.0.0.1", hostPort: 8080, containerPort: 80, protocolName: "tcp", count: 2),
             ],
@@ -13366,9 +13368,11 @@ private func discoveredContainers() -> [ComposeContainerSummary] {
                 composeConfigHashLabel: "api-hash",
                 composeProjectConfigFilesLabel: "/tmp/demo/compose.yml,/tmp/demo/compose.override.yml",
             ],
-            imageReference: "localhost:5000/example/api:latest",
-            imageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-            platform: "linux/arm64"
+            image: .init(
+                reference: "localhost:5000/example/api:latest",
+                digest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                platform: "linux/arm64"
+            )
         ),
         ComposeContainerSummary(
             id: "other-api-1",
@@ -13379,9 +13383,11 @@ private func discoveredContainers() -> [ComposeContainerSummary] {
                 composeConfigHashLabel: "other-hash",
                 composeProjectConfigFilesLabel: "/tmp/other/compose.yml",
             ],
-            imageReference: "other/api:latest",
-            imageDigest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-            platform: "linux/arm64"
+            image: .init(
+                reference: "other/api:latest",
+                digest: "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+                platform: "linux/arm64"
+            )
         ),
         ComposeContainerSummary(
             id: "demo-worker-1",
@@ -13392,9 +13398,11 @@ private func discoveredContainers() -> [ComposeContainerSummary] {
                 composeConfigHashLabel: "worker-hash",
                 composeProjectConfigFilesLabel: "/tmp/demo/compose.yml",
             ],
-            imageReference: "example/worker:debug",
-            imageDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-            platform: "linux/amd64"
+            image: .init(
+                reference: "example/worker:debug",
+                digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                platform: "linux/amd64"
+            )
         ),
     ]
 }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -11458,8 +11458,7 @@ struct ComposeOrchestratorTests {
                             type: "tmpfs",
                             target: "/scratch",
                             readOnly: true,
-                            tmpfsSize: "67108864",
-                            tmpfsMode: "1777"
+                            tmpfs: .init(size: "67108864", mode: "1777")
                         ),
                     ]
                 },


### PR DESCRIPTION
## Summary
- reuse the coverage build for CI smoke checks
- document the intentional quiet push emitter
- remove the unused replica validation parameter
- group constructor inputs for container summaries, mounts, and execution hooks to satisfy Swift Sonar parameter-count rules

## Validation
- git diff --check
- make check
- make coverage-check (Swift 90.62%, Go 93.27%)
- make ci
- local Sonar develop scans for each issue commit completed successfully

## Notes
- This PR batches the completed develop remediation commits into main so formal CI/Sonar runs once for the set.
- Existing untracked local .vscode files were left untouched.