### PR TITLE
fix(ci): defer SonarQube outage failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,7 +319,9 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: Install Sonar Scanner CLI
+        id: sonar_install
         if: github.ref == 'refs/heads/main'
+        continue-on-error: true
         env:
           SONAR_SCANNER_GPG_FINGERPRINT: 679F1EE92B19609DE816FDE81DB198F93525EC1A
           SONAR_SCANNER_VERSION: 8.1.0.6389
@@ -372,13 +374,38 @@ jobs:
           printf '%s\n' "$scanner_bin" >> "$GITHUB_PATH"
 
       - name: SonarQube scan
-        if: github.ref == 'refs/heads/main'
+        id: sonar_scan
+        if: github.ref == 'refs/heads/main' && steps.sonar_install.outcome == 'success'
+        continue-on-error: true
         timeout-minutes: 10
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_QUALITYGATE_WAIT: "true"
         run: make sonar-scan
         working-directory: container-compose
+
+      - name: Enforce SonarQube failures when the service is available
+        if: >
+          github.ref == 'refs/heads/main' &&
+          (steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
+        env:
+          SONAR_STATUS_URL: https://sonarcloud.io/api/system/status
+        run: |
+          set -euo pipefail
+          set +e
+          status_code="$(curl --location --silent --show-error --connect-timeout 5 --max-time 15 \
+            --retry 2 --retry-all-errors --write-out '%{http_code}' "${SONAR_STATUS_URL}" --output /dev/null)"
+          curl_status="$?"
+          set -e
+          if [[ "${curl_status}" -eq 0 && "${status_code}" =~ ^[1-4][0-9][0-9]$ ]]; then
+            printf 'SonarQube failed while its API is reachable; preserving the CI failure.\n' >&2
+            exit 1
+          fi
+          printf '::warning title=SonarQube unavailable::Scanner installation or analysis failed while the SonarQube API was unavailable; local checks and coverage gates remain enforced.\n'
+          {
+            printf '## SonarQube scan deferred\n\n'
+            printf 'The SonarQube API was unavailable after retries, so this external quality scan did not fail CI. Local source checks, tests, coverage gates, and CodeQL remain required.\n'
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   validate:
     name: Validate


### PR DESCRIPTION
## Summary
- keep Sonar scanner installation and scan failures non-blocking only while the SonarQube API is unavailable
- preserve CI failure when the API is reachable, so authentication, scanner, and quality-gate regressions remain actionable
- retain local source checks, test, coverage, and CodeQL gates during provider outages

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `actionlint .github/workflows/ci.yml`
- exercised the reachable and unreachable health-check decisions with `curl`
- `HAWKEYE_AUTO_INSTALL=1 make check`
- `git diff --check`

The SonarCloud API endpoint timed out from this environment while the main SonarCloud site still responded, so the warning path is currently required.