### PR TITLE
test(release): prevent interactive tag editors

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -465,6 +465,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("+refs/tags/current:refs/tags/current", self.script)
         self.assertNotIn("fetch --prune --tags --force", self.script)
 
+    def test_git_fixtures_never_launch_an_editor(self) -> None:
+        self.assertEqual(self.non_interactive_environment()["GIT_EDITOR"], ":")
+
     def test_release_fetch_refreshes_only_mutable_current_tag(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -937,12 +940,13 @@ gh() {
             lines.append(shell_setup)
         lines.append(function_call)
         command = "\n".join(lines)
+        environment = self.non_interactive_environment()
         return subprocess.run(
             ["bash", "-c", command],
             capture_output=True,
             text=True,
             check=False,
-            env=os.environ.copy(),
+            env=environment,
         )
 
     def git(self, repo: Path, *arguments: str) -> str:
@@ -954,7 +958,14 @@ gh() {
             capture_output=True,
             text=True,
             check=True,
+            env=self.non_interactive_environment(),
         )
+
+    def non_interactive_environment(self) -> dict[str, str]:
+        """Prevent Git fixtures from launching an editor during automated tests."""
+        environment = os.environ.copy()
+        environment["GIT_EDITOR"] = ":"
+        return environment
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Prevent release-test Git fixtures from launching an interactive editor.

## Root cause

A developer-level `tag.gpgSign=true` can make an accidental lightweight mutable-tag operation request a tag message. Git then opens the configured editor, which surfaced as VS Code `TAG_EDITMSG` files during validation.

## Change

All release-test shell and Git subprocesses now run with `GIT_EDITOR=:`. Production behaviour is unchanged: stable releases use explicit signed annotated tags and mutable `current` uses explicit `--no-sign`.

## Validation

- `python3 -m unittest Tools/release/test_container_stack_release.py`
- `git diff --check`