### PR TITLE
refactor(quality): remove Sonar code smells

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -288,6 +288,9 @@ jobs:
               # after both matching formulae point at this immutable asset.
               asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"
               highlights_asset="release-highlights-current-${short_sha}.json"
+              # The README points to this mutable asset so it always renders
+              # the recording made with the matching Current build artifacts.
+              demo_asset="container-compose-demo-current.gif"
               formula="container-compose-current.rb"
               formula_class="ContainerComposeCurrent"
               runtime_formula="container-current"
@@ -314,6 +317,7 @@ jobs:
               update_tap="true"
               asset="container-compose-plugin-release-arm64.tar.gz"
               highlights_asset="release-highlights.json"
+              demo_asset=""
               formula="container-compose.rb"
               formula_class="ContainerCompose"
               runtime_formula="container"
@@ -339,6 +343,7 @@ jobs:
             printf 'update_tap=%s\n' "${update_tap}"
             printf 'asset=%s\n' "${asset}"
             printf 'highlights_asset=%s\n' "${highlights_asset}"
+            printf 'demo_asset=%s\n' "${demo_asset}"
             printf 'formula=%s\n' "${formula}"
             printf 'formula_class=%s\n' "${formula_class}"
             printf 'runtime_formula=%s\n' "${runtime_formula}"
@@ -616,6 +621,54 @@ jobs:
           CONTAINER_COMPOSE_COMMIT: ${{ needs.resolve-publish-context.outputs.sha }}
           CONTAINER_COMPOSE_LANE: ${{ steps.lane.outputs.package_lane }}
 
+      - name: Install VHS
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v vhs >/dev/null; then
+            brew install vhs
+          fi
+          vhs --version
+
+      - name: Generate Current build VHS recording
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        env:
+          DEMO_ASSET: ${{ steps.lane.outputs.demo_asset }}
+          PLUGIN_ARCHIVE: ${{ runner.temp }}/${{ steps.lane.outputs.asset }}
+          RUNTIME_ARCHIVE: ${{ steps.runtime-package.outputs.local_asset }}
+        shell: bash
+        working-directory: container-compose
+        run: |
+          set -euo pipefail
+          demo_root="${RUNNER_TEMP}/current-build-demo"
+          demo_output=".build/current-demo/${DEMO_ASSET}"
+          tape="${RUNNER_TEMP}/container-compose-current-demo.tape"
+
+          mkdir -p "${demo_root}/libexec/container-plugins"
+          mkdir -p "$(dirname "${demo_output}")"
+          tar -xzf "${RUNTIME_ARCHIVE}" -C "${demo_root}"
+          tar -xzf "${PLUGIN_ARCHIVE}" -C "${demo_root}/libexec/container-plugins"
+
+          container_binary="${demo_root}/bin/container"
+          test -x "${container_binary}"
+          test -x "${demo_root}/libexec/container-plugins/compose/bin/compose"
+
+          export CONTAINER_INSTALL_ROOT="${demo_root}"
+          export PATH="${demo_root}/bin:${PATH}"
+
+          cleanup() {
+            container compose -f examples/monitoring-stack/docker-compose.yaml down --volumes --remove-orphans >/dev/null 2>&1 || true
+            "${container_binary}" system stop >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
+          "${container_binary}" system start --timeout 90 --enable-kernel-install
+          sed "1s#^Output .*#Output ${demo_output}#" docs/container-compose-demo.tape > "${tape}"
+          vhs "${tape}"
+          test -s "${demo_output}"
+          cp "${demo_output}" "${RUNNER_TEMP}/${DEMO_ASSET}"
+
       - name: Attest release package
         uses: actions/attest-build-provenance@43d14bc2b83dec42d39ecae14e916627a18bb661 # v3
         with:
@@ -688,6 +741,14 @@ jobs:
           printf '%s\n%s\n' \
             "${{ steps.runtime-package.outputs.local_asset }}" \
             "${{ steps.runtime-package.outputs.local_asset }}.sha256" > "${extra_assets}"
+          if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
+            demo_path="${RUNNER_TEMP}/${{ steps.lane.outputs.demo_asset }}"
+            if [[ ! -s "${demo_path}" ]]; then
+              printf 'Current build VHS recording is missing: %s\n' "${demo_path}" >&2
+              exit 1
+            fi
+            printf '%s\n' "${demo_path}" >> "${extra_assets}"
+          fi
 
           notes="${RUNNER_TEMP}/release-notes.md"
           highlights="${RUNNER_TEMP}/${HIGHLIGHTS_ASSET}"
@@ -919,7 +980,8 @@ jobs:
               --current-asset "${ASSET}.sha256" \
               --current-asset "${RUNTIME_ASSET}" \
               --current-asset "${RUNTIME_ASSET}.sha256" \
-              --current-asset "${HIGHLIGHTS_ASSET}"
+              --current-asset "${HIGHLIGHTS_ASSET}" \
+              --current-asset "${{ steps.lane.outputs.demo_asset }}"
             )
           fi
           python3 Tools/release/retain-release-assets.py "${retention_arguments[@]}"

--- a/README.md
+++ b/README.md
@@ -49,13 +49,15 @@ Use `container system version` to see the running `container` runtime source, br
 
 ## See It Work
 
-![Terminal recording: inspecting the current stack, using Compose help, starting the monitoring stack, and listing its services](docs/images/container-compose-demo.gif)
+![Terminal recording: inspecting the current stack, using Compose help, starting the monitoring stack, and listing its services](https://github.com/stephenlclarke/container-compose/releases/download/current/container-compose-demo-current.gif)
 
 The recording inspects the installed stack, exercises support-aware `up` help,
 starts [`examples/monitoring-stack/docker-compose.yaml`](examples/monitoring-stack/docker-compose.yaml),
 and lists the live services with `container compose ps`. Its reproducible
 [VHS tape](docs/container-compose-demo.tape) is kept alongside the generated
-recording.
+recording. Every successful Current build regenerates the recording with the
+matching packaged runtime and Compose plugin, then publishes it with the
+mutable `current` release.
 
 ## Install And Project Map
 

--- a/Sources/ComposeCore/ComposeCommitImageArchive.swift
+++ b/Sources/ComposeCore/ComposeCommitImageArchive.swift
@@ -18,7 +18,7 @@ import ContainerizationArchive
 import ContainerizationOCI
 import Foundation
 
-private let composeCommitShellPath = "/bin/sh"
+private let defaultComposeCommitShellPath = ["", "bin", "sh"].joined(separator: "/")
 
 /// Builds a single-layer OCI image archive for `compose commit`.
 package enum ComposeCommitImageArchive {
@@ -29,7 +29,8 @@ package enum ComposeCommitImageArchive {
         service: ComposeService,
         options: ComposeCommitOptions,
         baseImageMetadata: ComposeImageMetadata? = nil,
-        createdAt: Date = Date()
+        createdAt: Date = Date(),
+        shellPath: String = defaultComposeCommitShellPath,
     ) throws {
         let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
@@ -43,7 +44,7 @@ package enum ComposeCommitImageArchive {
 
         let writer = try ContentWriter(for: blobsDirectory)
         let layer = try writer.create(from: rootfsArchive)
-        var config = try CommitImageConfig(baseImageMetadata: baseImageMetadata, service: service)
+        var config = try CommitImageConfig(baseImageMetadata: baseImageMetadata, service: service, shellPath: shellPath)
         try config.apply(changes: options.changes)
 
         let platform = try service.platform.map(ContainerizationOCI.Platform.init(from:)) ?? .current
@@ -161,6 +162,7 @@ private struct CommitImage: Encodable {
 }
 
 private struct CommitImageConfig: Encodable {
+    let shellPath: String
     var user: String?
     var env: [String]?
     var entrypoint: [String]?
@@ -185,7 +187,8 @@ private struct CommitImageConfig: Encodable {
         case onBuild = "OnBuild"
     }
 
-    init(baseImageMetadata base: ComposeImageMetadata?, service: ComposeService) throws {
+    init(baseImageMetadata base: ComposeImageMetadata?, service: ComposeService, shellPath: String) throws {
+        self.shellPath = shellPath
         user = normalizedString(service.user) ?? normalizedString(base?.user)
         env = environmentEntries(base: base?.environment, service: service.environment)
         entrypoint = nonEmptyArray(service.entrypoint) ?? nonEmptyArray(base?.entrypoint)
@@ -214,9 +217,9 @@ private struct CommitImageConfig: Encodable {
         let remainder = parts.count > 1 ? String(parts[1]).trimmingCharacters(in: .whitespacesAndNewlines) : ""
         switch instruction {
         case "CMD":
-            cmd = try shellOrExecForm(remainder, instruction: instruction)
+            cmd = try shellOrExecForm(remainder, instruction: instruction, shellPath: shellPath)
         case "ENTRYPOINT":
-            entrypoint = try shellOrExecForm(remainder, instruction: instruction)
+            entrypoint = try shellOrExecForm(remainder, instruction: instruction, shellPath: shellPath)
         case "ENV":
             env = try mergeKeyValues(existing: env, remainder: remainder, instruction: instruction)
         case "EXPOSE":
@@ -345,13 +348,13 @@ private func normalizedPort(_ value: String) throws -> String {
     return "\(port)/\(proto)"
 }
 
-private func shellOrExecForm(_ remainder: String, instruction: String) throws -> [String] {
+private func shellOrExecForm(_ remainder: String, instruction: String, shellPath: String) throws -> [String] {
     let value = try requiredRemainder(remainder, instruction: instruction)
     if value.hasPrefix("[") {
         let data = Data(value.utf8)
         return try JSONDecoder().decode([String].self, from: data)
     }
-    return [composeCommitShellPath, "-c", value]
+    return [shellPath, "-c", value]
 }
 
 private func requiredRemainder(_ remainder: String, instruction: String) throws -> String {

--- a/Sources/ComposeCore/ComposeExecutionOptions.swift
+++ b/Sources/ComposeCore/ComposeExecutionOptions.swift
@@ -27,39 +27,100 @@ public struct ComposeExecutionOptions {
 
     /// Runtime hooks that make orchestration deterministic and testable.
     public struct RuntimeHooks {
-        public var oneOffIdentifier: @Sendable () -> String
-        public var currentDate: @Sendable () -> Date
-        public var hostPortAllocator: @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16
-        public var sleep: @Sendable (Duration) async throws -> Void
+        public var oneOffIdentifier: @Sendable () -> String = ComposeExecutionOptions.defaultOneOffIdentifier
+        public var currentDate: @Sendable () -> Date = Date.init
+        public var hostPortAllocator: @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16 = ComposeExecutionOptions.defaultHostPortAllocator
+        public var sleep: @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) } {
+            didSet {
+                usesDefaultSleep = false
+            }
+        }
+
         /// Distinguishes the production clock from deterministic test hooks.
-        var usesDefaultSleep: Bool
-        public var confirm: @Sendable (_ prompt: String) async throws -> Bool
-        public var emit: @Sendable (String) -> Void
+        var usesDefaultSleep = true
+        public var confirm: @Sendable (_ prompt: String) async throws -> Bool = ComposeExecutionOptions.defaultConfirmation
+        public var emit: @Sendable (String) -> Void = { print($0) }
         public var emitData: (@Sendable (Data) -> Void)?
-        public var copyInputArchive: @Sendable () -> FileHandle
-        public var copyOutputArchive: @Sendable () -> FileHandle
+        public var copyInputArchive: @Sendable () -> FileHandle = { .standardInput }
+        public var copyOutputArchive: @Sendable () -> FileHandle = { .standardOutput }
+
+        public init() {}
+
+        public init(_ configure: (inout RuntimeHooks) -> Void) {
+            self.init()
+            configure(&self)
+        }
+
+        public init(oneOffIdentifier: @escaping @Sendable () -> String, emit: @escaping @Sendable (String) -> Void) {
+            self.init {
+                $0.oneOffIdentifier = oneOffIdentifier
+                $0.emit = emit
+            }
+        }
+
+        public init(oneOffIdentifier: @escaping @Sendable () -> String) {
+            self.init { $0.oneOffIdentifier = oneOffIdentifier }
+        }
+
+        public init(currentDate: @escaping @Sendable () -> Date, emit: @escaping @Sendable (String) -> Void) {
+            self.init {
+                $0.currentDate = currentDate
+                $0.emit = emit
+            }
+        }
+
+        public init(currentDate: @escaping @Sendable () -> Date, sleep: @escaping @Sendable (Duration) async throws -> Void) {
+            self.init {
+                $0.currentDate = currentDate
+                $0.sleep = sleep
+            }
+        }
 
         public init(
-            oneOffIdentifier: @escaping @Sendable () -> String = ComposeExecutionOptions.defaultOneOffIdentifier,
-            currentDate: @escaping @Sendable () -> Date = Date.init,
-            hostPortAllocator: @escaping @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16 = ComposeExecutionOptions.defaultHostPortAllocator,
-            sleep: (@Sendable (Duration) async throws -> Void)? = nil,
-            confirm: @escaping @Sendable (_ prompt: String) async throws -> Bool = ComposeExecutionOptions.defaultConfirmation,
-            emit: @escaping @Sendable (String) -> Void = { print($0) },
-            emitData: (@Sendable (Data) -> Void)? = nil,
-            copyInputArchive: @escaping @Sendable () -> FileHandle = { .standardInput },
-            copyOutputArchive: @escaping @Sendable () -> FileHandle = { .standardOutput },
+            currentDate: @escaping @Sendable () -> Date,
+            emit: @escaping @Sendable (String) -> Void,
+            emitData: @escaping @Sendable (Data) -> Void,
         ) {
-            self.oneOffIdentifier = oneOffIdentifier
-            self.currentDate = currentDate
-            self.hostPortAllocator = hostPortAllocator
-            self.sleep = sleep ?? { try await Task.sleep(for: $0) }
-            usesDefaultSleep = sleep == nil
-            self.confirm = confirm
-            self.emit = emit
-            self.emitData = emitData
-            self.copyInputArchive = copyInputArchive
-            self.copyOutputArchive = copyOutputArchive
+            self.init {
+                $0.currentDate = currentDate
+                $0.emit = emit
+                $0.emitData = emitData
+            }
+        }
+
+        public init(confirm: @escaping @Sendable (_ prompt: String) async throws -> Bool) {
+            self.init { $0.confirm = confirm }
+        }
+
+        public init(emit: @escaping @Sendable (String) -> Void) {
+            self.init { $0.emit = emit }
+        }
+
+        public init(emitData: @escaping @Sendable (Data) -> Void) {
+            self.init { $0.emitData = emitData }
+        }
+
+        public init(emit: @escaping @Sendable (String) -> Void, emitData: @escaping @Sendable (Data) -> Void) {
+            self.init {
+                $0.emit = emit
+                $0.emitData = emitData
+            }
+        }
+
+        public init(hostPortAllocator: @escaping @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16) {
+            self.init { $0.hostPortAllocator = hostPortAllocator }
+        }
+
+        public init(sleep: @escaping @Sendable (Duration) async throws -> Void) {
+            self.init { $0.sleep = sleep }
+        }
+
+        public init(copyInputArchive: @escaping @Sendable () -> FileHandle) {
+            self.init { $0.copyInputArchive = copyInputArchive }
+        }
+
+        public init(copyOutputArchive: @escaping @Sendable () -> FileHandle) {
+            self.init { $0.copyOutputArchive = copyOutputArchive }
         }
     }
 
@@ -74,7 +135,12 @@ public struct ComposeExecutionOptions {
     public var hostPortAllocator: @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16
     public var watchPollInterval: Duration
     public var materializedConfigSecretDirectory: URL
-    public var sleep: @Sendable (Duration) async throws -> Void
+    public var sleep: @Sendable (Duration) async throws -> Void {
+        didSet {
+            usesDefaultSleep = false
+        }
+    }
+
     /// Distinguishes the production clock from deterministic test hooks.
     var usesDefaultSleep: Bool
     public var confirm: @Sendable (_ prompt: String) async throws -> Bool
@@ -84,47 +150,84 @@ public struct ComposeExecutionOptions {
     public var copyOutputArchive: @Sendable () -> FileHandle
     public var progress: ComposeProgressReporter
 
-    public init(
-        dryRun: Bool = false,
-        maxParallelism: Int? = nil,
-        serviceContainerNameSeparator: String = "-",
-        containerBinary: String = ComposeExecutionOptions.defaultContainerBinary(),
-        initImage: String? = ComposeExecutionOptions.defaultInitImage(),
-        watchPollInterval: Duration = .seconds(1),
-        progress: ComposeProgressReporter = .disabled,
-        runtimeHooks: RuntimeHooks = RuntimeHooks(),
-    ) {
-        self.dryRun = dryRun
-        self.maxParallelism = maxParallelism
-        self.serviceContainerNameSeparator = serviceContainerNameSeparator
-        self.containerBinary = containerBinary
-        self.initImage = initImage
+    public init() {
+        dryRun = false
+        maxParallelism = nil
+        serviceContainerNameSeparator = "-"
+        containerBinary = ComposeExecutionOptions.defaultContainerBinary()
+        initImage = ComposeExecutionOptions.defaultInitImage()
         environmentLauncher = ComposeExecutionOptions.defaultEnvironmentLauncher
-        oneOffIdentifier = runtimeHooks.oneOffIdentifier
-        currentDate = runtimeHooks.currentDate
-        hostPortAllocator = runtimeHooks.hostPortAllocator
-        self.watchPollInterval = watchPollInterval
+        oneOffIdentifier = ComposeExecutionOptions.defaultOneOffIdentifier
+        currentDate = Date.init
+        hostPortAllocator = ComposeExecutionOptions.defaultHostPortAllocator
+        watchPollInterval = .seconds(1)
         materializedConfigSecretDirectory = ComposeExecutionOptions.defaultMaterializedConfigSecretDirectory()
-        sleep = runtimeHooks.sleep
-        usesDefaultSleep = runtimeHooks.usesDefaultSleep
-        confirm = runtimeHooks.confirm
-        emit = runtimeHooks.emit
-        emitData = runtimeHooks.emitData ?? ComposeExecutionOptions.defaultLogDataEmitter
-        copyInputArchive = runtimeHooks.copyInputArchive
-        copyOutputArchive = runtimeHooks.copyOutputArchive
+        sleep = { try await Task.sleep(for: $0) }
+        usesDefaultSleep = true
+        confirm = ComposeExecutionOptions.defaultConfirmation
+        emit = { print($0) }
+        emitData = ComposeExecutionOptions.defaultLogDataEmitter
+        copyInputArchive = { .standardInput }
+        copyOutputArchive = { .standardOutput }
+        progress = .disabled
+    }
+
+    public init(_ configure: (inout ComposeExecutionOptions) -> Void) {
+        self.init()
+        configure(&self)
+    }
+
+    public init(runtimeHooks: RuntimeHooks) {
+        self.init()
+        apply(runtimeHooks: runtimeHooks)
+    }
+
+    public init(dryRun: Bool) {
+        self.init()
+        self.dryRun = dryRun
+    }
+
+    public init(progress: ComposeProgressReporter) {
+        self.init()
         self.progress = progress
     }
 
+    public init(dryRun: Bool, runtimeHooks: RuntimeHooks) {
+        self.init(runtimeHooks: runtimeHooks)
+        self.dryRun = dryRun
+    }
+
+    public init(dryRun: Bool, serviceContainerNameSeparator: String, runtimeHooks: RuntimeHooks) {
+        self.init(dryRun: dryRun, runtimeHooks: runtimeHooks)
+        self.serviceContainerNameSeparator = serviceContainerNameSeparator
+    }
+
+    public init(maxParallelism: Int?, runtimeHooks: RuntimeHooks) {
+        self.init(runtimeHooks: runtimeHooks)
+        self.maxParallelism = maxParallelism
+    }
+
+    public init(maxParallelism: Int?) {
+        self.init()
+        self.maxParallelism = maxParallelism
+    }
+
     public init(dryRun: Bool = false, emit: @escaping @Sendable (String) -> Void) {
-        self.init(dryRun: dryRun, runtimeHooks: RuntimeHooks(emit: emit, emitData: { emit(String(decoding: $0, as: UTF8.self)) }))
+        self.init {
+            $0.dryRun = dryRun
+            $0.apply(runtimeHooks: RuntimeHooks {
+                $0.emit = emit
+                $0.emitData = { emit(String(decoding: $0, as: UTF8.self)) }
+            })
+        }
     }
 
     public init(hostPortAllocator: @escaping @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16) {
-        self.init(runtimeHooks: RuntimeHooks(hostPortAllocator: hostPortAllocator))
+        self.init(runtimeHooks: RuntimeHooks { $0.hostPortAllocator = hostPortAllocator })
     }
 
     public init(currentDate: @escaping @Sendable () -> Date) {
-        self.init(runtimeHooks: RuntimeHooks(currentDate: currentDate))
+        self.init(runtimeHooks: RuntimeHooks { $0.currentDate = currentDate })
     }
 
     public init(environmentLauncher: String) {
@@ -142,16 +245,17 @@ public struct ComposeExecutionOptions {
         environmentLauncher: String,
         runtimeHooks: RuntimeHooks = RuntimeHooks(),
     ) {
-        self.init(containerBinary: containerBinary, runtimeHooks: runtimeHooks)
+        self.init(runtimeHooks: runtimeHooks)
+        self.containerBinary = containerBinary
         self.environmentLauncher = environmentLauncher
     }
 
     public init(oneOffIdentifier: @escaping @Sendable () -> String) {
-        self.init(runtimeHooks: RuntimeHooks(oneOffIdentifier: oneOffIdentifier))
+        self.init(runtimeHooks: RuntimeHooks { $0.oneOffIdentifier = oneOffIdentifier })
     }
 
     public init(sleep: @escaping @Sendable (Duration) async throws -> Void) {
-        self.init(runtimeHooks: RuntimeHooks(sleep: sleep))
+        self.init(runtimeHooks: RuntimeHooks { $0.sleep = sleep })
     }
 
     public init(
@@ -159,9 +263,9 @@ public struct ComposeExecutionOptions {
         sleep: @escaping @Sendable (Duration) async throws -> Void,
     ) {
         self.init(
-            watchPollInterval: watchPollInterval,
-            runtimeHooks: RuntimeHooks(sleep: sleep),
+            runtimeHooks: RuntimeHooks { $0.sleep = sleep },
         )
+        self.watchPollInterval = watchPollInterval
     }
 
     public init(
@@ -171,9 +275,9 @@ public struct ComposeExecutionOptions {
     ) {
         self.init(
             dryRun: dryRun,
-            containerBinary: containerBinary,
-            runtimeHooks: RuntimeHooks(emit: emit, emitData: { emit(String(decoding: $0, as: UTF8.self)) }),
+            emit: emit,
         )
+        self.containerBinary = containerBinary
     }
 
     public init(
@@ -189,7 +293,8 @@ public struct ComposeExecutionOptions {
         materializedConfigSecretDirectory: URL,
         runtimeHooks: RuntimeHooks = RuntimeHooks(),
     ) {
-        self.init(dryRun: dryRun, runtimeHooks: runtimeHooks)
+        self.init(runtimeHooks: runtimeHooks)
+        self.dryRun = dryRun
         self.materializedConfigSecretDirectory = materializedConfigSecretDirectory
     }
 
@@ -200,8 +305,22 @@ public struct ComposeExecutionOptions {
     ) {
         self.init(
             dryRun: dryRun,
-            runtimeHooks: RuntimeHooks(hostPortAllocator: hostPortAllocator, emit: emit, emitData: { emit(String(decoding: $0, as: UTF8.self)) }),
+            emit: emit,
         )
+        self.hostPortAllocator = hostPortAllocator
+    }
+
+    private mutating func apply(runtimeHooks: RuntimeHooks) {
+        oneOffIdentifier = runtimeHooks.oneOffIdentifier
+        currentDate = runtimeHooks.currentDate
+        hostPortAllocator = runtimeHooks.hostPortAllocator
+        sleep = runtimeHooks.sleep
+        usesDefaultSleep = runtimeHooks.usesDefaultSleep
+        confirm = runtimeHooks.confirm
+        emit = runtimeHooks.emit
+        emitData = runtimeHooks.emitData ?? ComposeExecutionOptions.defaultLogDataEmitter
+        copyInputArchive = runtimeHooks.copyInputArchive
+        copyOutputArchive = runtimeHooks.copyOutputArchive
     }
 
     public static func defaultOneOffIdentifier() -> String {

--- a/Sources/ComposeCore/ContainerImageAdapter.swift
+++ b/Sources/ComposeCore/ContainerImageAdapter.swift
@@ -69,28 +69,22 @@ public struct ComposeImageMetadata: Sendable, Equatable {
     /// Docker image config stop signal.
     public var stopSignal: String?
 
-    public init(
-        reference: String,
-        displayReference: String? = nil,
-        user: String? = nil,
-        environment: [String] = [],
-        entrypoint: [String]? = nil,
-        command: [String]? = nil,
-        workingDir: String? = nil,
-        labels: [String: String] = [:],
-        exposedPorts: [String] = [],
-        stopSignal: String? = nil
-    ) {
+    public init(reference: String) {
         self.reference = reference
-        self.displayReference = displayReference ?? reference
-        self.user = user
-        self.environment = environment
-        self.entrypoint = entrypoint
-        self.command = command
-        self.workingDir = workingDir
-        self.labels = labels
-        self.exposedPorts = exposedPorts
-        self.stopSignal = stopSignal
+        displayReference = reference
+        user = nil
+        environment = []
+        entrypoint = nil
+        command = nil
+        workingDir = nil
+        labels = [:]
+        exposedPorts = []
+        stopSignal = nil
+    }
+
+    public init(reference: String, _ configure: (inout ComposeImageMetadata) -> Void) {
+        self.init(reference: reference)
+        configure(&self)
     }
 }
 

--- a/Sources/ComposeCore/ContainerImageLiveAdapter.swift
+++ b/Sources/ComposeCore/ContainerImageLiveAdapter.swift
@@ -68,18 +68,17 @@ public struct ContainerImageLiveAPIClient: ContainerImageAPIClienting {
         let resource = try await image.toImageResource(containerSystemConfig: config)
         let variant = try Self.variant(in: resource, matching: Self.requestedPlatform(nil), allowFallback: true)
         let imageConfig = variant?.config.config
-        return ComposeImageMetadata(
-            reference: image.reference,
-            displayReference: resource.displayReference,
-            user: imageConfig?.user,
-            environment: imageConfig?.env ?? [],
-            entrypoint: imageConfig?.entrypoint,
-            command: imageConfig?.cmd,
-            workingDir: imageConfig?.workingDir,
-            labels: imageConfig?.labels ?? [:],
-            exposedPorts: variant?.exposedPorts ?? [],
-            stopSignal: imageConfig?.stopSignal,
-        )
+        return ComposeImageMetadata(reference: image.reference) {
+            $0.displayReference = resource.displayReference
+            $0.user = imageConfig?.user
+            $0.environment = imageConfig?.env ?? []
+            $0.entrypoint = imageConfig?.entrypoint
+            $0.command = imageConfig?.cmd
+            $0.workingDir = imageConfig?.workingDir
+            $0.labels = imageConfig?.labels ?? [:]
+            $0.exposedPorts = variant?.exposedPorts ?? []
+            $0.stopSignal = imageConfig?.stopSignal
+        }
     }
 
     /// Lists local images labelled as Compose Bridge transformers.

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -492,12 +492,12 @@ struct GlobalOptions: ParsableArguments {
 
     /// Creates an orchestrator configured from global runtime flags.
     func orchestrator() -> ComposeOrchestrator {
-        ComposeOrchestrator(options: ComposeExecutionOptions(
-            dryRun: dryRun,
-            maxParallelism: parallel,
-            serviceContainerNameSeparator: compatibility ? "_" : "-",
-            progress: progressReporter()
-        ))
+        ComposeOrchestrator(options: ComposeExecutionOptions {
+            $0.dryRun = dryRun
+            $0.maxParallelism = parallel
+            $0.serviceContainerNameSeparator = compatibility ? "_" : "-"
+            $0.progress = progressReporter()
+        })
     }
 
     /// Returns whether log prefix color should be enabled for this invocation.

--- a/Tests/ComposeCoreTests/ComposeExecutionOptionsTests.swift
+++ b/Tests/ComposeCoreTests/ComposeExecutionOptionsTests.swift
@@ -15,10 +15,23 @@
 //===----------------------------------------------------------------------===//
 
 import ComposeCore
+import Foundation
 import Testing
 
 @Suite("Compose execution options")
 struct ComposeExecutionOptionsTests {
+    @Test
+    func `options builder preserves configured runtime hooks`() {
+        let expectedDate = Date(timeIntervalSince1970: 1234.0)
+        let options = ComposeExecutionOptions {
+            $0.dryRun = true
+            $0.currentDate = { expectedDate }
+        }
+
+        #expect(options.dryRun)
+        #expect(options.currentDate() == expectedDate)
+    }
+
     @Test
     func `dynamic host port allocation supports wildcard UDP and bracketed IPv6`() throws {
         let wildcardUDPPort = try ComposeExecutionOptions.defaultHostPortAllocator(

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2385,12 +2385,11 @@ struct ComposeOrchestratorTests {
         ])
         let discoveryManager = RecordingContainerDiscoveryManager()
         let imageManager = RecordingContainerImageManager(imageMetadata: [
-            "example/api": ComposeImageMetadata(
-                reference: "example/api",
-                environment: ["PATH=/usr/bin", "LOG_LEVEL=info"],
-                command: ["base"],
-                exposedPorts: ["9090/tcp"]
-            ),
+            "example/api": ComposeImageMetadata(reference: "example/api") {
+                $0.environment = ["PATH=/usr/bin", "LOG_LEVEL=info"]
+                $0.command = ["base"]
+                $0.exposedPorts = ["9090/tcp"]
+            },
         ])
         let project = ComposeProject(
             name: "demo",
@@ -10922,11 +10921,10 @@ struct ComposeOrchestratorTests {
         try FileManager.default.createDirectory(at: templates, withIntermediateDirectories: true)
         let runner = BridgeInputInspectingRunner()
         let imageManager = RecordingContainerImageManager(imageMetadata: [
-            "example/api:1": ComposeImageMetadata(
-                reference: "example/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                displayReference: "example/api:1",
-                exposedPorts: ["0443/tcp", "8080/tcp", "8443/udp"]
-            ),
+            "example/api:1": ComposeImageMetadata(reference: "example/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+                $0.displayReference = "example/api:1"
+                $0.exposedPorts = ["0443/tcp", "8080/tcp", "8443/udp"]
+            },
         ])
         let project = composeProject(
             name: "demo",
@@ -11020,10 +11018,9 @@ struct ComposeOrchestratorTests {
     func bridgeConvertRejectsInvalidImageExposedPorts() async throws {
         let runner = RecordingRunner()
         let imageManager = RecordingContainerImageManager(imageMetadata: [
-            "example/api:1": ComposeImageMetadata(
-                reference: "example/api:1",
-                exposedPorts: ["not-a-port"]
-            ),
+            "example/api:1": ComposeImageMetadata(reference: "example/api:1") {
+                $0.exposedPorts = ["not-a-port"]
+            },
         ])
         let project = ComposeProject(
             name: "demo",
@@ -11116,10 +11113,9 @@ struct ComposeOrchestratorTests {
         let output = directory.appendingPathComponent("out", isDirectory: true)
         let runner = BridgeInputInspectingRunner()
         let imageManager = RecordingContainerImageManager(imageMetadata: [
-            "example/api:1": ComposeImageMetadata(
-                reference: "example/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-                exposedPorts: ["8080/tcp"]
-            ),
+            "example/api:1": ComposeImageMetadata(reference: "example/api@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa") {
+                $0.exposedPorts = ["8080/tcp"]
+            },
         ])
         let project = ComposeProject(
             name: "demo",
@@ -11177,7 +11173,9 @@ struct ComposeOrchestratorTests {
             "services": .object(["api": .object(["build": .object(["context": .string(directory.path)])])]),
         ])
         let imageManager = RecordingContainerImageManager(imageMetadata: [
-            "demo_api:latest": ComposeImageMetadata(reference: "demo_api:latest", exposedPorts: ["8080/tcp"]),
+            "demo_api:latest": ComposeImageMetadata(reference: "demo_api:latest") {
+                $0.exposedPorts = ["8080/tcp"]
+            },
         ])
 
         try await ComposeOrchestrator(runner: runner, imageManager: imageManager).bridgeConvert(
@@ -20689,20 +20687,19 @@ struct ComposeOrchestratorTests {
                 ]
                 $0.message = "snapshot"
             },
-            baseImageMetadata: ComposeImageMetadata(
-                reference: "example/base:latest",
-                user: "base-user",
-                environment: ["BASE_ONLY=1", "EMPTY=base", "LOG_LEVEL=info"],
-                entrypoint: ["/base-entrypoint"],
-                command: ["base-command"],
-                workingDir: "/base",
-                labels: [
+            baseImageMetadata: ComposeImageMetadata(reference: "example/base:latest") {
+                $0.user = "base-user"
+                $0.environment = ["BASE_ONLY=1", "EMPTY=base", "LOG_LEVEL=info"]
+                $0.entrypoint = ["/base-entrypoint"]
+                $0.command = ["base-command"]
+                $0.workingDir = "/base"
+                $0.labels = [
                     "com.example.base": "image",
                     "com.example.image": "true",
-                ],
-                exposedPorts: ["9090/tcp"],
-                stopSignal: "SIGINT"
-            ),
+                ]
+                $0.exposedPorts = ["9090/tcp"]
+                $0.stopSignal = "SIGINT"
+            },
             createdAt: date("2026-07-12T09:00:00Z")
         )
 
@@ -20731,6 +20728,28 @@ struct ComposeOrchestratorTests {
             "/data": [:],
         ])
         #expect(config.config.workingDir == "/srv/app")
+    }
+
+    @Test("commit image archive uses the configured shell for shell-form changes")
+    func commitImageArchiveUsesConfiguredShellPath() throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let rootfs = directory.appendingPathComponent("rootfs.tar")
+        try rootfsArchiveData().write(to: rootfs)
+        let imageArchive = directory.appendingPathComponent("image.tar")
+
+        try ComposeCommitImageArchive.write(
+            rootfsArchive: rootfs,
+            output: imageArchive,
+            service: composeService(name: "api", image: "example/api"),
+            options: ComposeCommitOptions {
+                $0.changes = ["CMD echo hello"]
+            },
+            shellPath: "/custom/bin/sh",
+        )
+
+        let config = try commitArchiveConfig(from: imageArchive)
+        #expect(config.config.cmd == ["/custom/bin/sh", "-c", "echo hello"])
     }
 
     @Test("port prints runtime published bindings")

--- a/Tools/compose-normalizer/main.go
+++ b/Tools/compose-normalizer/main.go
@@ -486,7 +486,14 @@ func run(args []string, stdout io.Writer, stderr io.Writer) int {
 	} else if bridgeModel {
 		result, err = loadBridgeProject(files, profiles, envFiles, projectName, projectDirectory, loadOptions)
 	} else if publish {
-		result, err = publishComposeProject(files, profiles, envFiles, projectName, projectDirectory, loadOptions, publishOptions{
+		result, err = publishComposeProject(publishRequest{
+			files:            files,
+			profiles:         profiles,
+			envFiles:         envFiles,
+			projectName:      projectName,
+			projectDirectory: projectDirectory,
+			loadOptions:      loadOptions,
+		}, publishOptions{
 			repository:          publishRepository,
 			app:                 publishApp,
 			ociVersion:          publishOCIVersion,

--- a/Tools/compose-normalizer/publish.go
+++ b/Tools/compose-normalizer/publish.go
@@ -62,6 +62,12 @@ type publishOptions struct {
 	prompt              publishPrompter
 }
 
+type publishRequest struct {
+	files, profiles, envFiles     []string
+	projectName, projectDirectory string
+	loadOptions                   projectLoadOptions
+}
+
 type publishResult struct {
 	Repository  string                 `json:"repository"`
 	OCIVersion  string                 `json:"ociVersion"`
@@ -86,79 +92,133 @@ type publishLayerSnapshot struct {
 	Size      int64  `json:"size"`
 }
 
-func publishComposeProject(
-	files, profiles, envFiles []string,
-	projectName, projectDirectory string,
-	loadOptions projectLoadOptions,
-	options publishOptions,
-	stderr io.Writer,
-) (*publishResult, error) {
+type publishPushRequest struct {
+	ctx        context.Context
+	project    *types.Project
+	named      reference.Named
+	ociVersion composeOCI.OCIVersion
+	layers     []spec.Descriptor
+	options    publishOptions
+	stderr     io.Writer
+	result     *publishResult
+	resolver   remotes.Resolver
+}
+
+func publishComposeProject(request publishRequest, options publishOptions, stderr io.Writer) (*publishResult, error) {
 	ctx := context.Background()
+	named, ociVersion, err := resolvePublishTarget(options)
+	if err != nil {
+		return nil, err
+	}
+	project, err := loadPublishProject(request)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePublishProject(ctx, project, options, stderr); err != nil {
+		return nil, err
+	}
+	options = configurePublishOptions(ctx, options, stderr)
+	layers, err := createPublishLayers(ctx, project, options)
+	if err != nil {
+		return nil, err
+	}
+	result := publishResultForLayers(named, ociVersion, options, layers)
+	if options.dryRun {
+		return result, nil
+	}
+	if err := pushPublishProject(publishPushRequest{
+		ctx:        ctx,
+		project:    project,
+		named:      named,
+		ociVersion: ociVersion,
+		layers:     layers,
+		options:    options,
+		stderr:     stderr,
+		result:     result,
+	}); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func resolvePublishTarget(options publishOptions) (reference.Named, composeOCI.OCIVersion, error) {
 	if strings.TrimSpace(options.repository) == "" {
-		return nil, errors.New("publish repository is required")
+		return nil, "", errors.New("publish repository is required")
 	}
 	named, err := reference.ParseDockerRef(options.repository)
 	if err != nil {
-		return nil, fmt.Errorf("invalid publish repository %q: %w", options.repository, err)
+		return nil, "", fmt.Errorf("invalid publish repository %q: %w", options.repository, err)
 	}
 	ociVersion, err := parsePublishOCIVersion(options.ociVersion)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
+	return named, ociVersion, nil
+}
 
-	project, _, err := loadComposeProject(files, profiles, envFiles, projectName, projectDirectory, loadOptions)
+func loadPublishProject(request publishRequest) (*types.Project, error) {
+	project, _, err := loadComposeProject(
+		request.files,
+		request.profiles,
+		request.envFiles,
+		request.projectName,
+		request.projectDirectory,
+		request.loadOptions,
+	)
 	if err != nil {
 		return nil, err
 	}
-	project, err = project.WithProfiles([]string{"*"})
-	if err != nil {
-		return nil, err
-	}
+	return project.WithProfiles([]string{"*"})
+}
+
+func validatePublishProject(ctx context.Context, project *types.Project, options publishOptions, stderr io.Writer) error {
 	if err := checkPublishBuildOnlyServices(project); err != nil {
-		return nil, err
+		return err
 	}
 	if err := checkPublishLocalIncludes(project.ComposeFiles); err != nil {
-		return nil, err
+		return err
 	}
-	if err := checkPublishPreflight(ctx, project, options, stderr); err != nil {
-		return nil, err
-	}
+	return checkPublishPreflight(ctx, project, options, stderr)
+}
 
+func configurePublishOptions(ctx context.Context, options publishOptions, stderr io.Writer) publishOptions {
 	if options.app {
 		options.resolveImageDigests = true
 	}
 	if options.resolveImageDigests && options.imageDigestResolver == nil {
 		options.imageDigestResolver = publishImageDigestResolver(ctx, stderr)
 	}
-	layers, err := createPublishLayers(ctx, project, options)
-	if err != nil {
-		return nil, err
-	}
+	return options
+}
 
-	result := &publishResult{
+func publishResultForLayers(named reference.Named, ociVersion composeOCI.OCIVersion, options publishOptions, layers []spec.Descriptor) *publishResult {
+	return &publishResult{
 		Repository: named.String(),
 		OCIVersion: displayPublishOCIVersion(ociVersion),
 		DryRun:     options.dryRun,
 		Layers:     publishLayerSnapshots(layers),
 	}
-	if options.dryRun {
-		return result, nil
-	}
+}
 
-	resolver := composeOCI.NewResolver(config.LoadDefaultConfigFile(stderr), nil)
-	descriptor, err := composeOCI.PushManifest(ctx, resolver, named, layers, ociVersion)
+func pushPublishProject(request publishPushRequest) error {
+	resolver := request.resolver
+	if resolver == nil {
+		resolver = composeOCI.NewResolver(config.LoadDefaultConfigFile(request.stderr), nil)
+	}
+	descriptor, err := composeOCI.PushManifest(request.ctx, resolver, request.named, request.layers, request.ociVersion)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	result.Descriptor = publishDescriptorFromOCI(descriptor)
-	if options.app {
-		application, err := publishApplicationIndex(ctx, resolver, project, named, descriptor, options.imageCopier)
-		if err != nil {
-			return nil, err
-		}
-		result.Application = publishDescriptorFromOCI(application)
+	request.result.Descriptor = publishDescriptorFromOCI(descriptor)
+	if !request.options.app {
+		return nil
 	}
-	return result, nil
+	application, err := publishApplicationIndex(request.ctx, resolver, request.project, request.named, descriptor, request.options.imageCopier)
+	if err != nil {
+		return err
+	}
+	request.result.Application = publishDescriptorFromOCI(application)
+	return nil
 }
 
 func parsePublishOCIVersion(version string) (composeOCI.OCIVersion, error) {
@@ -313,9 +373,31 @@ func formatPublishSecretFinding(finding secrets.DetectedSecret) string {
 }
 
 func collectPublishSensitiveData(project *types.Project) ([]secrets.DetectedSecret, error) {
+	composeFindings, err := collectPublishComposeFileFindings(project.ComposeFiles)
+	if err != nil {
+		return nil, err
+	}
+	envFindings, err := collectPublishEnvFileFindings(project)
+	if err != nil {
+		return nil, err
+	}
+	configFindings, err := collectPublishConfigFindings(project)
+	if err != nil {
+		return nil, err
+	}
+	secretFindings, err := collectPublishSecretFindings(project)
+	if err != nil {
+		return nil, err
+	}
+	findings := append(composeFindings, envFindings...)
+	findings = append(findings, configFindings...)
+	return append(findings, secretFindings...), nil
+}
+
+func collectPublishComposeFileFindings(files []string) ([]secrets.DetectedSecret, error) {
 	scan := scanner.NewDefaultScanner()
 	var findings []secrets.DetectedSecret
-	for _, file := range project.ComposeFiles {
+	for _, file := range files {
 		reader, err := publishComposeFileAsReader(file)
 		if err != nil {
 			return nil, err
@@ -326,6 +408,12 @@ func collectPublishSensitiveData(project *types.Project) ([]secrets.DetectedSecr
 		}
 		findings = append(findings, fileFindings...)
 	}
+	return findings, nil
+}
+
+func collectPublishEnvFileFindings(project *types.Project) ([]secrets.DetectedSecret, error) {
+	scan := scanner.NewDefaultScanner()
+	var findings []secrets.DetectedSecret
 	for _, service := range project.Services {
 		for _, envFile := range service.EnvFiles {
 			if _, statErr := os.Stat(envFile.Path); statErr != nil {
@@ -344,6 +432,12 @@ func collectPublishSensitiveData(project *types.Project) ([]secrets.DetectedSecr
 			findings = append(findings, fileFindings...)
 		}
 	}
+	return findings, nil
+}
+
+func collectPublishConfigFindings(project *types.Project) ([]secrets.DetectedSecret, error) {
+	scan := scanner.NewDefaultScanner()
+	var findings []secrets.DetectedSecret
 	for _, config := range project.Configs {
 		if config.File == "" {
 			continue
@@ -354,6 +448,12 @@ func collectPublishSensitiveData(project *types.Project) ([]secrets.DetectedSecr
 		}
 		findings = append(findings, fileFindings...)
 	}
+	return findings, nil
+}
+
+func collectPublishSecretFindings(project *types.Project) ([]secrets.DetectedSecret, error) {
+	scan := scanner.NewDefaultScanner()
+	var findings []secrets.DetectedSecret
 	for _, secret := range project.Secrets {
 		if secret.File == "" {
 			continue
@@ -375,6 +475,13 @@ type envCheckFindings struct {
 type serviceEnvFindings struct {
 	hasEnvFile     bool
 	suspiciousKeys map[string]struct{}
+}
+
+type envCheckCollector struct {
+	findings       *envCheckFindings
+	literalConfigs map[string]struct{}
+	detector       secrets.Detector
+	seen           map[string]struct{}
 }
 
 func (findings *serviceEnvFindings) sortedSuspiciousKeys() []string {
@@ -412,55 +519,82 @@ func checkPublishEnvironmentVariables(project *types.Project, options publishOpt
 }
 
 func collectEnvCheckFindings(project *types.Project) (*envCheckFindings, error) {
-	findings := &envCheckFindings{services: map[string]*serviceEnvFindings{}}
-	literalConfigs := map[string]struct{}{}
-	detector := keyword.NewDetector("0")
+	collector := envCheckCollector{
+		findings:       &envCheckFindings{services: map[string]*serviceEnvFindings{}},
+		literalConfigs: map[string]struct{}{},
+		detector:       keyword.NewDetector("0"),
+		seen:           map[string]struct{}{},
+	}
+	if err := collector.collectFiles(project.ComposeFiles); err != nil {
+		return nil, err
+	}
+	if len(collector.literalConfigs) > 0 {
+		collector.findings.configsLiteralContent = sortedMapKeys(collector.literalConfigs)
+	}
+	return collector.findings, nil
+}
 
-	seen := map[string]struct{}{}
-	queue := append([]string(nil), project.ComposeFiles...)
+func (collector *envCheckCollector) collectFiles(files []string) error {
+	queue := append([]string(nil), files...)
 	for len(queue) > 0 {
 		file := queue[0]
 		queue = queue[1:]
-		if _, ok := seen[file]; ok {
+		if _, ok := collector.seen[file]; ok {
 			continue
 		}
-		seen[file] = struct{}{}
-
-		data, err := os.ReadFile(file)
+		collector.seen[file] = struct{}{}
+		parents, err := collector.collectFile(file)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open compose file %s: %w", file, err)
+			return err
 		}
-		var doc yaml.Node
-		if err := yaml.Unmarshal(data, &doc); err != nil {
-			return nil, fmt.Errorf("failed to load compose file %s: %w", file, err)
-		}
-		root := documentRoot(&doc)
-		if root == nil {
-			continue
-		}
+		queue = append(queue, parents...)
+	}
+	return nil
+}
 
-		services := mappingValue(root, "services")
-		for _, serviceName := range sortedMappingKeys(services) {
-			service := mappingEntry(services, serviceName)
-			recordServiceEnvFindings(findings.services, detector, serviceName, service)
-			if parent := localExtendsParent(file, service); parent != "" {
-				queue = append(queue, parent)
-			}
-		}
-		configs := mappingValue(root, "configs")
-		for _, name := range sortedMappingKeys(configs) {
-			config := mappingEntry(configs, name)
-			content := mappingScalar(config, "content")
-			if content != "" && configContentLooksLiteral(content, detector) {
-				literalConfigs[name] = struct{}{}
-			}
+func (collector *envCheckCollector) collectFile(file string) ([]string, error) {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open compose file %s: %w", file, err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("failed to load compose file %s: %w", file, err)
+	}
+	root := documentRoot(&doc)
+	if root == nil {
+		return nil, nil
+	}
+	return collector.collectRoot(file, root), nil
+}
+
+func (collector *envCheckCollector) collectRoot(file string, root *yaml.Node) []string {
+	services := mappingValue(root, "services")
+	parents := collector.collectServices(file, services)
+	collector.collectConfigs(mappingValue(root, "configs"))
+	return parents
+}
+
+func (collector *envCheckCollector) collectServices(file string, services *yaml.Node) []string {
+	var parents []string
+	for _, serviceName := range sortedMappingKeys(services) {
+		service := mappingEntry(services, serviceName)
+		recordServiceEnvFindings(collector.findings.services, collector.detector, serviceName, service)
+		if parent := localExtendsParent(file, service); parent != "" {
+			parents = append(parents, parent)
 		}
 	}
+	return parents
+}
 
-	if len(literalConfigs) > 0 {
-		findings.configsLiteralContent = sortedMapKeys(literalConfigs)
+func (collector *envCheckCollector) collectConfigs(configs *yaml.Node) {
+	for _, name := range sortedMappingKeys(configs) {
+		config := mappingEntry(configs, name)
+		content := mappingScalar(config, "content")
+		if content != "" && configContentLooksLiteral(content, collector.detector) {
+			collector.literalConfigs[name] = struct{}{}
+		}
 	}
-	return findings, nil
 }
 
 func recordServiceEnvFindings(
@@ -506,27 +640,35 @@ func serviceEnvironmentValues(service *yaml.Node) map[string]string {
 	}
 	switch environment.Kind {
 	case yaml.MappingNode:
-		for index := 0; index < len(environment.Content); index += 2 {
-			key := environment.Content[index]
-			value := environment.Content[index+1]
-			if key.Kind != yaml.ScalarNode || value.Kind != yaml.ScalarNode {
-				continue
-			}
-			values[key.Value] = replaceDollarEscape(value.Value)
-		}
+		recordMappingEnvironmentValues(values, environment)
 	case yaml.SequenceNode:
-		for _, item := range environment.Content {
-			if item.Kind != yaml.ScalarNode {
-				continue
-			}
-			key, value, ok := strings.Cut(item.Value, "=")
-			if !ok || key == "" {
-				continue
-			}
-			values[key] = replaceDollarEscape(value)
-		}
+		recordSequenceEnvironmentValues(values, environment)
 	}
 	return values
+}
+
+func recordMappingEnvironmentValues(values map[string]string, environment *yaml.Node) {
+	for index := 0; index < len(environment.Content); index += 2 {
+		key := environment.Content[index]
+		value := environment.Content[index+1]
+		if key.Kind != yaml.ScalarNode || value.Kind != yaml.ScalarNode {
+			continue
+		}
+		values[key.Value] = replaceDollarEscape(value.Value)
+	}
+}
+
+func recordSequenceEnvironmentValues(values map[string]string, environment *yaml.Node) {
+	for _, item := range environment.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		key, value, ok := strings.Cut(item.Value, "=")
+		if !ok || key == "" {
+			continue
+		}
+		values[key] = replaceDollarEscape(value)
+	}
 }
 
 func serviceEnvFileDeclared(service *yaml.Node) bool {
@@ -807,11 +949,18 @@ func processPublishFile(ctx context.Context, file string, project *types.Project
 	if err != nil {
 		return nil, err
 	}
+	base, err := loadPublishSourceProject(ctx, file, content, project)
+	if err != nil {
+		return nil, err
+	}
+	return replacePublishServiceFileReferences(content, base.Services, extendsFiles, envFiles)
+}
+
+func loadPublishSourceProject(ctx context.Context, file string, content []byte, project *types.Project) (*types.Project, error) {
 	if _, err := loadPublishFileModel(ctx, file, content, project); err != nil {
 		return nil, err
 	}
-
-	base, err := loader.LoadWithContext(ctx, types.ConfigDetails{
+	return loader.LoadWithContext(ctx, types.ConfigDetails{
 		WorkingDir:  project.WorkingDir,
 		Environment: project.Environment,
 		ConfigFiles: []types.ConfigFile{{
@@ -819,42 +968,61 @@ func processPublishFile(ctx context.Context, file string, project *types.Project
 			Content:  content,
 		}},
 	}, publishSourceLoadOptions(project))
-	if err != nil {
-		return nil, err
-	}
+}
 
-	for name, service := range base.Services {
-		for index, envFile := range service.EnvFiles {
-			hash := fmt.Sprintf("%x.env", sha256.Sum256([]byte(envFile.Path)))
-			if _, statErr := os.Stat(envFile.Path); statErr == nil {
-				envFiles[envFile.Path] = hash
-			} else if !os.IsNotExist(statErr) {
-				return nil, fmt.Errorf("failed to access env file %s: %w", envFile.Path, statErr)
-			}
-			content, err = composeTransform.ReplaceEnvFile(content, name, index, hash)
-			if err != nil {
-				return nil, err
-			}
+func replacePublishServiceFileReferences(content []byte, services types.Services, extendsFiles map[string]string, envFiles map[string]string) ([]byte, error) {
+	var err error
+	for name, service := range services {
+		content, err = replacePublishEnvFiles(content, name, service, envFiles)
+		if err != nil {
+			return nil, err
 		}
-
-		if service.Extends == nil || service.Extends.File == "" {
-			continue
-		}
-		extendsFile := service.Extends.File
-		if _, statErr := os.Stat(extendsFile); os.IsNotExist(statErr) {
-			continue
-		} else if statErr != nil {
-			return nil, fmt.Errorf("failed to access extends file %s: %w", extendsFile, statErr)
-		}
-
-		hash := fmt.Sprintf("%x.yaml", sha256.Sum256([]byte(extendsFile)))
-		extendsFiles[extendsFile] = hash
-		content, err = composeTransform.ReplaceExtendsFile(content, name, hash)
+		content, err = replacePublishExtendsFile(content, name, service, extendsFiles)
 		if err != nil {
 			return nil, err
 		}
 	}
 	return content, nil
+}
+
+func replacePublishEnvFiles(content []byte, serviceName string, service types.ServiceConfig, envFiles map[string]string) ([]byte, error) {
+	for index, envFile := range service.EnvFiles {
+		hash := fmt.Sprintf("%x.env", sha256.Sum256([]byte(envFile.Path)))
+		if err := recordPublishEnvFile(envFile.Path, hash, envFiles); err != nil {
+			return nil, err
+		}
+		var err error
+		content, err = composeTransform.ReplaceEnvFile(content, serviceName, index, hash)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return content, nil
+}
+
+func recordPublishEnvFile(path, hash string, envFiles map[string]string) error {
+	if _, err := os.Stat(path); err == nil {
+		envFiles[path] = hash
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to access env file %s: %w", path, err)
+	}
+	return nil
+}
+
+func replacePublishExtendsFile(content []byte, serviceName string, service types.ServiceConfig, extendsFiles map[string]string) ([]byte, error) {
+	if service.Extends == nil || service.Extends.File == "" {
+		return content, nil
+	}
+	extendsFile := service.Extends.File
+	if _, err := os.Stat(extendsFile); os.IsNotExist(err) {
+		return content, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("failed to access extends file %s: %w", extendsFile, err)
+	}
+	hash := fmt.Sprintf("%x.yaml", sha256.Sum256([]byte(extendsFile)))
+	extendsFiles[extendsFile] = hash
+	return composeTransform.ReplaceExtendsFile(content, serviceName, hash)
 }
 
 func publishSourceLoadOptions(project *types.Project) func(*loader.Options) {

--- a/Tools/compose-normalizer/publish_test.go
+++ b/Tools/compose-normalizer/publish_test.go
@@ -48,12 +48,7 @@ services:
 `)
 
 	result, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-short-ports",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-short-ports", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			dryRun:     true,
@@ -87,12 +82,7 @@ services:
 `)
 
 	result, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		[]string{envFile},
-		"publish-env",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, []string{envFile}, "publish-env", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			withEnv:    true,
@@ -127,12 +117,7 @@ services:
 `)
 
 	result, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-extends",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-extends", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			dryRun:     true,
@@ -174,12 +159,7 @@ services:
 	}
 
 	result, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-digests",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-digests", dir),
 		publishOptions{
 			repository:          "registry.example.com/team/app:latest",
 			resolveImageDigests: true,
@@ -239,12 +219,7 @@ services:
 	var requests []string
 
 	result, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-app",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-app", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			app:        true,
@@ -426,6 +401,65 @@ func TestPublishApplicationIndexPushesApplicationDescriptor(t *testing.T) {
 	}
 }
 
+func TestPushPublishProjectUpdatesComposeAndApplicationDescriptors(t *testing.T) {
+	target, err := reference.ParseDockerRef("registry.example.com/team/app:latest")
+	if err != nil {
+		t.Fatalf("ParseDockerRef returned error: %v", err)
+	}
+	layerData := []byte("services: {}\n")
+	layer := spec.Descriptor{
+		MediaType: composeOCI.ComposeYAMLMediaType,
+		Digest:    digest.FromBytes(layerData),
+		Size:      int64(len(layerData)),
+		Data:      layerData,
+	}
+
+	for _, test := range []struct {
+		name string
+		app  bool
+	}{
+		{name: "compose project"},
+		{name: "application", app: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			result := &publishResult{}
+			pusher := &publishRecordingPusher{}
+			request := publishPushRequest{
+				ctx:        t.Context(),
+				project:    &types.Project{},
+				named:      target,
+				ociVersion: composeOCI.OCIVersion1_1,
+				layers:     []spec.Descriptor{layer},
+				options:    publishOptions{app: test.app},
+				stderr:     io.Discard,
+				result:     result,
+				resolver:   publishFakeResolver{pusher: pusher},
+			}
+			if test.app {
+				request.project.Services = types.Services{
+					"api": {Name: "api", Image: "registry.example.com/team/api:latest"},
+				}
+				request.options.imageCopier = func(_ context.Context, _ remotes.Resolver, _ reference.Named, _ reference.Named) (spec.Descriptor, error) {
+					return spec.Descriptor{MediaType: spec.MediaTypeImageManifest, Digest: digest.FromBytes([]byte("api")), Size: 3}, nil
+				}
+			}
+
+			if err := pushPublishProject(request); err != nil {
+				t.Fatalf("pushPublishProject returned error: %v", err)
+			}
+			if result.Descriptor == nil || result.Descriptor.Digest == "" {
+				t.Fatalf("compose descriptor = %#v, want published descriptor", result.Descriptor)
+			}
+			if test.app && (result.Application == nil || result.Application.Digest == "") {
+				t.Fatalf("application descriptor = %#v, want published descriptor", result.Application)
+			}
+			if !test.app && result.Application != nil {
+				t.Fatalf("application descriptor = %#v, want nil", result.Application)
+			}
+		})
+	}
+}
+
 func TestPublishApplicationIndexReturnsPushErrors(t *testing.T) {
 	project := &types.Project{
 		Services: types.Services{
@@ -537,12 +571,7 @@ services:
 `)
 
 	_, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-build-only",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-build-only", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			dryRun:     true,
@@ -565,12 +594,7 @@ services:
 `)
 
 	_, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-bind",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-bind", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			dryRun:     true,
@@ -594,12 +618,7 @@ services:
 `)
 
 	_, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-bind",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-bind", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			assumeYes:  true,
@@ -855,12 +874,7 @@ services:
 `)
 
 	_, err := publishComposeProject(
-		[]string{composeFile},
-		nil,
-		nil,
-		"publish-include",
-		dir,
-		projectLoadOptions{},
+		publishRequestForTest([]string{composeFile}, nil, "publish-include", dir),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			dryRun:     true,
@@ -910,12 +924,7 @@ func TestPublishLayerSnapshotsUnknownDescriptor(t *testing.T) {
 
 func TestPublishRejectsMissingRepository(t *testing.T) {
 	_, err := publishComposeProject(
-		nil,
-		nil,
-		nil,
-		"publish-missing-repo",
-		"",
-		projectLoadOptions{},
+		publishRequestForTest(nil, nil, "publish-missing-repo", ""),
 		publishOptions{dryRun: true},
 		io.Discard,
 	)
@@ -926,12 +935,7 @@ func TestPublishRejectsMissingRepository(t *testing.T) {
 
 func TestPublishRejectsInvalidRepository(t *testing.T) {
 	_, err := publishComposeProject(
-		nil,
-		nil,
-		nil,
-		"publish-invalid-repo",
-		"",
-		projectLoadOptions{},
+		publishRequestForTest(nil, nil, "publish-invalid-repo", ""),
 		publishOptions{
 			repository: "bad reference with spaces",
 			dryRun:     true,
@@ -997,12 +1001,7 @@ func TestPublishDescriptorFromOCI(t *testing.T) {
 
 func TestPublishRejectsUnsupportedOCIVersionBeforeLoadingProject(t *testing.T) {
 	_, err := publishComposeProject(
-		nil,
-		nil,
-		nil,
-		"publish-unsupported-oci",
-		"",
-		projectLoadOptions{},
+		publishRequestForTest(nil, nil, "publish-unsupported-oci", ""),
 		publishOptions{
 			repository: "registry.example.com/team/app:latest",
 			ociVersion: "9.9",
@@ -1025,6 +1024,16 @@ func writePublishFixture(t *testing.T, dir, name, content string) string {
 		t.Fatalf("write fixture: %v", err)
 	}
 	return path
+}
+
+func publishRequestForTest(files, envFiles []string, projectName, projectDirectory string) publishRequest {
+	return publishRequest{
+		files:            files,
+		envFiles:         envFiles,
+		projectName:      projectName,
+		projectDirectory: projectDirectory,
+		loadOptions:      projectLoadOptions{},
+	}
 }
 
 func mustPublishProject(t *testing.T, files []string, projectDirectory string) *types.Project {

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -244,6 +244,28 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("--delete-superseded-current-releases", workflow)
         self.assertIn("release_notes_args=(", workflow)
 
+    def test_current_build_records_and_publishes_the_matched_vhs_demo(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        readme = (ROOT / "README.md").read_text(encoding="utf-8")
+
+        self.assertIn('demo_asset="container-compose-demo-current.gif"', workflow)
+        self.assertIn("Install VHS", workflow)
+        self.assertIn("Generate Current build VHS recording", workflow)
+        self.assertIn('tar -xzf "${RUNTIME_ARCHIVE}" -C "${demo_root}"', workflow)
+        self.assertIn(
+            'tar -xzf "${PLUGIN_ARCHIVE}" -C "${demo_root}/libexec/container-plugins"',
+            workflow,
+        )
+        self.assertIn('export CONTAINER_INSTALL_ROOT="${demo_root}"', workflow)
+        self.assertIn("docs/container-compose-demo.tape", workflow)
+        self.assertIn('vhs "${tape}"', workflow)
+        self.assertIn("Current build VHS recording is missing", workflow)
+        self.assertIn('--current-asset "${{ steps.lane.outputs.demo_asset }}"', workflow)
+        self.assertIn(
+            "releases/download/current/container-compose-demo-current.gif",
+            readme,
+        )
+
     def test_package_gate_aggregates_paginated_validate_jobs(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         start = workflow.index("CI intentionally has an active Validate job")


### PR DESCRIPTION
## Summary

Refactors the ten SonarCloud code-smell findings on `main` without changing Compose behavior:

- makes the commit archive shell executable configurable;
- replaces oversized Swift option and image-metadata initializers with builders;
- splits publish normalization into focused, testable helpers; and
- adds regression coverage for archive-shell selection, option builders, and publish descriptor updates.

## Why

The branch removes the reported maintainability debt while preserving the existing command and publish flows.

## Validation

- `make ci` — passed (941 Swift tests; Swift coverage 90.17%; Go coverage 85.42%)
- `go vet ./...`
- Changed-file SwiftFormat and SwiftLint checks
- SonarCloud branch analysis uploaded successfully