### PR TITLE
fix(release): align stable gate wait budget

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -175,6 +175,9 @@ Before source promotion, the helper bootstraps the matched stack tools, fetches
 the required `containerization` integration kernel when it is absent, and runs
 the full local `make release-gate`. The hosted gate repeats that validation from
 the immutable source, runtime, and tap checkouts before package publication.
+The helper waits up to three hours for that hosted gate, which exceeds its
+120-minute workflow timeout; set `CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS` only
+when an operator needs a different bound.
 
 The helper is the only supported version mutator. It updates the Compose version
 when necessary, preserves the exact runtime stack pin, opens and merges the

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -177,6 +177,24 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow.index("Run release gate"),
         )
 
+    def test_release_helper_waits_longer_than_the_hosted_stable_gate_timeout(self) -> None:
+        dispatch = self.script[
+            self.script.index("dispatch_stable_release_gate() {") : self.script.index(
+                "publish_stable_release() {"
+            )
+        ]
+        self.assertIn(
+            'STABLE_RELEASE_GATE_WAIT_SECONDS="${CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS:-10800}"',
+            self.script,
+        )
+        self.assertIn("CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS", self.script)
+        self.assertIn("deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))", dispatch)
+        self.assertIn(
+            '"${run_id}" "hosted stable release gate" "${STABLE_RELEASE_GATE_WAIT_SECONDS}"',
+            dispatch,
+        )
+        self.assertIn("timeout-minutes: 120", STABLE_GATE_WORKFLOW.read_text(encoding="utf-8"))
+
     def test_new_stable_release_runs_the_local_gate_before_promotion(self) -> None:
         release = self.script[self.script.index("release_current_stack() {") :]
         self.assertIn("run_local_release_gate", release)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -100,6 +100,15 @@ Environment:
   CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS
       Override the default one-hour PR promotion wait and 30-second poll.
 
+  CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS
+      Override the default three-hour wait for the hosted Stable Release Gate.
+      The default exceeds the gate's 120-minute workflow timeout so a valid
+      queued or long-running gate does not prematurely end the local release.
+
+  CONTAINER_STACK_COMPOSE_PACKAGE_WAIT_SECONDS
+  CONTAINER_STACK_COMPOSE_PACKAGE_POLL_SECONDS
+      Override the default one-hour package workflow wait and 30-second poll.
+
   CONTAINER_STACK_RELEASE_ROOT
       Override the parent directory containing the four source checkouts and
       the Homebrew tap. Defaults to ~/github. Use an isolated stack root for
@@ -159,6 +168,7 @@ COMPOSE_REPO="container-compose"
 CONTAINER_REPO="container"
 COMPOSE_PACKAGE_WAIT_SECONDS="${CONTAINER_STACK_COMPOSE_PACKAGE_WAIT_SECONDS:-3600}"
 COMPOSE_PACKAGE_POLL_SECONDS="${CONTAINER_STACK_COMPOSE_PACKAGE_POLL_SECONDS:-30}"
+STABLE_RELEASE_GATE_WAIT_SECONDS="${CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS:-10800}"
 PROMOTION_WAIT_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS:-3600}"
 PROMOTION_POLL_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS:-30}"
 COMPOSE_MAIN_PROMOTION_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_PROMOTION_MODE:-pr}"
@@ -1193,8 +1203,9 @@ latest_stable_release_gate_dispatch_run() {
 
 # Wait for a GitHub Actions run to complete successfully.
 wait_for_github_run_success() {
-  local run_id="$1" label="$2" status conclusion url deadline now details
-  deadline=$((SECONDS + COMPOSE_PACKAGE_WAIT_SECONDS))
+  local run_id="$1" label="$2" wait_seconds="${3:-${COMPOSE_PACKAGE_WAIT_SECONDS}}"
+  local status conclusion url deadline now details
+  deadline=$((SECONDS + wait_seconds))
   while true; do
     details="$(
       github_cli run view "${run_id}" \
@@ -1399,12 +1410,13 @@ dispatch_stable_release_gate() {
     --ref main \
     -f "ref=${version}"
 
-  deadline=$((SECONDS + COMPOSE_PACKAGE_WAIT_SECONDS))
+  deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))
   while true; do
     run_id="$(latest_stable_release_gate_dispatch_run || true)"
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
       printf 'stable release gate started: %s\n' "${run_id}"
-      wait_for_github_run_success "${run_id}" "hosted stable release gate"
+      wait_for_github_run_success \
+        "${run_id}" "hosted stable release gate" "${STABLE_RELEASE_GATE_WAIT_SECONDS}"
       return 0
     fi
 


### PR DESCRIPTION
## Summary

- Give the hosted Stable Release Gate its own three-hour wait budget.
- Keep the existing one-hour package workflow budget unchanged.
- Document both wait controls and add regression coverage for the hosted gate timeout relationship.

## Root Cause

The hosted stable gate explicitly permits up to 120 minutes, while the local release helper used the one-hour package-workflow budget when waiting for it. A valid queued or long-running stable gate could therefore outlive the local command and leave release promotion incomplete.

## Validation

- `python3 Tools/release/test_container_stack_release.py` - 26 tests passed
- `python3 Tools/release/test_release_notes.py` - 19 tests passed
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `npx --no-install markdownlint BUILD.md`
- `make release-plan`
- `git diff --check`

## Compatibility

The default package workflow wait remains one hour. Operators can override the stable-gate bound with `CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS` when needed.