### PR TITLE
fix(release): retry unpublished stable tags

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -72,9 +72,18 @@ jobs:
             exit 1
           fi
           if [[ "${tag_sha}" != "${main_sha}" ]]; then
-            printf 'stable tag %s points at %s but main is %s; tags must be created at the validated main head\n' \
-              "${RELEASE_TAG}" "${tag_sha}" "${main_sha}" >&2
-            exit 1
+            tag_object="$(
+              gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha'
+            )"
+            tag_verified="$(
+              gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object}" --jq '.verification.verified'
+            )"
+            if [[ "${tag_verified}" != "true" ]]; then
+              printf 'stable tag %s no longer matches main and is not GitHub-verified\n' "${RELEASE_TAG}" >&2
+              exit 1
+            fi
+            printf 'stable tag %s no longer matches main; accepting its GitHub-verified source for a release retry\n' \
+              "${RELEASE_TAG}"
           fi
 
           deadline=$((SECONDS + 3600))
@@ -157,6 +166,14 @@ jobs:
           path: container
           fetch-depth: 0
           ref: ${{ steps.stack-refs.outputs.container_ref }}
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          repository: stephenlclarke/homebrew-tap
+          path: homebrew-tap
+          fetch-depth: 0
+          ref: main
 
       - name: Verify immutable dependency checkouts
         env:

--- a/BUILD.md
+++ b/BUILD.md
@@ -177,6 +177,12 @@ rebuilds and publishes the immutable stable assets and atomically updates both
 stable Homebrew formulae. Do not create a semantic tag, copy a prerelease
 asset, or edit either stable formula by hand.
 
+If a hosted gate fails before the semantic GitHub release is created, correct
+the release automation on `main` and rerun the same explicit version, for
+example `make release VERSION_SELECTOR=0.6.70`. The helper reuses only the
+existing GitHub-verified signed source tag, reruns the gates and package workflow,
+and refuses to change a tag or overwrite an existing semantic release.
+
 After the tag is published, the one mutable `current` prerelease continues to
 follow later green `main` commits. Homebrew users without `-current` always use
 the newly promoted stable formula pair; opted-in users continue to use the

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -30,6 +30,7 @@ ROOT = SCRIPT.parent.parent
 TEMPLATE = ROOT / "Tools" / "release" / "container-compose.rb.in"
 HOMEBREW_WORKFLOW = ROOT / ".github" / "workflows" / "homebrew.yml"
 PACKAGE_WORKFLOW = ROOT / ".github" / "workflows" / "prebuilt-binaries.yml"
+STABLE_GATE_WORKFLOW = ROOT / ".github" / "workflows" / "stable-release-gate.yml"
 
 
 class ContainerStackReleasePolicyTests(unittest.TestCase):
@@ -39,13 +40,17 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.script = SCRIPT.read_text(encoding="utf-8")
 
-    def test_existing_stable_tags_are_rejected_before_release_mutation(self) -> None:
+    def test_existing_stable_tags_resume_only_before_release_publication(self) -> None:
         release = self.script[self.script.index("release_current_stack() {") :]
+        self.assertIn('if stable_tag_exists "${version}"', release)
+        self.assertIn('resume_stable_release "${version}"', release)
         self.assertIn("ensure_new_stable_release \"${version}\"", release)
         self.assertLess(
+            release.index('resume_stable_release "${version}"'),
             release.index("ensure_new_stable_release \"${version}\""),
-            release.index("bump_compose_version_files"),
         )
+        self.assertIn("ensure_stable_release_is_unpublished() {", self.script)
+        self.assertIn("stable release %s already exists and is immutable", self.script)
         self.assertIn("tag_new_stable_version() {", self.script)
         self.assertIn("stable tag already exists locally", self.script)
         self.assertIn("stable tag already exists remotely", self.script)
@@ -113,6 +118,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("CONTAINER_COMPOSE_BUILD_CHECK_LIVE=1", makefile)
         self.assertIn("docker-compose-devices-parity", makefile)
         self.assertNotIn("repackage-release", makefile)
+
+    def test_stable_gate_checks_out_the_tap_and_accepts_verified_retry_tags(self) -> None:
+        workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("repository: stephenlclarke/homebrew-tap", workflow)
+        self.assertIn("path: homebrew-tap", workflow)
+        self.assertIn("accepting its GitHub-verified source for a release retry", workflow)
 
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -504,6 +504,39 @@ ensure_new_stable_release() {
   fi
 }
 
+# Return success when the semantic source tag already exists locally or remotely.
+stable_tag_exists() {
+  local version="$1" path remote
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+
+  if git -C "${path}" rev-parse -q --verify "refs/tags/${version}" >/dev/null; then
+    return 0
+  fi
+  git -C "${path}" ls-remote --exit-code --tags "${remote}" "refs/tags/${version}" >/dev/null 2>&1
+}
+
+# Refuse to retry a semantic tag once GitHub has made it a published release.
+ensure_stable_release_is_unpublished() {
+  local version="$1" output status
+  if output="$(github_cli release view "${version}" \
+    --repo "$(github_repo "${COMPOSE_REPO}")" \
+    --json id 2>&1)"; then
+    printf 'stable release %s already exists and is immutable\n' "${version}" >&2
+    exit 1
+  else
+    status="$?"
+  fi
+
+  if grep -Eqi 'release not found|HTTP 404' <<<"${output}"; then
+    return 0
+  fi
+
+  printf 'could not determine whether stable release %s exists (gh exit %s):\n%s\n' \
+    "${version}" "${status}" "${output}" >&2
+  exit 1
+}
+
 # Require GitHub to recognise the signature on a newly-pushed stable tag. A
 # local signature alone is not enough: it must be associated with the GitHub
 # account that publishes this release.
@@ -1332,11 +1365,9 @@ dispatch_stable_release_gate() {
   done
 }
 
-# Tag a compose state as the stable/latest release point.
-tag_stable_version() {
+# Publish the immutable assets and tap formulae for a signed stable source tag.
+publish_stable_release() {
   local version="$1"
-  print_header "tag container-compose main as ${version} latest"
-  tag_new_stable_version "${version}"
   dispatch_stable_release_gate "${version}"
   dispatch_compose_stable_package "${version}"
   print_component_refs
@@ -1350,6 +1381,23 @@ Stable release point:
 EOF
 }
 
+# Tag a compose state as the stable/latest release point.
+tag_stable_version() {
+  local version="$1"
+  print_header "tag container-compose main as ${version} latest"
+  tag_new_stable_version "${version}"
+  publish_stable_release "${version}"
+}
+
+# Resume an unreleased signed tag after a failed gate without mutating source identity.
+resume_stable_release() {
+  local version="$1"
+  print_header "resume stable release ${version}"
+  ensure_stable_release_is_unpublished "${version}"
+  verify_github_stable_tag_signature "${version}"
+  publish_stable_release "${version}"
+}
+
 release_current_stack() {
   local latest current version path
   latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
@@ -1358,6 +1406,11 @@ release_current_stack() {
   fi
   current="$(current_compose_version)"
   version="$(resolve_release_version "${VERSION_SELECTOR}")"
+  if stable_tag_exists "${version}"; then
+    printf 'resuming unpublished stable tag: %s\n' "${version}"
+    resume_stable_release "${version}"
+    return 0
+  fi
   ensure_release_version_is_valid "${latest}" "${current}" "${version}"
   ensure_new_stable_release "${version}"
   path="$(repo_path "${COMPOSE_REPO}")"


### PR DESCRIPTION
Fixes stable-release recovery when the gate fails before assets are published.

- checks out the tap required by `make release-gate`;
- permits retrying the same GitHub-verified, signed tag only while no semantic release exists;
- documents the retry path.