### PR TITLE
fix(stats): stop streaming on interrupt

### DIFF
--- a/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
@@ -147,13 +147,41 @@ public extension ComposeOrchestrator {
             emitComposeRuntimeOperation(args)
             return
         }
-        try await statsManager.stats(
-            ids: ids,
-            format: stats.format,
-            noStream: stats.noStream,
-            noTrunc: stats.noTrunc,
-            includeStopped: stats.all,
-            emit: options.emit,
+        let format = stats.format
+        let noStream = stats.noStream
+        let noTrunc = stats.noTrunc
+        let includeStopped = stats.all
+        let collectStats: @Sendable () async throws -> Void = {
+            try await self.statsManager.stats(
+                ids: ids,
+                format: format,
+                noStream: noStream,
+                noTrunc: noTrunc,
+                includeStopped: includeStopped,
+                emit: self.options.emit,
+            )
+        }
+        guard !noStream else {
+            try await collectStats()
+            return
+        }
+
+        let streamingTask = Task {
+            try await collectStats()
+        }
+        try await signalProxy.withSignalProxy(
+            signals: ["SIGINT", "SIGTERM"],
+            handler: { _ in
+                streamingTask.cancel()
+            },
+            operation: {
+                do {
+                    try await streamingTask.value
+                } catch is CancellationError {
+                    // Ctrl-C/termination ends a local stats stream. The stats
+                    // manager's defer restores the terminal before returning.
+                }
+            },
         )
     }
 

--- a/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
@@ -171,7 +171,7 @@ public extension ComposeOrchestrator {
 
     /// Runs a local stats stream and converts terminal interrupts into task cancellation.
     private func runInterruptibleStats(
-        _ collectStats: @escaping @Sendable () async throws -> Void
+        _ collectStats: @escaping @Sendable () async throws -> Void,
     ) async throws {
         let streamingTask = Task {
             try await collectStats()

--- a/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
@@ -166,6 +166,13 @@ public extension ComposeOrchestrator {
             return
         }
 
+        try await runInterruptibleStats(collectStats)
+    }
+
+    /// Runs a local stats stream and converts terminal interrupts into task cancellation.
+    private func runInterruptibleStats(
+        _ collectStats: @escaping @Sendable () async throws -> Void
+    ) async throws {
         let streamingTask = Task {
             try await collectStats()
         }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -9651,6 +9651,26 @@ struct ComposeOrchestratorTests {
         ])
     }
 
+    @Test("stats stops a streaming session on interrupt")
+    func statsStopsStreamingSessionOnInterrupt() async throws {
+        let signalProxy = RecordingComposeSignalProxy(forwardedSignals: ["SIGINT"])
+        let statsManager = InterruptibleStatsManager()
+        let project = ComposeProject(
+            name: "demo",
+            services: ["api": ComposeService(name: "api", image: "example/api")]
+        )
+
+        try await ComposeOrchestrator(
+            dependencies: orchestratorDependencies {
+                $0.signalProxy = signalProxy
+                $0.statsManager = statsManager
+            }
+        ).stats(project: project, options: ComposeStatsOptions())
+
+        #expect(await signalProxy.requests == [["SIGINT", "SIGTERM"]])
+        #expect(await statsManager.cancelled)
+    }
+
     @Test("stats dry run emits compose runtime operation")
     func statsDryRunEmitsComposeRuntimeOperation() async throws {
         let emitted = MessageRecorder()
@@ -26445,6 +26465,26 @@ private actor RecordingContainerStatsManager: ContainerStatsManaging {
         storage.append(ContainerStatsRequest(ids: ids, format: format, noStream: noStream, noTrunc: noTrunc, includeStopped: includeStopped))
         for output in outputs {
             emit(output)
+        }
+    }
+}
+
+private actor InterruptibleStatsManager: ContainerStatsManaging {
+    private(set) var cancelled = false
+
+    func stats(
+        ids _: [String],
+        format _: String,
+        noStream _: Bool,
+        noTrunc _: Bool,
+        includeStopped _: Bool,
+        emit _: @escaping @Sendable (String) -> Void
+    ) async throws {
+        do {
+            try await Task.sleep(for: .seconds(60))
+        } catch is CancellationError {
+            cancelled = true
+            throw CancellationError()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Handle SIGINT and SIGTERM for streaming compose stats sessions.
- Cancel only the local streaming task, allowing the stats manager to restore the terminal before returning.
- Preserve the non-streaming stats path.

## Validation
- Focused interrupt test passes.
- All 16 stats-related orchestrator tests pass.
- Debug compose product builds successfully.