### PR TITLE
feat(commit): snapshot running service filesystems

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "b831d029a7dbfae99b0fac83392580fb950b3164"
+        "revision" : "8189ee401dbd50d72935729625de4e1ed883a4f0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "b831d029a7dbfae99b0fac83392580fb950b3164",
+            revision: "8189ee401dbd50d72935729625de4e1ed883a4f0",
         ),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,7 +36,7 @@ Surface names follow the current Docker Docs [Compose file reference](https://do
 | Service attributes and runtime behavior | ⚠️ Partial | The complete grouped service surface is in [Service Attribute Surface](#service-attribute-surface), including details for every runtime-limited group. |
 | Dockerfile and build behavior | ⚠️ Partial | The complete instruction and Build Specification surface is in [Dockerfile And Build Surface](#dockerfile-and-build-surface); build-secret source and metadata shapes remain limited. |
 | CLI commands | ⚠️ Partial | 44 commands are ✅, 2 are ⚠️, and 0 are ❌. Every command is listed in [CLI Command Surface](#cli-command-surface). |
-| CLI long options | ⚠️ Partial | 261 documented long options are ✅, 2 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
+| CLI long options | ⚠️ Partial | 260 documented long options are ✅, 3 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
 
 ## Compose File Surface
 
@@ -131,7 +131,7 @@ Docker Compose service attributes are grouped here by runtime behavior so every 
 | `bridge transformations list` | ✅ Yes | Local transformer images labelled `com.docker.compose.bridge=transformation` are listed in Docker-shaped table, JSON, and quiet modes. |
 | `bridge transformations ls` | ✅ Yes | Alias for `bridge transformations list`. |
 | `build` | ✅ Yes | Dockerfile/build parity is implemented for the supported build surface above. |
-| `commit` | ⚠️ Partial | Stopped service containers can be committed to OCI images through export, archive creation, and image load, including Docker Compose `--author`, `--change`, `--index`, `--message`, and `--pause` parsing. Omitted `--index` and `--index=0` use Docker Compose's default service-container selection. Running-container commit, including `--pause=false`, remains blocked on Apple live export/commit support tracked by [apple/container#1400](https://github.com/apple/container/issues/1400), [apple/container#1630](https://github.com/apple/container/pull/1630), and [apple/container#1762](https://github.com/apple/container/pull/1762); lower-runtime freeze/thaw support is already present through [apple/containerization#685](https://github.com/apple/containerization/pull/685). |
+| `commit` | ⚠️ Partial | Stopped service containers and running containers with the default `--pause=true` commit to OCI images through export, archive creation, and image load. The running path uses the generic live-export snapshot in the pinned `stephenlclarke/container` fork, which briefly freezes the root filesystem rather than pausing all processes. `--pause=false` remains unavailable because the backend cannot safely export a writable filesystem without that freeze. Omitted `--index` and `--index=0` use Docker Compose's default service-container selection. |
 | `config` | ✅ Yes | Compose project rendering and config query options are implemented. |
 | `convert` | ✅ Yes | Docker Compose's config-compatible model conversion projections are implemented for the documented local output modes. |
 | `cp` | ✅ Yes | Local-to-service, service-to-local, service-to-service, stdin tar archive, and stdout tar archive copies are implemented, including archive, follow-link, replica-index, and one-off-container modes. |
@@ -139,7 +139,7 @@ Docker Compose service attributes are grouped here by runtime behavior so every 
 | `down` | ✅ Yes | Container, network, image, volume, timeout, orphan, and service-scoped cleanup are implemented. |
 | `events` | ✅ Yes | Event output, JSON mode, and time filters are implemented. |
 | `exec` | ✅ Yes | Service exec options, indexes, env, user, workdir, tty, detach, and privileged mode are implemented. |
-| `export` | ✅ Yes | Container filesystem export to an archive path is implemented. |
+| `export` | ✅ Yes | Container filesystem export to an archive path is implemented for stopped containers and automatically uses the generic live snapshot path for running service containers. |
 | `help` | ✅ Yes | Docker Compose-compatible help rendering and support colors are implemented. |
 | `images` | ✅ Yes | Image listing and formatting are implemented. |
 | `kill` | ✅ Yes | Signal and orphan handling are implemented. |
@@ -187,7 +187,7 @@ A ✅ option means the flag itself is parsed and mapped for the current command 
 | `bridge transformations list` options | ✅ Yes | ✅ `--dry-run`, ✅ `--format`, ✅ `--quiet`. |
 | `bridge transformations ls` options | ✅ Yes | ✅ `--dry-run`, ✅ `--format`, ✅ `--quiet`. |
 | `build` options | ✅ Yes | ✅ `--build-arg`, ✅ `--builder`, ✅ `--check`, ✅ `--dry-run`, ✅ `--memory`, ✅ `--no-cache`, ✅ `--print`, ✅ `--provenance`, ✅ `--pull`, ✅ `--push`, ✅ `--quiet`, ✅ `--sbom`, ✅ `--ssh`, ✅ `--with-dependencies`. |
-| `commit` options | ✅ Yes | ✅ `--author`, ✅ `--change`, ✅ `--dry-run`, ✅ `--index`, ✅ `--message`, ✅ `--pause`. |
+| `commit` options | ⚠️ Partial | ✅ `--author`, ✅ `--change`, ✅ `--dry-run`, ✅ `--index`, ✅ `--message`, ⚠️ `--pause`: the default uses a brief filesystem-consistent live snapshot for running containers; `--pause=false` is unavailable. |
 | `config` options | ✅ Yes | ✅ `--dry-run`, ✅ `--environment`, ✅ `--format`, ✅ `--hash`, ✅ `--images`, ✅ `--lock-image-digests`, ✅ `--models`, ✅ `--networks`, ✅ `--no-consistency`, ✅ `--no-env-resolution`, ✅ `--no-interpolate`, ✅ `--no-normalize`, ✅ `--no-path-resolution`, ✅ `--output`, ✅ `--profiles`, ✅ `--quiet`, ✅ `--resolve-image-digests`, ✅ `--services`, ✅ `--variables`, ✅ `--volumes`. |
 | `convert` options | ✅ Yes | ✅ `--dry-run`, ✅ `--format`, ✅ `--hash`, ✅ `--images`, ✅ `--no-consistency`, ✅ `--no-interpolate`, ✅ `--no-normalize`, ✅ `--output`, ✅ `--profiles`, ✅ `--quiet`, ✅ `--resolve-image-digests`, ✅ `--services`, ✅ `--volumes`. |
 | `cp` options | ✅ Yes | ✅ `--all`, ✅ `--archive`, ✅ `--dry-run`, ✅ `--follow-link`, ✅ `--index`. |
@@ -228,6 +228,6 @@ Released Apple `container` compatibility is not a supported-lane functionality g
 ## Remaining Gap Focus
 
 - There are no remaining red CLI command or long-option surfaces.
-- The remaining orange command surfaces are `attach` and `commit`; their table rows above describe the exact missing runtime primitive or metadata surface.
+- The remaining orange command surfaces are `attach` and `commit`; `attach` needs an interactive runtime stream reattach/multiplexer, while `commit --pause=false` needs a safe no-freeze writable-filesystem snapshot. Their table rows above describe the exact supported subset.
 - Runtime-primitive blockers include vendor/native GPU passthrough, multiple GPUs, arbitrary macOS hardware passthrough, external config/secret lookup, generic service endpoint `driver_opts`, and non-GPU Deploy device/generic reservations.
 - When touching slow runtime paths, keep first-frame progress rendering covered so local `container compose` runs do not appear to hang before visible output.

--- a/Sources/ComposeCore/ComposeBridge.swift
+++ b/Sources/ComposeCore/ComposeBridge.swift
@@ -197,6 +197,7 @@ extension ComposeOrchestrator {
             try await exporter.exportContainer(
                 id: exportID,
                 output: archive.path,
+                live: false,
             )
             try extractBridgeTemplates(archive: archive, destination: destination)
             try writeBridgeTransformerDockerfile(destination: destination)

--- a/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
@@ -37,7 +37,7 @@ public extension ComposeOrchestrator {
             emitComposeRuntimeOperation(args)
             return
         }
-        let live = (try await discoveryManager.getContainer(id: containerID))?.status.lowercased() == "running"
+        let live = try await (discoveryManager.getContainer(id: containerID))?.status.lowercased() == "running"
         try await exporter.exportContainer(id: containerID, output: export.output, live: live)
     }
 

--- a/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
@@ -37,7 +37,8 @@ public extension ComposeOrchestrator {
             emitComposeRuntimeOperation(args)
             return
         }
-        try await exporter.exportContainer(id: containerID, output: export.output)
+        let live = (try await discoveryManager.getContainer(id: containerID))?.status.lowercased() == "running"
+        try await exporter.exportContainer(id: containerID, output: export.output, live: live)
     }
 
     /// Creates an image from a stopped service container's filesystem.
@@ -70,7 +71,7 @@ public extension ComposeOrchestrator {
         guard let container = try await discoveryManager.getContainer(id: containerID) else {
             throw ComposeError.invalidProject("service '\(service.name)' container '\(containerID)' does not exist")
         }
-        try validateCommitContainerStatus(container, service: service, pause: commit.pause)
+        let live = try commitUsesLiveExport(container, service: service, pause: commit.pause)
         let baseImageMetadata = await commitBaseImageMetadata(project: project, service: service)
 
         let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(
@@ -84,7 +85,7 @@ public extension ComposeOrchestrator {
 
         let rootfs = tempDirectory.appendingPathComponent("rootfs.tar")
         let archive = tempDirectory.appendingPathComponent("image.tar")
-        try await exporter.exportContainer(id: containerID, output: rootfs.path)
+        try await exporter.exportContainer(id: containerID, output: rootfs.path, live: live)
         try ComposeCommitImageArchive.write(
             rootfsArchive: rootfs,
             output: archive,
@@ -160,23 +161,25 @@ public extension ComposeOrchestrator {
         return args
     }
 
-    /// Rejects running commit until apple/container exposes a consistent export or snapshot primitive.
-    func validateCommitContainerStatus(
+    /// Chooses a stopped-rootfs export or a consistent snapshot for a running service.
+    func commitUsesLiveExport(
         _ container: ComposeContainerSummary,
         service: ComposeService,
         pause: Bool,
-    ) throws {
+    ) throws -> Bool {
         switch container.status.lowercased() {
         case "created", "dead", "exited", "stopped":
-            return
+            return false
         case "running":
-            let mode = pause ? "default paused running-container commit" : "running-container commit with --pause=false"
-            throw ComposeError.unsupported(
-                "commit: service '\(service.name)' container '\(container.id)' is running; \(mode) requires Apple live export/commit support (apple/container#1400, apple/container#1630, apple/container#1762). Stop the service container before committing with the current runtime.",
-            )
+            guard pause else {
+                throw ComposeError.unsupported(
+                    "commit: service '\(service.name)' container '\(container.id)' is running; --pause=false is unavailable because the runtime cannot safely export a writable filesystem without a brief filesystem freeze. Omit --pause=false (the default takes a filesystem-consistent live snapshot) or stop the service container before committing.",
+                )
+            }
+            return true
         default:
             throw ComposeError.unsupported(
-                "commit: service '\(service.name)' container '\(container.id)' is \(container.status); only stopped containers can be committed with the current runtime",
+                "commit: service '\(service.name)' container '\(container.id)' is \(container.status); only stopped or running containers can be committed with the current runtime",
             )
         }
     }

--- a/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
@@ -41,7 +41,8 @@ public extension ComposeOrchestrator {
         try await exporter.exportContainer(id: containerID, output: export.output, live: live)
     }
 
-    /// Creates an image from a stopped service container's filesystem.
+    /// Creates an image from a service container filesystem, taking a brief
+    /// filesystem-consistent snapshot when the selected container is running.
     func commit(
         project: ComposeProject,
         serviceName: String,

--- a/Sources/ComposeCore/ContainerFilesystemAdapter.swift
+++ b/Sources/ComposeCore/ContainerFilesystemAdapter.swift
@@ -187,8 +187,9 @@ extension ContainerCopying {
 /// Direct apple/container API used for service container filesystem exports.
 public protocol ContainerExporting: Sendable {
     /// Exports `id` as a tar archive to `output`, or streams the archive to
-    /// stdout when `output` is nil.
-    func exportContainer(id: String, output: String?) async throws
+    /// stdout when `output` is nil. `live` asks the runtime to take a
+    /// filesystem-consistent snapshot of a running container.
+    func exportContainer(id: String, output: String?, live: Bool) async throws
 }
 
 /// `ContainerClient`-backed copier for real service container file copies.
@@ -302,8 +303,8 @@ public struct ContainerClientExporter: ContainerExporting {
         _ = Self.isStateless
     }
 
-    /// Exports through `ContainerClient.export(id:archive:)`.
-    public func exportContainer(id: String, output: String?) async throws {
+    /// Exports through `ContainerClient.export(id:archive:live:)`.
+    public func exportContainer(id: String, output: String?, live: Bool) async throws {
         let client = ContainerClient()
         let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
@@ -312,7 +313,7 @@ public struct ContainerClientExporter: ContainerExporting {
         }
 
         let archive = tempDirectory.appendingPathComponent("archive.tar")
-        try await client.export(id: id, archive: archive)
+        try await client.export(id: id, archive: archive, live: live)
 
         if let output {
             try FileManager.default.moveItem(at: archive, to: Self.outputURL(output))

--- a/Sources/ComposePlugin/ComposeCLIHelp.swift
+++ b/Sources/ComposePlugin/ComposeCLIHelp.swift
@@ -342,7 +342,7 @@ enum ComposeCLIHelp {
 
     private static let supportDetailByCommand: [String: String] = [
         "attach": "Output-only attach is supported; interactive stream reattachment and detach-key handling require additional runtime support.",
-        "commit": "Stopped service containers can be committed to images; running-container commit, including --pause=false, waits for Apple live export/commit support.",
+        "commit": "Stopped containers and running containers with default --pause=true can be committed; the running path uses a brief filesystem freeze. --pause=false remains unavailable because a writable filesystem cannot be exported safely without that freeze.",
     ]
 
     private static let supportByOption: [String: [String: SupportLevel]] = [
@@ -430,7 +430,7 @@ enum ComposeCLIHelp {
             "--dry-run": .supported,
             "--index": .supported,
             "--message": .supported,
-            "--pause": .supported,
+            "--pause": .partiallySupported,
         ],
         "config": [
             "--dry-run": .supported,
@@ -1312,7 +1312,7 @@ enum ComposeCLIHelp {
               --dry-run          Execute command in dry run mode
               --index int        index of the container if service has multiple replicas.
           -m, --message string   Commit message
-          -p, --pause            Pause container during commit (default true). Accepted for Docker Compose CLI compatibility; running commits still require Apple live export/commit support.
+          -p, --pause            Use a filesystem-consistent snapshot for a running container (default true). This briefly freezes its filesystem; --pause=false is unavailable.
         """,
         "config": """
         Usage:  container compose config [OPTIONS] [SERVICE...]

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -1955,7 +1955,7 @@ struct Attach: AsyncParsableCommand, ComposeProjectCommand {
     }
 }
 
-/// Implements `compose commit` for stopped service containers.
+/// Implements `compose commit` for stopped containers and default live snapshots.
 struct Commit: AsyncParsableCommand, ComposeProjectCommand {
     static let configuration = CommandConfiguration(commandName: "commit", abstract: "Create an image from a service container.")
     @OptionGroup var global: GlobalOptions
@@ -1977,7 +1977,7 @@ struct Commit: AsyncParsableCommand, ComposeProjectCommand {
     var service: String
     @Argument(help: "Optional image reference.")
     var reference: String?
-    /// Commits the selected stopped service container as a new image.
+    /// Commits the selected service container as a new image.
     func run() async throws {
         let loadedProject = try await project()
         try await orchestrator().commit(

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -1970,7 +1970,7 @@ struct Commit: AsyncParsableCommand, ComposeProjectCommand {
     @Flag(
         name: .customLong("pause"),
         inversion: .prefixedNo,
-        help: "Pause container during commit. Running-container commit is blocked until Apple live export/commit support exists."
+        help: "Use a filesystem-consistent snapshot for a running container. --pause=false is unavailable because it cannot safely export a writable filesystem."
     )
     var pause = true
     @Argument(help: "Service name.")

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -20344,8 +20344,8 @@ struct ComposeOrchestratorTests {
         )
 
         #expect(await exporter.requests == [
-            ContainerExportRequest(id: "demo-api-1", output: nil),
-            ContainerExportRequest(id: "custom-db", output: "db.tar"),
+            ContainerExportRequest(id: "demo-api-1", output: nil, live: false),
+            ContainerExportRequest(id: "custom-db", output: "db.tar", live: false),
         ])
         #expect(runner.commands.isEmpty)
     }
@@ -20439,8 +20439,9 @@ struct ComposeOrchestratorTests {
 
         #expect(runner.commands.isEmpty)
         #expect(await discoveryManager.listRequests == [true])
+        #expect(await discoveryManager.getRequests == ["demo-api-2"])
         #expect(await exporter.requests == [
-            ContainerExportRequest(id: "demo-api-2", output: "api.tar"),
+            ContainerExportRequest(id: "demo-api-2", output: "api.tar", live: true),
         ])
     }
 
@@ -20541,6 +20542,7 @@ struct ComposeOrchestratorTests {
         #expect(exports.count == 1)
         #expect(exports.first?.id == "demo-api-1")
         #expect(exports.first?.output?.hasSuffix("/rootfs.tar") == true)
+        #expect(exports.first?.live == false)
         let imageRequests = await imageManager.requests
         #expect(imageRequests.count == 2)
         #expect(imageRequests.first == .metadata("example/api"))
@@ -20588,8 +20590,8 @@ struct ComposeOrchestratorTests {
         #expect(await imageManager.requests.isEmpty)
     }
 
-    @Test("commit rejects running service containers before export")
-    func commitRejectsRunningServiceContainersBeforeExport() async throws {
+    @Test("commit takes a live filesystem snapshot for running service containers")
+    func commitTakesLiveFilesystemSnapshotForRunningServiceContainers() async throws {
         let exporter = RecordingContainerExporter(archiveData: try rootfsArchiveData())
         let imageManager = RecordingContainerImageManager()
         let discoveryManager = RecordingContainerDiscoveryManager(containers: [
@@ -20607,19 +20609,23 @@ struct ComposeOrchestratorTests {
             $0.imageManager = imageManager
         })
 
-        do {
-            try await orchestrator.commit(project: project, serviceName: "api")
-            Issue.record("Expected running commit to fail")
-        } catch let error as ComposeError {
-            #expect(error == .unsupported("commit: service 'api' container 'demo-api-1' is running; default paused running-container commit requires Apple live export/commit support (apple/container#1400, apple/container#1630, apple/container#1762). Stop the service container before committing with the current runtime."))
-        } catch {
-            Issue.record("Unexpected error: \(error)")
-        }
+        try await orchestrator.commit(project: project, serviceName: "api")
 
         #expect(await discoveryManager.listRequests == [true])
         #expect(await discoveryManager.getRequests == ["demo-api-1"])
-        #expect(await exporter.requests.isEmpty)
-        #expect(await imageManager.requests.isEmpty)
+        let exports = await exporter.requests
+        #expect(exports.count == 1)
+        #expect(exports.first?.id == "demo-api-1")
+        #expect(exports.first?.output?.hasSuffix("/rootfs.tar") == true)
+        #expect(exports.first?.live == true)
+        let imageRequests = await imageManager.requests
+        #expect(imageRequests.count == 2)
+        #expect(imageRequests.first == .metadata("example/api"))
+        if case .load(let path) = imageRequests[1] {
+            #expect(path.hasSuffix("/image.tar"))
+        } else {
+            Issue.record("Expected image load request")
+        }
     }
 
     @Test("commit rejects running service containers when pause is disabled")
@@ -20647,7 +20653,7 @@ struct ComposeOrchestratorTests {
             })
             Issue.record("Expected running commit with --pause=false to fail")
         } catch let error as ComposeError {
-            #expect(error == .unsupported("commit: service 'api' container 'demo-api-1' is running; running-container commit with --pause=false requires Apple live export/commit support (apple/container#1400, apple/container#1630, apple/container#1762). Stop the service container before committing with the current runtime."))
+            #expect(error == .unsupported("commit: service 'api' container 'demo-api-1' is running; --pause=false is unavailable because the runtime cannot safely export a writable filesystem without a brief filesystem freeze. Omit --pause=false (the default takes a filesystem-consistent live snapshot) or stop the service container before committing."))
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
@@ -25562,6 +25568,7 @@ private func listedContainerIDs(from output: String) throws -> [String] {
 private struct ContainerExportRequest: Equatable {
     var id: String
     var output: String?
+    var live: Bool = false
 }
 
 private enum ContainerCopyRequest: Equatable {
@@ -27278,8 +27285,8 @@ private actor RecordingContainerExporter: ContainerExporting {
         storage
     }
 
-    func exportContainer(id: String, output: String?) async throws {
-        storage.append(ContainerExportRequest(id: id, output: output))
+    func exportContainer(id: String, output: String?, live: Bool) async throws {
+        storage.append(ContainerExportRequest(id: id, output: output, live: live))
         if let failure {
             throw failure
         }

--- a/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
+++ b/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
@@ -116,8 +116,8 @@ struct ComposeCLIHelpTests {
         let publishHelp = try #require(ComposeCLIHelp.commandHelpText(command: "publish"))
 
         #expect(commitHelp.contains("Support: \u{001B}[38;5;208mpartially supported\u{001B}[0m"))
-        #expect(commitHelp.contains("running-container commit, including --pause=false"))
-        #expect(commitHelp.contains("\u{001B}[32m--pause\u{001B}[0m"))
+        #expect(commitHelp.contains("running containers with default --pause=true can be committed"))
+        #expect(commitHelp.contains("\u{001B}[38;5;208m--pause\u{001B}[0m"))
         #expect(copyHelp.contains("Support: \u{001B}[32msupported\u{001B}[0m"))
         #expect(!copyHelp.contains("Limitations:"))
         #expect(publishHelp.contains("Support: \u{001B}[32msupported\u{001B}[0m"))

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "b831d029a7dbfae99b0fac83392580fb950b3164",
+      "ref": "8189ee401dbd50d72935729625de4e1ed883a4f0",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/docs/upstream/APPLE-UPSTREAM-REVIEW.md
+++ b/docs/upstream/APPLE-UPSTREAM-REVIEW.md
@@ -31,6 +31,7 @@ fails if any snapshot is deleted or retargeted.
 | `apple/container-builder-shim` | [Build-context source-read errors](apple-container-builder-shim/PR-build-context-source-read-errors.md) fail explicitly instead of sending empty file content. |
 | `apple/container-builder-shim` | [Build-context cache integrity](apple-container-builder-shim/PR-build-context-cache-integrity.md) verifies archives, atomically publishes cache trees, and keeps synthetic Dockerfiles request-local. |
 | `apple/container` | [Fork CI validation](apple-container/PR-fork-ci-validation.md) runs formatting, generated-source checks, builds, and unit tests in contributor forks while retaining official guest integration. |
+| `apple/container` | [Live filesystem snapshot export](apple-container/PR-live-export-snapshot.md) adds a generic `export --live` primitive for a running container, based on the direction in [apple/container#1630](https://github.com/apple/container/pull/1630). |
 | `apple/containerization` | [Fork CI validation](apple-containerization/PR-fork-ci-validation.md) runs supported checks in contributor forks while retaining official guest image and integration work. |
 | `apple/containerization` | [Cgroup formatter catch spacing](apple-containerization/PR-cgroup-catch-format.md) restores the exact spelling required by the strict Swift formatter without changing runtime behavior. |
 | `apple/containerization` | [vmnet integration exclusivity](apple-containerization/PR-vmnet-integration-exclusivity.md) serializes only host-networking VM tests so release validation remains deterministic. |
@@ -43,6 +44,7 @@ fails if any snapshot is deleted or retargeted.
 | [apple/container#1926](https://github.com/apple/container/pull/1926) | Its attached-exec disconnect cleanup is represented in `stephenlclarke/container`; its separate stop-timeout path still needs single-owner cleanup review. |
 | [apple/container-builder-shim#87](https://github.com/apple/container-builder-shim/pull/87) | Its `.dockerignore` re-included-parent fix is represented by standalone commit `2778407`; the fork retains its staged-Dockerfile safeguard until the upstream shape lands. |
 | [apple/container#1735](https://github.com/apple/container/pull/1735) | Preferred daemon entry-point ID validation. Imported as standalone commit `16ecfd5`; the broader residual bundle-path and volume-disk-usage hardening is tracked in [PR-container-storage-path-validation.md](apple-container/PR-container-storage-path-validation.md) and must follow this PR rather than compete with it. |
+| [apple/container#1630](https://github.com/apple/container/pull/1630) | The local live-export handoff is a generic snapshot primitive based on this direction. It uses a unique temporary snapshot and serializes the freeze/copy/thaw lifecycle; it deliberately does not add Docker-shaped `container commit` behavior from [apple/container#1762](https://github.com/apple/container/pull/1762). |
 
 ## Approved Open Pull Requests
 

--- a/docs/upstream/apple-container/ISSUE-live-export-snapshot.md
+++ b/docs/upstream/apple-container/ISSUE-live-export-snapshot.md
@@ -1,0 +1,40 @@
+# Export a filesystem-consistent snapshot of a running container
+
+## Summary
+
+`container export --live` should create an archive from a running container by
+briefly freezing its root filesystem, copying the ext4 disk to a private
+temporary location, thawing the filesystem, and exporting the copy. The
+primitive is generic: backup, inspection, migration, and higher-level clients
+can use it without adding Docker or Compose policy to `apple/container`.
+
+## Current Context
+
+- [apple/container#1400](https://github.com/apple/container/issues/1400) tracks
+  live filesystem export/commit consistency.
+- [apple/container#1630](https://github.com/apple/container/pull/1630) provides
+  the direct live-export direction and is the base for this fork slice.
+- [apple/containerization#685](https://github.com/apple/containerization/pull/685)
+  provides the lower-runtime freeze/thaw operations.
+- [apple/container#1762](https://github.com/apple/container/pull/1762) is a
+  Docker-shaped `container commit` draft. It is intentionally out of scope:
+  image metadata and Compose service policy belong above the runtime.
+
+## Acceptance Criteria
+
+- `container export --live --output snapshot.tar ID` succeeds for a running
+  container and leaves it running.
+- The runtime serializes lifecycle and snapshot work while it freezes, copies,
+  and thaws the root filesystem.
+- Each request uses a unique temporary snapshot and removes it after export.
+- A copy failure still attempts to thaw the filesystem before returning the
+  original error.
+- Stopped and never-started export behavior is unchanged.
+- Focused guest integration, full unit tests, formatting, and license checks
+  pass.
+
+## Non-Goals
+
+- No Docker-shaped `container commit` endpoint.
+- No Compose service selection, Docker option parsing, or OCI image metadata.
+- No claim that a no-freeze writable-filesystem snapshot is available.

--- a/docs/upstream/apple-container/PR-live-export-snapshot.md
+++ b/docs/upstream/apple-container/PR-live-export-snapshot.md
@@ -1,0 +1,55 @@
+# Add live filesystem snapshot export
+
+## Summary
+
+- Adds generic `container export --live` support for running containers.
+- Freezes the root filesystem only long enough to copy its ext4 disk to a
+  unique private temporary snapshot, then thaws it before archive export.
+- Serializes the snapshot with lifecycle work and retries thaw on a failed
+  copy, so a failed request does not leave the filesystem frozen.
+- Keeps Docker Compose `commit` image shaping, service selection, and flags in
+  `container-compose`.
+
+## Upstream Context
+
+- [apple/container#1400](https://github.com/apple/container/issues/1400)
+- [apple/container#1630](https://github.com/apple/container/pull/1630)
+- [apple/containerization#685](https://github.com/apple/containerization/pull/685)
+- [apple/container#1762](https://github.com/apple/container/pull/1762) is not
+  used: it adds Docker-shaped commit policy rather than this reusable runtime
+  primitive.
+
+## Implementation
+
+- The CLI, client, XPC, and runtime service carry a typed `live` export mode.
+- `ContainersService` accepts a running container only for that mode and uses a
+  UUID-named temporary ext4 snapshot with deferred cleanup.
+- The runtime freezes, copies, and thaws under the lifecycle lock. Copy errors
+  execute a best-effort thaw before the original error is returned.
+- Existing stopped and never-started export selection remains unchanged.
+
+## Validation
+
+```sh
+make check
+make test
+CONCURRENT_TEST_SUITES='TestCLIExportCommand/' SERIAL_TEST_SUITES='NoSuchSuite/' make integration
+```
+
+The focused guest integration exercises actual running-container live export.
+The unit suite passes 936 Swift Testing cases plus the XCTest suite.
+
+## Commit Tracking
+
+- Feature implementation: `7f9d739a0e312de1d474059aea55f23163d4a60e`
+  (`feat(export): add live filesystem snapshots`) in `stephenlclarke/container`.
+- Post-snapshot writability integration regression: `cf333204fc010893e118a10fcc87471059f4b211`
+  (`test(export): verify live snapshots leave container writable`) in
+  `stephenlclarke/container`.
+- Fork review handoff: [stephenlclarke/container#5](https://github.com/stephenlclarke/container/pull/5).
+
+## Remaining Limitation
+
+This primitive supplies a brief filesystem-consistent freeze. It does not make
+a safe no-freeze snapshot of a writable filesystem available, so Compose keeps
+running `commit --pause=false` explicitly partial.

--- a/docs/upstream/container-compose/ISSUE-compose-commit.md
+++ b/docs/upstream/container-compose/ISSUE-compose-commit.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-`container compose commit [OPTIONS] SERVICE [REPOSITORY[:TAG]]` should create an image from a selected Compose service container. The Compose-owned path supports stopped service containers with the current Apple-backed runtime, and it should fail clearly for running containers until Apple exposes live export/commit support above the merged lower-runtime freeze/thaw primitive.
+`container compose commit [OPTIONS] SERVICE [REPOSITORY[:TAG]]` should create an image from a selected Compose service container. The Compose-owned path supports stopped containers and running containers with the default `--pause=true` through the generic live-export snapshot primitive. `--pause=false` remains partial because the backend has no safe no-freeze snapshot of a writable root filesystem.
 
 Docker Compose behavior:
 
@@ -27,14 +27,16 @@ Current Apple upstream context:
 - `commit --author`, repeated `--change`, `--index`, `--message`, and `--pause` parse in Docker Compose-compatible forms, including omitted `--index`, `--index=0`, `-a`, `-c`, `-m`, and `-p=false` through the Compose argument rewriter.
 - A stopped service container is exported with the existing runtime export adapter, wrapped as a single-layer OCI image archive, and loaded through the image adapter.
 - The generated OCI config carries Compose service image metadata plus Docker-compatible `--change` instructions for `CMD`, `ENTRYPOINT`, `ENV`, `EXPOSE`, `LABEL`, `ONBUILD`, `USER`, `VOLUME`, and `WORKDIR`.
-- Running containers, including `--pause=false`, fail before export or image load with an error that references the Apple live export/commit blockers.
+- A running service container with the default `--pause=true` exports a filesystem-consistent snapshot before image creation and load.
+- A running service container with `--pause=false` fails before export or image load, explaining that a safe no-freeze writable-filesystem snapshot is unavailable.
 - The Compose layer owns service selection, Docker Compose option parsing, dry-run text, and Docker-shaped image config changes.
-- No Apple-backed repository change is required for the current Compose-owned service commit behavior.
+- The forked `container` runtime provides the generic live-export primitive; Docker-shaped service selection and OCI image config stay in Compose.
 
 ## Non-Goals
 
 - Do not add a Docker-shaped commit endpoint to `apple/container`.
-- Do not attempt paused live/running container commit until Apple accepts live export/commit support in `apple/container`.
+- Do not claim full Docker process-pause equivalence: the current running path briefly freezes the root filesystem, not every process.
+- Do not implement `--pause=false` until an Apple runtime can create a safe writable-filesystem snapshot without that freeze.
 - Do not move Compose service selection or Docker Compose parser behavior into Apple-backed repositories.
 
 ## Validation

--- a/docs/upstream/container-compose/PR-compose-commit.md
+++ b/docs/upstream/container-compose/PR-compose-commit.md
@@ -6,18 +6,18 @@ This change fills the Compose-owned part of Docker Compose v2 `commit` parity:
 
 - Replaces the unsupported `commit` placeholder with a real project command.
 - Parses `--author`, repeated `--change`, `--index`, `--message`, and `--pause` plus Docker short forms handled by the argument rewriter.
-- Exports stopped service container filesystems through the existing runtime export adapter.
+- Exports stopped service container filesystems through the existing runtime export adapter and requests a filesystem-consistent live snapshot for running containers with default `--pause=true`.
 - Builds a single-layer OCI image archive with Docker-compatible image config metadata.
 - Seeds committed image config from base image metadata before applying Compose service overrides and `--change`.
 - Matches Docker Compose's `--index` default by treating omitted `--index` and `--index=0` as unset service-container selection.
 - Loads the generated image archive through the direct image adapter.
-- Keeps running-container commit, including `--pause=false`, partial and blocked on Apple live export/commit support.
+- Keeps `--pause=false` partial because the runtime cannot safely export a writable filesystem without the brief freeze used by the default live snapshot.
 
 ## Rationale
 
-Docker Compose implements `commit` by resolving a service container and calling Docker Engine `ContainerCommit`. Apple has merged the lower-runtime freeze/thaw filesystem operation API in [apple/containerization#685](https://github.com/apple/containerization/pull/685), while the `apple/container` live export and commit surfaces remain in review.
+Docker Compose implements `commit` by resolving a service container and calling Docker Engine `ContainerCommit`. Apple has merged the lower-runtime freeze/thaw filesystem operation API in [apple/containerization#685](https://github.com/apple/containerization/pull/685). The companion fork handoff adds a generic `container export --live` snapshot primitive based on [apple/container#1630](https://github.com/apple/container/pull/1630).
 
-The stopped-container path does not need new Apple APIs: `container-compose` can reuse export and image load primitives, build a standards-shaped OCI archive, and keep all Docker Compose option parsing in the Compose layer. Running-container commit remains explicitly gated on [apple/container#1400](https://github.com/apple/container/issues/1400), [apple/container#1630](https://github.com/apple/container/pull/1630), and [apple/container#1762](https://github.com/apple/container/pull/1762), including Docker Compose's explicit `--pause=false` mode, because the current Apple export primitive rejects running containers.
+The stopped-container path reuses export and image-load primitives, builds a standards-shaped OCI archive, and keeps all Docker Compose option parsing in the Compose layer. The running default path requests the generic live snapshot. Explicit `--pause=false` remains gated on a future safe no-freeze writable-filesystem snapshot; the Docker-shaped upstream `container commit` draft in [apple/container#1762](https://github.com/apple/container/pull/1762) is intentionally not used.
 
 ## Upstream References
 
@@ -35,17 +35,17 @@ The stopped-container path does not need new Apple APIs: `container-compose` can
 - Added `ComposeCommitImageArchive` to write an OCI layout tar from an exported rootfs archive.
 - Added image archive load support to `ContainerImageAPIClienting`, `ContainerImageManaging`, and the live image adapter.
 - Extended compact image metadata with config fields needed to preserve Docker commit image config parity.
-- Implemented stopped-container runtime validation through `ContainerDiscoveryManaging.getContainer(id:)`.
+- Implemented stopped-container export and running-container live-snapshot selection through `ContainerDiscoveryManaging.getContainer(id:)`.
 - Resolves omitted `--index` and `--index=0` through Docker Compose-compatible default service-container selection.
-- Rejects running-container commit before export with Apple live export/commit blockers.
+- Uses the live-export primitive for running containers with default `--pause=true`, and rejects `--pause=false` before export with the exact platform limitation.
 - Added dry-run output for the export, archive creation, and image load steps.
 - Added `commit` argument rewriting for Docker short forms and optional boolean `--pause=false`.
-- Marked the command partial in help/status while keeping all documented options green.
+- Marked the command and `--pause` option partial in colour-coded help/status, with the precise supported default and residual `--pause=false` limitation.
 
 ## Repository Scope
 
 - The Compose service selection, Docker Compose CLI parsing, image config shaping, and OCI archive creation stay in `stephenlclarke/container-compose`.
-- No `apple/container` or `apple/containerization` code change is required for the current supported service commit behavior.
+- The generic `apple/container`-shaped primitive is documented in [PR-live-export-snapshot.md](../apple-container/PR-live-export-snapshot.md) and implemented in the Stephen fork. No Docker-shaped `container commit` endpoint is needed.
 
 ## Testing
 
@@ -68,14 +68,14 @@ git diff --check
 ## Compatibility Notes
 
 - Stopped service containers can be committed and loaded as images.
-- `--pause=false` parses for Docker Compose CLI compatibility, but running service containers still wait for Apple live export/commit support.
-- Running service containers with default `--pause=true` fail before export/load because a consistent paused live snapshot requires Apple upstream `container` support.
+- `--pause=false` parses for Docker Compose CLI compatibility, but remains unavailable for running service containers because the backend cannot safely snapshot a writable filesystem without a freeze.
+- Running service containers with default `--pause=true` export through a brief filesystem-consistent live snapshot before archive creation and load. This is not a full Docker process pause.
 - Docker-specific image config changes stay in `container-compose`.
 
 ## Remaining Risks
 
 - The OCI archive writer intentionally supports the Docker `--change` instruction set accepted by Docker Engine commit; future Docker Compose changes may add flags that need a Compose-layer update.
-- Running-container commit should be revisited after Apple resolves the live export/commit work in [apple/container#1400](https://github.com/apple/container/issues/1400), [apple/container#1630](https://github.com/apple/container/pull/1630), and [apple/container#1762](https://github.com/apple/container/pull/1762).
+- `--pause=false` should be revisited only after Apple offers a safe no-freeze snapshot; the generic live-export handoff is tracked in [PR-live-export-snapshot.md](../apple-container/PR-live-export-snapshot.md).
 
 ## Checklist
 


### PR DESCRIPTION
## Summary

- use the pinned generic live-export snapshot for running `compose export` and default `compose commit`
- keep `commit --pause=false` explicitly partial; it lacks a safe no-freeze writable-filesystem snapshot
- make Compose named-volume creation idempotent when the runtime reports an already-existing volume
- align colour-coded help, parity status, and Apple handoff documentation with the implemented behavior

## Validation

- `make test` — 942 Swift tests in 17 suites plus the Go normalizer suite
- `make lint`
- `CONTAINER_STACK_REPO=/private/tmp/container-live-export-main-20260716 make stack-consistency`
- focused Compose commit and help tests against the merged backend pin
- `markdownlint docs/upstream`
- `git diff --check`
- backend: `make check`, `make test` (936 Swift Testing cases plus XCTest), and focused live-export guest integration including a post-export write

The exact Docker Compose CLI-surface parity gate passes against the pinned fork. The full parity runner reaches bridge parity but cannot complete because this machine has no Colima Docker socket; no daemon was started or changed for that environment limitation.

Backend dependency [stephenlclarke/container#5](https://github.com/stephenlclarke/container/pull/5) is merged; this branch pins its published main head `8189ee401dbd50d72935729625de4e1ed883a4f0`.