### PR TITLE
fix(release): bind package authority to the stable gate

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -33,6 +33,7 @@ on:
 permissions:
   actions: read
   attestations: write
+  checks: read
   contents: write
   id-token: write
   security-events: read
@@ -412,38 +413,58 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
+          PUBLISH_REF_NAME: ${{ needs.resolve-publish-context.outputs.ref_name }}
           PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
         shell: bash
         run: |
           set -euo pipefail
           case "${PUBLISH_REF_TYPE}" in
             branch)
-              workflow="ci.yml"
-              event="push"
-              required_name="green main CI (including SonarQube)"
+              conclusion="$(
+                gh run list --repo "${GITHUB_REPOSITORY}" --workflow ci.yml \
+                  --commit "${PUBLISH_SHA}" --event push --limit 50 \
+                  --json status,conclusion \
+                  --jq 'map(select(.status == "completed" and .conclusion == "success")) | .[0].conclusion // empty'
+              )"
+              if [[ "${conclusion}" != "success" ]]; then
+                printf 'refusing to package %s without green main CI (including SonarQube) at %s\n' \
+                  "${PUBLISH_SHA}" "${PUBLISH_SHA}" >&2
+                exit 1
+              fi
               ;;
             tag)
-              workflow="stable-release-gate.yml"
-              event="workflow_dispatch"
-              required_name="successful Stable Release Gate"
+              authority_name="Stable Release Authority (${PUBLISH_REF_NAME})"
+              authority_filter=".check_runs[] | select(.name == \"${authority_name}\""
+              authority_filter+=' and .status == "completed"'
+              authority_filter+=' and .conclusion == "success"'
+              authority_filter+=' and .app.slug == "github-actions")'
+              authority_filter+=' | .external_id'
+              authority_run_id="$(
+                gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PUBLISH_SHA}/check-runs?per_page=100" \
+                  --jq "${authority_filter}" \
+                  | tail -n 1
+              )"
+              if [[ ! "${authority_run_id}" =~ ^[0-9]+$ ]]; then
+                printf 'refusing to package %s without candidate-bound Stable Release Authority %s\n' \
+                  "${PUBLISH_SHA}" "${authority_name}" >&2
+                exit 1
+              fi
+              authority_conclusion="$(
+                gh run view "${authority_run_id}" --repo "${GITHUB_REPOSITORY}" \
+                  --json workflowName,event,status,conclusion \
+                  --jq 'select(.workflowName == "Stable Release Gate" and .event == "workflow_dispatch" and .status == "completed" and .conclusion == "success") | .conclusion'
+              )"
+              if [[ "${authority_conclusion}" != "success" ]]; then
+                printf 'refusing to package %s without a successful Stable Release Gate authority\n' \
+                  "${PUBLISH_SHA}" >&2
+                exit 1
+              fi
               ;;
             *)
               printf 'unsupported publish ref type: %s\n' "${PUBLISH_REF_TYPE}" >&2
               exit 1
               ;;
           esac
-
-          conclusion="$(
-            gh run list --repo "${GITHUB_REPOSITORY}" --workflow "${workflow}" \
-              --commit "${PUBLISH_SHA}" --event "${event}" --limit 50 \
-              --json status,conclusion \
-              --jq 'map(select(.status == "completed" and .conclusion == "success")) | .[0].conclusion // empty'
-          )"
-          if [[ "${conclusion}" != "success" ]]; then
-            printf 'refusing to package %s without %s at %s\n' \
-              "${PUBLISH_SHA}" "${required_name}" "${PUBLISH_SHA}" >&2
-            exit 1
-          fi
 
       - name: Build matched runtime package
         id: runtime-package

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -292,3 +292,37 @@ jobs:
           make -C container-compose ci
         env:
           HAWKEYE_AUTO_INSTALL: "1"
+
+  record-release-authority:
+    name: Record Stable Release Authority
+    needs: [resolve-candidate, release-gate]
+    if: >-
+      github.repository == 'stephenlclarke/container-compose' &&
+      needs.release-gate.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+    steps:
+      - name: Record candidate-bound stable release authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.ref }}
+          CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          authority_name="Stable Release Authority (${RELEASE_TAG})"
+          details_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          summary="Hosted Stable Release Gate passed for immutable source"
+          summary+=" ${CANDIDATE_SHA}."
+          gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
+            -f "name=${authority_name}" \
+            -f "head_sha=${CANDIDATE_SHA}" \
+            -f 'status=completed' \
+            -f 'conclusion=success' \
+            -f "external_id=${GITHUB_RUN_ID}" \
+            -f "details_url=${details_url}" \
+            -f "output[title]=${authority_name}" \
+            -f "output[summary]=${summary}" \
+            --silent

--- a/BUILD.md
+++ b/BUILD.md
@@ -137,9 +137,10 @@ checkout against immutable source, runtime, and tap checkouts instead. It
 validates the non-virtualized stack and Compose CI; the local full gate remains
 mandatory for runtime integration and Docker Compose parity. The helper promotes
 `container-compose` through an automated pull request by default, verifies the
-promoted main tree still matches the locally gated candidate before it tags, and
-the package workflow repeats `make ci` before it publishes assets or updates the
-tap.
+promoted main tree still matches the locally gated candidate before it tags. A
+successful hosted gate records a candidate-bound GitHub Actions release-authority
+check on that tag commit; the package workflow requires that check, then repeats
+`make ci` before it publishes assets or updates the tap.
 
 ## Promote `main` To A Stable Release
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -21,6 +21,7 @@ import os
 import shlex
 import subprocess
 import tempfile
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -118,6 +119,43 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("Skipping current package because current already points at", workflow)
         self.assertIn("refs/tags/current^{}", workflow)
         self.assertIn('current_tag_sha="$(', workflow)
+
+    def test_stable_package_requires_candidate_bound_release_authority(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        authority = workflow[
+            workflow.index("- name: Require the hosted release authority") : workflow.index(
+                "- name: Build matched runtime package"
+            )
+        ]
+        tag_authority = authority[authority.index("tag)") : authority.index("*)")]
+        self.assertIn("checks: read", workflow)
+        self.assertIn("PUBLISH_REF_NAME", authority)
+        self.assertIn('authority_name="Stable Release Authority (${PUBLISH_REF_NAME})"', tag_authority)
+        self.assertIn("commits/${PUBLISH_SHA}/check-runs?per_page=100", tag_authority)
+        self.assertIn(".app.slug", tag_authority)
+        self.assertIn("github-actions", tag_authority)
+        self.assertIn(".external_id", tag_authority)
+        self.assertIn('gh run view "${authority_run_id}"', tag_authority)
+        self.assertIn("workflowName", tag_authority)
+        self.assertIn("Stable Release Gate", tag_authority)
+        self.assertIn("workflow_dispatch", tag_authority)
+        self.assertNotIn('workflow="stable-release-gate.yml"', tag_authority)
+        self.assertNotIn('--commit "${PUBLISH_SHA}"', tag_authority)
+
+    def test_package_authority_requires_a_successful_candidate_bound_gate(self) -> None:
+        accepted = self.run_package_authority_step("tag", "0.6.70", "29288195238", "success")
+        self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+        missing_authority = self.run_package_authority_step("tag", "0.6.70", "", "success")
+        self.assertNotEqual(missing_authority.returncode, 0)
+        self.assertIn("candidate-bound Stable Release Authority", missing_authority.stderr)
+
+        failed_gate = self.run_package_authority_step("tag", "0.6.70", "29288195238", "")
+        self.assertNotEqual(failed_gate.returncode, 0)
+        self.assertIn("successful Stable Release Gate authority", failed_gate.stderr)
+
+        branch = self.run_package_authority_step("branch", "main", "", "success")
+        self.assertEqual(branch.returncode, 0, branch.stderr)
 
     def test_release_gate_includes_sibling_coverage_and_runtime_integration(self) -> None:
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
@@ -262,6 +300,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("git -C release-tools rev-parse HEAD", workflow)
         self.assertIn("run-stack-release-validation.sh hosted", workflow)
         self.assertIn("make -C container-compose ci", workflow)
+        self.assertIn("checks: write", workflow)
+        self.assertIn("name: Record Stable Release Authority", workflow)
+        self.assertIn("needs: [resolve-candidate, release-gate]", workflow)
+        self.assertIn("needs.release-gate.result == 'success'", workflow)
+        self.assertIn('authority_name="Stable Release Authority (${RELEASE_TAG})"', workflow)
+        self.assertIn('head_sha=${CANDIDATE_SHA}', workflow)
+        self.assertIn('external_id=${GITHUB_RUN_ID}', workflow)
         self.assertNotIn("Provision containerization integration kernel", workflow)
         self.assertNotIn("run: make fetch-default-kernel", workflow)
         self.assertNotIn("run: make release-gate-hosted", workflow)
@@ -654,6 +699,51 @@ exit 1
                     shlex.quote(candidate_tree),
                 ]
             ),
+        )
+
+    def run_package_authority_step(
+        self,
+        ref_type: str,
+        ref_name: str,
+        authority_run_id: str,
+        gate_conclusion: str,
+    ) -> subprocess.CompletedProcess[str]:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        authority = workflow[
+            workflow.index("- name: Require the hosted release authority") : workflow.index(
+                "- name: Build matched runtime package"
+            )
+        ]
+        run_marker = "        run: |\n"
+        run_start = authority.index(run_marker) + len(run_marker)
+        command = textwrap.dedent(authority[run_start:]).rstrip()
+        fake_gh = """\
+gh() {
+  case "$1:$2" in
+    api:*) printf '%s\\n' "${TEST_AUTHORITY_RUN_ID}" ;;
+    run:*) printf '%s\\n' "${TEST_GATE_CONCLUSION}" ;;
+    *) exit 64 ;;
+  esac
+}
+"""
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PUBLISH_REF_TYPE": ref_type,
+                "PUBLISH_REF_NAME": ref_name,
+                "PUBLISH_SHA": "0123456789012345678901234567890123456789",
+                "GITHUB_REPOSITORY": "stephenlclarke/container-compose",
+                "GH_TOKEN": "test",
+                "TEST_AUTHORITY_RUN_ID": authority_run_id,
+                "TEST_GATE_CONCLUSION": gate_conclusion,
+            }
+        )
+        return subprocess.run(
+            ["bash", "-c", f"{fake_gh}\n{command}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=environment,
         )
 
     def run_release_function(


### PR DESCRIPTION
## Summary

- Record a candidate-bound GitHub Actions release-authority check after the hosted Stable Release Gate succeeds.
- Require stable packaging to verify the immutable candidate SHA, exact semantic tag, trusted check-run app, and recorded successful gate run.
- Document the current release contract and cover both acceptance and rejection paths.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

The gate now runs from the current main control-plane revision while validating an immutable signed source tag. The package workflow previously looked for that workflow run at the tag SHA, so it could not find a successful gate and safely rejected the package. The new authority record preserves the candidate-to-gate relationship without conflating the workflow control SHA with the immutable candidate SHA.

## Testing

- [x] Tested locally: `make check`, `make ci`, `actionlint`, Ruby YAML parsing, and an executable authority accept/reject harness.
- [x] Added/updated tests: 32 release-policy tests cover candidate-bound authority requirements, missing authority rejection, failed-gate rejection, and branch CI behavior.
- [x] Added/updated docs: `BUILD.md` describes the current stable release authority contract.

## container-compose Checks

- [x] I updated `STATUS.md`, `BRANCHES.md`, or `docs/upstream/` for support, release, or runtime primitive changes, or no update is needed. No parity surface changed; `BUILD.md` now documents the current release flow.
- [x] This pull request is focused on one issue or one coherent change.
- [x] Runtime, release, security, upstream-import, or cross-repository stack changes have review notes and CI attached to this pull request.
- [x] I used Conventional Commits in commit messages and the pull request title.
- [x] I added a user-facing `Release-Note:` / `Release-Highlight:` trailer for visible Compose functionality, or `Release-Note: none` for internal-only work.
- [x] I included original upstream issue or pull request references for upstream-driven changes. Not applicable: this is a Stephen-owned release automation fix with no upstream import.
- [x] I signed my commits with a GitHub-supported signature method.
- [x] I removed credentials, tokens, private keys, personal data, and private registry details from code, tests, logs, and screenshots.

Release-Note: none