### PR TITLE
chore(release): promote 0.6.68 source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ SWIFT_COVERAGE_MIN ?= 90
 GO_COVERAGE_MIN ?= 85
 DIST_DIR ?= dist
 PLUGIN_ARCHIVE ?= container-compose-plugin-release-arm64.tar.gz
-COMPOSE_VERSION ?= 0.6.67
+COMPOSE_VERSION ?= 0.6.68
 CONTAINER_COMPOSE_SOURCE ?= $(shell $(PYTHON) -c 'import subprocess; result = subprocess.run(["git", "remote", "get-url", "origin"], capture_output=True, text=True); url = result.stdout.strip() if result.returncode == 0 else ""; url = url[len("git@github.com:"):] if url.startswith("git@github.com:") else url; url = url[len("https://github.com/"):] if url.startswith("https://github.com/") else url; url = url[:-4] if url.endswith(".git") else url; print(url)')
 CONTAINER_COMPOSE_BRANCH ?= $(shell git branch --show-current 2>/dev/null || git rev-parse --short HEAD)
 CONTAINER_COMPOSE_LANE ?= $(shell $(PYTHON) -c 'branch = "$(CONTAINER_COMPOSE_BRANCH)"; print("main" if branch == "main" else "release" if branch == "release" or branch.startswith("release-") else "detached" if branch in ("", "HEAD") else "development")')
@@ -304,28 +304,28 @@ cli-smoke-built:
 	.build/debug/compose --ansi never version >/dev/null
 	.build/debug/compose version --dry-run >/dev/null
 	version_short_output="$$(".build/debug/compose" version --short)"; \
-	[[ "$$version_short_output" == "0.6.67" ]]; \
+	[[ "$$version_short_output" == "0.6.68" ]]; \
 	version_pretty_output="$$(".build/debug/compose" version)"; \
-	[[ "$$version_pretty_output" == *"container-compose 0.6.67"* ]]; \
+	[[ "$$version_pretty_output" == *"container-compose 0.6.68"* ]]; \
 	[[ "$$version_pretty_output" == *"container:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"containerization:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"compose-go: $(COMPOSE_GO_VERSION)"* ]]; \
 	version_json_output="$$(".build/debug/compose" version --format json)"; \
-	[[ "$$version_json_output" == *'"version":"0.6.67"'* ]]; \
+	[[ "$$version_json_output" == *'"version":"0.6.68"'* ]]; \
 	[[ "$$version_json_output" == *'"containerSource":"stephenlclarke/container"'* ]]; \
 	[[ "$$version_json_output" == *'"containerDistribution":"custom"'* ]]; \
 	[[ "$$version_json_output" == *'"containerizationSource":'* ]]; \
 	[[ "$$version_json_output" == *'"containerizationDistribution":"custom"'* ]]; \
 	[[ "$$version_json_output" == *'"composeGoVersion":"$(COMPOSE_GO_VERSION)"'* ]]; \
 	version_short_format_output="$$(".build/debug/compose" version -f json)"; \
-	[[ "$$version_short_format_output" == *'"version":"0.6.67"'* ]]; \
+	[[ "$$version_short_format_output" == *'"version":"0.6.68"'* ]]; \
 	version_compact_format_output="$$(".build/debug/compose" version -fjson)"; \
-	[[ "$$version_compact_format_output" == *'"version":"0.6.67"'* ]]; \
+	[[ "$$version_compact_format_output" == *'"version":"0.6.68"'* ]]; \
 	package_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$package_tmp"' EXIT; \
 	mkdir -p "$$package_tmp/compose/bin" "$$package_tmp/compose/resources" "$$package_tmp/bin"; \
 	cp .build/debug/compose "$$package_tmp/compose/bin/compose"; \
-	printf '%s\n' '{"version":"0.6.67","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
+	printf '%s\n' '{"version":"0.6.68","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
 	ln -s ../compose/bin/compose "$$package_tmp/bin/container-compose"; \
 	packaged_version_output="$$(cd /tmp && "$$package_tmp/bin/container-compose" version --format json)"; \
 	[[ "$$packaged_version_output" == *'"branch":"symlink-smoke"'* ]]; \
@@ -349,7 +349,7 @@ cli-smoke-built:
 	[[ "$$compat_output" == *"https://github.com/stephenlclarke/container-compose/blob/main/INSTALL.md"* ]]; \
 	service_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$service_tmp"' EXIT; \
-	printf '%s\n' '{"version":"0.6.67","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
+	printf '%s\n' '{"version":"0.6.68","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
 	printf '%s\n' '#!/usr/bin/env bash' 'if [[ "$$*" == "system version --format json" ]]; then' '  printf '\''[{"appName":"container","buildType":"release","commit":"matched-container","containerization":"stephenlclarke/containerization@matched-containerization","distribution":"custom","source":"stephenlclarke/container","version":"homebrew-main"}]\n'\''' '  exit 0' 'fi' 'if [[ "$$*" == "system status" ]]; then' '  printf '\''apiserver is not running and not registered with launchd\n'\'' >&2' '  exit 1' 'fi' 'exit 2' > "$$service_tmp/container"; \
 	chmod +x "$$service_tmp/container"; \
 	set +e; \
@@ -569,7 +569,7 @@ cli-smoke-built:
 	printf 'services:\n  api:\n    image: alpine\n    build:\n      context: ./api\n    volumes:\n      - ./src:/src\n' > "$$tmpdir/relative-paths.yml"; \
 	printf 'services:\n  api:\n    image: alpine\n    depends_on:\n      - missing\n' > "$$tmpdir/missing-dependency.yml"; \
 	version_compact_global_output="$$(".build/debug/compose" -pcompact -f"$$tmpdir/compose.yml" version --short)"; \
-	[[ "$$version_compact_global_output" == "0.6.67" ]]; \
+	[[ "$$version_compact_global_output" == "0.6.68" ]]; \
 	config_output="$$(".build/debug/compose" -f "$$tmpdir/compose.yml" config)"; \
 	[[ "$$config_output" == *"name: \"demo\""* ]]; \
 	[[ "$$config_output" == *"services:"* ]]; \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4512fff94bfa1385317a4c444b1a90a935ad19f8d7f978beb4b781ea49ee35dc",
+  "originHash" : "d040ddea56b5d1d959227ac9888a9cdb6f1b5c2cbb025bac84c511ed19b6fc4a",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "03f8a105813ae680757f4f456a53130c11c0bf66"
+        "revision" : "6dc0c7be42687a9cf0d07eee1ba9cf2a1abf510c"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d040ddea56b5d1d959227ac9888a9cdb6f1b5c2cbb025bac84c511ed19b6fc4a",
+  "originHash" : "353d14974c6acc1f6372af565b9493f5fcb2ee0d147713bb3baebb53569853d3",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "6dc0c7be42687a9cf0d07eee1ba9cf2a1abf510c"
+        "revision" : "c3f8fe66d52c3509863ebbb439338d6dbe3284e0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(name: "container", path: "../container"),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",
-            revision: "6dc0c7be42687a9cf0d07eee1ba9cf2a1abf510c"
+            revision: "c3f8fe66d52c3509863ebbb439338d6dbe3284e0"
         ),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
         .package(name: "container", path: "../container"),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",
-            revision: "03f8a105813ae680757f4f456a53130c11c0bf66"
+            revision: "6dc0c7be42687a9cf0d07eee1ba9cf2a1abf510c"
         ),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -28,7 +28,7 @@ private let composePluginVersionNumber = composeBuildInfo.version
 private let composePluginVersionString = "container-compose \(composePluginVersionNumber)"
 
 private struct ComposeBuildInfo: Codable {
-    var version: String = "0.6.67"
+    var version: String = "0.6.68"
     var source: String = "unspecified"
     var branch: String = "unspecified"
     var lane: String = "unspecified"
@@ -103,7 +103,7 @@ private struct ComposeBuildInfo: Codable {
         let root = git(["rev-parse", "--show-toplevel"]) ?? FileManager.default.currentDirectoryPath
         let branch = git(["branch", "--show-current"], root: root) ?? "unspecified"
         return ComposeBuildInfo(
-            version: "0.6.67",
+            version: "0.6.68",
             source: remoteSource(root: root),
             branch: branch,
             lane: lane(for: branch),

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "9ccab7b69dfaee068ea09f7f75fa58206e01b7ab",
+      "ref": "712b3352946bc6fac65dd69d04743e0053e0e928",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "6dc0c7be42687a9cf0d07eee1ba9cf2a1abf510c",
+      "ref": "c3f8fe66d52c3509863ebbb439338d6dbe3284e0",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "c85edcff9b5b6eca925c2b6c4749db2d5e1fffab",
+      "ref": "9ccab7b69dfaee068ea09f7f75fa58206e01b7ab",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -10,11 +10,11 @@
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
         "tag": "0.13.8"
       },
-      "ref": "dbe6de48b20d0d29009617eac272935da5ae4040",
+      "ref": "84c9c39844eb390d64178175ef406845a53a33c0",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "03f8a105813ae680757f4f456a53130c11c0bf66",
+      "ref": "6dc0c7be42687a9cf0d07eee1ba9cf2a1abf510c",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/APPLE-UPSTREAM-REVIEW.md
+++ b/docs/upstream/APPLE-UPSTREAM-REVIEW.md
@@ -27,6 +27,7 @@ This is the current disposition of Apple work that affects the five-repository c
 | `apple/container` | [Fork CI validation](apple-container/PR-fork-ci-validation.md) runs formatting, generated-source checks, builds, and unit tests in contributor forks while retaining official guest integration. |
 | `apple/containerization` | [Fork CI validation](apple-containerization/PR-fork-ci-validation.md) runs supported checks in contributor forks while retaining official guest image and integration work. |
 | `apple/containerization` | [Cgroup formatter catch spacing](apple-containerization/PR-cgroup-catch-format.md) restores the exact spelling required by the strict Swift formatter without changing runtime behavior. |
+| `apple/containerization` | [vmnet integration exclusivity](apple-containerization/PR-vmnet-integration-exclusivity.md) serializes only host-networking VM tests so release validation remains deterministic. |
 
 ## Overlapping Upstream Work
 

--- a/docs/upstream/apple-containerization/ISSUE-vmnet-integration-exclusivity.md
+++ b/docs/upstream/apple-containerization/ISSUE-vmnet-integration-exclusivity.md
@@ -1,0 +1,37 @@
+# Serialize vmnet-backed integration tests
+
+## Summary
+
+The macOS integration runner executes vmnet-backed container and pod networking tests in its normal concurrent pool. Virtualization.framework can invalidate a VM's XPC connection when several of those host-networking cases start and stop at the same time.
+
+## Current Gap
+
+The intermittent failure is reported as `VZErrorDomain Code=1`, with the virtual machine stopping unexpectedly. It makes the release gate nondeterministic even though the same IPv6 case succeeds when run serially.
+
+No matching open Apple issue or pull request was found after reviewing the current `apple/containerization` IPv6, vmnet, and integration work.
+
+## Proposed Shape
+
+- Mark only vmnet-backed integration cases as requiring exclusive execution.
+- Keep the regular integration pool concurrent at its configured limit.
+- Run the marked cases one at a time after the concurrent pool completes.
+- Keep the change inside the integration executable; it does not alter Linux container runtime behavior or Docker Compose policy.
+
+## Acceptance Criteria
+
+- A full macOS integration run completes the vmnet and IPv6 coverage without concurrent VM lifecycle contention.
+- Non-vmnet integration tests retain their existing configurable concurrency.
+- The runner continues after a skipped or failed test and preserves its final pass/fail accounting.
+- No Docker-shaped CLI or Compose behavior is added to `containerization`.
+
+## Ownership
+
+`containerization` owns its integration runner and Virtualization.framework lifecycle coverage. `container-compose` has no runtime-policy change for this work.
+
+## Validation
+
+```sh
+make containerization integration
+```
+
+The signed macOS integration executable completed all 166 tests, including the eleven serialized vmnet and IPv6 cases.

--- a/docs/upstream/apple-containerization/PR-vmnet-integration-exclusivity.md
+++ b/docs/upstream/apple-containerization/PR-vmnet-integration-exclusivity.md
@@ -1,0 +1,54 @@
+# Pull Request
+
+## Summary
+
+- Serialize the vmnet-backed macOS integration cases after the normal concurrent test pool drains.
+- Retain the existing configurable concurrency for all other integration tests.
+- Prevent intermittent Virtualization.framework XPC invalidation during concurrent IPv6 and host-networking VM teardown.
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [x] Test infrastructure update
+
+## Motivation and Context
+
+The integration suite can fail an otherwise healthy release gate when concurrent vmnet-backed VM cases stop unexpectedly with `VZErrorDomain Code=1`. The failing IPv6 case succeeds repeatedly when run serially, showing host VM lifecycle contention rather than a functional IPv6 regression.
+
+No matching open Apple issue or pull request was found after reviewing current `apple/containerization` vmnet, IPv6, and integration work.
+
+## Implementation Details
+
+- Adds a typed `requiresExclusiveExecution` marker to integration jobs.
+- Marks only macOS 26 vmnet-backed container and pod networking cases as exclusive.
+- Executes ordinary jobs through the existing bounded task group.
+- Executes exclusive jobs sequentially after that group completes.
+- Preserves the runner's logging, skip handling, error reporting, and final accounting.
+
+## Compatibility Notes
+
+- This change affects test scheduling only.
+- Linux container runtime APIs and behavior are unchanged.
+- Docker Compose validation and policy remain in `container-compose`.
+
+## Commit Tracking
+
+- Fork commit: [`c3f8fe66d52c3509863ebbb439338d6dbe3284e0`](https://github.com/stephenlclarke/containerization/commit/c3f8fe66d52c3509863ebbb439338d6dbe3284e0) (`fix(integration): serialize vmnet integration tests`).
+
+## Validation
+
+```sh
+make check
+make containerization integration
+```
+
+The signed macOS integration executable completed all 166 tests. The eleven vmnet and IPv6 cases ran one at a time after the regular concurrent set.
+
+## Checklist
+
+- [x] Reviewed current upstream IPv6, vmnet, and integration issues and pull requests.
+- [x] Added focused scheduling coverage through the full signed runtime suite.
+- [x] Kept the change Apple-native and outside Docker Compose policy.
+- [x] Avoided pushing changes to Apple remotes.


### PR DESCRIPTION
Promotes the validated container-compose source state for 0.6.68.

Validation:
- make release-gate completed locally before this PR.
- The promoted main tree must match the locally gated candidate before tagging.
- Apple upstream remotes remain read-only; only stephenlclarke-owned remotes are push targets.

Candidate:
- container-compose: f802a4da3a2d2444d802bb2e1b83364dba7d9fc5