### PR TITLE
fix(release): support isolated stack roots

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -61,6 +61,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('verify_github_stable_tag_signature "${version}"', self.script)
         self.assertIn("GitHub did not verify stable tag", self.script)
 
+    def test_release_helper_supports_an_isolated_stack_root(self) -> None:
+        self.assertIn('ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"', self.script)
+        self.assertIn("CONTAINER_STACK_RELEASE_ROOT", self.script)
+
     def test_internal_dependency_pins_do_not_become_release_highlights(self) -> None:
         pin_commit = self.script[
             self.script.index("commit_containerization_package_pin() {") : self.script.index(

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -99,6 +99,11 @@ Environment:
   CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS
   CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS
       Override the default one-hour PR promotion wait and 30-second poll.
+
+  CONTAINER_STACK_RELEASE_ROOT
+      Override the parent directory containing the four source checkouts and
+      the Homebrew tap. Defaults to ~/github. Use an isolated stack root for
+      release validation without touching another local workspace.
 USAGE
 }
 
@@ -149,7 +154,7 @@ parse_arguments() {
   done
 }
 
-ROOT="${HOME}/github"
+ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"
 COMPOSE_REPO="container-compose"
 CONTAINER_REPO="container"
 COMPOSE_PACKAGE_WAIT_SECONDS="${CONTAINER_STACK_COMPOSE_PACKAGE_WAIT_SECONDS:-3600}"


### PR DESCRIPTION
## Summary
- allow the release helper to target an explicit isolated checkout root
- document the override and protect other local worktrees from release mutations

## Validation
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `python3 -m unittest Tools/release/test_container_stack_release.py`