### PR TITLE
docs(release): describe maintenance promotion

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -78,6 +78,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"', self.script)
         self.assertIn("CONTAINER_STACK_RELEASE_ROOT", self.script)
 
+    def test_release_plan_describes_the_maintenance_promotion_lane(self) -> None:
+        plan = self.script[self.script.index("\nplan() {") : self.script.index("\nmain() {")]
+        self.assertIn("RELEASE_INTENT=maintenance with --+", plan)
+        self.assertIn("documented operational", plan)
+
     def test_internal_dependency_pins_do_not_become_release_highlights(self) -> None:
         pin_commit = self.script[
             self.script.index("commit_containerization_package_pin() {") : self.script.index(

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -1909,7 +1909,8 @@ Process:
   1. Keep main as the releasable integration branch.
   2. Current builds publish from every green main commit.
   3. For a stable release, use RELEASE_INTENT=milestone after a seven-day current
-     soak, or RELEASE_INTENT=security with an advisory or incident reference.
+     soak, RELEASE_INTENT=maintenance with --+ and a documented operational
+     reason, or RELEASE_INTENT=security with an advisory or incident reference.
   4. The release mode resolves VERSION_SELECTOR from the latest semantic tag,
      requires reviewed sibling mains and Apple-upstream alignment, bumps
      container-compose on main when needed, promotes container-compose through


### PR DESCRIPTION
## Summary
- state the documented `maintenance` `--+` stable-promotion path in `make release-plan`
- keep the plan output aligned with the helper validation and BUILD guidance
- add a regression check for that operator-facing text

## Validation
- `python3 Tools/release/test_container_stack_release.py`
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `git diff --check`