### PR TITLE
fix(release): make stable release gates reproducible

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -258,6 +258,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          (
+            cd container-compose
+            HAWKEYE_AUTO_INSTALL=1 ./scripts/install-hawkeye.sh
+          )
           for repository in container-builder-shim containerization container; do
             (
               cd "${repository}"

--- a/BUILD.md
+++ b/BUILD.md
@@ -171,6 +171,11 @@ make release VERSION_SELECTOR=+--   # major: X.Y.Z -> (X+1).0.0
 make release VERSION_SELECTOR=0.7.0 # exact next semantic version
 ```
 
+Before source promotion, the helper bootstraps the matched stack tools, fetches
+the required `containerization` integration kernel when it is absent, and runs
+the full local `make release-gate`. The hosted gate repeats that validation from
+the immutable source, runtime, and tap checkouts before package publication.
+
 The helper is the only supported version mutator. It updates the Compose version
 when necessary, preserves the exact runtime stack pin, opens and merges the
 source-promotion PR, creates a signed semantic tag, waits for the hosted Stable

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -155,11 +155,15 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("git -C homebrew-tap rev-parse HEAD", workflow)
         self.assertIn("HOMEBREW_TAP_REPO: ../homebrew-tap", workflow)
         self.assertIn("Provision pinned stack tools", workflow)
+        self.assertIn("cd container-compose", workflow)
+        self.assertIn("HAWKEYE_AUTO_INSTALL=1 ./scripts/install-hawkeye.sh", workflow)
         self.assertIn(
             "for repository in container-builder-shim containerization container; do",
             workflow,
         )
         self.assertIn("./scripts/install-hawkeye.sh", workflow)
+        self.assertIn("Provision containerization integration kernel", workflow)
+        self.assertIn("run: make fetch-default-kernel", workflow)
         self.assertLess(
             workflow.index("Checkout immutable Homebrew tap snapshot"),
             workflow.index("Run release gate"),
@@ -168,8 +172,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow.index("Provision pinned stack tools"),
             workflow.index("Run release gate"),
         )
-        self.assertIn("Provision containerization integration kernel", workflow)
-        self.assertIn("run: make fetch-default-kernel", workflow)
+        self.assertLess(
+            workflow.index("Provision containerization integration kernel"),
+            workflow.index("Run release gate"),
+        )
+
+    def test_new_stable_release_runs_the_local_gate_before_promotion(self) -> None:
+        release = self.script[self.script.index("release_current_stack() {") :]
+        self.assertIn("run_local_release_gate", release)
+        self.assertLess(release.index("run_local_release_gate"), release.index("push_all_main"))
+        self.assertIn('HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"', self.script)
+        self.assertIn('"$(repo_path "container-builder-shim")"', self.script)
+        self.assertIn('make -C "$(repo_path "containerization")" fetch-default-kernel', self.script)
 
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -163,6 +163,7 @@ PROMOTION_WAIT_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS:-3600}"
 PROMOTION_POLL_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS:-30}"
 COMPOSE_MAIN_PROMOTION_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_PROMOTION_MODE:-pr}"
 COMPOSE_MAIN_MERGE_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_MERGE_MODE:-checked-admin}"
+HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"
 REPOS=(
   "container-builder-shim"
   "containerization"
@@ -321,6 +322,38 @@ ensure_clean() {
     printf 'dirty worktree blocks release for %s:\n%s\n' "${repo}" "${status}" >&2
     exit 1
   fi
+}
+
+# Run the full release gate locally before any source branch is promoted.
+run_local_release_gate() {
+  local path repository
+  path="$(repo_path "${COMPOSE_REPO}")"
+  if [[ ! -f "${HOMEBREW_TAP_REPO}/Formula/container-compose.rb" ]]; then
+    printf 'Homebrew tap checkout is required at %s\n' "${HOMEBREW_TAP_REPO}" >&2
+    exit 1
+  fi
+
+  print_header "run local release gate"
+  for repository in "${path}" \
+    "$(repo_path "container-builder-shim")" \
+    "$(repo_path "containerization")" \
+    "$(repo_path "container")"; do
+    if [[ "${EXECUTE}" != "1" ]]; then
+      printf 'would install Hawkeye in %s\n' "${repository}"
+      continue
+    fi
+    (
+      cd "${repository}"
+      if [[ "${repository}" == "${path}" ]]; then
+        HAWKEYE_AUTO_INSTALL=1 ./scripts/install-hawkeye.sh --auto-install
+      else
+        ./scripts/install-hawkeye.sh
+      fi
+    )
+  done
+  run make -C "$(repo_path "containerization")" fetch-default-kernel
+  run env HAWKEYE_AUTO_INSTALL=1 \
+    make -C "${path}" release-gate "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}"
 }
 
 # Verify that Apple remotes cannot be pushed and stephenlclarke remotes are the target.
@@ -1469,6 +1502,7 @@ release_current_stack() {
   fi
 
   ensure_clean "${COMPOSE_REPO}"
+  run_local_release_gate
   push_all_main "${version}"
   tag_stable_version "${version}"
 }


### PR DESCRIPTION
## Summary

- Run the complete matched-stack release gate locally before any source branch is promoted, tagged, or packaged.
- Bootstrap Hawkeye for the Compose checkout in the hosted immutable release gate, matching the sibling-stack setup.
- Document the local and hosted gate prerequisites as the current release workflow.

## Root Cause

Stable release gate run [29273617069](https://github.com/stephenlclarke/container-compose/actions/runs/29273617069) reached integration validation without `containerization/bin/vmlinux-arm64`, so the gate failed before stable package and Homebrew tap promotion.

## Upstream Alignment

This branch is rebased onto current `main`, which already contains the overlapping kernel, release-note, and isolated-stack-root work from [#65](https://github.com/stephenlclarke/container-compose/pull/65) and [#66](https://github.com/stephenlclarke/container-compose/pull/66). It intentionally retains only the remaining local pre-promotion gate and Compose Hawkeye bootstrap.

Original imported source reference: `fb20c72dbc17cb232a2fd55f890c0eaf3d5d4b64` (`fix(release): provision full stack gate`).

## Validation

- Full `make release-gate HOMEBREW_TAP_REPO=../homebrew-tap` passed before the upstream rebase, including matching-stack runtime, integration, coverage, Docker Compose CLI, bridge, GPU, and live parity checks.
- `python3 Tools/release/test_container_stack_release.py` - 25 tests passed after rebase.
- `python3 Tools/release/test_release_notes.py` - 19 tests passed.
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `actionlint .github/workflows/stable-release-gate.yml .github/workflows/prebuilt-binaries.yml`
- `make release-plan`

## Release Impact

This repair makes the signed, verified, unpublished `0.6.70` tag safely retryable. It does not alter Compose user-facing behavior; it makes the release workflow deterministic and able to complete the required validation.