### PR TITLE
fix(release): refresh the mutable current tag before release

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -85,10 +85,12 @@ tag and its single **Current build** prerelease are deliberately mutable: after
 green `main` CI, automation replaces their assets and notes with the exact
 latest stack. Automation removes superseded generated current-release objects
 without deleting their tags, so upstream PR snapshots and source references
-remain available. Correct a failed stable release through an explicitly reviewed
-incident change. If the signed source tag remains unpublished, the corrected
-automation can resume the latest tag's gates and package publication against
-that exact identity; it never changes the tag or overwrites a stable release.
+remain available. The release helper force-refreshes only that mutable local
+`current` tag; semantic source tags are never force-updated. Correct a failed
+stable release through an explicitly reviewed incident change. If the signed
+source tag remains unpublished, the corrected automation can resume the latest
+tag's gates and package publication against that exact identity; it never
+changes the tag or overwrites a stable release.
 
 Release notes are rendered by [Tools/release/release-notes.py](Tools/release/release-notes.py). The notes compare against the newest published stable GitHub release when release metadata is available, with local semantic tags as the offline fallback, so unpublished source tags cannot hide user-facing changes. They include a raw commit audit list, and they promote user-facing `Release-Note:` or `Release-Highlight:` commit trailers into a `Highlights` section before that list. Write one complete sentence that names the Docker Compose feature, CLI option, or workflow users now get; internal release, CI, and documentation chores should normally omit the trailer or use `Release-Note: none`, which suppresses an automatic highlight. When a user-facing conventional commit has no trailer, the renderer uses the first prose paragraph from its body before falling back to the subject. The active package also contains a machine-readable `release-highlights.json` copy; stable notes preserve those highlights after retired assets are removed. Each stable release also records static, non-clickable SonarQube and CodeQL badges for the exact promoted commit; this block never contains release-version or visitor badges. For upstream-driven work, also record the original `owner/repository#number` under `Upstream-Ref:`, `Bug-Ref:`, `Refs:`, or `Follow-up-To:`. The renderer preserves references already written into the highlight and appends any missing references, including highlights collected from stack component commits.
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -352,6 +352,33 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)
+        self.assertIn("+refs/tags/current:refs/tags/current", self.script)
+        self.assertNotIn("fetch --prune --tags --force", self.script)
+
+    def test_release_fetch_refreshes_only_mutable_current_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, local = self.create_compose_checkout(root)
+            self.run_command("git", "-C", str(local), "tag", "current")
+            self.run_command("git", "-C", str(local), "push", "origin", "refs/tags/current")
+
+            updater = root / "updater"
+            self.run_command("git", "clone", "--branch", "main", str(remote), str(updater))
+            self.configure_repo(updater)
+            self.commit_file(updater, "CURRENT.md", "current\n", "chore: advance current")
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+            self.run_command("git", "-C", str(updater), "tag", "-f", "current")
+            self.run_command("git", "-C", str(updater), "push", "origin", "+refs/tags/current")
+
+            result = self.run_release_function(root / "github", "fetch_release_remote container-compose")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("refreshing mutable current tag", result.stdout)
+            local_current = self.git(local, "rev-parse", "refs/tags/current")
+            remote_current = self.run_command(
+                "git", "ls-remote", "--tags", "--refs", str(remote), "refs/tags/current"
+            ).stdout.split()[0]
+            self.assertEqual(local_current, remote_current)
 
     def test_release_helper_uses_the_active_github_cli_credential(self) -> None:
         self.assertIn("github_cli() {", self.script)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -246,6 +246,28 @@ stephen_https_url() {
   esac
 }
 
+# Refresh the one intentionally mutable release pointer without forcing semantic tags.
+refresh_mutable_current_tag() {
+  local repo="$1" path="$2" remote="$3" local_current remote_current
+  if [[ "${repo}" != "${COMPOSE_REPO}" ]]; then
+    return 0
+  fi
+
+  remote_current="$(git -C "${path}" ls-remote --tags --refs "${remote}" refs/tags/current 2>/dev/null || true)"
+  remote_current="$(awk '{ print $1 }' <<<"${remote_current}" | tail -n 1)"
+  if [[ -z "${remote_current}" ]]; then
+    return 0
+  fi
+
+  local_current="$(git -C "${path}" rev-parse --verify -q refs/tags/current 2>/dev/null || true)"
+  if [[ "${local_current}" == "${remote_current}" ]]; then
+    return 0
+  fi
+
+  printf 'refreshing mutable current tag for %s\n' "${repo}"
+  git -C "${path}" fetch "${remote}" '+refs/tags/current:refs/tags/current'
+}
+
 fetch_release_remote() {
   local repo="$1" path remote url fallback_url
   path="$(repo_path "${repo}")"
@@ -263,6 +285,7 @@ fetch_release_remote() {
     url="${fallback_url}"
   fi
 
+  refresh_mutable_current_tag "${repo}" "${path}" "${remote}"
   printf '+ git -C %s fetch --prune --tags %s\n' "${path}" "${remote}"
   if git -C "${path}" fetch --prune --tags "${remote}"; then
     return 0


### PR DESCRIPTION
# Pull Request

## Summary

- Refresh only the intentionally mutable local `current` tag before the ordinary non-forced tag fetch.
- Keep every semantic source tag non-forced and immutable.
- Add a bare-remote regression test for a stale local `current` tag.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

A real `make release VERSION_SELECTOR=0.6.70` recovery stopped safely before dispatching a workflow because the local `current` tag lagged the remote pointer and `git fetch --prune --tags` refuses to overwrite changed tags. `current` is the single documented mutable prerelease pointer; semantic source tags must remain immutable.

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

`make check` passed, including the release-policy, stack-consistency, documentation, and license gates. The focused release-policy suite passed 30 tests; the release-notes suite passed 19 tests; `bash -n`, ShellCheck, Markdownlint, and `git diff --check` passed.

## container-compose Checks

- [x] I updated `STATUS.md`, `BRANCHES.md`, or `docs/upstream/` for support, release, or runtime primitive changes, or no update is needed.
- [x] This pull request is focused on one issue or one coherent change.
- [x] Runtime, release, security, upstream-import, or cross-repository stack changes have review notes and CI attached to this pull request.
- [x] I used Conventional Commits in commit messages and the pull request title.
- [x] I added a user-facing `Release-Note:` / `Release-Highlight:` trailer for visible Compose functionality, or `Release-Note: none` for internal-only work.
- [x] I included original upstream issue or pull request references for upstream-driven changes. This repair is not upstream-driven.
- [x] I signed my commits with a GitHub-supported signature method.
- [x] I removed credentials, tokens, private keys, personal data, and private registry details from code, tests, logs, and screenshots.