### PR TITLE
fix(compose): reuse existing project volumes

### DIFF
--- a/Sources/ComposeCore/ContainerResourceAdapter.swift
+++ b/Sources/ComposeCore/ContainerResourceAdapter.swift
@@ -15,9 +15,9 @@
 //===----------------------------------------------------------------------===//
 
 import ContainerAPIClient
-import ContainerResource
 import ContainerizationError
 import ContainerizationExtras
+import ContainerResource
 
 /// Runtime volume metadata needed by Compose project commands.
 public struct ComposeVolumeSummary: Codable, Equatable, Sendable {
@@ -32,7 +32,7 @@ public struct ComposeVolumeSummary: Codable, Equatable, Sendable {
         driver: String = "local",
         source: String = "",
         labels: [String: String] = [:],
-        sizeInBytes: UInt64? = nil
+        sizeInBytes: UInt64? = nil,
     ) {
         self.name = name
         self.driver = driver
@@ -48,7 +48,7 @@ public struct ComposeVolumeSummary: Codable, Equatable, Sendable {
             driver: configuration.driver,
             source: configuration.source,
             labels: configuration.labels,
-            sizeInBytes: configuration.sizeInBytes
+            sizeInBytes: configuration.sizeInBytes,
         )
     }
 }
@@ -68,7 +68,7 @@ public struct ComposeNetworkCreateRequest: Equatable, Sendable {
         ipv4Subnet: String? = nil,
         ipv6Subnet: String? = nil,
         driverOpts: [String: String] = [:],
-        labels: [String: String] = [:]
+        labels: [String: String] = [:],
     ) {
         self.name = name
         self.isInternal = isInternal
@@ -90,7 +90,7 @@ public struct ComposeVolumeCreateRequest: Equatable, Sendable {
         name: String,
         driver: String? = nil,
         driverOpts: [String: String] = [:],
-        labels: [String: String] = [:]
+        labels: [String: String] = [:],
     ) {
         self.name = name
         self.driver = driver
@@ -194,18 +194,18 @@ public struct ContainerResourceAPIClient: ContainerResourceAPIClienting {
                 name: $0.name,
                 driver: $0.resolvedDriver,
                 driverOpts: $0.driverOpts,
-                labels: $0.labels
+                labels: $0.labels,
             )
         },
         listVolumes: @escaping ListVolumes = { try await ClientVolume.list().map(ComposeVolumeSummary.init(configuration:)) },
-        deleteVolume: @escaping DeleteVolume = { try await ClientVolume.delete(name: $0) }
+        deleteVolume: @escaping DeleteVolume = { try await ClientVolume.delete(name: $0) },
     ) {
-        self.createNetworkOperation = createNetwork
-        self.networkExistsOperation = networkExists
-        self.deleteNetworkOperation = deleteNetwork
-        self.createVolumeOperation = createVolume
-        self.listVolumesOperation = listVolumes
-        self.deleteVolumeOperation = deleteVolume
+        createNetworkOperation = createNetwork
+        networkExistsOperation = networkExists
+        deleteNetworkOperation = deleteNetwork
+        createVolumeOperation = createVolume
+        listVolumesOperation = listVolumes
+        deleteVolumeOperation = deleteVolume
     }
 
     /// Creates a network through `NetworkClient`.
@@ -253,11 +253,11 @@ public struct ContainerClientResourceManager: ContainerResourceManaging {
         let configuration = try NetworkConfiguration(
             name: request.name,
             mode: request.isInternal ? .hostOnly : .nat,
-            ipv4Subnet: try request.ipv4Subnet.map { try CIDRv4($0) },
-            ipv6Subnet: try request.ipv6Subnet.map { try CIDRv6($0) },
-            labels: try ResourceLabels(request.labels),
+            ipv4Subnet: request.ipv4Subnet.map { try CIDRv4($0) },
+            ipv6Subnet: request.ipv6Subnet.map { try CIDRv6($0) },
+            labels: ResourceLabels(request.labels),
             plugin: "container-network-vmnet",
-            options: request.driverOpts
+            options: request.driverOpts,
         )
         do {
             try await client.createNetwork(configuration: configuration)
@@ -280,7 +280,14 @@ public struct ContainerClientResourceManager: ContainerResourceManaging {
 
     /// Creates a Compose project volume through `ClientVolume`.
     public func createVolume(_ request: ComposeVolumeCreateRequest) async throws {
-        try await client.createVolume(request)
+        do {
+            try await client.createVolume(request)
+        } catch let error as VolumeError {
+            if case .volumeAlreadyExists = error {
+                return
+            }
+            throw error
+        }
     }
 
     /// Lists local volumes through `ClientVolume`.

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -17232,6 +17232,20 @@ struct ComposeOrchestratorTests {
         ])
     }
 
+    @Test("resource manager ignores existing volume create errors")
+    func resourceManagerIgnoresExistingVolumeCreateErrors() async throws {
+        let client = RecordingContainerResourceAPIClient(
+            volumeCreateError: VolumeError.volumeAlreadyExists("demo_cache")
+        )
+        let manager = ContainerClientResourceManager(client: client)
+
+        try await manager.createVolume(ComposeVolumeCreateRequest(name: "demo_cache"))
+
+        #expect(await client.requests == [
+            .createVolume(ComposeVolumeCreateRequest(name: "demo_cache")),
+        ])
+    }
+
     @Test("resource manager rejects invalid network subnet before API create")
     func resourceManagerRejectsInvalidNetworkSubnetBeforeAPICreate() async throws {
         let client = RecordingContainerResourceAPIClient()
@@ -27119,6 +27133,7 @@ private actor RecordingContainerResourceAPIClient: ContainerResourceAPIClienting
     private let volumes: [ComposeVolumeSummary]
     private let networkCreateError: (any Error)?
     private let networkDeleteError: (any Error)?
+    private let volumeCreateError: (any Error)?
     private let volumeDeleteError: (any Error)?
     private var storage: [ContainerResourceAPIRequest] = []
 
@@ -27127,12 +27142,14 @@ private actor RecordingContainerResourceAPIClient: ContainerResourceAPIClienting
         volumes: [ComposeVolumeSummary] = [],
         networkCreateError: (any Error)? = nil,
         networkDeleteError: (any Error)? = nil,
+        volumeCreateError: (any Error)? = nil,
         volumeDeleteError: (any Error)? = nil
     ) {
         self.existingNetworks = existingNetworks
         self.volumes = volumes
         self.networkCreateError = networkCreateError
         self.networkDeleteError = networkDeleteError
+        self.volumeCreateError = volumeCreateError
         self.volumeDeleteError = volumeDeleteError
     }
 
@@ -27169,6 +27186,9 @@ private actor RecordingContainerResourceAPIClient: ContainerResourceAPIClienting
 
     func createVolume(_ request: ComposeVolumeCreateRequest) async throws {
         storage.append(.createVolume(request))
+        if let volumeCreateError {
+            throw volumeCreateError
+        }
     }
 
     func listVolumes() async throws -> [ComposeVolumeSummary] {


### PR DESCRIPTION
## Summary

Reuse an existing named Compose project volume instead of failing a repeated `up` after `down`.

## Root cause

`down` retains named volumes by design, but the resource manager forwarded the runtime’s typed `volumeAlreadyExists` error unchanged on the next `up`.

## Validation

- `swiftformat --lint Sources/ComposeCore/ContainerResourceAdapter.swift Tests/ComposeCoreTests/ComposeOrchestratorTests.swift --swift-version 6.2`
- `swift test --filter resourceManagerIgnoresExistingVolumeCreateErrors`
- `git diff --check`