### PR TITLE
fix(release): provision full stack gate

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -572,7 +572,21 @@ jobs:
           notes="$(mktemp)"
           highlights="${RUNNER_TEMP}/release-highlights.json"
           git fetch --force --tags origin
-          quality_snapshot_args=()
+          release_notes_args=(
+            --release-tag "${RELEASE_TAG}"
+            --release-label "${RELEASE_LABEL}"
+            --compose-version "${COMPOSE_VERSION}"
+            --asset "${ASSET}"
+            --asset-sha "${sha256}"
+            --runtime-asset "${{ steps.runtime-package.outputs.asset }}"
+            --runtime-asset-sha "${{ steps.runtime-package.outputs.sha256 }}"
+            --head "${PUBLISH_SHA}"
+            --release-repo "${GITHUB_REPOSITORY}"
+            --component-repo container-builder-shim=../container-builder-shim
+            --component-repo containerization=../containerization
+            --component-repo container=../container
+            --highlights-json "${highlights}"
+          )
           if [[ "${PUBLISH_REF_TYPE}" == "tag" ]]; then
             quality_snapshot="${RUNNER_TEMP}/quality-snapshot.md"
             # A stable release records the exact SonarQube and CodeQL analyses
@@ -581,23 +595,9 @@ jobs:
             python3 Tools/release/capture-quality-snapshot.py \
               --repo "${GITHUB_REPOSITORY}" \
               --commit "${PUBLISH_SHA}" > "${quality_snapshot}"
-            quality_snapshot_args=(--quality-snapshot "${quality_snapshot}")
+            release_notes_args+=(--quality-snapshot "${quality_snapshot}")
           fi
-          python3 Tools/release/release-notes.py \
-            --release-tag "${RELEASE_TAG}" \
-            --release-label "${RELEASE_LABEL}" \
-            --compose-version "${COMPOSE_VERSION}" \
-            --asset "${ASSET}" \
-            --asset-sha "${sha256}" \
-            --runtime-asset "${{ steps.runtime-package.outputs.asset }}" \
-            --runtime-asset-sha "${{ steps.runtime-package.outputs.sha256 }}" \
-            --head "${PUBLISH_SHA}" \
-            --release-repo "${GITHUB_REPOSITORY}" \
-            --component-repo container-builder-shim=../container-builder-shim \
-            --component-repo containerization=../containerization \
-            --component-repo container=../container \
-            "${quality_snapshot_args[@]}" \
-            --highlights-json "${highlights}" > "${notes}"
+          python3 Tools/release/release-notes.py "${release_notes_args[@]}" > "${notes}"
 
           if [[ "${PUBLISH_REF_TYPE}" == "tag" ]]; then
             tag_target="$(

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -265,6 +265,10 @@ jobs:
             )
           done
 
+      - name: Provision containerization integration kernel
+        run: make fetch-default-kernel
+        working-directory: containerization
+
       - name: Run release gate
         run: make release-gate
         working-directory: container-compose

--- a/BUILD.md
+++ b/BUILD.md
@@ -144,7 +144,9 @@ There are two package lanes, with no manual asset copying:
 - Every green `main` commit refreshes the one mutable GitHub prerelease named **Current build** (tag `current`) and the opt-in `container-current` / `container-compose-current` Homebrew pair.
 - A semantic release is an immutable `x.y.z` tag and becomes Homebrew's default `container` / `container-compose` pair.
 
-From a clean `~/github/container-compose` checkout, inspect the deterministic plan first:
+From clean `~/github/container-compose`, `~/github/container-builder-shim`,
+`~/github/containerization`, `~/github/container`, and
+`~/github/homebrew-tap` checkouts, inspect the deterministic plan first:
 
 ```sh
 make release-plan

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -104,6 +104,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('release_title="Current build"', workflow)
         self.assertIn('RELEASE_MUTABLE="${release_mutable}"', workflow)
         self.assertIn("--delete-superseded-current-releases", workflow)
+        self.assertIn("release_notes_args=(", workflow)
+        self.assertIn('python3 Tools/release/release-notes.py "${release_notes_args[@]}"', workflow)
+        self.assertNotIn("quality_snapshot_args", workflow)
 
     def test_current_package_skips_only_when_the_pointer_already_matches_main(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -161,6 +161,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow.index("Provision pinned stack tools"),
             workflow.index("Run release gate"),
         )
+        self.assertIn("Provision containerization integration kernel", workflow)
+        self.assertIn("run: make fetch-default-kernel", workflow)
 
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)


### PR DESCRIPTION
## Summary
- install Hawkeye in each pinned stack checkout before the stable release gate
- fetch the pinned containerization integration kernel before validation
- run the same full gate locally before source promotion and document its clean-checkout requirement

## Validation
- `python3 -m unittest Tools/release/test_container_stack_release.py`
- `make -C ../containerization fetch-default-kernel`
- `make -C ../containerization integration` (166/166 passed)
- YAML and Bash syntax checks