### PR TITLE
fix(release): make current publication transactional

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -137,13 +137,20 @@ jobs:
             if [[ "${WORKFLOW_RUN_EVENT}" != "push" ]]; then
               printf 'Skipping non-push CI event: %s\n' "${WORKFLOW_RUN_EVENT}"
             else
-              validate_conclusion="$(
-                gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/jobs" \
-                  --jq ".jobs[] | select(.name == \"Validate\") | .conclusion" \
-                  | tail -n 1
+              # CI intentionally has an active Validate job and a skipped
+              # companion for the opposite change set. The package authority
+              # is satisfied when at least one Validate succeeds and every
+              # matching job is either successful or intentionally skipped.
+              validate_conclusions="$(
+                gh api --paginate --slurp \
+                  "repos/${GITHUB_REPOSITORY}/actions/runs/${WORKFLOW_RUN_ID}/jobs?per_page=100" \
+                  | jq -c '[.[] | .jobs[] | select(.name == "Validate") | .conclusion]'
               )"
-              if [[ "${validate_conclusion}" != "success" ]]; then
-                printf 'Skipping package publish because CI Validate concluded %s.\n' "${validate_conclusion:-missing}"
+              if ! jq -e \
+                'length > 0 and any(.[]; . == "success") and all(.[]; . == "success" or . == "skipped")' \
+                <<<"${validate_conclusions}" >/dev/null; then
+                printf 'Skipping package publish because CI Validate results were %s.\n' \
+                  "$(jq -r 'if length == 0 then "missing" else join(",") end' <<<"${validate_conclusions}")"
               elif [[ "${WORKFLOW_RUN_HEAD_BRANCH}" == "main" ]]; then
                 current_main="$(git ls-remote --heads "${remote}" refs/heads/main | awk "{ print \$1 }" | tail -n 1)"
                 if [[ "${current_main}" != "${WORKFLOW_RUN_HEAD_SHA}" ]]; then
@@ -276,14 +283,18 @@ jobs:
               release_latest="false"
               release_prerelease="true"
               update_tap="true"
-              asset="container-compose-plugin-current-arm64.tar.gz"
+              # A commit-identified asset keeps the old formula pair valid
+              # while the candidate is staged. The current tag moves only
+              # after both matching formulae point at this immutable asset.
+              asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"
+              highlights_asset="release-highlights-current-${short_sha}.json"
               formula="container-compose-current.rb"
               formula_class="ContainerComposeCurrent"
               runtime_formula="container-current"
               container_formula="container-current.rb"
               container_formula_class="ContainerCurrent"
               container_compose_formula="container-compose-current"
-              formula_version="current-release.${GITHUB_RUN_NUMBER}.${short_sha}"
+              formula_version="current.${short_sha}"
               package_lane="current"
               ;;
             tag:*)
@@ -302,6 +313,7 @@ jobs:
               release_prerelease="false"
               update_tap="true"
               asset="container-compose-plugin-release-arm64.tar.gz"
+              highlights_asset="release-highlights.json"
               formula="container-compose.rb"
               formula_class="ContainerCompose"
               runtime_formula="container"
@@ -326,6 +338,7 @@ jobs:
             printf 'release_prerelease=%s\n' "${release_prerelease}"
             printf 'update_tap=%s\n' "${update_tap}"
             printf 'asset=%s\n' "${asset}"
+            printf 'highlights_asset=%s\n' "${highlights_asset}"
             printf 'formula=%s\n' "${formula}"
             printf 'formula_class=%s\n' "${formula_class}"
             printf 'runtime_formula=%s\n' "${runtime_formula}"
@@ -536,11 +549,11 @@ jobs:
           case "${PUBLISH_REF_TYPE}" in
             branch)
               runtime_tag="${RELEASE_TAG}"
-              runtime_asset="container-current-arm64.tar.gz"
+              runtime_asset="container-current-${PUBLISH_SHA:0:12}-arm64.tar.gz"
               runtime_local_asset="${RUNNER_TEMP}/${runtime_asset}"
               make -C container package BUILD_CONFIGURATION=release HOMEBREW_ARCHIVE="${runtime_local_asset}"
               runtime_sha="$(awk '{print $1}' "${runtime_local_asset}.sha256")"
-              runtime_version="current-release.${GITHUB_RUN_NUMBER}.${PUBLISH_SHA:0:12}"
+              runtime_version="current.${PUBLISH_SHA:0:12}"
               runtime_repository="${GITHUB_REPOSITORY}"
               ;;
             tag)
@@ -629,7 +642,7 @@ jobs:
             ${{ steps.runtime-package.outputs.local_asset }}
             ${{ steps.runtime-package.outputs.local_asset }}.sha256
 
-      - name: Publish GitHub release
+      - name: Stage release assets and notes
         env:
           GH_TOKEN: ${{ github.token }}
           ASSET: ${{ steps.lane.outputs.asset }}
@@ -639,6 +652,7 @@ jobs:
           RELEASE_LABEL: ${{ steps.lane.outputs.release_label }}
           RELEASE_LATEST: ${{ steps.lane.outputs.release_latest }}
           RELEASE_PRERELEASE: ${{ steps.lane.outputs.release_prerelease }}
+          HIGHLIGHTS_ASSET: ${{ steps.lane.outputs.highlights_asset }}
           PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
           PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
         shell: bash
@@ -651,8 +665,8 @@ jobs:
             "${{ steps.runtime-package.outputs.local_asset }}" \
             "${{ steps.runtime-package.outputs.local_asset }}.sha256" > "${extra_assets}"
 
-          notes="$(mktemp)"
-          highlights="${RUNNER_TEMP}/release-highlights.json"
+          notes="${RUNNER_TEMP}/release-notes.md"
+          highlights="${RUNNER_TEMP}/${HIGHLIGHTS_ASSET}"
           git fetch --force --tags origin
           release_notes_args=(
             --release-tag "${RELEASE_TAG}"
@@ -706,8 +720,10 @@ jobs:
           fi
 
           release_mutable="false"
+          release_phase="publish"
           if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
             release_mutable="true"
+            release_phase="stage"
           fi
 
           RELEASE_REPOSITORY="${GITHUB_REPOSITORY}" \
@@ -719,6 +735,7 @@ jobs:
             RELEASE_LATEST="${RELEASE_LATEST}" \
             RELEASE_PRERELEASE="${RELEASE_PRERELEASE}" \
             RELEASE_MUTABLE="${release_mutable}" \
+            RELEASE_PHASE="${release_phase}" \
             PUBLISH_REF_TYPE="${PUBLISH_REF_TYPE}" \
             PUBLISH_SHA="${PUBLISH_SHA}" \
             RELEASE_ASSET_PATH="${RUNNER_TEMP}/${ASSET}" \
@@ -801,14 +818,66 @@ jobs:
           git commit -m "chore(homebrew): update ${{ steps.lane.outputs.package_lane }} stack ${{ steps.lane.outputs.compose_version }}"
           git push
 
-      - name: Retain only current release assets
+      - name: Finalize current release pointer
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
         env:
           GH_TOKEN: ${{ github.token }}
+          ASSET: ${{ steps.lane.outputs.asset }}
+          RELEASE_TAG: ${{ steps.lane.outputs.release_tag }}
+          RELEASE_TITLE: ${{ steps.lane.outputs.release_title }}
+          RELEASE_LATEST: ${{ steps.lane.outputs.release_latest }}
+          RELEASE_PRERELEASE: ${{ steps.lane.outputs.release_prerelease }}
+          PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+          HIGHLIGHTS_ASSET: ${{ steps.lane.outputs.highlights_asset }}
         shell: bash
         working-directory: container-compose
         run: |
           set -euo pipefail
-          python3 Tools/release/retain-release-assets.py \
+          notes="${RUNNER_TEMP}/release-notes.md"
+          highlights="${RUNNER_TEMP}/${HIGHLIGHTS_ASSET}"
+          extra_assets="${RUNNER_TEMP}/release-extra-assets"
+          for required_file in \
+            "${notes}" \
+            "${highlights}" \
+            "${extra_assets}" \
+            "${RUNNER_TEMP}/${ASSET}" \
+            "${RUNNER_TEMP}/${ASSET}.sha256"; do
+            if [[ ! -f "${required_file}" ]]; then
+              printf 'cannot finalize current release; required staged file is missing: %s\n' \
+                "${required_file}" >&2
+              exit 1
+            fi
+          done
+
+          RELEASE_REPOSITORY="${GITHUB_REPOSITORY}" \
+            RELEASE_TAG="${RELEASE_TAG}" \
+            RELEASE_TITLE="${RELEASE_TITLE}" \
+            RELEASE_NOTES_FILE="${notes}" \
+            RELEASE_HIGHLIGHTS_PATH="${highlights}" \
+            RELEASE_EXTRA_ASSETS_FILE="${extra_assets}" \
+            RELEASE_LATEST="${RELEASE_LATEST}" \
+            RELEASE_PRERELEASE="${RELEASE_PRERELEASE}" \
+            RELEASE_MUTABLE="true" \
+            RELEASE_PHASE="finalize" \
+            PUBLISH_REF_TYPE="${PUBLISH_REF_TYPE}" \
+            PUBLISH_SHA="${PUBLISH_SHA}" \
+            RELEASE_ASSET_PATH="${RUNNER_TEMP}/${ASSET}" \
+            RELEASE_CHECKSUM_PATH="${RUNNER_TEMP}/${ASSET}.sha256" \
+            Tools/release/publish-github-release.sh
+
+      - name: Retain only current release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
+          ASSET: ${{ steps.lane.outputs.asset }}
+          RUNTIME_ASSET: ${{ steps.runtime-package.outputs.asset }}
+          HIGHLIGHTS_ASSET: ${{ steps.lane.outputs.highlights_asset }}
+        shell: bash
+        working-directory: container-compose
+        run: |
+          set -euo pipefail
+          retention_arguments=(
             --repo "${GITHUB_REPOSITORY}" \
             --bootstrap-command "brew install go node python" \
             --build-command "make package" \
@@ -818,6 +887,17 @@ jobs:
             --install-command "sudo rm -rf /usr/local/libexec/container-plugins/compose && sudo install -d /usr/local/libexec/container-plugins && sudo tar -xzf container-compose-plugin-release-arm64.tar.gz -C /usr/local/libexec/container-plugins" \
             --delete-superseded-current-releases \
             --apply
+          )
+          if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
+            retention_arguments+=(
+              --current-asset "${ASSET}" \
+              --current-asset "${ASSET}.sha256" \
+              --current-asset "${RUNTIME_ASSET}" \
+              --current-asset "${RUNTIME_ASSET}.sha256" \
+              --current-asset "${HIGHLIGHTS_ASSET}"
+            )
+          fi
+          python3 Tools/release/retain-release-assets.py "${retention_arguments[@]}"
 
   repair-stable-tap:
     name: Repair Stable Homebrew Formulae

--- a/.github/workflows/scheduled-stable-release.yml
+++ b/.github/workflows/scheduled-stable-release.yml
@@ -103,7 +103,7 @@ jobs:
           current_release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/current")"
           current_is_prerelease="$(jq -r '.prerelease' <<<"${current_release}")"
           current_built_at="$(
-            jq -r '[.assets[] | select(.name == "container-compose-plugin-current-arm64.tar.gz") | .updated_at] | max // empty' \
+            jq -r '[.assets[] | select(.name | test("^container-compose-plugin-current-[0-9a-f]{12}-arm64[.]tar[.]gz$")) | .updated_at] | max // empty' \
               <<<"${current_release}"
           )"
           latest_stable_tag="$(

--- a/BUILD.md
+++ b/BUILD.md
@@ -174,12 +174,21 @@ There are two package lanes, with no manual asset copying:
 its verification describe a prior commit as soon as it advances. Stable semantic
 tags are SSH-signed and GitHub-verified before their release gate starts.
 
-Current is the normal delivery lane. Create a stable release only for a
-milestone after the current build has soaked for seven days, or for a documented
-security incident. The soak starts when the mutable
-`container-compose-plugin-current-arm64.tar.gz` asset is refreshed, not when
-the long-lived Current prerelease was first created. The release helper enforces
-both rules.
+Current is the normal delivery lane. Create a stable release after the current
+build has soaked for seven days for a milestone, as a documented `--+`
+maintenance promotion, or for a documented security incident. A maintenance
+promotion is manual, must record its operational reason, and is limited to a
+patch bump; it is suitable for an explicit baseline promotion or a release
+mechanism fix. The soak starts when the commit-identified current plugin asset
+(`container-compose-plugin-current-<12-character-sha>-arm64.tar.gz`) is
+published, not when the long-lived Current prerelease was first created. The
+release helper enforces these rules.
+
+Current publication is recoverable across GitHub and Homebrew: it stages
+immutable commit-identified archives on the existing Current prerelease, updates
+the matching Homebrew formula pair, and only then advances the mutable `current`
+tag and release notes. If a later phase fails, the preceding formula pair stays
+installable and rerunning the same publication resumes it.
 
 ### Scheduled Stable Releases
 

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -20,6 +20,7 @@ set -Eeuo pipefail
 GH="${GH:-gh}"
 GIT="${GIT:-git}"
 RELEASE_MUTABLE="${RELEASE_MUTABLE:-false}"
+RELEASE_PHASE="${RELEASE_PHASE:-publish}"
 
 required_variables=(
   RELEASE_REPOSITORY
@@ -119,6 +120,38 @@ case "${PUBLISH_REF_TYPE}:${RELEASE_MUTABLE}" in
     ;;
 esac
 
+# A stable release is created once. The mutable current lane is deliberately
+# split into two resumable phases:
+#
+#   stage    upload immutable, commit-addressed assets while the existing tap
+#            formulae and current tag remain usable;
+#   finalize update the release notes and then advance the current tag, after
+#            the matching Homebrew formula pair has been committed.
+#
+# GitHub releases and the Homebrew tap are separate repositories, so this is
+# not a distributed transaction. It does guarantee that an interrupted current
+# publication leaves the previously installed package valid and can be resumed
+# without rebuilding or replacing its candidate assets.
+case "${PUBLISH_REF_TYPE}:${RELEASE_PHASE}" in
+  tag:publish)
+    ;;
+  tag:stage|tag:finalize)
+    printf 'stable releases support only the publish phase, got: %s\n' "${RELEASE_PHASE}" >&2
+    exit 2
+    ;;
+  branch:stage|branch:finalize)
+    ;;
+  branch:publish)
+    printf 'mutable current releases require an explicit stage or finalize phase\n' >&2
+    exit 2
+    ;;
+  *)
+    printf 'unsupported release publish phase: %s for %s\n' \
+      "${RELEASE_PHASE}" "${PUBLISH_REF_TYPE}" >&2
+    exit 2
+    ;;
+esac
+
 release_assets=(
   "${RELEASE_ASSET_PATH}"
   "${RELEASE_CHECKSUM_PATH}"
@@ -144,11 +177,12 @@ if [[ "${published_release_state}" == "exists" ]]; then
     exit 1
   fi
 
-  # Keep the current release continuously available. Upload and edit it in
-  # place, then advance the mutable tag only after the new assets and notes are
-  # visible. Stable release tags never use this path.
-  "${GH}" release upload "${RELEASE_TAG}" "${release_assets[@]}" \
-    --repo "${RELEASE_REPOSITORY}" --clobber
+  if [[ "${RELEASE_PHASE}" == "stage" ]]; then
+    "${GH}" release upload "${RELEASE_TAG}" "${release_assets[@]}" \
+      --repo "${RELEASE_REPOSITORY}" --clobber
+    exit 0
+  fi
+
   "${GH}" release edit "${RELEASE_TAG}" \
     --repo "${RELEASE_REPOSITORY}" \
     --title "${RELEASE_TITLE}" \
@@ -161,6 +195,11 @@ if [[ "${published_release_state}" == "exists" ]]; then
   "${GIT}" tag --no-sign --force "${RELEASE_TAG}" "${PUBLISH_SHA}"
   "${GIT}" push --force origin "refs/tags/${RELEASE_TAG}"
   exit 0
+fi
+
+if [[ "${PUBLISH_REF_TYPE}" == "branch" && "${RELEASE_PHASE}" == "finalize" ]]; then
+  printf 'cannot finalize current: release %s does not exist\n' "${RELEASE_TAG}" >&2
+  exit 1
 fi
 
 if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then

--- a/Tools/release/retain-release-assets.py
+++ b/Tools/release/retain-release-assets.py
@@ -77,6 +77,15 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="delete obsolete mutable current release objects while preserving their tags",
     )
+    parser.add_argument(
+        "--current-asset",
+        action="append",
+        default=[],
+        help=(
+            "asset name that belongs to the finalized current build; may be repeated. "
+            "All other current-release assets are retired after promotion."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -226,6 +235,21 @@ def delete_assets(repo: str, release: dict) -> None:
         run_gh("api", "--method", "DELETE", f"repos/{repo}/releases/assets/{asset['id']}")
 
 
+def stale_current_assets(release: dict, retained_names: set[str]) -> list[dict]:
+    """Return superseded assets from the sole mutable current release."""
+
+    return [
+        asset
+        for asset in release.get("assets", [])
+        if asset.get("name") not in retained_names
+    ]
+
+
+def delete_named_assets(repo: str, assets: Iterable[dict]) -> None:
+    for asset in assets:
+        run_gh("api", "--method", "DELETE", f"repos/{repo}/releases/assets/{asset['id']}")
+
+
 def update_release_notes(repo: str, release: dict, body: str) -> None:
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", delete=False) as notes_file:
         notes_file.write(body)
@@ -282,6 +306,21 @@ def main() -> None:
         print(f"documenting Homebrew installation for {release['tag_name']}")
         if args.apply:
             update_release_notes(args.repo, release, body)
+
+    retained_current_assets = set(args.current_asset)
+    if retained_current_assets:
+        for release in published_releases(releases):
+            if release["id"] not in retained or release.get("tag_name") != "current":
+                continue
+            stale_assets = stale_current_assets(release, retained_current_assets)
+            if not stale_assets:
+                continue
+            print(
+                "retiring superseded current assets: "
+                + ", ".join(str(asset.get("name")) for asset in stale_assets)
+            )
+            if args.apply:
+                delete_named_assets(args.repo, stale_assets)
 
     for release in stale:
         if args.delete_superseded_current_releases and obsolete_current_release(release):

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -180,13 +180,33 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_current_formulae_use_the_matched_runtime_in_the_single_prerelease(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn('runtime_asset="container-current-arm64.tar.gz"', workflow)
+        self.assertIn('runtime_asset="container-current-${PUBLISH_SHA:0:12}-arm64.tar.gz"', workflow)
         self.assertIn('runtime_repository="${GITHUB_REPOSITORY}"', workflow)
         self.assertIn('release_tag="current"', workflow)
         self.assertIn('release_title="Current build"', workflow)
+        self.assertIn('asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"', workflow)
+        self.assertIn('highlights_asset="release-highlights-current-${short_sha}.json"', workflow)
+        self.assertIn('RELEASE_PHASE="${release_phase}"', workflow)
+        self.assertIn("Finalize current release pointer", workflow)
+        self.assertLess(
+            workflow.index("Commit atomic Homebrew stack update"),
+            workflow.index("Finalize current release pointer"),
+        )
         self.assertIn('RELEASE_MUTABLE="${release_mutable}"', workflow)
         self.assertIn("--delete-superseded-current-releases", workflow)
         self.assertIn("release_notes_args=(", workflow)
+
+    def test_package_gate_aggregates_paginated_validate_jobs(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        start = workflow.index("CI intentionally has an active Validate job")
+        end = workflow.index("elif [[ \"${WORKFLOW_RUN_HEAD_BRANCH}\" == \"main\" ]];", start)
+        gate = workflow[start:end]
+
+        self.assertIn("gh api --paginate --slurp", gate)
+        self.assertIn('[.[] | .jobs[] | select(.name == "Validate") | .conclusion]', gate)
+        self.assertIn('any(.[]; . == "success")', gate)
+        self.assertIn('all(.[]; . == "success" or . == "skipped")', gate)
+        self.assertIn('if length == 0 then "missing" else join(",") end', gate)
         self.assertIn('quality_release_kind="current"', workflow)
         self.assertIn('quality_release_kind="stable"', workflow)
         self.assertIn('--release-kind "${quality_release_kind}"', workflow)
@@ -475,6 +495,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         promotion = self.script[self.script.index("push_all_main() {") : self.script.index("# Require an executable command")]
 
         self.assertIn("CONTAINER_STACK_RELEASE_INTENT is required", self.script)
+        self.assertIn("CONTAINER_STACK_MAINTENANCE_REASON is required", self.script)
+        self.assertIn("maintenance releases must use the --+ patch selector", self.script)
         self.assertIn("CONTAINER_STACK_SECURITY_REASON is required", self.script)
         self.assertIn("STABLE_CURRENT_SOAK_SECONDS=604800", self.script)
         self.assertIn("upstream-divergence-release-check", self.script)
@@ -489,7 +511,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         ]
         self.assertIn('releases/tags/current', readiness)
         self.assertIn(".prerelease", readiness)
-        self.assertIn("container-compose-plugin-current-arm64.tar.gz", readiness)
+        self.assertIn("container-compose-plugin-current-[0-9a-f]{12}-arm64", readiness)
         self.assertIn(".updated_at", readiness)
         self.assertNotIn("publishedAt", readiness)
 
@@ -499,7 +521,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('cron: "17 9 * * 1"', workflow)
         self.assertIn('default: "-+-"', workflow)
         self.assertIn('  - "+--"', workflow)
-        self.assertIn("container-compose-plugin-current-arm64.tar.gz", workflow)
+        self.assertIn("container-compose-plugin-current-[0-9a-f]{12}-arm64", workflow)
         self.assertIn(".updated_at", workflow)
         self.assertIn("current_is_prerelease", workflow)
         self.assertNotIn("--current-published-at", workflow)

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -65,6 +65,7 @@ touch "${asset}" "${checksum}" "${notes}"
 # Run the publisher with a temporary, recorded GitHub CLI implementation.
 run_publisher() {
   local ref_type="$1" release_tag release_title release_latest release_prerelease release_mutable
+  local release_phase="${5:-publish}"
   if [[ "${ref_type}" == "branch" ]]; then
     release_tag="current"
     release_title="Current build"
@@ -88,6 +89,7 @@ run_publisher() {
     RELEASE_LATEST="${release_latest}" \
     RELEASE_PRERELEASE="${release_prerelease}" \
     RELEASE_MUTABLE="${release_mutable}" \
+    RELEASE_PHASE="${release_phase}" \
     PUBLISH_REF_TYPE="${ref_type}" \
     PUBLISH_SHA="0123456789012345678901234567890123456789" \
     RELEASE_ASSET_PATH="${asset}" \
@@ -127,22 +129,45 @@ if [[ -e "${stable_unavailable_calls}" ]]; then
   exit 1
 fi
 
-main_existing_calls="${temporary_directory}/main-existing.calls"
-run_publisher branch exists "${main_existing_calls}"
-grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_existing_calls}.git"
-grep -Fqx "push --force origin refs/tags/current" "${main_existing_calls}.git"
-grep -Fqx "release upload current ${asset} ${checksum} --repo stephenlclarke/container-compose --clobber" "${main_existing_calls}"
-grep -Fqx "release edit current --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --target 0123456789012345678901234567890123456789 --prerelease" "${main_existing_calls}"
-if grep -Eq 'release (create|delete)' "${main_existing_calls}"; then
-  printf 'current publication replaced its live release instead of updating it in place\n' >&2
+main_implicit_calls="${temporary_directory}/main-implicit.calls"
+if run_publisher branch exists "${main_implicit_calls}"; then
+  printf 'current publication unexpectedly accepted an implicit phase\n' >&2
+  exit 1
+fi
+
+main_stage_calls="${temporary_directory}/main-stage.calls"
+run_publisher branch exists "${main_stage_calls}" "" stage
+grep -Fqx "release upload current ${asset} ${checksum} --repo stephenlclarke/container-compose --clobber" "${main_stage_calls}"
+if [[ -e "${main_stage_calls}.git" ]] || grep -Eq 'release (create|edit|delete)' "${main_stage_calls}"; then
+  printf 'current staging changed a release identity instead of only uploading assets\n' >&2
+  exit 1
+fi
+
+main_finalize_calls="${temporary_directory}/main-finalize.calls"
+run_publisher branch exists "${main_finalize_calls}" "" finalize
+grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_finalize_calls}.git"
+grep -Fqx "push --force origin refs/tags/current" "${main_finalize_calls}.git"
+grep -Fqx "release edit current --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --target 0123456789012345678901234567890123456789 --prerelease" "${main_finalize_calls}"
+if grep -Eq 'release (create|upload|delete)' "${main_finalize_calls}"; then
+  printf 'current finalization unexpectedly changed release assets\n' >&2
   exit 1
 fi
 
 main_create_calls="${temporary_directory}/main-create.calls"
-run_publisher branch missing "${main_create_calls}"
+run_publisher branch missing "${main_create_calls}" "" stage
 grep -Fqx "release create current ${asset} ${checksum} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --verify-tag --prerelease --latest=false" "${main_create_calls}"
 grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_create_calls}.git"
 grep -Fqx "push --force origin refs/tags/current" "${main_create_calls}.git"
+
+main_missing_finalize_calls="${temporary_directory}/main-missing-finalize.calls"
+if run_publisher branch missing "${main_missing_finalize_calls}" "" finalize; then
+  printf 'current finalization unexpectedly created a missing release\n' >&2
+  exit 1
+fi
+if [[ -e "${main_missing_finalize_calls}" || -e "${main_missing_finalize_calls}.git" ]]; then
+  printf 'current finalization mutated a missing release\n' >&2
+  exit 1
+fi
 
 runtime_asset="${temporary_directory}/container-release-arm64.tar.gz"
 runtime_checksum="${runtime_asset}.sha256"
@@ -154,6 +179,5 @@ run_publisher tag missing "${stable_extra_calls}" "${extra_assets}"
 grep -Fqx "release create 1.2.3 ${asset} ${checksum} ${runtime_asset} ${runtime_checksum} --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --verify-tag --latest" "${stable_extra_calls}"
 
 current_extra_calls="${temporary_directory}/current-extra.calls"
-run_publisher branch exists "${current_extra_calls}" "${extra_assets}"
+run_publisher branch exists "${current_extra_calls}" "${extra_assets}" stage
 grep -Fqx "release upload current ${asset} ${checksum} ${runtime_asset} ${runtime_checksum} --repo stephenlclarke/container-compose --clobber" "${current_extra_calls}"
-grep -Fqx "release edit current --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --target 0123456789012345678901234567890123456789 --prerelease" "${current_extra_calls}"

--- a/Tools/release/test_retain_release_assets.py
+++ b/Tools/release/test_retain_release_assets.py
@@ -146,6 +146,25 @@ class ReleaseAssetRetentionTests(unittest.TestCase):
         self.assertIn("Useful user-facing change", cleaned)
         self.assertNotIn("Release automation pins", cleaned)
 
+    def test_only_finalized_current_assets_are_retained(self) -> None:
+        module = load_module()
+        release = {
+            "assets": [
+                {"id": 1, "name": "container-compose-plugin-current-old.tar.gz"},
+                {"id": 2, "name": "container-current-old.tar.gz"},
+                {"id": 3, "name": "container-compose-plugin-current-new.tar.gz"},
+                {"id": 4, "name": "container-current-new.tar.gz"},
+            ]
+        }
+        stale = module.stale_current_assets(
+            release,
+            {
+                "container-compose-plugin-current-new.tar.gz",
+                "container-current-new.tar.gz",
+            },
+        )
+        self.assertEqual([asset["id"] for asset in stale], [1, 2])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -40,8 +40,8 @@ Modes:
 
   release VERSION_SELECTOR
       Deterministically promote the prepared stack and Homebrew tap to the next
-      stable release. A stable release requires an explicit milestone or
-      security intent. The version selector is resolved from the
+      stable release. A stable release requires an explicit milestone,
+      maintenance, or security intent. The version selector is resolved from the
       latest local semantic container-compose tag, not from mutable
       working-tree state. The helper bumps container-compose on main when
       needed, commits that bump, promotes the stephenlclarke source main
@@ -101,10 +101,16 @@ Environment:
       normal merge, then uses an admin merge only when GitHub blocks the merge
       on the solo-maintainer review requirement. Use "strict" to fail instead.
 
-  CONTAINER_STACK_RELEASE_INTENT=milestone|security
+  CONTAINER_STACK_RELEASE_INTENT=milestone|maintenance|security
       Required for a new stable release. milestone requires the current build
-      to have soaked for at least seven days. security bypasses only that soak
-      after CONTAINER_STACK_SECURITY_REASON records the advisory or incident.
+      to have soaked for at least seven days. maintenance is a manual --+
+      patch promotion for a documented operational fix. security bypasses only
+      that soak after CONTAINER_STACK_SECURITY_REASON records the advisory or
+      incident.
+
+  CONTAINER_STACK_MAINTENANCE_REASON
+      Required when CONTAINER_STACK_RELEASE_INTENT=maintenance. Record the
+      operational fix or explicit baseline-promotion rationale.
 
   CONTAINER_STACK_SECURITY_REASON
       Required when CONTAINER_STACK_RELEASE_INTENT=security. Record a CVE,
@@ -189,6 +195,7 @@ COMPOSE_MAIN_PROMOTION_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_PROMOTION_MO
 COMPOSE_MAIN_MERGE_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_MERGE_MODE:-checked-admin}"
 RELEASE_INTENT="${CONTAINER_STACK_RELEASE_INTENT:-}"
 SECURITY_REASON="${CONTAINER_STACK_SECURITY_REASON:-}"
+MAINTENANCE_REASON="${CONTAINER_STACK_MAINTENANCE_REASON:-}"
 readonly STABLE_CURRENT_SOAK_SECONDS=604800
 HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"
 REPOS=(
@@ -242,10 +249,20 @@ ensure_compose_promotion_mode() {
 }
 
 # Require an intentional stable-release classification. Current builds are the
-# normal delivery lane; stable releases are milestone or security boundaries.
+# normal delivery lane; stable releases are milestone, maintenance, or security boundaries.
 ensure_release_intent() {
   case "${RELEASE_INTENT}" in
     milestone)
+      ;;
+    maintenance)
+      if [[ "${VERSION_SELECTOR}" != "--+" ]]; then
+        printf 'maintenance releases must use the --+ patch selector\n' >&2
+        exit 2
+      fi
+      if [[ -z "${MAINTENANCE_REASON}" ]]; then
+        printf 'CONTAINER_STACK_MAINTENANCE_REASON is required for a maintenance release\n' >&2
+        exit 2
+      fi
       ;;
     security)
       if [[ -z "${SECURITY_REASON}" ]]; then
@@ -255,15 +272,16 @@ ensure_release_intent() {
       ;;
     *)
       printf 'CONTAINER_STACK_RELEASE_INTENT is required for a new stable release\n' >&2
-      printf 'expected milestone or security\n' >&2
+      printf 'expected milestone, maintenance, or security\n' >&2
       exit 2
       ;;
   esac
 }
 
 # Require the mutable Current build to identify the same source as local main.
-# Milestone releases additionally require a seven-day soak; security releases
-# retain the source-identity check but may bypass that waiting period.
+# Milestone releases additionally require a seven-day soak; explicit
+# maintenance and security releases retain the source-identity check but may
+# bypass that waiting period.
 ensure_current_build_release_readiness() {
   local path main_commit current_commit current_is_prerelease current_built_at
   path="$(repo_path "${COMPOSE_REPO}")"
@@ -287,7 +305,7 @@ ensure_current_build_release_readiness() {
     --jq '.prerelease')"
   current_built_at="$(github_cli api \
     "repos/$(github_repo "${COMPOSE_REPO}")/releases/tags/current" \
-    --jq '[.assets[] | select(.name == "container-compose-plugin-current-arm64.tar.gz") | .updated_at] | max // empty')"
+    --jq '[.assets[] | select(.name | test("^container-compose-plugin-current-[0-9a-f]{12}-arm64[.]tar[.]gz$")) | .updated_at] | max // empty')"
   if [[ "${current_is_prerelease}" != "true" || -z "${current_built_at}" ]]; then
     printf 'current GitHub prerelease or package asset is missing; wait for green main package publication\n' >&2
     exit 1


### PR DESCRIPTION
## Summary
- Stage immutable commit-addressed Current assets before publishing the matching Homebrew formulas.
- Finalize the mutable current tag and release notes only after formula publication succeeds.
- Retire superseded Current assets only after successful finalization, and eliminate duplicate Validate jobs.
- Document explicit, auditable maintenance --+ promotions.

## Validation
- Full CI using the resolved dependency checkout: 937 Swift tests, coverage gates, Go build, CLI smoke suite, release and CI checks.
- actionlint and focused release-script tests pass.