### PR TITLE
fix(release): recover stable tap promotion

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -29,6 +29,11 @@ on:
         description: "main for the installable current stack, or a MAJOR.MINOR.PATCH tag for stable"
         required: true
         type: string
+      repair_tap:
+        description: "Repair a published stable release's Homebrew formula pair from immutable release assets"
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   actions: read
@@ -57,12 +62,14 @@ jobs:
       ref_name: ${{ steps.publish.outputs.ref_name }}
       checkout_ref: ${{ steps.publish.outputs.checkout_ref }}
       sha: ${{ steps.publish.outputs.sha }}
+      repair_tap: ${{ steps.publish.outputs.repair_tap }}
     steps:
       - name: Resolve publish context
         id: publish
         env:
           GH_TOKEN: ${{ github.token }}
           DISPATCH_REF: ${{ inputs.ref }}
+          REPAIR_TAP: ${{ inputs.repair_tap }}
           WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
           WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -76,6 +83,7 @@ jobs:
           ref_name=""
           checkout_ref=""
           sha=""
+          repair_tap="false"
 
           remote="https://github.com/${GITHUB_REPOSITORY}.git"
 
@@ -198,6 +206,21 @@ jobs:
               exit 1
             fi
             resolve_remote_ref "${DISPATCH_REF}"
+            case "${REPAIR_TAP:-false}" in
+              false|"")
+                ;;
+              true)
+                if [[ "${ref_type}" != "tag" ]]; then
+                  printf 'Homebrew tap repair requires a stable semantic tag, got: %s\n' "${DISPATCH_REF}" >&2
+                  exit 1
+                fi
+                repair_tap="true"
+                ;;
+              *)
+                printf 'repair_tap must be true or false, got: %s\n' "${REPAIR_TAP}" >&2
+                exit 1
+                ;;
+            esac
           else
             printf 'Unsupported package event: %s\n' "${GITHUB_EVENT_NAME}" >&2
             exit 1
@@ -209,12 +232,15 @@ jobs:
             printf 'ref_name=%s\n' "${ref_name}"
             printf 'checkout_ref=%s\n' "${checkout_ref}"
             printf 'sha=%s\n' "${sha}"
+            printf 'repair_tap=%s\n' "${repair_tap}"
           } >> "$GITHUB_OUTPUT"
 
   package:
     name: Package
     needs: resolve-publish-context
-    if: needs.resolve-publish-context.outputs.publish == 'true'
+    if: >
+      needs.resolve-publish-context.outputs.publish == 'true' &&
+      needs.resolve-publish-context.outputs.repair_tap != 'true'
     runs-on: macos-26
     steps:
       - name: Checkout container-compose
@@ -664,6 +690,29 @@ jobs:
             RELEASE_CHECKSUM_PATH="${RUNNER_TEMP}/${ASSET}.sha256" \
             Tools/release/publish-github-release.sh
 
+      - name: Checkout immutable release control tools
+        if: steps.lane.outputs.update_tap == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: release-tools
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+          token: ${{ github.token }}
+
+      - name: Verify immutable release control tools
+        if: steps.lane.outputs.update_tap == 'true'
+        env:
+          RELEASE_CONTROL_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git -C release-tools rev-parse HEAD)"
+          if [[ "${actual}" != "${RELEASE_CONTROL_SHA}" ]]; then
+            printf 'release control checkout mismatch: expected %s, got %s\n' \
+              "${RELEASE_CONTROL_SHA}" "${actual}" >&2
+            exit 1
+          fi
+
       - name: Checkout Homebrew tap
         if: steps.lane.outputs.update_tap == 'true'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -675,94 +724,27 @@ jobs:
       - name: Render matched Homebrew stack formulae
         if: steps.lane.outputs.update_tap == 'true'
         env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ steps.lane.outputs.release_tag }}
+          RELEASE_PRERELEASE: ${{ steps.lane.outputs.release_prerelease }}
+          RELEASE_LABEL: ${{ steps.lane.outputs.release_label }}
           ASSET: ${{ steps.lane.outputs.asset }}
           FORMULA: ${{ steps.lane.outputs.formula }}
           FORMULA_CLASS: ${{ steps.lane.outputs.formula_class }}
           FORMULA_VERSION: ${{ steps.lane.outputs.formula_version }}
+          PLUGIN_VERSION: ${{ steps.lane.outputs.compose_version }}
           RUNTIME_FORMULA: ${{ steps.lane.outputs.runtime_formula }}
           CONTAINER_FORMULA: ${{ steps.lane.outputs.container_formula }}
           CONTAINER_FORMULA_CLASS: ${{ steps.lane.outputs.container_formula_class }}
           CONTAINER_COMPOSE_FORMULA: ${{ steps.lane.outputs.container_compose_formula }}
-          RUNTIME_RELEASE_TAG: ${{ steps.runtime-package.outputs.tag }}
-          RUNTIME_RELEASE_REPOSITORY: ${{ steps.runtime-package.outputs.repository }}
           RUNTIME_ASSET: ${{ steps.runtime-package.outputs.asset }}
-          RUNTIME_SHA256: ${{ steps.runtime-package.outputs.sha256 }}
           RUNTIME_VERSION: ${{ steps.runtime-package.outputs.version }}
-          RELEASE_TAG: ${{ steps.lane.outputs.release_tag }}
-          VERSION: ${{ steps.lane.outputs.compose_version }}
+          COMPOSE_SOURCE_DIR: container-compose
+          CONTAINER_SOURCE_DIR: container
+          TAP_DIR: homebrew-tap
         shell: bash
-        run: |
-          set -euo pipefail
-          url="https://github.com/stephenlclarke/container-compose/releases/download/${RELEASE_TAG}/${ASSET}"
-          tmp="$(mktemp -d)"
-          trap 'rm -rf "${tmp}"' EXIT
-
-          download_release_asset() {
-            local attempt max_attempts status
-            max_attempts=6
-            for attempt in $(seq 1 "${max_attempts}"); do
-              printf 'Downloading %s (attempt %s/%s)\n' "${url}" "${attempt}" "${max_attempts}"
-              if curl -fsSL --connect-timeout 20 --max-time 180 "${url}" -o "${tmp}/${ASSET}"; then
-                if [[ -s "${tmp}/${ASSET}" ]]; then
-                  return 0
-                fi
-                status=1
-                printf 'Downloaded asset is empty: %s\n' "${tmp}/${ASSET}" >&2
-              else
-                status="$?"
-              fi
-
-              if (( attempt == max_attempts )); then
-                return "${status}"
-              fi
-              sleep "$((attempt * 10))"
-            done
-          }
-
-          download_release_asset
-          sha256="$(shasum -a 256 "${tmp}/${ASSET}" | awk '{print $1}')"
-          python3 container-compose/Tools/release/update-homebrew-formula.py \
-            --formula "homebrew-tap/Formula/${FORMULA}" \
-            --template "container-compose/Tools/release/container-compose.rb.in" \
-            --formula-class "${FORMULA_CLASS}" \
-            --runtime-formula "${RUNTIME_FORMULA}" \
-            --url "$url" \
-            --version "$FORMULA_VERSION" \
-            --plugin-version "$VERSION" \
-            --asset "$ASSET" \
-            --label "${{ steps.lane.outputs.release_label }}" \
-            --sha256 "$sha256"
-
-          runtime_url="https://github.com/${RUNTIME_RELEASE_REPOSITORY}/releases/download/${RUNTIME_RELEASE_TAG}/${RUNTIME_ASSET}"
-          gh release download "${RUNTIME_RELEASE_TAG}" --repo "${RUNTIME_RELEASE_REPOSITORY}" \
-            --pattern "${RUNTIME_ASSET}" --dir "${tmp}"
-          actual_runtime_sha="$(shasum -a 256 "${tmp}/${RUNTIME_ASSET}" | awk '{print $1}')"
-          if [[ "${actual_runtime_sha}" != "${RUNTIME_SHA256}" ]]; then
-            printf 'runtime package checksum mismatch: expected %s, got %s\n' \
-              "${RUNTIME_SHA256}" "${actual_runtime_sha}" >&2
-            exit 1
-          fi
-          if ! tar -tzf "${tmp}/${RUNTIME_ASSET}" >/dev/null; then
-            printf 'published runtime package archive is corrupt: %s\n' "${RUNTIME_ASSET}" >&2
-            exit 1
-          fi
-          if ! tar -tzf "${tmp}/${RUNTIME_ASSET}" | grep -Fx './bin/container' >/dev/null; then
-            printf 'published runtime package is missing bin/container: %s\n' "${RUNTIME_ASSET}" >&2
-            exit 1
-          fi
-          python3 container/scripts/update-homebrew-formula.py \
-            --formula "homebrew-tap/Formula/${CONTAINER_FORMULA}" \
-            --template "container/Formula/container.rb" \
-            --formula-class "${CONTAINER_FORMULA_CLASS}" \
-            --compose-formula "${CONTAINER_COMPOSE_FORMULA}" \
-            --url "${runtime_url}" \
-            --sha256 "${RUNTIME_SHA256}" \
-            --version "${RUNTIME_VERSION}" \
-            --label "${{ steps.lane.outputs.release_label }}" \
-            --asset "${RUNTIME_ASSET}"
-          ruby -c "homebrew-tap/Formula/${FORMULA}"
-          ruby -c "homebrew-tap/Formula/${CONTAINER_FORMULA}"
-          git -C homebrew-tap diff -- "Formula/${FORMULA}" "Formula/${CONTAINER_FORMULA}"
+        run: release-tools/Tools/release/render-homebrew-stack-formulae.sh
 
       - name: Commit atomic Homebrew stack update
         if: steps.lane.outputs.update_tap == 'true'
@@ -801,3 +783,188 @@ jobs:
             --install-command "sudo rm -rf /usr/local/libexec/container-plugins/compose && sudo install -d /usr/local/libexec/container-plugins && sudo tar -xzf container-compose-plugin-release-arm64.tar.gz -C /usr/local/libexec/container-plugins" \
             --delete-superseded-current-releases \
             --apply
+
+  repair-stable-tap:
+    name: Repair Stable Homebrew Formulae
+    needs: resolve-publish-context
+    if: >
+      needs.resolve-publish-context.outputs.publish == 'true' &&
+      needs.resolve-publish-context.outputs.ref_type == 'tag' &&
+      needs.resolve-publish-context.outputs.repair_tap == 'true'
+    runs-on: macos-26
+    steps:
+      - name: Checkout tagged container-compose source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: container-compose
+          fetch-depth: 1
+          ref: ${{ needs.resolve-publish-context.outputs.checkout_ref }}
+          token: ${{ github.token }}
+
+      - name: Checkout immutable release control tools
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: release-tools
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+          token: ${{ github.token }}
+
+      - name: Verify immutable release control tools
+        env:
+          RELEASE_CONTROL_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git -C release-tools rev-parse HEAD)"
+          if [[ "${actual}" != "${RELEASE_CONTROL_SHA}" ]]; then
+            printf 'release control checkout mismatch: expected %s, got %s\n' \
+              "${RELEASE_CONTROL_SHA}" "${actual}" >&2
+            exit 1
+          fi
+
+      - name: Validate published stable source
+        env:
+          PUBLISH_REF_NAME: ${{ needs.resolve-publish-context.outputs.ref_name }}
+        shell: bash
+        working-directory: container-compose
+        run: |
+          set -euo pipefail
+          if [[ ! "${PUBLISH_REF_NAME}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            printf 'tap repair requires a stable semantic tag: %s\n' "${PUBLISH_REF_NAME}" >&2
+            exit 1
+          fi
+          compose_version="$(sed -n 's/^COMPOSE_VERSION ?= //p' Makefile | head -n 1)"
+          if [[ "${compose_version}" != "${PUBLISH_REF_NAME}" ]]; then
+            printf 'COMPOSE_VERSION %s does not match stable tag %s\n' \
+              "${compose_version}" "${PUBLISH_REF_NAME}" >&2
+            exit 1
+          fi
+
+      - name: Require the hosted release authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_REF_NAME: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          authority_name="Stable Release Authority (${PUBLISH_REF_NAME})"
+          authority_filter=".check_runs[] | select(.name == \"${authority_name}\""
+          authority_filter+=' and .status == "completed"'
+          authority_filter+=' and .conclusion == "success"'
+          authority_filter+=' and .app.slug == "github-actions")'
+          authority_filter+=' | .external_id'
+          authority_run_id="$(
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PUBLISH_SHA}/check-runs?per_page=100" \
+              --jq "${authority_filter}" \
+              | tail -n 1
+          )"
+          if [[ ! "${authority_run_id}" =~ ^[0-9]+$ ]]; then
+            printf 'refusing to repair %s without candidate-bound Stable Release Authority %s\n' \
+              "${PUBLISH_SHA}" "${authority_name}" >&2
+            exit 1
+          fi
+          authority_conclusion="$(
+            gh run view "${authority_run_id}" --repo "${GITHUB_REPOSITORY}" \
+              --json workflowName,event,status,conclusion \
+              --jq 'select(.workflowName == "Stable Release Gate" and .event == "workflow_dispatch" and .status == "completed" and .conclusion == "success") | .conclusion'
+          )"
+          if [[ "${authority_conclusion}" != "success" ]]; then
+            printf 'refusing to repair %s without a successful Stable Release Gate authority\n' \
+              "${PUBLISH_SHA}" >&2
+            exit 1
+          fi
+
+      - name: Require Homebrew tap token for formula promotion
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_TOKEN}" ]]; then
+            printf 'HOMEBREW_TAP_TOKEN is required for a stack formula promotion.\n' >&2
+            exit 1
+          fi
+
+      - name: Resolve pinned container dependency
+        id: container-ref
+        shell: bash
+        working-directory: container-compose
+        run: |
+          set -euo pipefail
+          ref="$(python3 Tools/release/resolve-container-ref.py --repo ../container)"
+          if [[ ! "${ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'container stack ref is not immutable: %s\n' "${ref}" >&2
+            exit 1
+          fi
+          printf 'ref=%s\n' "${ref}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pinned container dependency
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          repository: stephenlclarke/container
+          path: container
+          fetch-depth: 1
+          ref: ${{ steps.container-ref.outputs.ref }}
+
+      - name: Verify pinned container dependency
+        env:
+          EXPECTED_CONTAINER_REF: ${{ steps.container-ref.outputs.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git -C container rev-parse HEAD)"
+          if [[ "${actual}" != "${EXPECTED_CONTAINER_REF}" ]]; then
+            printf 'container checkout mismatch: expected %s, got %s\n' \
+              "${EXPECTED_CONTAINER_REF}" "${actual}" >&2
+            exit 1
+          fi
+
+      - name: Checkout Homebrew tap
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          repository: stephenlclarke/homebrew-tap
+          path: homebrew-tap
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Render verified stable Homebrew stack formulae
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          RELEASE_PRERELEASE: "false"
+          RELEASE_LABEL: stable release
+          ASSET: container-compose-plugin-release-arm64.tar.gz
+          FORMULA: container-compose.rb
+          FORMULA_CLASS: ContainerCompose
+          FORMULA_VERSION: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          PLUGIN_VERSION: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          RUNTIME_ASSET: container-release-arm64.tar.gz
+          RUNTIME_VERSION: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          RUNTIME_FORMULA: container
+          CONTAINER_FORMULA: container.rb
+          CONTAINER_FORMULA_CLASS: Container
+          CONTAINER_COMPOSE_FORMULA: container-compose
+          COMPOSE_SOURCE_DIR: container-compose
+          CONTAINER_SOURCE_DIR: container
+          TAP_DIR: homebrew-tap
+        shell: bash
+        run: release-tools/Tools/release/render-homebrew-stack-formulae.sh
+
+      - name: Commit repaired stable Homebrew stack
+        shell: bash
+        working-directory: homebrew-tap
+        env:
+          RELEASE_VERSION: ${{ needs.resolve-publish-context.outputs.ref_name }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$(git status --porcelain -- Formula/container-compose.rb Formula/container.rb)" ]]; then
+            printf 'Homebrew tap formulae already point at the matched stable stack.\n'
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/container-compose.rb Formula/container.rb
+          git commit -m "chore(homebrew): repair stable stack ${RELEASE_VERSION}"
+          git push

--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -80,17 +80,7 @@ Docker Compose parity run in the required local pre-tag gate. The package
 workflow verifies the hosted evidence and runtime asset before it creates the
 release and atomically updates the tap.
 
-Semantic source tags and stable GitHub releases are immutable. The `current`
-tag and its single **Current build** prerelease are deliberately mutable: after
-green `main` CI, automation replaces their assets and notes with the exact
-latest stack. Automation removes superseded generated current-release objects
-without deleting their tags, so upstream PR snapshots and source references
-remain available. The release helper force-refreshes only that mutable local
-`current` tag; semantic source tags are never force-updated. Correct a failed
-stable release through an explicitly reviewed incident change. If the signed
-source tag remains unpublished, the corrected automation can resume the latest
-tag's gates and package publication against that exact identity; it never
-changes the tag or overwrites a stable release.
+Semantic source tags and stable GitHub releases are immutable. The `current` tag and its single **Current build** prerelease are deliberately mutable: after green `main` CI, automation replaces their assets and notes with the exact latest stack. Automation removes superseded generated current-release objects without deleting their tags, so upstream PR snapshots and source references remain available. The release helper force-refreshes only that mutable local `current` tag; semantic source tags are never force-updated. The current recovery procedure lives in [BUILD.md](BUILD.md): an unpublished latest signed tag resumes package publication, while a published latest release may repair only its matching formula pair from verified immutable assets.
 
 Release notes are rendered by [Tools/release/release-notes.py](Tools/release/release-notes.py). The notes compare against the newest published stable GitHub release when release metadata is available, with local semantic tags as the offline fallback, so unpublished source tags cannot hide user-facing changes. They include a raw commit audit list, and they promote user-facing `Release-Note:` or `Release-Highlight:` commit trailers into a `Highlights` section before that list. Write one complete sentence that names the Docker Compose feature, CLI option, or workflow users now get; internal release, CI, and documentation chores should normally omit the trailer or use `Release-Note: none`, which suppresses an automatic highlight. When a user-facing conventional commit has no trailer, the renderer uses the first prose paragraph from its body before falling back to the subject. The active package also contains a machine-readable `release-highlights.json` copy; stable notes preserve those highlights after retired assets are removed. Each stable release also records static, non-clickable SonarQube and CodeQL badges for the exact promoted commit; this block never contains release-version or visitor badges. For upstream-driven work, also record the original `owner/repository#number` under `Upstream-Ref:`, `Bug-Ref:`, `Refs:`, or `Follow-up-To:`. The renderer preserves references already written into the highlight and appends any missing references, including highlights collected from stack component commits.
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -194,11 +194,7 @@ rebuilds and publishes the immutable stable assets and atomically updates both
 stable Homebrew formulae. Do not create a semantic tag, copy a prerelease
 asset, or edit either stable formula by hand.
 
-If a hosted gate fails before the semantic GitHub release is created, correct
-the release automation on `main` and rerun the same explicit version, for
-example `make release VERSION_SELECTOR=0.6.70`. The helper reuses only the
-latest existing GitHub-verified signed source tag, reruns the gates and package
-workflow, and refuses to change a tag or overwrite an existing semantic release.
+If a hosted gate fails before the semantic GitHub release is created, correct the release automation on `main` and rerun the same explicit version, for example `make release VERSION_SELECTOR=0.6.70`. The helper reuses only the latest existing GitHub-verified signed source tag, reruns the gates and package workflow, and refuses to change a tag or overwrite an existing semantic release. If the semantic GitHub release is published but its stable Homebrew formula pair is absent or incomplete, the same command dispatches formula-only recovery. It validates the existing immutable Compose and runtime assets and updates only the paired stable formulae; it never rebuilds a package, changes a signed tag, or replaces release assets.
 
 After the tag is published, the one mutable `current` prerelease continues to
 follow later green `main` commits. Homebrew users without `-current` always use

--- a/Tools/release/render-homebrew-stack-formulae.sh
+++ b/Tools/release/render-homebrew-stack-formulae.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+#===----------------------------------------------------------------------===#
+# Copyright © 2026 container-compose project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===----------------------------------------------------------------------===#
+
+set -Eeuo pipefail
+
+RELEASE_TOOL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly RELEASE_TOOL_DIR
+
+REQUIRED_VARIABLES=(
+  GH_TOKEN
+  RELEASE_REPOSITORY
+  RELEASE_TAG
+  RELEASE_PRERELEASE
+  RELEASE_LABEL
+  ASSET
+  FORMULA
+  FORMULA_CLASS
+  FORMULA_VERSION
+  PLUGIN_VERSION
+  RUNTIME_ASSET
+  RUNTIME_VERSION
+  RUNTIME_FORMULA
+  CONTAINER_FORMULA
+  CONTAINER_FORMULA_CLASS
+  CONTAINER_COMPOSE_FORMULA
+  COMPOSE_SOURCE_DIR
+  CONTAINER_SOURCE_DIR
+  TAP_DIR
+)
+
+# Print a release-rendering error and terminate the workflow step.
+error() {
+  printf '%s\n' "$*" >&2
+  exit 1
+}
+
+# Require a command supplied by the GitHub Actions runner.
+need_command() {
+  local command_name="$1"
+  if ! command -v "${command_name}" >/dev/null 2>&1; then
+    error "required command not found: ${command_name}"
+  fi
+}
+
+# Require every release input before reading or rendering package metadata.
+require_release_inputs() {
+  local variable
+  for variable in "${REQUIRED_VARIABLES[@]}"; do
+    if [[ -z "${!variable:-}" ]]; then
+      error "required release variable is empty: ${variable}"
+    fi
+  done
+
+  case "${RELEASE_PRERELEASE}" in
+    true|false)
+      ;;
+    *)
+      error "RELEASE_PRERELEASE must be true or false: ${RELEASE_PRERELEASE}"
+      ;;
+  esac
+
+  if [[ ! -f "${COMPOSE_SOURCE_DIR}/Tools/release/update-homebrew-formula.py" ]]; then
+    error "Compose formula updater is missing: ${COMPOSE_SOURCE_DIR}/Tools/release/update-homebrew-formula.py"
+  fi
+  if [[ ! -f "${COMPOSE_SOURCE_DIR}/Tools/release/container-compose.rb.in" ]]; then
+    error "Compose formula template is missing: ${COMPOSE_SOURCE_DIR}/Tools/release/container-compose.rb.in"
+  fi
+  if [[ ! -f "${RELEASE_TOOL_DIR}/update-homebrew-container-formula.py" ]]; then
+    error "container formula updater is missing: ${RELEASE_TOOL_DIR}/update-homebrew-container-formula.py"
+  fi
+  if [[ ! -f "${CONTAINER_SOURCE_DIR}/Formula/container.rb" ]]; then
+    error "container formula template is missing: ${CONTAINER_SOURCE_DIR}/Formula/container.rb"
+  fi
+  # TAP_DIR is a required environment input validated by the loop above.
+  # shellcheck disable=SC2153
+  if [[ ! -d "${TAP_DIR}" ]]; then
+    error "Homebrew tap checkout is missing: ${TAP_DIR}"
+  fi
+}
+
+# Wait for the released GitHub object to be visible and match the selected lane.
+verify_published_release() {
+  local attempt details exit_status actual_tag is_draft is_prerelease
+  local max_attempts=6
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if details="$(gh release view "${RELEASE_TAG}" \
+      --repo "${RELEASE_REPOSITORY}" \
+      --json tagName,isDraft,isPrerelease \
+      --jq '[.tagName, .isDraft, .isPrerelease] | @tsv' 2>&1)"; then
+      IFS=$'\t' read -r actual_tag is_draft is_prerelease <<<"${details}"
+      if [[ "${actual_tag}" != "${RELEASE_TAG}" || "${is_draft}" != "false" || "${is_prerelease}" != "${RELEASE_PRERELEASE}" ]]; then
+        error "published release state does not match ${RELEASE_TAG}: tag=${actual_tag:-missing}, draft=${is_draft:-missing}, prerelease=${is_prerelease:-missing}"
+      fi
+      return 0
+    else
+      exit_status=$?
+    fi
+
+    if (( attempt == max_attempts )); then
+      error "could not read published release ${RELEASE_TAG} after ${max_attempts} attempts (gh exit ${exit_status}): ${details}"
+    fi
+    printf 'Waiting for published release %s (attempt %s/%s)\n' \
+      "${RELEASE_TAG}" "${attempt}" "${max_attempts}"
+    sleep "$((attempt * 10))"
+  done
+}
+
+# Download one immutable release asset with bounded retries for transient API failures.
+download_release_asset() {
+  local asset="$1" attempt exit_status
+  local max_attempts=6
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    rm -f "${TMP_DIR}/${asset}"
+    printf 'Downloading %s from %s (attempt %s/%s)\n' \
+      "${asset}" "${RELEASE_TAG}" "${attempt}" "${max_attempts}"
+    if gh release download "${RELEASE_TAG}" \
+      --repo "${RELEASE_REPOSITORY}" \
+      --pattern "${asset}" \
+      --dir "${TMP_DIR}"; then
+      if [[ -s "${TMP_DIR}/${asset}" ]]; then
+        return 0
+      fi
+      exit_status=1
+      printf 'Downloaded release asset is empty: %s\n' "${asset}" >&2
+    else
+      exit_status=$?
+    fi
+
+    if (( attempt == max_attempts )); then
+      error "could not download release asset ${asset} after ${max_attempts} attempts (gh exit ${exit_status})"
+    fi
+    sleep "$((attempt * 10))"
+  done
+}
+
+# Verify a downloaded asset against its paired SHA-256 file and print its digest.
+verify_release_checksum() {
+  local asset="$1" expected_sha actual_sha
+  expected_sha="$(awk 'NR == 1 { print $1; exit }' "${TMP_DIR}/${asset}.sha256")"
+  if [[ ! "${expected_sha}" =~ ^[0-9a-f]{64}$ ]]; then
+    error "release checksum is invalid for ${asset}: ${expected_sha:-missing}"
+  fi
+  actual_sha="$(shasum -a 256 "${TMP_DIR}/${asset}" | awk '{ print $1 }')"
+  if [[ "${actual_sha}" != "${expected_sha}" ]]; then
+    error "release checksum mismatch for ${asset}: expected ${expected_sha}, got ${actual_sha}"
+  fi
+  printf '%s\n' "${actual_sha}"
+}
+
+# Require a complete package archive and a binary at its expected stable path.
+verify_archive_entry() {
+  local asset="$1" entry="$2" label="$3"
+  if ! tar -tzf "${TMP_DIR}/${asset}" >/dev/null; then
+    error "published ${label} package archive is corrupt: ${asset}"
+  fi
+  if ! tar -tzf "${TMP_DIR}/${asset}" | grep -Fx "${entry}" >/dev/null; then
+    error "published ${label} package is missing ${entry}: ${asset}"
+  fi
+}
+
+# Render both tap-owned formulae from the verified immutable release assets.
+main() {
+  local compose_sha runtime_sha compose_url runtime_url
+
+  require_release_inputs
+  need_command gh
+  need_command git
+  need_command python3
+  need_command ruby
+  need_command shasum
+  need_command tar
+  need_command grep
+  need_command awk
+  verify_published_release
+
+  TMP_DIR="$(mktemp -d)"
+  readonly TMP_DIR
+  trap 'rm -rf "${TMP_DIR}"' EXIT
+
+  # ASSET is a required environment input validated before this function runs.
+  # shellcheck disable=SC2153
+  download_release_asset "${ASSET}"
+  download_release_asset "${ASSET}.sha256"
+  download_release_asset "${RUNTIME_ASSET}"
+  download_release_asset "${RUNTIME_ASSET}.sha256"
+
+  compose_sha="$(verify_release_checksum "${ASSET}")"
+  runtime_sha="$(verify_release_checksum "${RUNTIME_ASSET}")"
+  verify_archive_entry "${ASSET}" "compose/bin/compose" "Compose"
+  verify_archive_entry "${RUNTIME_ASSET}" "./bin/container" "runtime"
+
+  compose_url="https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/${ASSET}"
+  runtime_url="https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/${RUNTIME_ASSET}"
+
+  python3 "${COMPOSE_SOURCE_DIR}/Tools/release/update-homebrew-formula.py" \
+    --formula "${TAP_DIR}/Formula/${FORMULA}" \
+    --template "${COMPOSE_SOURCE_DIR}/Tools/release/container-compose.rb.in" \
+    --formula-class "${FORMULA_CLASS}" \
+    --runtime-formula "${RUNTIME_FORMULA}" \
+    --url "${compose_url}" \
+    --version "${FORMULA_VERSION}" \
+    --plugin-version "${PLUGIN_VERSION}" \
+    --asset "${ASSET}" \
+    --label "${RELEASE_LABEL}" \
+    --sha256 "${compose_sha}"
+
+  python3 "${RELEASE_TOOL_DIR}/update-homebrew-container-formula.py" \
+    --formula "${TAP_DIR}/Formula/${CONTAINER_FORMULA}" \
+    --template "${CONTAINER_SOURCE_DIR}/Formula/container.rb" \
+    --formula-class "${CONTAINER_FORMULA_CLASS}" \
+    --compose-formula "${CONTAINER_COMPOSE_FORMULA}" \
+    --url "${runtime_url}" \
+    --sha256 "${runtime_sha}" \
+    --version "${RUNTIME_VERSION}" \
+    --label "${RELEASE_LABEL}" \
+    --asset "${RUNTIME_ASSET}"
+
+  ruby -c "${TAP_DIR}/Formula/${FORMULA}"
+  ruby -c "${TAP_DIR}/Formula/${CONTAINER_FORMULA}"
+  git -C "${TAP_DIR}" diff -- "Formula/${FORMULA}" "Formula/${CONTAINER_FORMULA}"
+}
+
+main "$@"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -33,6 +33,7 @@ HOMEBREW_WORKFLOW = ROOT / ".github" / "workflows" / "homebrew.yml"
 PACKAGE_WORKFLOW = ROOT / ".github" / "workflows" / "prebuilt-binaries.yml"
 STABLE_GATE_WORKFLOW = ROOT / ".github" / "workflows" / "stable-release-gate.yml"
 STACK_RELEASE_VALIDATION = ROOT / "Tools" / "ci" / "run-stack-release-validation.sh"
+FORMULA_RENDERER = ROOT / "Tools" / "release" / "render-homebrew-stack-formulae.sh"
 
 
 class ContainerStackReleasePolicyTests(unittest.TestCase):
@@ -42,7 +43,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def setUpClass(cls) -> None:
         cls.script = SCRIPT.read_text(encoding="utf-8")
 
-    def test_existing_stable_tags_resume_only_before_release_publication(self) -> None:
+    def test_existing_stable_tags_resume_without_changing_identity(self) -> None:
         release = self.script[self.script.index("release_current_stack() {") :]
         self.assertIn('if stable_tag_exists "${version}"', release)
         self.assertIn('resume_stable_release "${version}"', release)
@@ -53,7 +54,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             release.index("ensure_new_stable_release \"${version}\""),
         )
         self.assertIn("ensure_stable_release_is_unpublished() {", self.script)
+        self.assertIn("stable_release_is_published() {", self.script)
         self.assertIn("stable release %s already exists and is immutable", self.script)
+        self.assertIn('if stable_release_is_published "${version}"; then', self.script)
+        self.assertIn('dispatch_compose_stable_tap_repair "${version}"', self.script)
         self.assertIn("tag_new_stable_version() {", self.script)
         self.assertIn("stable tag already exists locally", self.script)
         self.assertIn("stable tag already exists remotely", self.script)
@@ -80,6 +84,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertNotIn("package VERSION", self.script)
         self.assertNotIn("package_existing_stable", self.script)
         self.assertNotIn("sync_source_homebrew_formula", self.script)
+        self.assertIn("formula-only recovery from immutable release assets", self.script)
+        self.assertIn('repair_tap=true', self.script)
 
     def test_release_formula_is_tap_owned_and_template_backed(self) -> None:
         self.assertFalse((ROOT / "Formula" / "container-compose.rb").exists())
@@ -93,14 +99,55 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('runtime_asset="container-release-arm64.tar.gz"', workflow)
         self.assertIn('runtime_repository="${GITHUB_REPOSITORY}"', workflow)
         self.assertIn("RELEASE_EXTRA_ASSETS_FILE=\"${extra_assets}\"", workflow)
-        self.assertIn("RUNTIME_RELEASE_REPOSITORY", workflow)
+        self.assertTrue(FORMULA_RENDERER.is_file())
+        self.assertIn("RUNTIME_ASSET", FORMULA_RENDERER.read_text(encoding="utf-8"))
 
     def test_runtime_archive_is_verified_before_formula_promotion(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        renderer = FORMULA_RENDERER.read_text(encoding="utf-8")
         self.assertIn('tar -tzf "${runtime_local_asset}" >/dev/null', workflow)
         self.assertIn("grep -Fx './bin/container'", workflow)
-        self.assertIn('tar -tzf "${tmp}/${RUNTIME_ASSET}" >/dev/null', workflow)
-        self.assertIn("published runtime package archive is corrupt", workflow)
+        self.assertIn('verify_archive_entry "${RUNTIME_ASSET}" "./bin/container" "runtime"', renderer)
+        self.assertIn("published ${label} package archive is corrupt", renderer)
+
+    def test_formula_renderer_uses_an_authenticated_published_release(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        renderer_step = workflow[
+            workflow.index("- name: Render matched Homebrew stack formulae") : workflow.index(
+                "- name: Commit atomic Homebrew stack update"
+            )
+        ]
+        renderer = FORMULA_RENDERER.read_text(encoding="utf-8")
+        self.assertIn("GH_TOKEN: ${{ github.token }}", renderer_step)
+        self.assertIn("release-tools/Tools/release/render-homebrew-stack-formulae.sh", renderer_step)
+        self.assertNotIn("gh release download", renderer_step)
+        self.assertIn("gh release view", renderer)
+        self.assertIn("gh release download", renderer)
+        self.assertIn("verify_release_checksum", renderer)
+        self.assertIn("update-homebrew-container-formula.py", renderer)
+        self.assertNotIn("${CONTAINER_SOURCE_DIR}/scripts/update-homebrew-formula.py", renderer)
+        self.assertIn("compose/bin/compose", renderer)
+
+    def test_published_stable_tap_repair_does_not_repackage_or_replace_assets(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        repair = workflow[workflow.index("repair-stable-tap:") :]
+        self.assertIn("repair_tap:", workflow)
+        self.assertIn("Repair Stable Homebrew Formulae", repair)
+        self.assertIn("needs.resolve-publish-context.outputs.repair_tap == 'true'", repair)
+        self.assertIn("Checkout tagged container-compose source", repair)
+        self.assertIn("Checkout immutable release control tools", repair)
+        self.assertIn("Resolve pinned container dependency", repair)
+        self.assertIn("Require the hosted release authority", repair)
+        self.assertIn("candidate-bound Stable Release Authority", repair)
+        self.assertIn("render-homebrew-stack-formulae.sh", repair)
+        self.assertNotIn("Build matched runtime package", repair)
+        self.assertNotIn("Publish GitHub release", repair)
+        self.assertNotIn("Attest release package", repair)
+
+    def test_release_helper_tracks_the_stable_package_dispatch_by_tag(self) -> None:
+        self.assertIn('title="Prebuilt Binaries · ${version}"', self.script)
+        self.assertIn("--json databaseId,displayTitle", self.script)
+        self.assertIn('latest_compose_package_dispatch_run "${version}"', self.script)
 
     def test_current_formulae_use_the_matched_runtime_in_the_single_prerelease(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
@@ -621,6 +668,107 @@ exit 1
             )
             self.assertNotEqual(published.returncode, 0)
             self.assertIn("stable release 0.6.70 already exists and is immutable", published.stderr)
+
+    def test_stable_release_state_requires_a_published_nonprerelease(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            bin_directory = root / "bin"
+            bin_directory.mkdir()
+            fake_gh = bin_directory / "gh"
+            fake_gh.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" != "release" || "$2" != "view" ]]; then
+  exit 1
+fi
+
+case "${GH_RELEASE_STATE}" in
+  published)
+    printf '%s\\t%s\\n' false false
+    ;;
+  prerelease)
+    printf '%s\\t%s\\n' false true
+    ;;
+  missing)
+    printf '%s\\n' 'release not found' >&2
+    exit 1
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            shell_setup = "\n".join(
+                [
+                    f"export PATH={shlex.quote(str(bin_directory))}:$PATH",
+                    "export GH_RELEASE_STATE=published",
+                ]
+            )
+
+            published = self.run_release_function(
+                root,
+                "stable_release_is_published 0.6.70",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(published.returncode, 0, published.stderr)
+
+            missing = self.run_release_function(
+                root,
+                "stable_release_is_published 0.6.70",
+                shell_setup=shell_setup.replace("published", "missing"),
+            )
+            self.assertNotEqual(missing.returncode, 0)
+
+            prerelease = self.run_release_function(
+                root,
+                "stable_release_is_published 0.6.70",
+                shell_setup=shell_setup.replace("published", "prerelease"),
+            )
+            self.assertNotEqual(prerelease.returncode, 0)
+            self.assertIn("not published and immutable", prerelease.stderr)
+
+    def test_resume_routes_published_tags_to_formula_only_recovery(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            published = self.run_release_function(
+                root,
+                "resume_stable_release 0.6.70",
+                shell_setup="\n".join(
+                    [
+                        "ensure_latest_stable_retry() { :; }",
+                        "verify_github_stable_tag_signature() { :; }",
+                        "stable_release_is_published() { return 0; }",
+                        "ensure_stable_release_is_unpublished() { exit 71; }",
+                        "dispatch_compose_stable_tap_repair() { printf 'repair %s\\n' \"$1\"; }",
+                        "publish_stable_release() { exit 72; }",
+                        "print_stable_release_point() { printf 'point %s %s\\n' \"$1\" \"$2\"; }",
+                    ]
+                ),
+            )
+            self.assertEqual(published.returncode, 0, published.stderr)
+            self.assertIn("repair 0.6.70", published.stdout)
+            self.assertIn("formula-only recovery from immutable release assets", published.stdout)
+
+            unpublished = self.run_release_function(
+                root,
+                "resume_stable_release 0.6.70",
+                shell_setup="\n".join(
+                    [
+                        "ensure_latest_stable_retry() { :; }",
+                        "verify_github_stable_tag_signature() { :; }",
+                        "stable_release_is_published() { return 1; }",
+                        "ensure_stable_release_is_unpublished() { :; }",
+                        "dispatch_compose_stable_tap_repair() { exit 73; }",
+                        "publish_stable_release() { printf 'publish %s\\n' \"$1\"; }",
+                    ]
+                ),
+            )
+            self.assertEqual(unpublished.returncode, 0, unpublished.stderr)
+            self.assertIn("publish 0.6.70", unpublished.stdout)
 
     def test_retry_rejects_a_stale_semantic_tag(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_update_homebrew_container_formula.py
+++ b/Tools/release/test_update_homebrew_container_formula.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Unit tests for the Compose-owned container formula renderer."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+UPDATER = Path(__file__).with_name("update-homebrew-container-formula.py")
+TEMPLATE = """class Container < Formula
+  url "https://example.invalid/container.tar.gz"
+  version "main-release.1"
+  sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+  def post_install
+    compose_plugin = HOMEBREW_PREFIX/"opt/container-compose/libexec/container-plugins/compose"
+  end
+
+  def caveats
+    <<~EOS
+      This formula installs the main lane prebuilt package asset:
+        container-homebrew-main-release-arm64.tar.gz
+
+      If stephenlclarke/tap/container-compose is installed, this formula links
+      the Compose plugin into:
+        #{opt_prefix}/libexec/container-plugins/compose
+    EOS
+  end
+end
+"""
+
+
+class UpdateHomebrewContainerFormulaTests(unittest.TestCase):
+    """The runtime formula must link the matching Compose lane."""
+
+    def render(self, directory: Path, compose_formula: str, formula_class: str) -> Path:
+        template = directory / "container.rb.in"
+        formula = directory / "container.rb"
+        template.write_text(TEMPLATE, encoding="utf-8")
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(UPDATER),
+                "--formula",
+                str(formula),
+                "--template",
+                str(template),
+                "--formula-class",
+                formula_class,
+                "--compose-formula",
+                compose_formula,
+                "--url",
+                "https://github.com/stephenlclarke/container-compose/releases/download/0.6.70/container-release-arm64.tar.gz",
+                "--sha256",
+                "b" * 64,
+                "--version",
+                "0.6.70",
+                "--label",
+                "stable release",
+                "--asset",
+                "container-release-arm64.tar.gz",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return formula
+
+    def test_stable_formula_uses_the_stable_compose_plugin(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            formula = self.render(Path(directory), "container-compose", "Container")
+            rendered = formula.read_text(encoding="utf-8")
+
+            subprocess.run(["ruby", "-c", str(formula)], check=True)
+            self.assertIn("class Container < Formula", rendered)
+            self.assertIn(
+                "releases/download/0.6.70/container-release-arm64.tar.gz",
+                rendered,
+            )
+            self.assertIn('version "0.6.70"', rendered)
+            self.assertIn('sha256 "' + "b" * 64 + '"', rendered)
+            self.assertIn("stephenlclarke/tap/container-compose", rendered)
+            self.assertIn("opt/container-compose/libexec/container-plugins/compose", rendered)
+            self.assertIn(
+                "This formula installs the stable release prebuilt package asset:",
+                rendered,
+            )
+            self.assertIn("container-release-arm64.tar.gz", rendered)
+
+    def test_current_formula_uses_the_current_compose_plugin(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            formula = self.render(Path(directory), "container-compose-current", "ContainerCurrent")
+            rendered = formula.read_text(encoding="utf-8")
+
+            subprocess.run(["ruby", "-c", str(formula)], check=True)
+            self.assertIn("class ContainerCurrent < Formula", rendered)
+            self.assertIn("stephenlclarke/tap/container-compose-current", rendered)
+            self.assertIn(
+                "opt/container-compose-current/libexec/container-plugins/compose",
+                rendered,
+            )
+
+    def test_unknown_compose_formula_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            template = path / "container.rb.in"
+            template.write_text(TEMPLATE, encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(UPDATER),
+                    "--formula",
+                    str(path / "container.rb"),
+                    "--template",
+                    str(template),
+                    "--formula-class",
+                    "Container",
+                    "--compose-formula",
+                    "container-compose-preview",
+                    "--url",
+                    "https://example.invalid/container.tar.gz",
+                    "--sha256",
+                    "b" * 64,
+                    "--version",
+                    "0.6.70",
+                    "--label",
+                    "stable release",
+                    "--asset",
+                    "container-release-arm64.tar.gz",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertNotEqual(completed.returncode, 0)
+            self.assertIn("compose formula must be one of", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/update-homebrew-container-formula.py
+++ b/Tools/release/update-homebrew-container-formula.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Render a container Homebrew formula for a matched Compose release."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--formula", required=True, type=Path)
+    parser.add_argument("--template", required=True, type=Path)
+    parser.add_argument("--formula-class", required=True)
+    parser.add_argument(
+        "--compose-formula",
+        required=True,
+        help="Fully qualified tap formula name without the stephenlclarke/tap prefix.",
+    )
+    parser.add_argument("--url", required=True)
+    parser.add_argument("--sha256", required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--label", required=True)
+    parser.add_argument("--asset", required=True)
+    return parser.parse_args()
+
+
+def replace_once(pattern: str, replacement: str, text: str) -> str:
+    updated, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise SystemExit(f"expected exactly one match for pattern: {pattern}")
+    return updated
+
+
+def main() -> None:
+    args = parse_args()
+    if re.fullmatch(r"container-compose(?:-current)?", args.compose_formula) is None:
+        raise SystemExit(
+            "compose formula must be one of: container-compose, container-compose-current"
+        )
+
+    text = args.template.read_text(encoding="utf-8")
+    text = replace_once(r"^class \w+ < Formula$", f"class {args.formula_class} < Formula", text)
+    text = replace_once(r'^  url ".+"$', f'  url "{args.url}"', text)
+    text = replace_once(r"^  sha256 .+$", f'  sha256 "{args.sha256}"', text)
+    text = replace_once(r'^  version ".+"$', f'  version "{args.version}"', text)
+    text = re.sub(
+        r"stephenlclarke/tap/container-compose(?:-current)?",
+        f"stephenlclarke/tap/{args.compose_formula}",
+        text,
+    )
+    text = re.sub(
+        r"opt/container-compose(?:-current)?/",
+        f"opt/{args.compose_formula}/",
+        text,
+    )
+    text = replace_once(
+        r"This formula installs the .+ prebuilt (?:release|package) asset:\n        .+\.tar\.gz",
+        f"This formula installs the {args.label} prebuilt package asset:\n        {args.asset}",
+        text,
+    )
+    args.formula.parent.mkdir(parents=True, exist_ok=True)
+    args.formula.write_text(text, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -48,7 +48,9 @@ Modes:
       dispatches the hosted Stable Release Gate, then dispatches the stable
       package workflow only after the gate succeeds. That workflow publishes
       immutable release assets and atomically updates the matching Homebrew
-      formula pair. container-compose main promotions use an automated
+      formula pair. If publication succeeds but tap promotion does not, rerun
+      the same explicit semantic version to validate the existing immutable
+      assets and repair only the formula pair. container-compose main promotions use an automated
       short-lived PR by default so pull-request checks and review state remain
       visible before tagging. The Homebrew tap is the only owner of live
       formulae.
@@ -80,7 +82,7 @@ Rules enforced:
   - The hosted Stable Release Gate runs after the signed tag and before stable package publication.
   - Stable package and Homebrew tap updates are explicitly dispatched and waited for.
   - Stable package assets and the Homebrew tap SHA are verified before success.
-  - Published stable releases are immutable; only the latest GitHub-verified signed tag may resume before publication.
+  - Published stable releases are immutable; the latest GitHub-verified signed tag may repair only its matching formula pair from immutable assets.
   - container-compose main updates use pull-request promotion by default.
   - An equivalent tree already squash-merged on main is reconciled before tagging.
   - Long-lived release branches are not used.
@@ -639,6 +641,40 @@ ensure_stable_release_is_unpublished() {
   fi
 
   printf 'could not determine whether stable release %s exists (gh exit %s):\n%s\n' \
+    "${version}" "${status}" "${output}" >&2
+  exit 1
+}
+
+# Return success only when the semantic release is published and immutable.
+stable_release_is_published() {
+  local version="$1" output status is_draft is_prerelease
+
+  if [[ "${EXECUTE}" != "1" ]]; then
+    printf 'would determine whether stable release %s is published\n' "${version}"
+    return 1
+  fi
+
+  need_command gh
+  if output="$(github_cli release view "${version}" \
+    --repo "$(github_repo "${COMPOSE_REPO}")" \
+    --json isDraft,isPrerelease \
+    --jq '[.isDraft, .isPrerelease] | @tsv' 2>&1)"; then
+    IFS=$'\t' read -r is_draft is_prerelease <<<"${output}"
+    if [[ "${is_draft}" == "false" && "${is_prerelease}" == "false" ]]; then
+      return 0
+    fi
+    printf 'stable release %s exists but is not published and immutable (draft=%s, prerelease=%s)\n' \
+      "${version}" "${is_draft:-missing}" "${is_prerelease:-missing}" >&2
+    exit 1
+  else
+    status="$?"
+  fi
+
+  if grep -Eqi 'release not found|HTTP 404' <<<"${output}"; then
+    return 1
+  fi
+
+  printf 'could not determine whether stable release %s is published (gh exit %s):\n%s\n' \
     "${version}" "${status}" "${output}" >&2
   exit 1
 }
@@ -1221,15 +1257,17 @@ github_cli() {
   gh "$@"
 }
 
-# Return the newest workflow_dispatch run id for the compose package workflow.
+# Return the newest workflow-dispatch package run for one stable semantic tag.
 latest_compose_package_dispatch_run() {
+  local version="$1" title
+  title="Prebuilt Binaries · ${version}"
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow "Prebuilt Binaries" \
     --event workflow_dispatch \
-    --limit 1 \
-    --json databaseId \
-    --jq '.[0].databaseId // ""'
+    --limit 100 \
+    --json databaseId,displayTitle \
+    --jq "map(select(.displayTitle == \"${title}\")) | .[0].databaseId // \"\""
 }
 
 latest_stable_release_gate_dispatch_run() {
@@ -1392,45 +1430,76 @@ verify_compose_stable_package() {
   printf 'stable stack %s package pair verified: %s + %s\n' "${version}" "${asset_sha}" "${runtime_asset_sha}"
 }
 
-# Dispatch and wait for the stable compose package workflow for a semantic tag.
-dispatch_compose_stable_package() {
-  local version="$1" previous_run run_id deadline now
-  print_header "dispatch container-compose ${version} package"
+# Dispatch and verify one stable package workflow mode for a semantic tag.
+dispatch_compose_stable_workflow() {
+  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label
+  print_header "dispatch container-compose ${version} ${mode}"
+
+  if [[ "${repair_tap}" == "true" ]]; then
+    label="container-compose stable tap repair workflow"
+  else
+    label="container-compose stable package workflow"
+  fi
 
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run: gh workflow run prebuilt-binaries.yml --repo %s --ref main -f ref=%s\n' \
+    printf 'would run: gh workflow run prebuilt-binaries.yml --repo %s --ref main -f ref=%s' \
       "$(github_repo "${COMPOSE_REPO}")" "${version}"
-    printf 'would wait for the container-compose stable package workflow to publish assets and update Homebrew\n'
+    if [[ "${repair_tap}" == "true" ]]; then
+      printf ' -f repair_tap=true'
+    fi
+    printf '\n'
+    printf 'would wait for the %s to verify the immutable assets and matching Homebrew formula pair\n' \
+      "${label}"
     return 0
   fi
 
   need_command gh
-  previous_run="$(latest_compose_package_dispatch_run || true)"
-  run github_cli workflow run prebuilt-binaries.yml \
-    --repo "$(github_repo "${COMPOSE_REPO}")" \
-    --ref main \
-    -f "ref=${version}"
+  previous_run="$(latest_compose_package_dispatch_run "${version}" || true)"
+  if [[ "${repair_tap}" == "true" ]]; then
+    run github_cli workflow run prebuilt-binaries.yml \
+      --repo "$(github_repo "${COMPOSE_REPO}")" \
+      --ref main \
+      -f "ref=${version}" \
+      -f "repair_tap=true"
+  else
+    run github_cli workflow run prebuilt-binaries.yml \
+      --repo "$(github_repo "${COMPOSE_REPO}")" \
+      --ref main \
+      -f "ref=${version}"
+  fi
 
   deadline=$((SECONDS + COMPOSE_PACKAGE_WAIT_SECONDS))
   while true; do
-    run_id="$(latest_compose_package_dispatch_run || true)"
+    run_id="$(latest_compose_package_dispatch_run "${version}" || true)"
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
-      printf 'container-compose package workflow started: %s\n' "${run_id}"
-      wait_for_github_run_success "${run_id}" "container-compose stable package workflow"
+      printf '%s started: %s\n' "${label}" "${run_id}"
+      wait_for_github_run_success "${run_id}" "${label}"
       verify_compose_stable_package "${version}"
       return 0
     fi
 
     now="${SECONDS}"
     if (( now >= deadline )); then
-      printf 'timed out waiting for container-compose package workflow dispatch for %s\n' "${version}" >&2
+      printf 'timed out waiting for %s dispatch for %s\n' "${label}" "${version}" >&2
       exit 1
     fi
 
-    printf 'waiting for container-compose package workflow dispatch for %s; next check in %ss\n' \
-      "${version}" "${COMPOSE_PACKAGE_POLL_SECONDS}"
+    printf 'waiting for %s dispatch for %s; next check in %ss\n' \
+      "${label}" "${version}" "${COMPOSE_PACKAGE_POLL_SECONDS}"
     sleep "${COMPOSE_PACKAGE_POLL_SECONDS}"
   done
+}
+
+# Dispatch and wait for a new stable package publication.
+dispatch_compose_stable_package() {
+  local version="$1"
+  dispatch_compose_stable_workflow "${version}" "package" "false"
+}
+
+# Repair a published stable formula pair without rebuilding or replacing release assets.
+dispatch_compose_stable_tap_repair() {
+  local version="$1"
+  dispatch_compose_stable_workflow "${version}" "Homebrew tap repair" "true"
 }
 
 dispatch_stable_release_gate() {
@@ -1474,20 +1543,26 @@ dispatch_stable_release_gate() {
   done
 }
 
-# Publish the immutable assets and tap formulae for a signed stable source tag.
-publish_stable_release() {
-  local version="$1"
-  dispatch_stable_release_gate "${version}"
-  dispatch_compose_stable_package "${version}"
+# Print the verified boundary for a stable release or its formula-only recovery.
+print_stable_release_point() {
+  local version="$1" generation="$2"
   print_component_refs
   cat <<EOF
 
 Stable release point:
   version: ${version}
   label: latest
-  release generation: container-compose stable package workflow dispatch
-  tap update: stable container-compose formula published with the release package
+  release generation: ${generation}
+  tap update: stable container and container-compose formula pair verified
 EOF
+}
+
+# Publish the immutable assets and tap formulae for a signed stable source tag.
+publish_stable_release() {
+  local version="$1"
+  dispatch_stable_release_gate "${version}"
+  dispatch_compose_stable_package "${version}"
+  print_stable_release_point "${version}" "container-compose stable package workflow dispatch"
 }
 
 # Tag a compose state as the stable/latest release point.
@@ -1498,13 +1573,18 @@ tag_stable_version() {
   publish_stable_release "${version}"
 }
 
-# Resume an unreleased signed tag after a failed gate without mutating source identity.
+# Resume the latest signed tag without mutating its stable source identity.
 resume_stable_release() {
   local version="$1"
   print_header "resume stable release ${version}"
   ensure_latest_stable_retry "${version}"
-  ensure_stable_release_is_unpublished "${version}"
   verify_github_stable_tag_signature "${version}"
+  if stable_release_is_published "${version}"; then
+    dispatch_compose_stable_tap_repair "${version}"
+    print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
+    return 0
+  fi
+  ensure_stable_release_is_unpublished "${version}"
   publish_stable_release "${version}"
 }
 
@@ -1517,7 +1597,7 @@ release_current_stack() {
   current="$(current_compose_version)"
   version="$(resolve_release_version "${VERSION_SELECTOR}")"
   if stable_tag_exists "${version}"; then
-    printf 'resuming unpublished stable tag: %s\n' "${version}"
+    printf 'resuming stable tag: %s\n' "${version}"
     resume_stable_release "${version}"
     return 0
   fi


### PR DESCRIPTION
# Pull Request

## Summary

- Adds an authenticated, checksum-validating renderer for the matched `container` and `container-compose` Homebrew formula pair.
- Adds a formula-only recovery lane for a published stable release, invoked by the existing `make release VERSION_SELECTOR=<tag>` command.
- Keeps the renderer in the Compose release-control layer so it can render the exact runtime template pinned by a historical release without depending on a mutable runtime helper API.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

The stable 0.6.70 package workflow published its immutable GitHub release but failed before the tap commit because the formula-render step invoked `gh release download` without `GH_TOKEN`. The existing release helper correctly treated the published release as immutable, but could not repair the absent formula pair.

This change makes the same explicit release command deterministic in both states:
- Before publication, it runs the normal gate and package path.
- After publication, it verifies the signed tag, candidate-bound Stable Release Authority, published non-prerelease release, asset checksums, archive contents, and then updates only the paired stable formulae.

It never retags, rebuilds, attests, republishes, or replaces stable release assets during recovery.

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

- `make check`
- `make ci` (Swift coverage 90.16%; Go coverage 85.18%)
- `actionlint .github/workflows/prebuilt-binaries.yml`
- Ruby YAML parse, Bash syntax, ShellCheck, and diff whitespace checks
- Isolated rendering smoke against the real immutable 0.6.70 Compose and runtime assets using the exact pinned container source
- Isolated current-lane rendering smoke, including the `container-current` -> `container-compose-current` plugin path

## container-compose Checks

- [x] I updated `STATUS.md`, `BRANCHES.md`, or `docs/upstream/` for support, release, or runtime primitive changes, or no update is needed.
- [x] This pull request is focused on one issue or one coherent change.
- [x] Runtime, release, security, upstream-import, or cross-repository stack changes have review notes and CI attached to this pull request.
- [x] I used Conventional Commits in commit messages and the pull request title.
- [x] I added a user-facing `Release-Note:` / `Release-Highlight:` trailer for visible Compose functionality, or `Release-Note: none` for internal-only work.
- [x] I included original upstream issue or pull request references for upstream-driven changes.
- [x] I signed my commits with a GitHub-supported signature method.
- [x] I removed credentials, tokens, private keys, personal data, and private registry details from code, tests, logs, and screenshots.

No Apple remote is pushed by this change.