### PR TITLE
fix(workflow): scan squash commits independently

### DIFF
--- a/Tools/ci/test_worktree_audit.py
+++ b/Tools/ci/test_worktree_audit.py
@@ -115,6 +115,7 @@ class WorktreeAuditTests(unittest.TestCase):
             git(repository, "switch", "main")
             git(repository, "cherry-pick", "--no-commit", "squashed-topic~1", "squashed-topic")
             git(repository, "commit", "-m", "squashed topic")
+            commit_file(repository, "unrelated.txt", "unrelated\n", "unrelated main change")
 
             audits = {entry.name: entry for entry in audit.audit_branches(repository, "main")}
 

--- a/Tools/ci/worktree-audit.py
+++ b/Tools/ci/worktree-audit.py
@@ -117,7 +117,7 @@ def has_squash_merged_patch(repository: Path, main_branch: str, branch: str) -> 
         return True
     main_patch_ids = patch_ids(
         repository,
-        run_git(repository, "log", "--no-merges", "--format=", "--patch", f"{merge_base}..{main_branch}").stdout,
+        run_git(repository, "log", "--no-merges", "--patch", f"{merge_base}..{main_branch}").stdout,
     )
     return branch_patch_ids <= main_patch_ids
 


### PR DESCRIPTION
## Summary
- preserve individual commit boundaries while computing main patch IDs
- correctly detect a topic whose net patch was squash-merged before later unrelated main commits
- cover the exact multi-commit squash and subsequent-main-commit regression

## Validation
- `python3 -m unittest Tools/ci/test_worktree_audit.py`
- `HAWKEYE_AUTO_INSTALL=1 make check-licenses`
- `python3 -m unittest discover Tools/ci`
- `git diff --check`

This follow-up makes the branch close-out audit reliable after normal sequential PR merges.