### PR TITLE
chore(release): promote 0.6.69 source

### DIFF
--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -10,7 +10,7 @@
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
         "tag": "0.13.8"
       },
-      "ref": "84c9c39844eb390d64178175ef406845a53a33c0",
+      "ref": "e159c5cec122a44fbd7fe14fb1b70faec06925ab",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -10,7 +10,7 @@
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
         "tag": "0.13.8"
       },
-      "ref": "e159c5cec122a44fbd7fe14fb1b70faec06925ab",
+      "ref": "e521a27fa7ff8fe57d11c793ba607bbac921d5b2",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {


### PR DESCRIPTION
Promotes the validated container-compose source state for 0.6.69.

Validation:
- make release-gate completed locally before this PR.
- The promoted main tree must match the locally gated candidate before tagging.
- Apple upstream remotes remain read-only; only stephenlclarke-owned remotes are push targets.

Candidate:
- container-compose: cc7cd25058b6968a204c695c8bf6b6933b9c8ae2