### PR TITLE
fix(docs): make current VHS recording runner-safe

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -657,13 +657,6 @@ jobs:
           export CONTAINER_INSTALL_ROOT="${demo_root}"
           export PATH="${demo_root}/bin:${PATH}"
 
-          cleanup() {
-            container compose -f examples/monitoring-stack/docker-compose.yaml down --volumes --remove-orphans >/dev/null 2>&1 || true
-            "${container_binary}" system stop >/dev/null 2>&1 || true
-          }
-          trap cleanup EXIT
-
-          "${container_binary}" system start --timeout 90 --enable-kernel-install
           sed "1s#^Output .*#Output ${demo_output}#" docs/container-compose-demo.tape > "${tape}"
           vhs "${tape}"
           test -s "${demo_output}"

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Use `container system version` to see the running `container` runtime source, br
 
 ## See It Work
 
-![Terminal recording: inspecting the current stack, using Compose help, starting the monitoring stack, and listing its services](https://github.com/stephenlclarke/container-compose/releases/download/current/container-compose-demo-current.gif)
+![Terminal recording: inspecting the current stack, using Compose help, and planning the monitoring stack](https://github.com/stephenlclarke/container-compose/releases/download/current/container-compose-demo-current.gif)
 
 The recording inspects the installed stack, exercises support-aware `up` help,
-starts [`examples/monitoring-stack/docker-compose.yaml`](examples/monitoring-stack/docker-compose.yaml),
-and lists the live services with `container compose ps`. Its reproducible
+and renders the real [`examples/monitoring-stack/docker-compose.yaml`](examples/monitoring-stack/docker-compose.yaml)
+creation, readiness, status, and teardown plans with `--dry-run`. Its reproducible
 [VHS tape](docs/container-compose-demo.tape) is kept alongside the generated
 recording. Every successful Current build regenerates the recording with the
 matching packaged runtime and Compose plugin, then publishes it with the

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -259,8 +259,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('export CONTAINER_INSTALL_ROOT="${demo_root}"', workflow)
         self.assertIn("docs/container-compose-demo.tape", workflow)
         self.assertIn('vhs "${tape}"', workflow)
+        self.assertNotIn('"${container_binary}" system start', workflow)
         self.assertIn("Current build VHS recording is missing", workflow)
         self.assertIn('--current-asset "${{ steps.lane.outputs.demo_asset }}"', workflow)
+        tape = (ROOT / "docs" / "container-compose-demo.tape").read_text(encoding="utf-8")
+        self.assertIn("up --dry-run --wait", tape)
+        self.assertIn("ps --dry-run", tape)
+        self.assertIn("down --dry-run --volumes --remove-orphans", tape)
         self.assertIn(
             "releases/download/current/container-compose-demo-current.gif",
             readme,

--- a/docs/container-compose-demo.tape
+++ b/docs/container-compose-demo.tape
@@ -22,18 +22,18 @@ Type "container compose up --help | sed -n '1,18p'"
 Enter
 Sleep 2s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --volumes --remove-orphans"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --dry-run --volumes --remove-orphans"
+Enter
+Sleep 2s
+
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml up --dry-run --wait"
 Enter
 Sleep 3s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml up -d --wait"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml ps --dry-run"
 Enter
-Sleep 6s
+Sleep 2s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml ps"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --dry-run --volumes --remove-orphans"
 Enter
-Sleep 3s
-
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --volumes --remove-orphans"
-Enter
-Sleep 3s
+Sleep 2s


### PR DESCRIPTION
## Summary

- replace the hardware-dependent live monitoring-stack commands in the release VHS tape with the real `--dry-run` Compose plan
- record the Current build against the exact packaged runtime and plugin without attempting to start unavailable GitHub-hosted virtualization
- update the README copy and release-policy regression test

## Verification

- `make coverage-tools-test`
- `actionlint .github/workflows/prebuilt-binaries.yml`
- `vhs validate docs/container-compose-demo.tape`
- locally rendered the dry-run tape and inspected a mid-recording frame; it contains the monitoring plan with no virtualization bootstrap error.