### PR TITLE
docs(demo): show Compose stats after startup

### DIFF
--- a/docs/container-compose-demo.tape
+++ b/docs/container-compose-demo.tape
@@ -22,18 +22,22 @@ Type "container compose up --help | sed -n '1,18p'"
 Enter
 Sleep 2s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --dry-run --volumes --remove-orphans"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --volumes --remove-orphans"
 Enter
 Sleep 2s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml up --dry-run --wait"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml up --wait"
 Enter
 Sleep 3s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml ps --dry-run"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml stats --no-stream"
 Enter
 Sleep 2s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --dry-run --volumes --remove-orphans"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml ps"
+Enter
+Sleep 2s
+
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml down --volumes --remove-orphans"
 Enter
 Sleep 2s


### PR DESCRIPTION
## Summary
- start the monitoring stack for the current-build VHS recording
- capture a one-shot `container compose stats` view after startup
- retain live `ps` and teardown output

## Validation
- `git diff --check`
- tape uses bounded `stats --no-stream` after `up --wait`