### PR TITLE
chore(release): sync source formula 0.6.67

### DIFF
--- a/Formula/container-compose.rb
+++ b/Formula/container-compose.rb
@@ -1,9 +1,9 @@
 class ContainerCompose < Formula
   desc "Docker Compose style plugin for Apple's container CLI"
   homepage "https://github.com/stephenlclarke/container-compose"
-  url "https://github.com/stephenlclarke/container-compose/releases/download/0.6.66/container-compose-plugin-release-arm64.tar.gz"
-  version "0.6.66"
-  sha256 "a10d3b25e744f043b45a7b9116a977949e489a6f3eead812ff43dbf1919b436f"
+  url "https://github.com/stephenlclarke/container-compose/releases/download/0.6.67/container-compose-plugin-release-arm64.tar.gz"
+  version "0.6.67"
+  sha256 "fe35e0efe5e50852155c08339f8699c5b65fbb1a375ffa09d4d79095856297f5"
   license "Apache-2.0"
 
   depends_on arch: :arm64
@@ -34,7 +34,7 @@ class ContainerCompose < Formula
   end
 
   test do
-    assert_match "0.6.66", shell_output("#{bin}/container-compose version --short")
+    assert_match "0.6.67", shell_output("#{bin}/container-compose version --short")
     assert_path_exists libexec/"container-plugins/compose/config.toml"
     assert_predicate libexec/"container-plugins/compose/resources/compose-normalizer", :executable?
   end


### PR DESCRIPTION
Syncs the checked-in source formula template after the 0.6.67 stable package was verified.

Validation:
- The stable package workflow published the 0.6.67 release assets.
- The release archive SHA-256 is fe35e0efe5e50852155c08339f8699c5b65fbb1a375ffa09d4d79095856297f5.
- The live stephenlclarke/tap formula matched the verified URL, version, and SHA before this source sync.

Release asset:
- https://github.com/stephenlclarke/container-compose/releases/download/0.6.67/container-compose-plugin-release-arm64.tar.gz