### PR TITLE
fix(release): harden stable tag recovery

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -251,6 +251,20 @@ jobs:
           path: container-compose/.local/bin
           key: ${{ runner.os }}-${{ runner.arch }}-local-tools-hawkeye-v6.5.1
 
+      # Each pinned repository checks its own .local/bin rather than PATH.
+      # Bootstrap those verified per-repository tools before invoking the
+      # aggregate gate from container-compose.
+      - name: Provision pinned stack tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          for repository in container-builder-shim containerization container; do
+            (
+              cd "${repository}"
+              ./scripts/install-hawkeye.sh
+            )
+          done
+
       - name: Run release gate
         run: make release-gate
         working-directory: container-compose

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -72,18 +72,49 @@ jobs:
             printf 'could not resolve stable tag %s or main\n' "${RELEASE_TAG}" >&2
             exit 1
           fi
+          tag_object="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha'
+          )"
+          tag_verified="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object}" --jq '.verification.verified'
+          )"
+          if [[ "${tag_verified}" != "true" ]]; then
+            printf 'stable tag %s is not GitHub-verified\n' "${RELEASE_TAG}" >&2
+            exit 1
+          fi
+
+          latest_stable_tag="$(
+            git ls-remote --tags --refs "${remote}" \
+              | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
+              | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
+              | sort -V \
+              | tail -n 1
+          )"
+          if [[ "${latest_stable_tag}" != "${RELEASE_TAG}" ]]; then
+            printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
+              "${RELEASE_TAG}" "${latest_stable_tag:-missing}" >&2
+            exit 1
+          fi
+
+          release_output=""
+          set +e
+          release_output="$(
+            gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" 2>&1
+          )"
+          release_status=$?
+          set -e
+          if (( release_status == 0 )); then
+            printf 'stable release %s already exists and is immutable\n' "${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          if [[ "${release_output}" != *"HTTP 404"* ]]; then
+            printf 'could not determine whether stable release %s exists:\n%s\n' \
+              "${RELEASE_TAG}" "${release_output}" >&2
+            exit 1
+          fi
+
           if [[ "${tag_sha}" != "${main_sha}" ]]; then
-            tag_object="$(
-              gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha'
-            )"
-            tag_verified="$(
-              gh api "repos/${GITHUB_REPOSITORY}/git/tags/${tag_object}" --jq '.verification.verified'
-            )"
-            if [[ "${tag_verified}" != "true" ]]; then
-              printf 'stable tag %s no longer matches main and is not GitHub-verified\n' "${RELEASE_TAG}" >&2
-              exit 1
-            fi
-            printf 'stable tag %s no longer matches main; accepting its GitHub-verified source for a release retry\n' \
+            printf 'stable tag %s no longer matches main; accepting its GitHub-verified unpublished source for a release retry\n' \
               "${RELEASE_TAG}"
           fi
 

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       sha: ${{ steps.candidate.outputs.sha }}
+      homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}
     steps:
       - name: Require an immutable main tag and green main CI
         id: candidate
@@ -86,6 +87,16 @@ jobs:
               "${RELEASE_TAG}"
           fi
 
+          homebrew_tap_ref="$(
+            git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git refs/heads/main \
+              | awk '{ print $1 }' \
+              | tail -n 1
+          )"
+          if [[ ! "${homebrew_tap_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'could not resolve an immutable homebrew-tap main revision\n' >&2
+            exit 1
+          fi
+
           deadline=$((SECONDS + 3600))
           while true; do
             run="$(
@@ -111,6 +122,7 @@ jobs:
           done
 
           printf 'sha=%s\n' "${tag_sha}" >> "$GITHUB_OUTPUT"
+          printf 'homebrew_tap_ref=%s\n' "${homebrew_tap_ref}" >> "$GITHUB_OUTPUT"
 
   release-gate:
     name: Run Full Release Gate
@@ -167,25 +179,27 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.stack-refs.outputs.container_ref }}
 
-      - name: Checkout Homebrew tap
+      - name: Checkout immutable Homebrew tap snapshot
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: stephenlclarke/homebrew-tap
           path: homebrew-tap
           fetch-depth: 0
-          ref: main
+          ref: ${{ needs.resolve-candidate.outputs.homebrew_tap_ref }}
 
       - name: Verify immutable dependency checkouts
         env:
           BUILDER_REF: ${{ steps.stack-refs.outputs.container_builder_shim_ref }}
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           CONTAINER_REF: ${{ steps.stack-refs.outputs.container_ref }}
+          HOMEBREW_TAP_REF: ${{ needs.resolve-candidate.outputs.homebrew_tap_ref }}
         shell: bash
         run: |
           set -euo pipefail
           [[ "$(git -C container-builder-shim rev-parse HEAD)" == "${BUILDER_REF}" ]]
           [[ "$(git -C containerization rev-parse HEAD)" == "${CONTAINERIZATION_REF}" ]]
           [[ "$(git -C container rev-parse HEAD)" == "${CONTAINER_REF}" ]]
+          [[ "$(git -C homebrew-tap rev-parse HEAD)" == "${HOMEBREW_TAP_REF}" ]]
 
       - name: Use pinned containerization dependency
         run: Tools/ci/use-stack-containerization.sh ../containerization
@@ -211,3 +225,4 @@ jobs:
         working-directory: container-compose
         env:
           HAWKEYE_AUTO_INSTALL: "1"
+          HOMEBREW_TAP_REPO: ../homebrew-tap

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -73,9 +73,10 @@ release-preparation commit. This is the helper's only version mutation. It then
 promotes the source branches, creates one new semantic `container-compose` tag,
 dispatches the hosted Stable Release Gate, and then dispatches the stable package workflow.
 The hosted gate first requires green `main` CI—the only place SonarQube analyses
-the project—then runs full stack parity against the exact tagged commit. The
-package workflow verifies that hosted evidence and the runtime asset before it
-creates the release and atomically updates the tap.
+the project—then runs full stack parity against the exact tagged commit and an
+immutable Homebrew tap snapshot. The package workflow verifies that hosted
+evidence and the runtime asset before it creates the release and atomically
+updates the tap.
 
 Semantic source tags and stable GitHub releases are immutable. The `current`
 tag and its single **Current build** prerelease are deliberately mutable: after

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -84,7 +84,9 @@ green `main` CI, automation replaces their assets and notes with the exact
 latest stack. Automation removes superseded generated current-release objects
 without deleting their tags, so upstream PR snapshots and source references
 remain available. Correct a failed stable release through an explicitly reviewed
-incident change; do not replay an identity.
+incident change. If the signed source tag remains unpublished, the corrected
+automation can resume the latest tag's gates and package publication against
+that exact identity; it never changes the tag or overwrites a stable release.
 
 Release notes are rendered by [Tools/release/release-notes.py](Tools/release/release-notes.py). The notes compare against the newest published stable GitHub release when release metadata is available, with local semantic tags as the offline fallback, so unpublished source tags cannot hide user-facing changes. They include a raw commit audit list, and they promote user-facing `Release-Note:` or `Release-Highlight:` commit trailers into a `Highlights` section before that list. Write one complete sentence that names the Docker Compose feature, CLI option, or workflow users now get; internal release, CI, and documentation chores should normally omit the trailer or use `Release-Note: none`, which suppresses an automatic highlight. When a user-facing conventional commit has no trailer, the renderer uses the first prose paragraph from its body before falling back to the subject. The active package also contains a machine-readable `release-highlights.json` copy; stable notes preserve those highlights after retired assets are removed. Each stable release also records static, non-clickable SonarQube and CodeQL badges for the exact promoted commit; this block never contains release-version or visitor badges. For upstream-driven work, also record the original `owner/repository#number` under `Upstream-Ref:`, `Bug-Ref:`, `Refs:`, or `Follow-up-To:`. The renderer preserves references already written into the highlight and appends any missing references, including highlights collected from stack component commits.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -180,8 +180,8 @@ asset, or edit either stable formula by hand.
 If a hosted gate fails before the semantic GitHub release is created, correct
 the release automation on `main` and rerun the same explicit version, for
 example `make release VERSION_SELECTOR=0.6.70`. The helper reuses only the
-existing GitHub-verified signed source tag, reruns the gates and package workflow,
-and refuses to change a tag or overwrite an existing semantic release.
+latest existing GitHub-verified signed source tag, reruns the gates and package
+workflow, and refuses to change a tag or overwrite an existing semantic release.
 
 After the tag is published, the one mutable `current` prerelease continues to
 follow later green `main` commits. Homebrew users without `-current` always use

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -135,6 +135,17 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("run github_cli workflow run", self.script)
         self.assertNotIn("env -u GITHUB_TOKEN -u GH_TOKEN gh", self.script)
 
+    def test_release_helper_describes_the_hosted_stable_gate(self) -> None:
+        self.assertIn(
+            "The hosted Stable Release Gate runs after the signed tag and before stable package publication.",
+            self.script,
+        )
+        self.assertIn(
+            "- The hosted Stable Release Gate must pass before stable package publication.",
+            self.script,
+        )
+        self.assertNotIn("make release-gate completed locally before this PR.", self.script)
+
     def test_release_helper_preserves_formatted_swiftpm_dependency_pins(self) -> None:
         self.assertIn(r'r"(\s*,?\s*\))"', self.script)
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -44,6 +44,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         release = self.script[self.script.index("release_current_stack() {") :]
         self.assertIn('if stable_tag_exists "${version}"', release)
         self.assertIn('resume_stable_release "${version}"', release)
+        self.assertIn('ensure_latest_stable_retry "${version}"', self.script)
         self.assertIn("ensure_new_stable_release \"${version}\"", release)
         self.assertLess(
             release.index('resume_stable_release "${version}"'),
@@ -119,9 +120,17 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("docker-compose-devices-parity", makefile)
         self.assertNotIn("repackage-release", makefile)
 
-    def test_hosted_release_gate_uses_a_verified_immutable_tap_snapshot(self) -> None:
+    def test_hosted_release_gate_uses_an_unpublished_verified_tag_and_immutable_tap_snapshot(
+        self,
+    ) -> None:
         workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("accepting its GitHub-verified source for a release retry", workflow)
+        self.assertIn("stable tag %s is not GitHub-verified", workflow)
+        self.assertIn("stable tag %s is not the latest semantic source tag", workflow)
+        self.assertIn("stable release %s already exists and is immutable", workflow)
+        self.assertIn(
+            "accepting its GitHub-verified unpublished source for a release retry",
+            workflow,
+        )
         self.assertIn(
             "homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}",
             workflow,
@@ -295,6 +304,73 @@ esac
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("auto-merge was not available", result.stdout)
             self.assertIn("promotion PR already merged: #42", result.stdout)
+
+    def test_retry_requires_an_unpublished_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_directory = root / "bin"
+            bin_directory.mkdir()
+            fake_gh = bin_directory / "gh"
+            fake_gh.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" != "release" || "$2" != "view" ]]; then
+  exit 1
+fi
+
+if [[ "${GH_RELEASE_STATE}" == "published" ]]; then
+  printf '%s\\n' '{"id": 1}'
+  exit 0
+fi
+
+printf '%s\\n' 'release not found' >&2
+exit 1
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            shell_setup = "\n".join(
+                [
+                    f"export PATH={shlex.quote(str(bin_directory))}:$PATH",
+                    "export GH_RELEASE_STATE=unpublished",
+                ]
+            )
+
+            unpublished = self.run_release_function(
+                root,
+                "ensure_stable_release_is_unpublished 0.6.70",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(unpublished.returncode, 0, unpublished.stderr)
+
+            published = self.run_release_function(
+                root,
+                "ensure_stable_release_is_unpublished 0.6.70",
+                shell_setup=shell_setup.replace("unpublished", "published"),
+            )
+            self.assertNotEqual(published.returncode, 0)
+            self.assertIn("stable release 0.6.70 already exists and is immutable", published.stderr)
+
+    def test_retry_rejects_a_stale_semantic_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            shell_setup = "latest_local_semver_tag() { printf '%s\\n' 0.6.71; }"
+
+            latest = self.run_release_function(
+                root,
+                "ensure_latest_stable_retry 0.6.71",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(latest.returncode, 0, latest.stderr)
+
+            stale = self.run_release_function(
+                root,
+                "ensure_latest_stable_retry 0.6.70",
+                shell_setup=shell_setup,
+            )
+            self.assertNotEqual(stale.returncode, 0)
+            self.assertIn("stable tag 0.6.70 is not the latest semantic source tag (0.6.71)", stale.stderr)
 
     def create_compose_checkout(self, root: Path) -> tuple[Path, Path]:
         remote = root / "remote.git"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -119,11 +119,29 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("docker-compose-devices-parity", makefile)
         self.assertNotIn("repackage-release", makefile)
 
-    def test_stable_gate_checks_out_the_tap_and_accepts_verified_retry_tags(self) -> None:
+    def test_hosted_release_gate_uses_a_verified_immutable_tap_snapshot(self) -> None:
         workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("accepting its GitHub-verified source for a release retry", workflow)
+        self.assertIn(
+            "homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}",
+            workflow,
+        )
+        self.assertIn(
+            "git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git refs/heads/main",
+            workflow,
+        )
         self.assertIn("repository: stephenlclarke/homebrew-tap", workflow)
         self.assertIn("path: homebrew-tap", workflow)
-        self.assertIn("accepting its GitHub-verified source for a release retry", workflow)
+        self.assertIn(
+            "ref: ${{ needs.resolve-candidate.outputs.homebrew_tap_ref }}",
+            workflow,
+        )
+        self.assertIn("git -C homebrew-tap rev-parse HEAD", workflow)
+        self.assertIn("HOMEBREW_TAP_REPO: ../homebrew-tap", workflow)
+        self.assertLess(
+            workflow.index("Checkout immutable Homebrew tap snapshot"),
+            workflow.index("Run release gate"),
+        )
 
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -147,8 +147,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertIn("git -C homebrew-tap rev-parse HEAD", workflow)
         self.assertIn("HOMEBREW_TAP_REPO: ../homebrew-tap", workflow)
+        self.assertIn("Provision pinned stack tools", workflow)
+        self.assertIn(
+            "for repository in container-builder-shim containerization container; do",
+            workflow,
+        )
+        self.assertIn("./scripts/install-hawkeye.sh", workflow)
         self.assertLess(
             workflow.index("Checkout immutable Homebrew tap snapshot"),
+            workflow.index("Run release gate"),
+        )
+        self.assertLess(
+            workflow.index("Provision pinned stack tools"),
             workflow.index("Run release gate"),
         )
 

--- a/docs/upstream/APPLE-UPSTREAM-REVIEW.md
+++ b/docs/upstream/APPLE-UPSTREAM-REVIEW.md
@@ -20,7 +20,7 @@ This is the current disposition of Apple work that affects the five-repository c
 
 The exact current heads of these proposals, plus
 [apple/container-builder-shim#87](https://github.com/apple/container-builder-shim/pull/87),
-are retained as immutable Stephen-owned branches in
+are retained as immutable stephenlclarke-owned branches in
 [PR-ARCHIVE.json](PR-ARCHIVE.json). The daily archive verification workflow
 fails if any snapshot is deleted or retargeted.
 

--- a/docs/upstream/README.md
+++ b/docs/upstream/README.md
@@ -18,7 +18,7 @@ build instructions live at the repository root.
 - Treat this `container-compose` tree as the only home for handoff documentation. Do not keep `ISSUE-*.md` or `PR-*.md` draft files in the sibling `container`, `containerization`, or `container-builder-shim` fork worktrees; if one is created there while shaping code, move it into the matching `docs/upstream/` folder here and remove the fork copy.
 - Keep drafts current. Remove obsolete branch names, completed migration notes, dated snapshots, and superseded implementation procedures instead of preserving project history here. Current branch and release rules live in [BRANCHES.md](../../BRANCHES.md).
 - Every open Apple pull request with code we may need to recover must also have
-  an immutable, Stephen-owned `upstream-pr-NUMBER-SHORTSHA` branch recorded in
+  an immutable, stephenlclarke-owned `upstream-pr-NUMBER-SHORTSHA` branch recorded in
   [PR-ARCHIVE.json](PR-ARCHIVE.json). Never force-push, delete, or retarget an
   archive branch. Add a new snapshot when an upstream PR head changes.
 
@@ -40,7 +40,7 @@ The review must cover every potential PR independently:
 | Area | Paths | Notes |
 | --- | --- | --- |
 | Current Apple review | `docs/upstream/APPLE-UPSTREAM-REVIEW.md` | Live disposition of affected bugs, approved open pull requests, local ports, and unresolved follow-up work. |
-| Immutable PR code archive | `docs/upstream/PR-ARCHIVE.json` | Full-SHA, Stephen-owned snapshots of every open upstream proposal that the stack depends on. [Verify Upstream PR Archives](../../.github/workflows/upstream-pr-archive.yml) checks them daily. |
+| Immutable PR code archive | `docs/upstream/PR-ARCHIVE.json` | Full-SHA, stephenlclarke-owned snapshots of every open upstream proposal that the stack depends on. [Verify Upstream PR Archives](../../.github/workflows/upstream-pr-archive.yml) checks them daily. |
 | Compose-owned compatibility slices | `docs/upstream/container-compose/` | Plugin-owned issue/PR drafts with commit tracking. These drafts may describe Docker/Compose compatibility and the temporary command-vector bridge while the typed service-create adapter is still being wired. |
 | Copy slices | `docs/upstream/copy/` | Compose-facing copy follow-link and archive drafts with commit tracking. Runtime copy primitives live under the Apple folders. |
 | Process listing / `top` slice | `docs/upstream/process-list/`, `docs/upstream/apple-container/`, and `docs/upstream/apple-containerization/` | Compose-facing Docker-shaped `top` drafts plus generic Apple runtime/API/init-image handoffs and commit tracking. |

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -80,7 +80,7 @@ Rules enforced:
   - The hosted Stable Release Gate runs after the signed tag and before stable package publication.
   - Stable package and Homebrew tap updates are explicitly dispatched and waited for.
   - Stable package assets and the Homebrew tap SHA are verified before success.
-  - Stable releases are created once; existing stable tags and releases fail.
+  - Published stable releases are immutable; only the latest GitHub-verified signed tag may resume before publication.
   - container-compose main updates use pull-request promotion by default.
   - An equivalent tree already squash-merged on main is reconciled before tagging.
   - Long-lived release branches are not used.
@@ -516,9 +516,26 @@ stable_tag_exists() {
   git -C "${path}" ls-remote --exit-code --tags "${remote}" "refs/tags/${version}" >/dev/null 2>&1
 }
 
+# Reject a stale unpublished tag so a retry cannot replace a newer stable lane.
+ensure_latest_stable_retry() {
+  local version="$1" latest
+  latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
+  if [[ "${version}" != "${latest}" ]]; then
+    printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
+      "${version}" "${latest:-missing}" >&2
+    exit 1
+  fi
+}
+
 # Refuse to retry a semantic tag once GitHub has made it a published release.
 ensure_stable_release_is_unpublished() {
   local version="$1" output status
+  if [[ "${EXECUTE}" != "1" ]]; then
+    printf 'would verify that stable release %s is unpublished\n' "${version}"
+    return 0
+  fi
+
+  need_command gh
   if output="$(github_cli release view "${version}" \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --json id 2>&1)"; then
@@ -1393,6 +1410,7 @@ tag_stable_version() {
 resume_stable_release() {
   local version="$1"
   print_header "resume stable release ${version}"
+  ensure_latest_stable_retry "${version}"
   ensure_stable_release_is_unpublished "${version}"
   verify_github_stable_tag_signature "${version}"
   publish_stable_release "${version}"

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -77,7 +77,7 @@ Rules enforced:
   - Worktrees must be clean before release changes.
   - Stable container-compose release tags are SSH-signed and point at the validated main commit.
   - GitHub must verify each stable tag signature before the release gate starts.
-  - The full Docker Compose parity release gate runs locally before push/tag.
+  - The hosted Stable Release Gate runs after the signed tag and before stable package publication.
   - Stable package and Homebrew tap updates are explicitly dispatched and waited for.
   - Stable package assets and the Homebrew tap SHA are verified before success.
   - Stable releases are created once; existing stable tags and releases fail.
@@ -728,11 +728,11 @@ compose_source_promotion_body() {
   path="$(repo_path "${COMPOSE_REPO}")"
   head="$(git -C "${path}" rev-parse main)"
   cat <<EOF
-Promotes the validated container-compose source state for ${version}.
+Promotes the container-compose source candidate for ${version}.
 
 Validation:
-- make release-gate completed locally before this PR.
-- The promoted main tree must match the locally gated candidate before tagging.
+- The hosted Stable Release Gate must pass before stable package publication.
+- The promoted main tree must match this candidate before tagging.
 - Apple upstream remotes remain read-only; only stephenlclarke-owned remotes are push targets.
 
 Candidate:


### PR DESCRIPTION
## Summary
- resolve and verify an immutable Homebrew tap snapshot before the hosted stable gate runs
- enforce GitHub verification, unpublished-release status, and latest-tag ordering for every recovery run
- correct the release helper and current upstream handoff terminology

## Validation
- `make check`
- `actionlint .github/workflows/stable-release-gate.yml`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- dry-run recovery of `0.6.70`
- `markdownlint docs/upstream`

## Recovery
After merge, `make release VERSION_SELECTOR=0.6.70` will validate and package the existing signed source tag without retagging it.