### PR TITLE
fix(release): defer compose stack resolution

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -132,6 +132,14 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertLess(
             sync.index('update_container_package_pin "${container_ref}" 0'),
+            sync.index('unedit_release_dependency "${path}" containerization'),
+        )
+        self.assertLess(
+            sync.index('unedit_release_dependency "${path}" containerization\n'),
+            sync.index('unedit_release_dependency "${path}" container\n'),
+        )
+        self.assertLess(
+            sync.index('unedit_release_dependency "${path}" container\n'),
             sync.index('swift package --package-path "${path}" resolve'),
         )
         self.assertIn("commit_compose_stack_package_pins", sync)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -927,8 +927,8 @@ if count != 1:
     raise SystemExit(f"{package} is missing the stephenlclarke containerization dependency")
 package.write_text(updated, encoding="utf-8")
 PY
-  unedit_release_dependency "${path}" containerization
   if [[ "${resolve}" == "1" ]]; then
+    unedit_release_dependency "${path}" containerization
     run swift package --package-path "${path}" resolve
   fi
 }
@@ -984,8 +984,8 @@ if count != 1:
     raise SystemExit(f"{package} is missing the stephenlclarke container dependency")
 package.write_text(updated, encoding="utf-8")
 PY
-  unedit_release_dependency "${path}" container
   if [[ "${resolve}" == "1" ]]; then
+    unedit_release_dependency "${path}" container
     run swift package --package-path "${path}" resolve
   fi
 }
@@ -1034,6 +1034,8 @@ sync_container_package_pin() {
   print_header "sync exact compose runtime stack pins"
   update_containerization_package_pin "${COMPOSE_REPO}" "${containerization_ref}" 0
   update_container_package_pin "${container_ref}" 0
+  unedit_release_dependency "${path}" containerization
+  unedit_release_dependency "${path}" container
   run swift package --package-path "${path}" resolve
   commit_compose_stack_package_pins "${container_ref}" "${containerization_ref}"
 }


### PR DESCRIPTION
## Summary

- defers both SwiftPM `unedit` operations until Compose has matching container and containerization manifest revisions
- prevents `unedit` from resolving the transient incompatible dependency graph
- extends the release policy test to require manifest updates, then both `unedit` operations, then one resolution

## Validation

- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `python3 -m unittest Tools/release/test_container_stack_release.py` (52 tests)
- `make check`

This was found by executing the stable helper against the validated current baseline. No stable tag or stable assets were created by that stopped attempt.