### PR TITLE
fix(release): gate stable promotions

### DIFF
--- a/BRANCHES.md
+++ b/BRANCHES.md
@@ -26,16 +26,18 @@ Keep this guide in `container-compose` only. Do not copy it into Apple upstream 
 
 Use short-lived topic or review branches for runtime, release, security, upstream-import, and cross-repository stack changes. Keep each branch focused on one coherent slice, attach CI and review notes through a pull request or equivalent review record, then land the validated result on `main` before release. Delete the branch locally and remotely unless it is still needed for an open review.
 
-The stable release helper promotes `container-compose` `main` through an automated short-lived pull request by default, so pull-request checks and review state remain visible before the semantic release tag is created. The Apple-backed sibling forks are still pushed directly to their stephenlclarke-owned remotes during stack promotion, after the helper verifies that Apple remotes are read-only.
+The stable release helper promotes `container-compose` `main` through an automated short-lived pull request by default, so pull-request checks and review state remain visible before the semantic release tag is created. Every Apple-backed sibling fork must already be merged to its stephenlclarke-owned `main` through its own reviewable pull request; the release helper never pushes sibling source branches.
 
 Do not create additional long-lived integration or packaging lanes. Non-main branches are topic or review references only.
 
 ## Version And Release Rhythm
 
-Normal work lands on `main`. After each completed and validated slice, create the next stable release with:
+Normal work lands on `main` and every green commit refreshes the mutable Current
+build. Stable releases are deliberate: create at most one milestone release
+after Current has soaked for seven days, or a documented security release.
 
 ```sh
-make release VERSION_SELECTOR=--+
+CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=--+
 ```
 
 The release helper resolves symbolic selectors from the latest local semantic `container-compose` tag, not from mutable working-tree state. Bare `MAJOR.MINOR.PATCH` source tags match Apple repository conventions; do not add a `v` prefix. Existing tags are never moved.
@@ -62,16 +64,22 @@ Run it from the `container-compose` checkout through Makefile targets:
 
 ```sh
 make release-plan
-make release VERSION_SELECTOR=--+
+CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=--+
 ```
 
 `make release-plan` is a dry run over the four local source checkouts and the
-Homebrew tap workflow boundary. `make release` validates the source worktrees
-and `stephenlclarke` push targets, synchronizes exact `containerization` SwiftPM
-revision pins when the local runtime stack moved, and creates a reviewable
-release-preparation commit. This is the helper's only version mutation. It then
-promotes the source branches, creates one new semantic `container-compose` tag,
-dispatches the hosted Stable Release Gate, and then dispatches the stable package workflow.
+Homebrew tap workflow boundary. `make release` requires
+`CONTAINER_STACK_RELEASE_INTENT=milestone` or `security`; security also requires
+`CONTAINER_STACK_SECURITY_REASON` with an advisory or incident reference. It
+validates the source worktrees and `stephenlclarke` push targets, requires the
+`current` tag to identify the validated Compose `main` head, applies the
+seven-day milestone soak, blocks when any sibling fork is behind Apple upstream,
+synchronizes exact `containerization` SwiftPM revision pins when the local
+runtime stack moved, and creates a reviewable release-preparation commit. This
+is the helper's only version mutation. It verifies that sibling source mains
+were already merged through their own PRs, then promotes only `container-compose`
+through its release PR, creates one new semantic tag, dispatches the hosted
+Stable Release Gate, and then dispatches the stable package workflow.
 The hosted gate first requires green `main` CI—the only place SonarQube analyses
 the project—then validates the non-virtualized stack against the exact tagged
 commit and an immutable Homebrew tap snapshot. GitHub-hosted macOS runners cannot
@@ -90,6 +98,16 @@ Release notes are rendered by [Tools/release/release-notes.py](Tools/release/rel
 - `-+-`: minor bump from the latest semantic tag and reset patch to `0`.
 - `+--`: major bump from the latest semantic tag and reset minor and patch to `0`.
 - `MAJOR.MINOR.PATCH`: explicit stable release version.
+
+Use the same selector with `CONTAINER_STACK_RELEASE_INTENT=milestone` for a
+normal release. Only an advisory- or incident-backed command may use
+`CONTAINER_STACK_RELEASE_INTENT=security`, for example:
+
+```sh
+CONTAINER_STACK_RELEASE_INTENT=security \
+CONTAINER_STACK_SECURITY_REASON='CVE-2026-12345' \
+make release VERSION_SELECTOR=--+
+```
 
 The Compose package and pull-request promotion waits default to one hour with 30-second polls. Override them only for emergency maintenance with `CONTAINER_STACK_COMPOSE_PACKAGE_WAIT_SECONDS`, `CONTAINER_STACK_COMPOSE_PACKAGE_POLL_SECONDS`, `CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS`, or `CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS`.
 
@@ -119,7 +137,7 @@ Before upstream handoff, runtime-stack promotion, or release review work, run:
 make upstream-divergence-report
 ```
 
-The report fetches the stephenlclarke and Apple `main` refs for `container`, `containerization`, and `container-builder-shim`, writes Markdown and JSON under `.build/reports/`, lists fork-only and upstream-only commit subjects, and records whether Apple upstream can merge cleanly into each local checkout. Use `make upstream-divergence-check` when dirty worktrees, unpushed local commits, missing refs, or Apple upstream merge conflicts should fail the review.
+The report fetches the stephenlclarke and Apple `main` refs for `container`, `containerization`, and `container-builder-shim`, writes Markdown and JSON under `.build/reports/`, lists fork-only and upstream-only commit subjects, and records whether Apple upstream can merge cleanly into each local checkout. Use `make upstream-divergence-check` when dirty worktrees, unpushed local commits, missing refs, or Apple upstream merge conflicts should fail the review. Stable release automation uses `make upstream-divergence-release-check`, which also blocks a fork that is behind Apple upstream.
 
 ## Homebrew Formulae
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -106,6 +106,7 @@ Useful focused targets are:
 | `make swift-runtime-test` | Build and run the isolated matched runtime smoke suite. |
 | `make upstream-divergence-report` | Fetch Apple upstream and stephenlclarke refs for the Apple-backed sibling repos, then write `.build/reports/upstream-divergence.md` and `.build/reports/upstream-divergence.json`. |
 | `make upstream-divergence-check` | Run the same report as a strict check that fails on dirty worktrees, unpushed local commits, missing refs, or Apple upstream merge conflicts. |
+| `make upstream-divergence-release-check` | Stable-release check: also fails when a fork `main` is behind Apple upstream. |
 
 Override local coverage floors only for deliberate stricter validation:
 
@@ -120,7 +121,7 @@ Coverage outputs are `coverage.lcov`, `coverage.xml`,
 marker-protected `.build/container-runtime` directory, retains only the kernel
 cache between runs, and always stops the test runtime when it exits.
 
-Run `make upstream-divergence-report` before upstream handoff, runtime-stack promotion, or release review work. The report compares `container`, `containerization`, and `container-builder-shim` against their Apple upstream `main` refs, lists fork-only and upstream-only commit subjects, and checks whether Apple upstream can merge cleanly into the local checkout. Use `make upstream-divergence-check` when the review needs a hard failure instead of an informational report.
+Run `make upstream-divergence-report` before upstream handoff, runtime-stack promotion, or release review work. The report compares `container`, `containerization`, and `container-builder-shim` against their Apple upstream `main` refs, lists fork-only and upstream-only commit subjects, and checks whether Apple upstream can merge cleanly into the local checkout. Use `make upstream-divergence-check` when the review needs a hard failure, and `make upstream-divergence-release-check` before a stable release so an upstream-behind fork cannot be promoted.
 
 GitHub Actions separates source checks, macOS runtime validation, sanitizers,
 formatting, CodeQL, SonarCloud, package publication, and Homebrew formula syntax
@@ -137,7 +138,9 @@ checkout against immutable source, runtime, and tap checkouts instead. It
 validates the non-virtualized stack and Compose CI; the local full gate remains
 mandatory for runtime integration and Docker Compose parity. The helper promotes
 `container-compose` through an automated pull request by default, verifies the
-promoted main tree still matches the locally gated candidate before it tags. A
+promoted main tree still matches the locally gated candidate before it tags, and
+refuses to push sibling source mains: those must already be merged through their
+own reviewable pull requests. A
 successful hosted gate records a candidate-bound GitHub Actions release-authority
 check on that tag commit; the package workflow requires that check, then repeats
 `make ci` before it publishes assets or updates the tap.
@@ -148,6 +151,10 @@ There are two package lanes, with no manual asset copying:
 
 - Every green `main` commit refreshes the one mutable GitHub prerelease named **Current build** (tag `current`) and the opt-in `container-current` / `container-compose-current` Homebrew pair.
 - A semantic release is an immutable `x.y.z` tag and becomes Homebrew's default `container` / `container-compose` pair.
+
+Current is the normal delivery lane. Create a stable release only for a
+milestone after the current build has soaked for seven days, or for a documented
+security incident. The release helper enforces both rules.
 
 From clean `~/github/container-compose`, `~/github/container-builder-shim`,
 `~/github/containerization`, `~/github/container`, and
@@ -167,17 +174,22 @@ formulae, and release notes deterministic.
 
 After `make release-plan` confirms the intended next version, promote the
 validated `main` source with one selector. The selector is resolved from the
-latest semantic tag—not from the working-tree version:
+latest semantic tag—not from the working-tree version. The explicit intent
+makes a stable release a conscious boundary rather than an automatic response to
+every green slice:
 
 ```sh
-make release VERSION_SELECTOR=--+   # patch: X.Y.Z -> X.Y.(Z+1)
-make release VERSION_SELECTOR=-+-   # minor: X.Y.Z -> X.(Y+1).0
-make release VERSION_SELECTOR=+--   # major: X.Y.Z -> (X+1).0.0
-make release VERSION_SELECTOR=0.7.0 # exact next semantic version
+CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=--+   # patch: X.Y.Z -> X.Y.(Z+1)
+CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=-+-   # minor: X.Y.Z -> X.(Y+1).0
+CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=+--   # major: X.Y.Z -> (X+1).0.0
+CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=0.7.0 # exact next semantic version
+CONTAINER_STACK_RELEASE_INTENT=security CONTAINER_STACK_SECURITY_REASON='CVE-2026-12345' make release VERSION_SELECTOR=--+
 ```
 
-Before source promotion, the helper requires `kern.hv_support=1`, bootstraps the
-matched stack tools, fetches the required `containerization` integration kernel
+Before source promotion, the helper requires the mutable `current` tag to point
+at the validated `main` head. Milestones also require that Current build's
+seven-day soak. It then blocks if a sibling fork is behind Apple upstream,
+requires `kern.hv_support=1`, bootstraps the matched stack tools, fetches the required `containerization` integration kernel
 when it is absent, and runs the full local `make release-gate`. The hosted gate
 then runs the `make release-gate-hosted` equivalent from its immutable
 release-control checkout against the immutable source, runtime, and tap

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -euo pipefail -c
 .DEFAULT_GOAL := all
-.PHONY: upstream-divergence-report upstream-divergence-check
+.PHONY: upstream-divergence-report upstream-divergence-check upstream-divergence-release-check
 
 SWIFT ?= swift
 SWIFT_RESOLVED_FLAGS ?= --disable-automatic-resolution
@@ -1367,6 +1367,9 @@ upstream-divergence-report:
 
 upstream-divergence-check:
 	$(PYTHON) Tools/ci/upstream-divergence-report.py --fetch --strict --output .build/reports/upstream-divergence.md --json-output .build/reports/upstream-divergence.json
+
+upstream-divergence-release-check:
+	$(PYTHON) Tools/ci/upstream-divergence-report.py --fetch --strict --require-upstream-current --output .build/reports/upstream-divergence.md --json-output .build/reports/upstream-divergence.json
 
 stack-consistency:
 	$(PYTHON) Tools/ci/check-stack-consistency.py

--- a/Tools/ci/test_upstream_divergence_report.py
+++ b/Tools/ci/test_upstream_divergence_report.py
@@ -130,6 +130,17 @@ class UpstreamDivergenceReportTests(unittest.TestCase):
             self.assertIn("fixture: local commits are not pushed to the fork remote", failures)
             self.assertIn("fixture: Apple upstream merge conflicts", failures)
 
+    def test_release_strict_mode_blocks_forks_behind_upstream(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            upstream, _, _ = create_fixture(root)
+            commit_file(upstream, "upstream-only.txt", "upstream\n", "add upstream fix")
+
+            stack_report = reporter.build_report(root, fetch=True, max_commits=5, specs=(self.spec(),))
+            failures = reporter.strict_failures(stack_report, require_upstream_current=True)
+
+            self.assertIn("fixture: fork main is 1 commit(s) behind Apple upstream", failures)
+
     def test_renders_markdown_and_json_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/Tools/ci/upstream-divergence-report.py
+++ b/Tools/ci/upstream-divergence-report.py
@@ -450,7 +450,7 @@ def write_output(path: Path | None, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
-def strict_failures(report: StackReport) -> list[str]:
+def strict_failures(report: StackReport, *, require_upstream_current: bool = False) -> list[str]:
     failures: list[str] = []
     for repo in report.repositories:
         if repo.errors:
@@ -465,6 +465,10 @@ def strict_failures(report: StackReport) -> list[str]:
             failures.append(f"{repo.name}: Apple upstream merge conflicts")
         if repo.merge_upstream_into_local.status == "unknown":
             failures.append(f"{repo.name}: Apple upstream merge status is unknown")
+        if require_upstream_current and repo.fork_to_upstream.behind > 0:
+            failures.append(
+                f"{repo.name}: fork main is {repo.fork_to_upstream.behind} commit(s) behind Apple upstream"
+            )
     return failures
 
 
@@ -500,6 +504,11 @@ def parse_args(argv: Sequence[str]) -> argparse.Namespace:
         action="store_true",
         help="return non-zero when repos are dirty, unpushed, missing refs, or conflict with Apple upstream",
     )
+    parser.add_argument(
+        "--require-upstream-current",
+        action="store_true",
+        help="with --strict, also fail when a fork main is behind Apple upstream",
+    )
     return parser.parse_args(argv)
 
 
@@ -513,7 +522,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         write_output(args.json_output, report_to_json(report))
 
     if args.strict:
-        failures = strict_failures(report)
+        failures = strict_failures(report, require_upstream_current=args.require_upstream_current)
         if failures:
             for failure in failures:
                 print(failure, file=sys.stderr)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -390,11 +390,26 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_new_stable_release_runs_the_local_gate_before_promotion(self) -> None:
         release = self.script[self.script.index("release_current_stack() {") :]
+        self.assertIn("ensure_release_intent", release)
+        self.assertIn("ensure_current_build_release_readiness", release)
+        self.assertIn("require_release_upstream_alignment", release)
         self.assertIn("run_local_release_gate", release)
+        self.assertLess(release.index("ensure_release_intent"), release.index("run_local_release_gate"))
+        self.assertLess(release.index("require_release_upstream_alignment"), release.index("run_local_release_gate"))
         self.assertLess(release.index("run_local_release_gate"), release.index("push_all_main"))
         self.assertIn('HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"', self.script)
         self.assertIn('"$(repo_path "container-builder-shim")"', self.script)
         self.assertIn('make -C "$(repo_path "containerization")" fetch-default-kernel', self.script)
+
+    def test_stable_release_requires_intent_and_reviewed_sibling_mains(self) -> None:
+        promotion = self.script[self.script.index("push_all_main() {") : self.script.index("# Require an executable command")]
+
+        self.assertIn("CONTAINER_STACK_RELEASE_INTENT is required", self.script)
+        self.assertIn("CONTAINER_STACK_SECURITY_REASON is required", self.script)
+        self.assertIn("STABLE_CURRENT_SOAK_SECONDS=604800", self.script)
+        self.assertIn("upstream-divergence-release-check", self.script)
+        self.assertIn("land it through its own PR before releasing", promotion)
+        self.assertNotIn('push "${remote}" "refs/heads/main"', promotion)
 
     def test_local_release_gate_requires_hardware_virtualization(self) -> None:
         local_gate = self.script[

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -39,8 +39,9 @@ Modes:
       This mode never mutates repositories.
 
   release VERSION_SELECTOR
-      Deterministically promote the four source repositories and Homebrew tap
-      to the next stable release. The version selector is resolved from the
+      Deterministically promote the prepared stack and Homebrew tap to the next
+      stable release. A stable release requires an explicit milestone or
+      security intent. The version selector is resolved from the
       latest local semantic container-compose tag, not from mutable
       working-tree state. The helper bumps container-compose on main when
       needed, commits that bump, promotes the stephenlclarke source main
@@ -86,6 +87,8 @@ Rules enforced:
   - container-compose main updates use pull-request promotion by default.
   - An equivalent tree already squash-merged on main is reconciled before tagging.
   - Long-lived release branches are not used.
+  - Companion source repositories must already be merged to their fork mains
+    through their own reviewable pull requests; this helper never pushes them.
 
 Environment:
   CONTAINER_STACK_RELEASE_COMPOSE_MAIN_PROMOTION_MODE=pr|direct
@@ -97,6 +100,15 @@ Environment:
       Use "checked-admin" by default. The helper waits for PR checks, tries a
       normal merge, then uses an admin merge only when GitHub blocks the merge
       on the solo-maintainer review requirement. Use "strict" to fail instead.
+
+  CONTAINER_STACK_RELEASE_INTENT=milestone|security
+      Required for a new stable release. milestone requires the current build
+      to have soaked for at least seven days. security bypasses only that soak
+      after CONTAINER_STACK_SECURITY_REASON records the advisory or incident.
+
+  CONTAINER_STACK_SECURITY_REASON
+      Required when CONTAINER_STACK_RELEASE_INTENT=security. Record a CVE,
+      upstream security advisory, or incident reference.
 
   CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS
   CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS
@@ -175,6 +187,9 @@ PROMOTION_WAIT_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS:-3600}"
 PROMOTION_POLL_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS:-30}"
 COMPOSE_MAIN_PROMOTION_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_PROMOTION_MODE:-pr}"
 COMPOSE_MAIN_MERGE_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_MERGE_MODE:-checked-admin}"
+RELEASE_INTENT="${CONTAINER_STACK_RELEASE_INTENT:-}"
+SECURITY_REASON="${CONTAINER_STACK_SECURITY_REASON:-}"
+readonly STABLE_CURRENT_SOAK_SECONDS=604800
 HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"
 REPOS=(
   "container-builder-shim"
@@ -223,6 +238,73 @@ ensure_compose_promotion_mode() {
 
   if [[ "${EXECUTE}" == "1" && "${COMPOSE_MAIN_PROMOTION_MODE}" == "pr" ]]; then
     need_command gh
+  fi
+}
+
+# Require an intentional stable-release classification. Current builds are the
+# normal delivery lane; stable releases are milestone or security boundaries.
+ensure_release_intent() {
+  case "${RELEASE_INTENT}" in
+    milestone)
+      ;;
+    security)
+      if [[ -z "${SECURITY_REASON}" ]]; then
+        printf 'CONTAINER_STACK_SECURITY_REASON is required for a security release\n' >&2
+        exit 2
+      fi
+      ;;
+    *)
+      printf 'CONTAINER_STACK_RELEASE_INTENT is required for a new stable release\n' >&2
+      printf 'expected milestone or security\n' >&2
+      exit 2
+      ;;
+  esac
+}
+
+# Require the mutable Current build to identify the same source as local main.
+# Milestone releases additionally require a seven-day soak; security releases
+# retain the source-identity check but may bypass that waiting period.
+ensure_current_build_release_readiness() {
+  local path main_commit current_commit published_at
+  path="$(repo_path "${COMPOSE_REPO}")"
+
+  if [[ "${EXECUTE}" != "1" ]]; then
+    printf 'would verify current tag targets container-compose main and has the required soak\n'
+    return 0
+  fi
+
+  need_command gh
+  main_commit="$(git -C "${path}" rev-parse main)"
+  current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
+  if [[ "${current_commit}" != "${main_commit}" ]]; then
+    printf 'current tag targets %s, not the validated container-compose main %s\n' \
+      "${current_commit}" "${main_commit}" >&2
+    exit 1
+  fi
+
+  published_at="$(github_cli release view current \
+    --repo "$(github_repo "${COMPOSE_REPO}")" \
+    --json publishedAt --jq '.publishedAt')"
+  if [[ -z "${published_at}" || "${published_at}" == "null" ]]; then
+    printf 'current GitHub prerelease is missing; wait for green main package publication\n' >&2
+    exit 1
+  fi
+
+  if [[ "${RELEASE_INTENT}" == "milestone" ]]; then
+    python3 - "${published_at}" "${STABLE_CURRENT_SOAK_SECONDS}" <<'PY'
+from datetime import datetime, timezone
+import sys
+
+published_at = datetime.fromisoformat(sys.argv[1].replace("Z", "+00:00"))
+minimum = int(sys.argv[2])
+age = int((datetime.now(timezone.utc) - published_at).total_seconds())
+if age < minimum:
+    remaining = minimum - age
+    raise SystemExit(
+        f"current build has soaked for {age}s; milestone releases require {minimum}s "
+        f"({remaining}s remaining). Use a documented security release only for an advisory or incident."
+    )
+PY
   fi
 }
 
@@ -1226,22 +1308,27 @@ promote_compose_main() {
 }
 
 push_all_main() {
-  local version="$1" repo path remote body
-  print_header "promote stephenlclarke-owned source main branches"
+  local version="$1" repo path local_head remote_head body
+  print_header "verify reviewed sibling mains and promote container-compose"
   for repo in "${REPOS[@]}"; do
-    path="$(repo_path "${repo}")"
-    remote="$(push_remote "${repo}")"
     if [[ "${repo}" == "${COMPOSE_REPO}" ]]; then
-      body="$(compose_source_promotion_body "${version}")"
-      promote_compose_main \
-        "${version}" \
-        "source" \
-        "chore(release): promote ${version} source" \
-        "${body}"
-    else
-      run git -C "${path}" push "${remote}" "refs/heads/main"
+      continue
+    fi
+    path="$(repo_path "${repo}")"
+    local_head="$(git -C "${path}" rev-parse main)"
+    remote_head="$(remote_main_commit "${repo}")"
+    if [[ -z "${remote_head}" || "${local_head}" != "${remote_head}" ]]; then
+      printf '%s main is not the reviewed fork head; land it through its own PR before releasing\n' "${repo}" >&2
+      exit 1
     fi
   done
+
+  body="$(compose_source_promotion_body "${version}")"
+  promote_compose_main \
+    "${version}" \
+    "source" \
+    "chore(release): promote ${version} source" \
+    "${body}"
 }
 
 # Require an executable command when an executed workflow depends on it.
@@ -1590,6 +1677,14 @@ resume_stable_release() {
   publish_stable_release "${version}"
 }
 
+# Stable releases must not knowingly leave an Apple-backed sibling behind its
+# upstream main. The report remains useful for ordinary development; this
+# stricter mode is intentionally a release boundary.
+require_release_upstream_alignment() {
+  print_header "verify Apple upstream alignment"
+  run make -C "$(repo_path "${COMPOSE_REPO}")" upstream-divergence-release-check
+}
+
 release_current_stack() {
   local latest current version path
   latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
@@ -1605,6 +1700,9 @@ release_current_stack() {
   fi
   ensure_release_version_is_valid "${latest}" "${current}" "${version}"
   ensure_new_stable_release "${version}"
+  ensure_release_intent
+  ensure_current_build_release_readiness
+  require_release_upstream_alignment
   path="$(repo_path "${COMPOSE_REPO}")"
 
   print_header "prepare stable release ${version}"
@@ -1691,6 +1789,7 @@ plan() {
   printf 'next patch release:      %s\n' "${next_patch}"
   printf 'next minor release:      %s\n' "${next_minor}"
   printf 'next major release:      %s\n\n' "${next_major}"
+  printf 'stable release intent:   %s\n\n' "${RELEASE_INTENT:-required for release}"
   printf '%-26s %-40s %-18s\n' "component" "main-sha" "changed-since-tag"
   for repo in "${REPOS[@]}"; do
     changed="yes"
@@ -1704,12 +1803,15 @@ plan() {
 
 Process:
   1. Keep main as the releasable integration branch.
-  2. For a stable release, run release VERSION_SELECTOR after validation.
-  3. The release mode resolves VERSION_SELECTOR from the latest semantic tag,
-     bumps container-compose on main when needed, promotes stephenlclarke-owned
-     source main branches, promotes container-compose through an automated PR by
-     default, creates a new container-compose tag, dispatches the stable package
-     workflow, and verifies the immutable release assets plus Homebrew tap update.
+  2. Current builds publish from every green main commit.
+  3. For a stable release, use RELEASE_INTENT=milestone after a seven-day current
+     soak, or RELEASE_INTENT=security with an advisory or incident reference.
+  4. The release mode resolves VERSION_SELECTOR from the latest semantic tag,
+     requires reviewed sibling mains and Apple-upstream alignment, bumps
+     container-compose on main when needed, promotes container-compose through
+     an automated PR by default, creates a new container-compose tag, dispatches
+     the stable package workflow, and verifies immutable assets plus the paired
+     Homebrew update.
 EOF
 }
 


### PR DESCRIPTION
## What changed

- make a new stable release require an explicit `milestone` or `security` intent
- require a seven-day Current-build soak for milestones and an advisory/incident reference for security releases
- block stable release when any Apple-backed fork is behind upstream
- require companion source mains to have landed through their own PRs; the helper no longer pushes them directly

## Why

Stable `0.6.x` releases were being created for routine slices. The former helper also bypassed review records for sibling source branches and treated upstream lag as informational.

## Validation

- `python3 -m unittest Tools/ci/test_upstream_divergence_report.py Tools/release/test_container_stack_release.py`
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- Markdown lint for `BUILD.md` and `BRANCHES.md`