### PR TITLE
chore(workflow): audit stale topic worktrees

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,39 @@ pull request title and body clear enough to stand alone as the final change
 description. Use imperative wording, describe what changed, and include the
 reason for the change.
 
+### Topic Worktree Close-Out
+
+Use one named topic branch only when it has an active pull request or a recorded
+review purpose. Create exploratory and validation-only worktrees detached from
+the target commit so they cannot leave a branch behind.
+
+Before creating a topic branch, and again when a pull request reaches a terminal
+state, run:
+
+```sh
+git fetch --all --prune --no-tags
+make worktree-audit
+```
+
+After a pull request is merged or deliberately superseded, remove its clean
+worktree and local branch in the same close-out step, then prune stale worktree
+metadata:
+
+```sh
+git worktree remove /path/to/topic-worktree
+git branch -d topic-branch || git branch -D topic-branch
+git worktree prune
+```
+
+Do not delete a branch merely because its remote was removed: squash merges and
+closed pull requests can leave unique local commits. `make worktree-audit`
+separates active remote branches, safe integrated cleanup candidates, and local
+branches that need a pull request or an explicit retention decision. Use
+`make worktree-audit-strict` after close-out to fail when a clean integrated
+candidate is still present. The forced fallback is only appropriate after the
+pull request is confirmed merged or deliberately superseded and the audit shows
+no unique patches.
+
 ## Conventional Commits
 
 Use Conventional Commits for commit messages and pull request titles:

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,8 @@ endif
 
 .PHONY: all workflow ci ci-fast release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-runtime-test-build swift-runtime-test swift-coverage go-test go-build go-release-check cli-smoke cli-smoke-built container-stack-build docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-isolation-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-rm-parity docker-compose-restart-policy-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-test lint format fmt check check-licenses update-licenses pre-commit
 
+.PHONY: worktree-audit worktree-audit-strict
+
 all: workflow
 
 workflow: ci package
@@ -1404,6 +1406,12 @@ serve-docs:
 
 stack-consistency:
 	CONTAINER_STACK_REPO="$(CONTAINER_STACK_REPO)" $(PYTHON) Tools/ci/check-stack-consistency.py
+
+worktree-audit:
+	$(PYTHON) Tools/ci/worktree-audit.py --repository "$(CURDIR)" --main main
+
+worktree-audit-strict:
+	$(PYTHON) Tools/ci/worktree-audit.py --repository "$(CURDIR)" --main main --strict
 
 check: lint stack-consistency check-licenses
 

--- a/Tools/ci/test_worktree_audit.py
+++ b/Tools/ci/test_worktree_audit.py
@@ -6,7 +6,7 @@
 ## you may not use this file except in compliance with the License.
 ## You may obtain a copy of the License at
 ##
-## http://www.apache.org/licenses/LICENSE-2.0
+##   https://www.apache.org/licenses/LICENSE-2.0
 ##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/ci/test_worktree_audit.py
+++ b/Tools/ci/test_worktree_audit.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("worktree-audit.py")
+SPEC = importlib.util.spec_from_file_location("worktree_audit", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+audit = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = audit
+SPEC.loader.exec_module(audit)
+
+
+def git(repository: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repository, check=True, capture_output=True, text=True)
+
+
+def commit_file(repository: Path, name: str, contents: str, message: str) -> None:
+    (repository / name).write_text(contents, encoding="utf-8")
+    git(repository, "add", name)
+    git(repository, "commit", "-m", message)
+
+
+class WorktreeAuditTests(unittest.TestCase):
+    def test_classifies_active_integrated_and_unique_local_branches(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            git(repository, "init", "-b", "main")
+            git(repository, "config", "user.email", "test@example.com")
+            git(repository, "config", "user.name", "Test User")
+            commit_file(repository, "README.md", "base\n", "base")
+
+            git(repository, "switch", "-c", "integrated")
+            commit_file(repository, "integrated.txt", "integrated\n", "integrated change")
+            git(repository, "switch", "main")
+            git(repository, "cherry-pick", "integrated")
+
+            git(repository, "switch", "-c", "active")
+            commit_file(repository, "active.txt", "active\n", "active change")
+            active_head = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repository,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            git(repository, "update-ref", "refs/remotes/origin/active", active_head)
+
+            git(repository, "switch", "main")
+            git(repository, "switch", "-c", "retained")
+            commit_file(repository, "retained.txt", "retained\n", "retained change")
+            git(repository, "switch", "main")
+
+            audits = {entry.name: entry for entry in audit.audit_branches(repository, "main")}
+
+            self.assertEqual(audits["active"].category, "active")
+            self.assertEqual(audits["integrated"].category, "integrated")
+            self.assertEqual(audits["retained"].category, "retain")
+
+    def test_retains_a_merge_commit_even_when_its_patch_is_on_main(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repository = Path(temporary_directory)
+            git(repository, "init", "-b", "main")
+            git(repository, "config", "user.email", "test@example.com")
+            git(repository, "config", "user.name", "Test User")
+            commit_file(repository, "README.md", "base\n", "base")
+
+            git(repository, "switch", "-c", "merged-topic")
+            git(repository, "switch", "-c", "contribution")
+            commit_file(repository, "feature.txt", "feature\n", "feature")
+            git(repository, "switch", "merged-topic")
+            git(repository, "merge", "--no-ff", "contribution", "-m", "merge contribution")
+            git(repository, "switch", "main")
+            git(repository, "cherry-pick", "contribution")
+            git(repository, "branch", "-D", "contribution")
+
+            audits = {entry.name: entry for entry in audit.audit_branches(repository, "main")}
+
+            self.assertEqual(audits["merged-topic"].category, "retain")

--- a/Tools/ci/worktree-audit.py
+++ b/Tools/ci/worktree-audit.py
@@ -6,7 +6,7 @@
 ## you may not use this file except in compliance with the License.
 ## You may obtain a copy of the License at
 ##
-## http://www.apache.org/licenses/LICENSE-2.0
+##   https://www.apache.org/licenses/LICENSE-2.0
 ##
 ## Unless required by applicable law or agreed to in writing, software
 ## distributed under the License is distributed on an "AS IS" BASIS,

--- a/Tools/ci/worktree-audit.py
+++ b/Tools/ci/worktree-audit.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+## http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Classify local topic branches without modifying worktrees or refs."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class BranchAudit:
+    name: str
+    category: str
+    worktree: Path | None
+    dirty: bool
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", type=Path, default=Path.cwd())
+    parser.add_argument("--main", default="main", help="integration branch to compare against")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="fail when an integrated cleanup candidate remains",
+    )
+    return parser.parse_args()
+
+
+def run_git(repository: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or f"exit {result.returncode}"
+        raise RuntimeError(f"git {' '.join(args)} failed: {detail}")
+    return result
+
+
+def checked_out_worktrees(repository: Path) -> dict[str, Path]:
+    worktrees: dict[str, Path] = {}
+    path: Path | None = None
+    for line in run_git(repository, "worktree", "list", "--porcelain").stdout.splitlines():
+        if not line:
+            path = None
+            continue
+        if line.startswith("worktree "):
+            path = Path(line.removeprefix("worktree "))
+        elif line.startswith("branch refs/heads/") and path is not None:
+            worktrees[line.removeprefix("branch refs/heads/")] = path
+    return worktrees
+
+
+def local_branches(repository: Path) -> list[str]:
+    output = run_git(repository, "for-each-ref", "--format=%(refname:short)", "refs/heads").stdout
+    return [line for line in output.splitlines() if line]
+
+
+def has_remote_branch(repository: Path, branch: str) -> bool:
+    result = run_git(
+        repository,
+        "show-ref",
+        "--verify",
+        "--quiet",
+        f"refs/remotes/origin/{branch}",
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def has_unique_patch(repository: Path, main_branch: str, branch: str) -> bool:
+    merge_commits = run_git(
+        repository,
+        "rev-list",
+        "--merges",
+        "--max-count=1",
+        f"{main_branch}..{branch}",
+    ).stdout.strip()
+    if merge_commits:
+        return True
+    result = run_git(repository, "cherry", main_branch, branch, check=False)
+    if result.returncode != 0:
+        return True
+    return any(line.startswith("+") for line in result.stdout.splitlines())
+
+
+def is_dirty(repository: Path, worktree: Path | None) -> bool:
+    if worktree is None or not worktree.is_dir():
+        return False
+    return bool(run_git(repository, "-C", str(worktree), "status", "--porcelain").stdout.strip())
+
+
+def audit_branches(repository: Path, main_branch: str) -> list[BranchAudit]:
+    worktrees = checked_out_worktrees(repository)
+    audits: list[BranchAudit] = []
+    for branch in local_branches(repository):
+        if branch == main_branch:
+            continue
+        worktree = worktrees.get(branch)
+        dirty = is_dirty(repository, worktree)
+        if has_remote_branch(repository, branch):
+            category = "active"
+        elif has_unique_patch(repository, main_branch, branch):
+            category = "retain"
+        else:
+            category = "integrated"
+        audits.append(BranchAudit(branch, category, worktree, dirty))
+    return audits
+
+
+def format_audit(audit: BranchAudit) -> str:
+    details = []
+    if audit.worktree is not None:
+        details.append(str(audit.worktree))
+    if audit.dirty:
+        details.append("dirty")
+    return f"  - {audit.name}" + (f" ({'; '.join(details)})" if details else "")
+
+
+def main() -> int:
+    args = parse_args()
+    repository = args.repository.resolve()
+    audits = audit_branches(repository, args.main)
+    grouped = {
+        "active": "Active topic branches (origin branch exists)",
+        "integrated": "Cleanup candidates (no remote branch and no unique patches)",
+        "retain": "Retain or close deliberately (no remote branch and unique patches)",
+    }
+
+    print(f"Worktree audit for {repository} against {args.main}")
+    print("Fetch with --prune before acting; this command never changes worktrees or refs.")
+    for category, title in grouped.items():
+        entries = [audit for audit in audits if audit.category == category]
+        print(f"\n{title}:")
+        if entries:
+            for audit in entries:
+                print(format_audit(audit))
+        else:
+            print("  - none")
+
+    if args.strict and any(audit.category == "integrated" and not audit.dirty for audit in audits):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a read-only worktree audit that distinguishes active, integrated, and locally unique branches
- document the required topic-worktree close-out step
- retain merge-commit branches conservatively so cleanup never loses unreviewed history

## Root cause

Temporary validation worktrees were created on named branches, but the maintainer workflow had no mandatory close-out after merge or supersession. Remote branch deletion therefore left local worktree and branch references behind.

## Validation

- `make coverage-tools-test`
- `make worktree-audit-strict`
- `npx --yes markdownlint-cli2 CONTRIBUTING.md`
- `git diff --check`