### PR TITLE
fix(release): recover unpublished candidate

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -78,6 +78,24 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"', self.script)
         self.assertIn("CONTAINER_STACK_RELEASE_ROOT", self.script)
 
+    def test_release_helper_recovers_only_its_unpublished_candidate_before_readiness(self) -> None:
+        recovery = self.script[
+            self.script.index("recover_unpublished_release_candidate() {") : self.script.index(
+                "# Print and optionally execute a command."
+            )
+        ]
+        release = self.script[self.script.index("release_current_stack() {") :]
+        self.assertIn('git -C "${path}" reset --soft "${remote_head}"', recovery)
+        self.assertNotIn("reset --hard", recovery)
+        self.assertIn('"chore(release): prepare ${version}"', recovery)
+        self.assertIn('"chore(deps): pin containerization "[0-9a-f]*', recovery)
+        self.assertIn('"chore(deps): pin container "[0-9a-f]*', recovery)
+        self.assertIn("dirty worktree blocks recovery", recovery)
+        self.assertLess(
+            release.index('recover_unpublished_release_candidate "${version}"'),
+            release.index("ensure_current_build_release_readiness"),
+        )
+
     def test_release_plan_describes_the_maintenance_promotion_lane(self) -> None:
         plan = self.script[self.script.index("\nplan() {") : self.script.index("\nmain() {")]
         self.assertIn("RELEASE_INTENT=maintenance with --+", plan)
@@ -630,6 +648,44 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "git", "ls-remote", "--tags", "--refs", str(remote), "refs/tags/current"
             ).stdout.split()[0]
             self.assertEqual(local_current, remote_current)
+
+    def test_release_helper_reconstructs_an_unpublished_prepared_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _remote, local = self.create_compose_checkout(root)
+            remote_head = self.git(local, "rev-parse", "origin/main")
+            self.commit_file(
+                local,
+                "VERSION",
+                "0.6.71\n",
+                "chore(release): prepare 0.6.71",
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("reconstructing unpublished release candidate", result.stdout)
+            self.assertEqual(self.git(local, "rev-parse", "main"), remote_head)
+            self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "VERSION")
+
+    def test_release_helper_refuses_to_reconstruct_an_unrelated_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _remote, local = self.create_compose_checkout(root)
+            self.commit_file(local, "candidate.yml", "candidate\n", "feat: unrelated candidate")
+            candidate_head = self.git(local, "rev-parse", "main")
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("unpublished non-release commit", result.stderr)
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
 
     def test_release_helper_uses_the_active_github_cli_credential(self) -> None:
         self.assertIn("github_cli() {", self.script)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -329,6 +329,50 @@ PY
   fi
 }
 
+# Reconstruct a helper-created candidate after a local release gate fails before promotion.
+recover_unpublished_release_candidate() {
+  local version="$1" path remote local_head remote_head subject subjects
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+  local_head="$(git -C "${path}" rev-parse main)"
+  remote_head="$(remote_main_commit "${COMPOSE_REPO}")"
+
+  if [[ "${local_head}" == "${remote_head}" ]]; then
+    return 0
+  fi
+  if [[ -z "${remote_head}" ]]; then
+    printf 'cannot recover an unpublished release candidate without %s/main\n' "${remote}" >&2
+    exit 1
+  fi
+  if ! git -C "${path}" merge-base --is-ancestor "${remote_head}" "${local_head}"; then
+    printf 'container-compose main is not based on %s/main; refusing to recover a release candidate\n' "${remote}" >&2
+    exit 1
+  fi
+  if [[ -n "$(git -C "${path}" status --short)" ]]; then
+    printf 'dirty worktree blocks recovery of an unpublished release candidate for container-compose\n' >&2
+    exit 1
+  fi
+
+  subjects="$(git -C "${path}" log --format='%s' "${remote_head}..${local_head}")"
+  if [[ -z "${subjects}" ]]; then
+    printf 'container-compose main differs from %s/main without an unpublished release candidate\n' "${remote}" >&2
+    exit 1
+  fi
+  while IFS= read -r subject; do
+    case "${subject}" in
+      "chore(release): prepare ${version}"|"chore(deps): pin containerization "[0-9a-f]*|"chore(deps): pin container "[0-9a-f]*)
+        ;;
+      *)
+        printf 'container-compose main contains an unpublished non-release commit; refusing recovery: %s\n' "${subject}" >&2
+        exit 1
+        ;;
+    esac
+  done <<<"${subjects}"
+
+  printf 'reconstructing unpublished release candidate from %s/main after an earlier local gate failure\n' "${remote}"
+  run git -C "${path}" reset --soft "${remote_head}"
+}
+
 # Print and optionally execute a command.
 run() {
   if [[ "${EXECUTE}" == "1" ]]; then
@@ -1804,6 +1848,7 @@ release_current_stack() {
   ensure_release_version_is_valid "${latest}" "${current}" "${version}"
   ensure_new_stable_release "${version}"
   ensure_release_intent
+  recover_unpublished_release_candidate "${version}"
   ensure_current_build_release_readiness
   require_release_upstream_alignment
   path="$(repo_path "${COMPOSE_REPO}")"


### PR DESCRIPTION
## Summary

Recover a helper-created, unpromoted stable-release candidate after a local release gate fails.

## Root cause

The helper prepared a local candidate before the full gate. A rerun then compared `current` with that unpublished local commit and stopped before it could refresh dependency pins or retry the gate.

## Fix

Only a clean, remote-based sequence of release-helper commits may be reconstructed. The helper soft-resets to the verified remote main while preserving the candidate changes staged, then recomputes the candidate deterministically. Any unrelated local commit is refused.

## Validation

- `python3 Tools/release/test_container_stack_release.py` (51 tests)
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `git diff --check`