### PR TITLE
fix(release): validate stable tags without nested virtualization

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -156,7 +156,7 @@ jobs:
           printf 'homebrew_tap_ref=%s\n' "${homebrew_tap_ref}" >> "$GITHUB_OUTPUT"
 
   release-gate:
-    name: Run Full Release Gate
+    name: Run Hosted Release Gate
     needs: resolve-candidate
     runs-on: macos-26
     timeout-minutes: 120
@@ -167,6 +167,15 @@ jobs:
           path: container-compose
           fetch-depth: 0
           ref: ${{ needs.resolve-candidate.outputs.sha }}
+
+      # Stable tags are immutable, so use the immutable workflow revision for
+      # release-control tooling while validating the tag checkout separately.
+      - name: Checkout immutable stable-gate tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: release-tools
+          fetch-depth: 0
+          ref: ${{ github.sha }}
 
       - name: Read exact stack refs
         id: stack-refs
@@ -224,6 +233,7 @@ jobs:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           CONTAINER_REF: ${{ steps.stack-refs.outputs.container_ref }}
           HOMEBREW_TAP_REF: ${{ needs.resolve-candidate.outputs.homebrew_tap_ref }}
+          CONTROL_SHA: ${{ github.sha }}
         shell: bash
         run: |
           set -euo pipefail
@@ -231,6 +241,7 @@ jobs:
           [[ "$(git -C containerization rev-parse HEAD)" == "${CONTAINERIZATION_REF}" ]]
           [[ "$(git -C container rev-parse HEAD)" == "${CONTAINER_REF}" ]]
           [[ "$(git -C homebrew-tap rev-parse HEAD)" == "${HOMEBREW_TAP_REF}" ]]
+          [[ "$(git -C release-tools rev-parse HEAD)" == "${CONTROL_SHA}" ]]
 
       - name: Use pinned containerization dependency
         run: Tools/ci/use-stack-containerization.sh ../containerization
@@ -253,7 +264,7 @@ jobs:
 
       # Each pinned repository checks its own .local/bin rather than PATH.
       # Bootstrap those verified per-repository tools before invoking the
-      # aggregate gate from container-compose.
+      # immutable control-plane release gate.
       - name: Provision pinned stack tools
         shell: bash
         run: |
@@ -269,13 +280,15 @@ jobs:
             )
           done
 
-      - name: Provision containerization integration kernel
-        run: make fetch-default-kernel
-        working-directory: containerization
-
-      - name: Run release gate
-        run: make release-gate
-        working-directory: container-compose
+      # GitHub-hosted macOS runners are VMs and cannot launch nested
+      # Virtualization.framework guests. The release helper runs the full live
+      # gate on a supported local Mac before it creates the signed source tag.
+      - name: Run hosted release gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          release-tools/Tools/ci/run-stack-release-validation.sh hosted \
+            container-compose container-builder-shim containerization container homebrew-tap
+          make -C container-compose ci
         env:
           HAWKEYE_AUTO_INSTALL: "1"
-          HOMEBREW_TAP_REPO: ../homebrew-tap

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -73,10 +73,12 @@ release-preparation commit. This is the helper's only version mutation. It then
 promotes the source branches, creates one new semantic `container-compose` tag,
 dispatches the hosted Stable Release Gate, and then dispatches the stable package workflow.
 The hosted gate first requires green `main` CI—the only place SonarQube analyses
-the project—then runs full stack parity against the exact tagged commit and an
-immutable Homebrew tap snapshot. The package workflow verifies that hosted
-evidence and the runtime asset before it creates the release and atomically
-updates the tap.
+the project—then validates the non-virtualized stack against the exact tagged
+commit and an immutable Homebrew tap snapshot. GitHub-hosted macOS runners cannot
+run nested Virtualization.framework guests, so full runtime integration and
+Docker Compose parity run in the required local pre-tag gate. The package
+workflow verifies the hosted evidence and runtime asset before it creates the
+release and atomically updates the tap.
 
 Semantic source tags and stable GitHub releases are immutable. The `current`
 tag and its single **Current build** prerelease are deliberately mutable: after

--- a/BUILD.md
+++ b/BUILD.md
@@ -98,6 +98,7 @@ Useful focused targets are:
 | `make test` | Swift and Go unit/integration-style tests that do not require a live runtime. |
 | `make ci-fast` | Source checks, tests, helper build, and CLI smoke without coverage export. |
 | `make release-gate` | Full builder, containerization, container, and Compose validation, including runtime integration coverage and the complete Docker Compose parity suite, required before stable package dispatch. |
+| `make release-gate-hosted` | GitHub-hosted static stack validation: source checks, builds, unit coverage, Compose CI, and Homebrew formula syntax without Virtualization.framework or Docker-engine runtime tests. |
 | `make ci-release` | Full release gate plus the release package build. |
 | `make check` | Lint, documentation, formatting, and license checks. |
 | `make coverage-check` | Enforce at least 90% Swift line and 85% Go statement coverage. |
@@ -129,13 +130,16 @@ stable release helper runs `make release-gate` locally against the candidate
 tree before source promotion. That gate runs builder-shim coverage, containerization
 coverage plus integration, container coverage plus integration, Compose CI, tap
 formula syntax, and the complete Compose parity suite, including live `build --check`
-against the matched container backend. The helper promotes `container-compose` through an automated
-pull request by default, and verifies the promoted main tree still matches the
-locally gated candidate before it tags. The package workflow then repeats
-`make ci` before publishing package assets or updating the tap. The package
-workflow does not replace the local `make release-gate`; use
-`make release VERSION_SELECTOR=--+` for stable promotion so the full Docker
-Compose parity suite remains mandatory.
+against the matched container backend. GitHub-hosted macOS runners cannot launch
+nested Virtualization.framework guests, so the post-tag Stable Release Gate runs
+the `make release-gate-hosted` equivalent from its immutable release-control
+checkout against immutable source, runtime, and tap checkouts instead. It
+validates the non-virtualized stack and Compose CI; the local full gate remains
+mandatory for runtime integration and Docker Compose parity. The helper promotes
+`container-compose` through an automated pull request by default, verifies the
+promoted main tree still matches the locally gated candidate before it tags, and
+the package workflow repeats `make ci` before it publishes assets or updates the
+tap.
 
 ## Promote `main` To A Stable Release
 
@@ -171,13 +175,15 @@ make release VERSION_SELECTOR=+--   # major: X.Y.Z -> (X+1).0.0
 make release VERSION_SELECTOR=0.7.0 # exact next semantic version
 ```
 
-Before source promotion, the helper bootstraps the matched stack tools, fetches
-the required `containerization` integration kernel when it is absent, and runs
-the full local `make release-gate`. The hosted gate repeats that validation from
-the immutable source, runtime, and tap checkouts before package publication.
-The helper waits up to three hours for that hosted gate, which exceeds its
-120-minute workflow timeout; set `CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS` only
-when an operator needs a different bound.
+Before source promotion, the helper requires `kern.hv_support=1`, bootstraps the
+matched stack tools, fetches the required `containerization` integration kernel
+when it is absent, and runs the full local `make release-gate`. The hosted gate
+then runs the `make release-gate-hosted` equivalent from its immutable
+release-control checkout against the immutable source, runtime, and tap
+checkouts before package publication. The helper waits up to three hours for
+that hosted gate, which exceeds its 120-minute workflow timeout; set
+`CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS` only when an operator needs a
+different bound.
 
 The helper is the only supported version mutator. It updates the Compose version
 when necessary, preserves the exact runtime stack pin, opens and merges the

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ else
 SWIFT_TEST_FLAGS ?=
 endif
 
-.PHONY: all workflow ci ci-fast release-gate ci-release clean run build build-release test resolve swift-test-build swift-test swift-runtime-test-build swift-runtime-test swift-coverage go-test go-build go-release-check cli-smoke cli-smoke-built container-stack-build docker-log-fixtures docker-log-fixtures-update docker-compose-e2e-fixtures docker-compose-parity docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-isolation-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-volume-labels-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-ipam-options-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-rm-parity docker-compose-restart-policy-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-test lint format fmt check check-licenses update-licenses pre-commit
+.PHONY: all workflow ci ci-fast release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-runtime-test-build swift-runtime-test swift-coverage go-test go-build go-release-check cli-smoke cli-smoke-built container-stack-build docker-log-fixtures docker-log-fixtures-update docker-compose-e2e-fixtures docker-compose-parity docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-isolation-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-ipam-options-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-rm-parity docker-compose-restart-policy-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-test lint format fmt check check-licenses update-licenses pre-commit
 
 all: workflow
 
@@ -149,6 +149,8 @@ ci: check coverage-check go-build cli-smoke-built
 ci-fast: check test go-build cli-smoke-built
 
 release-gate: container-stack-release-validation ci docker-compose-parity
+
+release-gate-hosted: container-stack-hosted-release-validation ci
 
 ci-release: release-gate package-release
 
@@ -1147,28 +1149,16 @@ container-stack-build:
 			"$(CONTAINER_STACK_REPO)" "$(CONTAINER_COMPOSE_CONTAINER)" >&2; \
 	fi
 
-.PHONY: container-stack-release-validation
+.PHONY: container-stack-release-validation container-stack-hosted-release-validation
 container-stack-release-validation:
-	@test -f "$(CONTAINER_BUILDER_SHIM_STACK_REPO)/Makefile" || { \
-		printf 'container-builder-shim checkout is required at %s\n' "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" >&2; \
-		exit 2; \
-	}
-	@test -f "$(CONTAINERIZATION_STACK_REPO)/Makefile" || { \
-		printf 'containerization checkout is required at %s\n' "$(CONTAINERIZATION_STACK_REPO)" >&2; \
-		exit 2; \
-	}
-	@test -f "$(CONTAINER_STACK_REPO)/Makefile" || { \
-		printf 'container checkout is required at %s\n' "$(CONTAINER_STACK_REPO)" >&2; \
-		exit 2; \
-	}
-	@test -f "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" || { \
-		printf 'Homebrew tap formula is required at %s\n' "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" >&2; \
-		exit 2; \
-	}
-	$(MAKE) -C "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" check-licenses vet lint coverage build
-	$(MAKE) -C "$(CONTAINERIZATION_STACK_REPO)" check containerization examples docs coverage integration
-	$(MAKE) -C "$(CONTAINER_STACK_REPO)" check container dsym docs coverage
-	ruby -c "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb"
+	./Tools/ci/run-stack-release-validation.sh full "$(CURDIR)" \
+		"$(CONTAINER_BUILDER_SHIM_STACK_REPO)" "$(CONTAINERIZATION_STACK_REPO)" \
+		"$(CONTAINER_STACK_REPO)" "$(HOMEBREW_TAP_REPO)"
+
+container-stack-hosted-release-validation:
+	./Tools/ci/run-stack-release-validation.sh hosted "$(CURDIR)" \
+		"$(CONTAINER_BUILDER_SHIM_STACK_REPO)" "$(CONTAINERIZATION_STACK_REPO)" \
+		"$(CONTAINER_STACK_REPO)" "$(HOMEBREW_TAP_REPO)"
 
 docker-compose-e2e-fixtures:
 	./Tools/parity/sync-docker-compose-e2e-fixtures.sh --strict

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#===----------------------------------------------------------------------===#
+# Copyright © 2026 container-compose project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===----------------------------------------------------------------------===#
+
+# Run the sibling stack validation used by local and hosted release gates.
+set -euo pipefail
+
+if (($# != 6)); then
+  printf 'usage: %s {full|hosted} COMPOSE_REPO BUILDER_REPO CONTAINERIZATION_REPO CONTAINER_REPO HOMEBREW_TAP_REPO\n' "$0" >&2
+  exit 2
+fi
+
+mode="$1"
+compose_repo="$2"
+builder_repo="$3"
+containerization_repo="$4"
+container_repo="$5"
+homebrew_tap_repo="$6"
+
+case "${mode}" in
+  full)
+    containerization_targets=(check containerization examples docs coverage integration)
+    container_targets=(check container dsym docs coverage)
+    ;;
+  hosted)
+    containerization_targets=(check containerization examples docs coverage)
+    container_targets=(check container dsym docs coverage-unit)
+    ;;
+  *)
+    printf 'unknown stack release validation mode: %s\n' "${mode}" >&2
+    exit 2
+    ;;
+esac
+
+for path in "${compose_repo}" "${builder_repo}" "${containerization_repo}" "${container_repo}"; do
+  if [[ ! -f "${path}/Makefile" ]]; then
+    printf 'required stack checkout is missing a Makefile: %s\n' "${path}" >&2
+    exit 2
+  fi
+done
+if [[ ! -f "${homebrew_tap_repo}/Formula/container-compose.rb" ]]; then
+  printf 'Homebrew tap formula is required at %s/Formula/container-compose.rb\n' "${homebrew_tap_repo}" >&2
+  exit 2
+fi
+
+printf 'running %s stack release validation\n' "${mode}"
+make -C "${builder_repo}" check-licenses vet lint coverage build
+make -C "${containerization_repo}" "${containerization_targets[@]}"
+make -C "${container_repo}" "${container_targets[@]}"
+ruby -c "${homebrew_tap_repo}/Formula/container-compose.rb"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -31,6 +31,7 @@ TEMPLATE = ROOT / "Tools" / "release" / "container-compose.rb.in"
 HOMEBREW_WORKFLOW = ROOT / ".github" / "workflows" / "homebrew.yml"
 PACKAGE_WORKFLOW = ROOT / ".github" / "workflows" / "prebuilt-binaries.yml"
 STABLE_GATE_WORKFLOW = ROOT / ".github" / "workflows" / "stable-release-gate.yml"
+STACK_RELEASE_VALIDATION = ROOT / "Tools" / "ci" / "run-stack-release-validation.sh"
 
 
 class ContainerStackReleasePolicyTests(unittest.TestCase):
@@ -120,12 +121,105 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_release_gate_includes_sibling_coverage_and_runtime_integration(self) -> None:
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
-        self.assertIn("check-licenses vet lint coverage build", makefile)
-        self.assertIn("check containerization examples docs coverage integration", makefile)
-        self.assertIn("check container dsym docs coverage", makefile)
+        validation = STACK_RELEASE_VALIDATION.read_text(encoding="utf-8")
+        self.assertIn("check-licenses vet lint coverage build", validation)
+        self.assertIn("run-stack-release-validation.sh full", makefile)
+        self.assertIn("run-stack-release-validation.sh hosted", makefile)
+        self.assertIn(
+            "containerization_targets=(check containerization examples docs coverage integration)",
+            validation,
+        )
+        self.assertIn(
+            "container_targets=(check container dsym docs coverage)",
+            validation,
+        )
+        self.assertIn(
+            "release-gate-hosted: container-stack-hosted-release-validation ci",
+            makefile,
+        )
+        self.assertIn(
+            "containerization_targets=(check containerization examples docs coverage)",
+            validation,
+        )
+        self.assertIn(
+            "container_targets=(check container dsym docs coverage-unit)",
+            validation,
+        )
         self.assertIn("CONTAINER_COMPOSE_BUILD_CHECK_LIVE=1", makefile)
         self.assertIn("docker-compose-devices-parity", makefile)
         self.assertNotIn("repackage-release", makefile)
+
+    def test_hosted_stack_validation_excludes_virtualization_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose"
+            builder = root / "container-builder-shim"
+            containerization = root / "containerization"
+            container = root / "container"
+            tap = root / "homebrew-tap"
+            for checkout in (compose, builder, containerization, container):
+                checkout.mkdir()
+                (checkout / "Makefile").touch()
+            (tap / "Formula").mkdir(parents=True)
+            (tap / "Formula" / "container-compose.rb").touch()
+
+            tools = root / "tools"
+            tools.mkdir()
+            log = root / "commands.log"
+            for name in ("make", "ruby"):
+                tool = tools / name
+                tool.write_text(
+                    "#!/usr/bin/env bash\n"
+                    "printf '%s:%s\\n' \"$(basename \"$0\")\" \"$*\" >> \"${STACK_VALIDATION_LOG:?}\"\n",
+                    encoding="utf-8",
+                )
+                tool.chmod(0o755)
+
+            environment = os.environ.copy()
+            environment["PATH"] = f"{tools}{os.pathsep}{environment['PATH']}"
+            environment["STACK_VALIDATION_LOG"] = str(log)
+            validation_paths = [
+                str(compose),
+                str(builder),
+                str(containerization),
+                str(container),
+                str(tap),
+            ]
+
+            full = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+            )
+            self.assertEqual(full.returncode, 0, full.stderr)
+            full_commands = log.read_text(encoding="utf-8")
+            self.assertIn(
+                f"make:-C {containerization} check containerization examples docs coverage integration",
+                full_commands,
+            )
+            self.assertIn(f"make:-C {container} check container dsym docs coverage", full_commands)
+
+            log.unlink()
+            hosted = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+            )
+            self.assertEqual(hosted.returncode, 0, hosted.stderr)
+            hosted_commands = log.read_text(encoding="utf-8")
+            self.assertIn(
+                f"make:-C {containerization} check containerization examples docs coverage",
+                hosted_commands,
+            )
+            self.assertIn(
+                f"make:-C {container} check container dsym docs coverage-unit",
+                hosted_commands,
+            )
+            self.assertNotIn(" integration", hosted_commands)
 
     def test_hosted_release_gate_uses_an_unpublished_verified_tag_and_immutable_tap_snapshot(
         self,
@@ -153,7 +247,6 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("git -C homebrew-tap rev-parse HEAD", workflow)
-        self.assertIn("HOMEBREW_TAP_REPO: ../homebrew-tap", workflow)
         self.assertIn("Provision pinned stack tools", workflow)
         self.assertIn("cd container-compose", workflow)
         self.assertIn("HAWKEYE_AUTO_INSTALL=1 ./scripts/install-hawkeye.sh", workflow)
@@ -162,19 +255,24 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("./scripts/install-hawkeye.sh", workflow)
-        self.assertIn("Provision containerization integration kernel", workflow)
-        self.assertIn("run: make fetch-default-kernel", workflow)
+        self.assertIn("name: Run Hosted Release Gate", workflow)
+        self.assertIn("Checkout immutable stable-gate tools", workflow)
+        self.assertIn("path: release-tools", workflow)
+        self.assertIn("ref: ${{ github.sha }}", workflow)
+        self.assertIn("git -C release-tools rev-parse HEAD", workflow)
+        self.assertIn("run-stack-release-validation.sh hosted", workflow)
+        self.assertIn("make -C container-compose ci", workflow)
+        self.assertNotIn("Provision containerization integration kernel", workflow)
+        self.assertNotIn("run: make fetch-default-kernel", workflow)
+        self.assertNotIn("run: make release-gate-hosted", workflow)
+        self.assertNotIn("run: make release-gate\n", workflow)
         self.assertLess(
             workflow.index("Checkout immutable Homebrew tap snapshot"),
-            workflow.index("Run release gate"),
+            workflow.index("Run hosted release gate"),
         )
         self.assertLess(
             workflow.index("Provision pinned stack tools"),
-            workflow.index("Run release gate"),
-        )
-        self.assertLess(
-            workflow.index("Provision containerization integration kernel"),
-            workflow.index("Run release gate"),
+            workflow.index("Run hosted release gate"),
         )
 
     def test_release_helper_waits_longer_than_the_hosted_stable_gate_timeout(self) -> None:
@@ -202,6 +300,55 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"', self.script)
         self.assertIn('"$(repo_path "container-builder-shim")"', self.script)
         self.assertIn('make -C "$(repo_path "containerization")" fetch-default-kernel', self.script)
+
+    def test_local_release_gate_requires_hardware_virtualization(self) -> None:
+        local_gate = self.script[
+            self.script.index("run_local_release_gate() {") : self.script.index(
+                "# Verify that Apple remotes cannot be pushed"
+            )
+        ]
+        self.assertIn("require_local_virtualization() {", self.script)
+        self.assertIn("require_local_virtualization", local_gate)
+        self.assertIn("sysctl -n kern.hv_support", self.script)
+        self.assertIn("kern.hv_support=1", self.script)
+
+    def test_local_virtualization_preflight_requires_hardware_support(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_directory = root / "bin"
+            bin_directory.mkdir()
+            for name, output in (("uname", "Darwin"), ("sysctl", "0")):
+                command = bin_directory / name
+                command.write_text(
+                    "#!/usr/bin/env bash\n"
+                    "set -euo pipefail\n"
+                    f"printf '%s\\n' {shlex.quote(output)}\n",
+                    encoding="utf-8",
+                )
+                command.chmod(0o755)
+
+            shell_setup = f"export PATH={shlex.quote(str(bin_directory))}:$PATH"
+            unsupported = self.run_release_function(
+                root,
+                "require_local_virtualization",
+                shell_setup=shell_setup,
+            )
+            self.assertNotEqual(unsupported.returncode, 0)
+            self.assertIn("kern.hv_support=1", unsupported.stderr)
+
+            (bin_directory / "sysctl").write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                "printf '%s\\n' 1\n",
+                encoding="utf-8",
+            )
+            (bin_directory / "sysctl").chmod(0o755)
+            supported = self.run_release_function(
+                root,
+                "require_local_virtualization",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(supported.returncode, 0, supported.stderr)
 
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -334,6 +334,23 @@ ensure_clean() {
   fi
 }
 
+# Require a host that can execute the live runtime validation before promotion.
+require_local_virtualization() {
+  local support
+  if [[ "${EXECUTE}" != "1" ]]; then
+    return 0
+  fi
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    printf 'stable promotion requires macOS hardware virtualization; run make release on a supported Apple silicon Mac\n' >&2
+    exit 1
+  fi
+  support="$(sysctl -n kern.hv_support 2>/dev/null || true)"
+  if [[ "${support}" != "1" ]]; then
+    printf 'stable promotion requires kern.hv_support=1 for the full local runtime and parity gate\n' >&2
+    exit 1
+  fi
+}
+
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
   local path repository
@@ -344,6 +361,7 @@ run_local_release_gate() {
   fi
 
   print_header "run local release gate"
+  require_local_virtualization
   for repository in "${path}" \
     "$(repo_path "container-builder-shim")" \
     "$(repo_path "containerization")" \
@@ -1399,7 +1417,8 @@ dispatch_stable_release_gate() {
   if [[ "${EXECUTE}" != "1" ]]; then
     printf 'would run: gh workflow run stable-release-gate.yml --repo %s --ref main -f ref=%s\n' \
       "$(github_repo "${COMPOSE_REPO}")" "${version}"
-    printf 'would wait for the hosted gate to confirm green main CI, SonarQube, and full parity.\n'
+    printf 'would wait for the hosted gate to confirm green main CI, SonarQube, and immutable static stack validation.\n'
+    printf 'full runtime integration and Docker Compose parity run locally before the tag is created.\n'
     return 0
   fi
 


### PR DESCRIPTION
## Summary

- Run the stable post-tag gate through an immutable release-control checkout, so an already-signed stable tag can be validated without requiring new Make targets in that immutable source.
- Keep the full runtime integration and Docker Compose parity gate mandatory on the local release Mac before tagging; the GitHub-hosted macOS gate now runs the non-virtualized stack validation, Compose CI, coverage, and Homebrew formula syntax only.
- Fail stable promotion early when `kern.hv_support=1` is unavailable, and cover both hosted/local validation modes with deterministic regression tests.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

GitHub-hosted macOS runners are virtual machines and cannot create nested `Virtualization.framework` guests. The previous hosted stable gate therefore could not complete its containerization runtime integration phase, which blocked publication of the already signed, unpublished `0.6.70` tag. The repair preserves the complete local gate while making the hosted control plane reproducible and bounded.

## Testing

- [x] Tested locally: `make release-gate-hosted HOMEBREW_TAP_REPO=/Users/sclarke/github/homebrew-tap`
- [x] Added/updated tests: 29 release-policy tests, including fake-host virtualization preflight coverage and hosted/full command selection.
- [x] Added/updated docs: `BUILD.md` and `BRANCHES.md` now distinguish the local full gate from the hosted static gate.

The full hosted-equivalent run completed builder-shim, containerization, and container builds/checks; containerization unit coverage; container unit coverage; formula syntax; 937 Compose tests; 90.16% Swift coverage; 85.18% Go coverage; Go release build; and the compiled Compose CLI smoke matrix.

## container-compose Checks

- [x] I updated `STATUS.md`, `BRANCHES.md`, or `docs/upstream/` for support, release, or runtime primitive changes, or no update is needed.
- [x] This pull request is focused on one issue or one coherent change.
- [x] Runtime, release, security, upstream-import, or cross-repository stack changes have review notes and CI attached to this pull request.
- [x] I used Conventional Commits in commit messages and the pull request title.
- [x] I added a user-facing `Release-Note:` / `Release-Highlight:` trailer for visible Compose functionality, or `Release-Note: none` for internal-only work.
- [x] I included original upstream issue or pull request references for upstream-driven changes. Not upstream-driven.
- [x] I signed my commits with a GitHub-supported signature method.
- [x] I removed credentials, tokens, private keys, personal data, and private registry details from code, tests, logs, and screenshots.