### PR TITLE
chore(release): promote 0.6.70 source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ SWIFT_COVERAGE_MIN ?= 90
 GO_COVERAGE_MIN ?= 85
 DIST_DIR ?= dist
 PLUGIN_ARCHIVE ?= container-compose-plugin-release-arm64.tar.gz
-COMPOSE_VERSION ?= 0.6.69
+COMPOSE_VERSION ?= 0.6.70
 CONTAINER_COMPOSE_SOURCE ?= $(shell $(PYTHON) -c 'import subprocess; result = subprocess.run(["git", "remote", "get-url", "origin"], capture_output=True, text=True); url = result.stdout.strip() if result.returncode == 0 else ""; url = url[len("git@github.com:"):] if url.startswith("git@github.com:") else url; url = url[len("https://github.com/"):] if url.startswith("https://github.com/") else url; url = url[:-4] if url.endswith(".git") else url; print(url)')
 CONTAINER_COMPOSE_BRANCH ?= $(shell git branch --show-current 2>/dev/null || git rev-parse --short HEAD)
 CONTAINER_COMPOSE_LANE ?= $(shell $(PYTHON) -c 'branch = "$(CONTAINER_COMPOSE_BRANCH)"; print("main" if branch == "main" else "release" if branch == "release" or branch.startswith("release-") else "detached" if branch in ("", "HEAD") else "development")')
@@ -304,28 +304,28 @@ cli-smoke-built:
 	.build/debug/compose --ansi never version >/dev/null
 	.build/debug/compose version --dry-run >/dev/null
 	version_short_output="$$(".build/debug/compose" version --short)"; \
-	[[ "$$version_short_output" == "0.6.69" ]]; \
+	[[ "$$version_short_output" == "0.6.70" ]]; \
 	version_pretty_output="$$(".build/debug/compose" version)"; \
-	[[ "$$version_pretty_output" == *"container-compose 0.6.69"* ]]; \
+	[[ "$$version_pretty_output" == *"container-compose 0.6.70"* ]]; \
 	[[ "$$version_pretty_output" == *"container:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"containerization:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"compose-go: $(COMPOSE_GO_VERSION)"* ]]; \
 	version_json_output="$$(".build/debug/compose" version --format json)"; \
-	[[ "$$version_json_output" == *'"version":"0.6.69"'* ]]; \
+	[[ "$$version_json_output" == *'"version":"0.6.70"'* ]]; \
 	[[ "$$version_json_output" == *'"containerSource":"stephenlclarke/container"'* ]]; \
 	[[ "$$version_json_output" == *'"containerDistribution":"custom"'* ]]; \
 	[[ "$$version_json_output" == *'"containerizationSource":'* ]]; \
 	[[ "$$version_json_output" == *'"containerizationDistribution":"custom"'* ]]; \
 	[[ "$$version_json_output" == *'"composeGoVersion":"$(COMPOSE_GO_VERSION)"'* ]]; \
 	version_short_format_output="$$(".build/debug/compose" version -f json)"; \
-	[[ "$$version_short_format_output" == *'"version":"0.6.69"'* ]]; \
+	[[ "$$version_short_format_output" == *'"version":"0.6.70"'* ]]; \
 	version_compact_format_output="$$(".build/debug/compose" version -fjson)"; \
-	[[ "$$version_compact_format_output" == *'"version":"0.6.69"'* ]]; \
+	[[ "$$version_compact_format_output" == *'"version":"0.6.70"'* ]]; \
 	package_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$package_tmp"' EXIT; \
 	mkdir -p "$$package_tmp/compose/bin" "$$package_tmp/compose/resources" "$$package_tmp/bin"; \
 	cp .build/debug/compose "$$package_tmp/compose/bin/compose"; \
-	printf '%s\n' '{"version":"0.6.69","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
+	printf '%s\n' '{"version":"0.6.70","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
 	ln -s ../compose/bin/compose "$$package_tmp/bin/container-compose"; \
 	packaged_version_output="$$(cd /tmp && "$$package_tmp/bin/container-compose" version --format json)"; \
 	[[ "$$packaged_version_output" == *'"branch":"symlink-smoke"'* ]]; \
@@ -349,7 +349,7 @@ cli-smoke-built:
 	[[ "$$compat_output" == *"https://github.com/stephenlclarke/container-compose/blob/main/INSTALL.md"* ]]; \
 	service_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$service_tmp"' EXIT; \
-	printf '%s\n' '{"version":"0.6.69","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
+	printf '%s\n' '{"version":"0.6.70","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
 	printf '%s\n' '#!/usr/bin/env bash' 'if [[ "$$*" == "system version --format json" ]]; then' '  printf '\''[{"appName":"container","buildType":"release","commit":"matched-container","containerization":"stephenlclarke/containerization@matched-containerization","distribution":"custom","source":"stephenlclarke/container","version":"homebrew-main"}]\n'\''' '  exit 0' 'fi' 'if [[ "$$*" == "system status" ]]; then' '  printf '\''apiserver is not running and not registered with launchd\n'\'' >&2' '  exit 1' 'fi' 'exit 2' > "$$service_tmp/container"; \
 	chmod +x "$$service_tmp/container"; \
 	set +e; \
@@ -569,7 +569,7 @@ cli-smoke-built:
 	printf 'services:\n  api:\n    image: alpine\n    build:\n      context: ./api\n    volumes:\n      - ./src:/src\n' > "$$tmpdir/relative-paths.yml"; \
 	printf 'services:\n  api:\n    image: alpine\n    depends_on:\n      - missing\n' > "$$tmpdir/missing-dependency.yml"; \
 	version_compact_global_output="$$(".build/debug/compose" -pcompact -f"$$tmpdir/compose.yml" version --short)"; \
-	[[ "$$version_compact_global_output" == "0.6.69" ]]; \
+	[[ "$$version_compact_global_output" == "0.6.70" ]]; \
 	config_output="$$(".build/debug/compose" -f "$$tmpdir/compose.yml" config)"; \
 	[[ "$$config_output" == *"name: \"demo\""* ]]; \
 	[[ "$$config_output" == *"services:"* ]]; \

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -28,7 +28,7 @@ private let composePluginVersionNumber = composeBuildInfo.version
 private let composePluginVersionString = "container-compose \(composePluginVersionNumber)"
 
 private struct ComposeBuildInfo: Codable {
-    var version: String = "0.6.69"
+    var version: String = "0.6.70"
     var source: String = "unspecified"
     var branch: String = "unspecified"
     var lane: String = "unspecified"
@@ -103,7 +103,7 @@ private struct ComposeBuildInfo: Codable {
         let root = git(["rev-parse", "--show-toplevel"]) ?? FileManager.default.currentDirectoryPath
         let branch = git(["branch", "--show-current"], root: root) ?? "unspecified"
         return ComposeBuildInfo(
-            version: "0.6.69",
+            version: "0.6.70",
             source: remoteSource(root: root),
             branch: branch,
             lane: lane(for: branch),

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,14 +1,14 @@
 {
   "components": {
     "container": {
-      "ref": "3de8fe309dc7ec7c43a3a32acbe9200d6cf407b0",
+      "ref": "8b7b4fdd2301c22274a87d6abef0f8c0e913c717",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
       "image": {
-        "digest": "sha256:1add3f370d2024d005c62250bea285588390e0f04996297f88ee73f72a4050bb",
+        "digest": "sha256:e4a1294b27c9602c3b7b26b1af753cbe5b688d91f1880e5990ed45ce5c711cc9",
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
-        "tag": "current-29258644969-e521a27fa7ff"
+        "tag": "0.13.8"
       },
       "ref": "e521a27fa7ff8fe57d11c793ba607bbac921d5b2",
       "repository": "stephenlclarke/container-builder-shim"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -120,6 +120,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def test_release_helper_uses_the_active_github_cli_credential(self) -> None:
         self.assertIn("github_cli() {", self.script)
         self.assertIn("github_cli pr create", self.script)
+        self.assertIn('--add-assignee "@me"', self.script)
         self.assertIn("run github_cli workflow run", self.script)
         self.assertNotIn("env -u GITHUB_TOKEN -u GH_TOKEN gh", self.script)
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -117,6 +117,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)
 
+    def test_release_helper_uses_the_active_github_cli_credential(self) -> None:
+        self.assertIn("github_cli() {", self.script)
+        self.assertIn("github_cli pr create", self.script)
+        self.assertIn("run github_cli workflow run", self.script)
+        self.assertNotIn("env -u GITHUB_TOKEN -u GH_TOKEN gh", self.script)
+
     def test_release_helper_preserves_formatted_swiftpm_dependency_pins(self) -> None:
         self.assertIn(r'r"(\s*,?\s*\))"', self.script)
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -711,7 +711,7 @@ open_compose_promotion_pr() {
   local branch="$1" title="$2" body="$3" repo existing url
   repo="$(github_repo "${COMPOSE_REPO}")"
   existing="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh pr list \
+    github_cli pr list \
       --repo "${repo}" \
       --head "${branch}" \
       --state open \
@@ -726,7 +726,7 @@ open_compose_promotion_pr() {
   fi
 
   url="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh pr create \
+    github_cli pr create \
       --repo "${repo}" \
       --base main \
       --head "${branch}" \
@@ -735,7 +735,7 @@ open_compose_promotion_pr() {
   )"
   COMPOSE_PROMOTION_PR_URL="${url}"
   COMPOSE_PROMOTION_PR_NUMBER="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh pr view "${url}" \
+    github_cli pr view "${url}" \
       --repo "${repo}" \
       --json number \
       --jq '.number'
@@ -756,7 +756,7 @@ wait_for_compose_pr_checks() {
   fi
 
   while true; do
-    if output="$(env -u GITHUB_TOKEN -u GH_TOKEN gh pr checks "${number}" \
+    if output="$(github_cli pr checks "${number}" \
       --repo "${repo}" \
       "${check_args[@]}" 2>&1)"; then
       status=0
@@ -795,7 +795,7 @@ wait_for_compose_pr_checks() {
 
 compose_pr_check_mode() {
   local number="$1" repo="$2" output status
-  if output="$(env -u GITHUB_TOKEN -u GH_TOKEN gh pr checks "${number}" \
+  if output="$(github_cli pr checks "${number}" \
     --repo "${repo}" \
     --required 2>&1)"; then
     printf 'required'
@@ -826,7 +826,7 @@ wait_for_compose_pr_merged() {
 
   while true; do
     details="$(
-      env -u GITHUB_TOKEN -u GH_TOKEN gh pr view "${number}" \
+      github_cli pr view "${number}" \
         --repo "${repo}" \
         --json state,mergedAt,url \
         --jq '[.state, (.mergedAt // ""), .url] | @tsv'
@@ -859,7 +859,7 @@ compose_pr_is_merged() {
   local number="$1" repo merged_at
   repo="$(github_repo "${COMPOSE_REPO}")"
   if ! merged_at="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh pr view "${number}" \
+    github_cli pr view "${number}" \
       --repo "${repo}" \
       --json mergedAt \
       --jq '.mergedAt // ""'
@@ -878,7 +878,7 @@ merge_compose_promotion_pr() {
     return 0
   fi
 
-  if env -u GITHUB_TOKEN -u GH_TOKEN gh pr merge "${number}" \
+  if github_cli pr merge "${number}" \
     --repo "${repo}" \
     --merge \
     --delete-branch \
@@ -893,7 +893,7 @@ merge_compose_promotion_pr() {
     return 0
   fi
   wait_for_compose_pr_checks "${number}"
-  if env -u GITHUB_TOKEN -u GH_TOKEN gh pr merge "${number}" \
+  if github_cli pr merge "${number}" \
     --repo "${repo}" \
     --merge \
     --delete-branch; then
@@ -907,14 +907,14 @@ merge_compose_promotion_pr() {
   fi
 
   review_decision="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh pr view "${number}" \
+    github_cli pr view "${number}" \
       --repo "${repo}" \
       --json reviewDecision \
       --jq '.reviewDecision // ""'
   )"
   if [[ "${COMPOSE_MAIN_MERGE_MODE}" == "checked-admin" && "${review_decision}" == "REVIEW_REQUIRED" ]]; then
     printf 'normal merge is blocked by the solo-maintainer review requirement; using checked admin merge after PR checks passed\n'
-    run env -u GITHUB_TOKEN -u GH_TOKEN gh pr merge "${number}" \
+    run github_cli pr merge "${number}" \
       --repo "${repo}" \
       --merge \
       --delete-branch \
@@ -1073,9 +1073,15 @@ need_command() {
   fi
 }
 
+# Run GitHub CLI commands with the caller's authenticated credential. This
+# supports the documented GITHUB_TOKEN path as well as gh's stored login.
+github_cli() {
+  gh "$@"
+}
+
 # Return the newest workflow_dispatch run id for the compose package workflow.
 latest_compose_package_dispatch_run() {
-  env -u GITHUB_TOKEN -u GH_TOKEN gh run list \
+  github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow "Prebuilt Binaries" \
     --event workflow_dispatch \
@@ -1085,7 +1091,7 @@ latest_compose_package_dispatch_run() {
 }
 
 latest_stable_release_gate_dispatch_run() {
-  env -u GITHUB_TOKEN -u GH_TOKEN gh run list \
+  github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow stable-release-gate.yml \
     --event workflow_dispatch \
@@ -1100,7 +1106,7 @@ wait_for_github_run_success() {
   deadline=$((SECONDS + COMPOSE_PACKAGE_WAIT_SECONDS))
   while true; do
     details="$(
-      env -u GITHUB_TOKEN -u GH_TOKEN gh run view "${run_id}" \
+      github_cli run view "${run_id}" \
         --repo "$(github_repo "${COMPOSE_REPO}")" \
         --json status,conclusion,url \
         --jq '[.status, (.conclusion // ""), .url] | @tsv'
@@ -1143,7 +1149,7 @@ verify_compose_stable_package() {
 
   tmp="$(mktemp -d)"
   asset_names="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh release view "${version}" \
+    github_cli release view "${version}" \
       --repo "${repo}" \
       --json assets \
       --jq '.assets[].name'
@@ -1167,7 +1173,7 @@ verify_compose_stable_package() {
     exit 1
   fi
 
-  env -u GITHUB_TOKEN -u GH_TOKEN gh release download "${version}" \
+  github_cli release download "${version}" \
     --repo "${repo}" \
     --pattern "${asset}" \
     --pattern "${asset}.sha256" \
@@ -1191,7 +1197,7 @@ verify_compose_stable_package() {
   fi
 
   formula_text="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh api \
+    github_cli api \
       repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose.rb \
       --jq '.content' | base64 --decode
   )"
@@ -1219,7 +1225,7 @@ verify_compose_stable_package() {
 
   runtime_url="https://github.com/${repo}/releases/download/${version}/${runtime_asset}"
   runtime_formula_text="$(
-    env -u GITHUB_TOKEN -u GH_TOKEN gh api \
+    github_cli api \
       repos/stephenlclarke/homebrew-tap/contents/Formula/container.rb \
       --jq '.content' | base64 --decode
   )"
@@ -1257,7 +1263,7 @@ dispatch_compose_stable_package() {
 
   need_command gh
   previous_run="$(latest_compose_package_dispatch_run || true)"
-  run env -u GITHUB_TOKEN -u GH_TOKEN gh workflow run prebuilt-binaries.yml \
+  run github_cli workflow run prebuilt-binaries.yml \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --ref main \
     -f "ref=${version}"
@@ -1297,7 +1303,7 @@ dispatch_stable_release_gate() {
 
   need_command gh
   previous_run="$(latest_stable_release_gate_dispatch_run || true)"
-  run env -u GITHUB_TOKEN -u GH_TOKEN gh workflow run stable-release-gate.yml \
+  run github_cli workflow run stable-release-gate.yml \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --ref main \
     -f "ref=${version}"

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -740,6 +740,9 @@ open_compose_promotion_pr() {
       --json number \
       --jq '.number'
   )"
+  github_cli pr edit "${COMPOSE_PROMOTION_PR_NUMBER}" \
+    --repo "${repo}" \
+    --add-assignee "@me"
   printf 'container-compose promotion PR opened: %s\n' "${COMPOSE_PROMOTION_PR_URL}"
 }
 


### PR DESCRIPTION
Promotes the validated container-compose source state for 0.6.70.

Validation:
- make release-gate completed locally before this PR.
- The promoted main tree must match the locally gated candidate before tagging.
- Apple upstream remotes remain read-only; only stephenlclarke-owned remotes are push targets.

Candidate:
- container-compose: 0844250a63ed5c30d1c4e7a6e1d30b6731ac84f0