### PR TITLE
docs(attach): document runtime reattach boundary

### DIFF
--- a/docs/upstream/APPLE-UPSTREAM-REVIEW.md
+++ b/docs/upstream/APPLE-UPSTREAM-REVIEW.md
@@ -73,6 +73,7 @@ fails if any snapshot is deleted or retargeted.
 - Keep `apple/container#1933`, `#1934`, `#1935`, `apple/containerization#798` and `#799`, and `apple/container-builder-shim#87` open until Apple merges, replaces, or explicitly rejects their current changes.
 - Rebase `apple/container#1935` after `apple/container#1862` lands so the preferred upstream XPC commit is not duplicated.
 - Generic log-retrieval runtime primitives still need minimal Apple proposals; Docker timestamp parsing remains owned by `container-compose`.
+- [apple/container#378](https://github.com/apple/container/issues/378) needs a running-process stream reattach primitive before Compose can support interactive `attach`; the required runtime contract and the deliberate output-only fallback are documented in [ISSUE-attach-stream-reattach.md](apple-container/ISSUE-attach-stream-reattach.md).
 - The container storage-boundary follow-up must wait for `apple/container#1735` and retain only its residual `FilePath` and volume-disk-usage protections. The independent `containerization` handoff is ready in [PR-container-storage-path-validation.md](apple-containerization/PR-container-storage-path-validation.md).
 - The two builder-shim handoffs are independently constructible and have no matching open upstream issue or pull request. Keep them separate from [apple/container-builder-shim#87](https://github.com/apple/container-builder-shim/pull/87), which changes `.dockerignore` filtering only.
 

--- a/docs/upstream/apple-container/ISSUE-attach-stream-reattach.md
+++ b/docs/upstream/apple-container/ISSUE-attach-stream-reattach.md
@@ -1,0 +1,47 @@
+# Reattach standard streams to a running container
+
+## Summary
+
+`container compose attach SERVICE` needs an Apple runtime primitive that can
+reattach a client to the original process's standard input, output, error, and
+PTY after the container is already running. The current output-only Compose
+path is intentionally implemented as `logs --follow`; it is not an
+interactive attach substitute.
+
+This is tracked upstream by [apple/container#378](https://github.com/apple/container/issues/378).
+
+## Why This Cannot Be Implemented in `container-compose`
+
+The runtime accepts the original standard-file-descriptor handles only while it
+bootstraps the sandbox. Its process routes create, start, exec, resize, signal,
+and wait processes, but provide no route that returns or multiplexes a running
+main process's streams. Once started, the main process writes through the
+runtime's log writer; replaying that persisted output cannot provide stdin,
+terminal semantics, resize handling, signal delivery, or a detach-key escape
+sequence.
+
+The current `container start --attach` implementation makes the same boundary
+explicit: it rejects attachment to an already-running container. A Compose-side
+client cannot safely recreate the original process or infer which PTY bytes
+belong to a new client without changing runtime ownership of those streams.
+
+## Required Runtime Shape
+
+- An attach-session API for a running container's original init process.
+- Bidirectional stdin/stdout/stderr forwarding with a defined multi-client
+  policy and disconnect cleanup.
+- PTY resize and signal-proxy support for terminal-backed processes.
+- A lifecycle-safe detach operation so Compose can own Docker-compatible
+  detach-key handling without killing the container.
+- Focused runtime integration coverage for reconnect, stream closure, and a
+  container that continues running after the client detaches.
+
+## Compose Disposition
+
+- Supported now: `container compose attach --no-stdin SERVICE` follows output
+  through the log API; `--detach-keys` is accepted as a no-op in that mode.
+- Intentionally partial: default interactive attach, detach-key handling, and
+  full stream/signal reattachment.
+- Do not emulate interactive attach with `exec`, `tmux`, or log replay. Those
+  create a different process or lose terminal semantics and would misrepresent
+  Docker Compose behavior.

--- a/docs/upstream/container-compose/ISSUE-compose-attach-detach-keys-no-stdin.md
+++ b/docs/upstream/container-compose/ISSUE-compose-attach-detach-keys-no-stdin.md
@@ -4,7 +4,7 @@
 
 `container compose attach --no-stdin --detach-keys=ctrl-x SERVICE` should use the supported output-only attach path instead of failing on detach-key validation.
 
-Docker Compose accepts `--detach-keys` as an attach option. This plugin cannot implement interactive detach handling until apple/container exposes a stdin/stdout/stderr reattach primitive, but the option is irrelevant when `--no-stdin` has already selected log-follow output mode.
+Docker Compose accepts `--detach-keys` as an attach option. This plugin cannot implement interactive detach handling until `apple/container` exposes a stdin/stdout/stderr reattach primitive, but the option is irrelevant when `--no-stdin` has already selected log-follow output mode. The exact runtime boundary and required Apple-shaped primitive are documented in [ISSUE-attach-stream-reattach.md](../apple-container/ISSUE-attach-stream-reattach.md) and tracked by [apple/container#378](https://github.com/apple/container/issues/378).
 
 ## Acceptance Criteria
 
@@ -16,4 +16,4 @@ Docker Compose accepts `--detach-keys` as an attach option. This plugin cannot i
 
 ## Notes
 
-This does not add interactive attach support. It only accepts a harmless option value on the already-supported output-only attach path.
+This does not add interactive attach support. It only accepts a harmless option value on the already-supported output-only attach path. Do not replace the missing reattach primitive with `exec`, `tmux`, or log replay: those do not reconnect to the original init process or preserve Docker-compatible terminal semantics.


### PR DESCRIPTION
## Summary
- document why Compose cannot implement interactive `attach` without a runtime stream-reattach primitive
- link the exact Apple runtime requirement to apple/container#378
- clarify that output-only log follow is intentional and that exec, tmux, or log replay are not equivalent

## Validation
- `markdownlint docs/upstream/apple-container/ISSUE-attach-stream-reattach.md docs/upstream/container-compose/ISSUE-compose-attach-detach-keys-no-stdin.md docs/upstream/APPLE-UPSTREAM-REVIEW.md`
- `git diff --check`