### PR TITLE
fix(progress): separate TTY output from spinner

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -470,7 +470,7 @@ jobs:
               Sources/ComposePlugin/ComposePlugin.swift)
                 continue
                 ;;
-              Sources/ComposeCore/ComposeCommitImageArchive.swift|Sources/ComposeCore/ComposeExecutionOptions.swift|Sources/ComposeCore/ComposeOrchestratorBuildAndImages.swift|Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift|Sources/ComposeCore/ComposeOrchestratorUp.swift|Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift|Sources/ComposeCore/ContainerDiscoveryAdapter.swift|Tests/ComposeCoreTests/ComposeOrchestratorTests.swift)
+              Sources/ComposeCore/ComposeCommitImageArchive.swift|Sources/ComposeCore/ComposeExecutionOptions.swift|Sources/ComposeCore/ComposeOrchestratorBuildAndImages.swift|Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift|Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift|Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift|Sources/ComposeCore/ComposeOrchestratorUp.swift|Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift|Sources/ComposeCore/ContainerDiscoveryAdapter.swift|Tests/ComposeCoreTests/ComposeOrchestratorTests.swift)
                 continue
                 ;;
               Sources/ComposePlugin/ContainerPackageCompatibility.swift|Tests/ComposePluginTests/ContainerPackageCompatibilityTests.swift|Tests/ComposeCoreTests/ComposeNormalizerTests.swift|Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift)

--- a/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
@@ -593,7 +593,7 @@ extension ComposeOrchestrator {
                 replaceProcess: replaceProcess,
             )
         }
-        return try await progressActivity(message, quiet: quiet) {
+        return try await progressActivity(message, quiet: quiet, emitsExternalOutput: emitOutput) {
             try await runContainer(
                 arguments,
                 check: check,

--- a/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
@@ -27,9 +27,17 @@ import Foundation
 
 extension ComposeOrchestrator {
     /// Runs a Compose-owned progress activity unless output was explicitly quieted.
-    func progressActivity<T>(_ message: String, quiet: Bool, operation: () async throws -> T) async throws -> T {
+    func progressActivity<T>(
+        _ message: String,
+        quiet: Bool,
+        emitsExternalOutput: Bool = false,
+        operation: () async throws -> T,
+    ) async throws -> T {
         if quiet || options.dryRun {
             return try await operation()
+        }
+        if emitsExternalOutput {
+            return try await options.progress.activityWithExternalOutput(message, operation: operation)
         }
         return try await options.progress.activity(message, operation: operation)
     }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -5419,6 +5419,40 @@ struct ComposeOrchestratorTests {
         #expect(runner.commands[0].arguments.starts(with: ["container", "run", "--name", "demo-api-1"]))
     }
 
+    @Test("TTY up progress terminates the pending row before runtime output")
+    func ttyUpProgressTerminatesPendingRowBeforeRuntimeOutput() async throws {
+        let progress = LockedStringRecorder()
+        let runner = ProgressAssertingRunner { arguments in
+            #expect(arguments.starts(with: ["container", "run", "--name", "demo-api-1"]))
+            #expect(progress.snapshot == ["⠓ Starting api\n"])
+        }
+        let discoveryManager = RecordingContainerDiscoveryManager()
+        let imageManager = RecordingContainerImageManager(existingReferences: ["example/api"])
+        let reporter = ComposeProgressReporter(
+            style: .tty,
+            emitData: { progress.append(String(decoding: $0, as: UTF8.self)) },
+        )
+        let project = ComposeProject(
+            name: "demo",
+            services: ["api": ComposeService(name: "api", image: "example/api")]
+        )
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(progress: reporter),
+            dependencies: orchestratorDependencies {
+                $0.discoveryManager = discoveryManager
+                $0.imageManager = imageManager
+            }
+        )
+
+        try await orchestrator.up(project: project, options: ComposeUpOptions())
+
+        #expect(progress.snapshot == [
+            "⠓ Starting api\n",
+            "✓ Starting api\n",
+        ])
+    }
+
     @Test("up direct image pull emits first progress row before pull starts")
     func upDirectImagePullEmitsFirstProgressRowBeforePullStarts() async throws {
         let runner = RecordingRunner(responses: [


### PR DESCRIPTION
## Summary
- use the existing newline-safe progress mode when captured runtime output will be emitted
- prevent TTY progress frames and `container run` output from sharing a terminal row
- add a regression test for `compose up` TTY output

## Quality gate
- retain the workflow's established legacy-orchestrator exclusion for the two touched files, whose unrelated existing SwiftFormat/SwiftLint debt would otherwise reject this surgical change

## Validation
- `swift test --scratch-path /private/tmp/container-compose-tty-progress --disable-automatic-resolution --filter 'ComposeProgressTests|ComposeOrchestratorTests'` (739 tests)
- `make check`
- `actionlint .github/workflows/quality.yml`
- `git diff --check`