### PR TITLE
fix(release): defer SonarQube snapshots during outages

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -766,10 +766,32 @@ jobs:
             quality_release_kind="current"
           fi
           quality_snapshot="${RUNNER_TEMP}/quality-snapshot.md"
-          python3 Tools/release/capture-quality-snapshot.py \
-            --repo "${GITHUB_REPOSITORY}" \
-            --commit "${PUBLISH_SHA}" \
-            --release-kind "${quality_release_kind}" > "${quality_snapshot}"
+          sonar_snapshot_available=false
+          if nc -z -w 5 sonarcloud.io 443; then
+            set +e
+            sonar_status_code="$(curl --location --silent --show-error --connect-timeout 3 --max-time 5 \
+              --write-out '%{http_code}' https://sonarcloud.io/api/system/status --output /dev/null)"
+            sonar_status=$?
+            set -e
+            if [[ "${sonar_status}" -eq 0 && "${sonar_status_code}" =~ ^[1-4][0-9][0-9]$ ]]; then
+              sonar_snapshot_available=true
+            fi
+          fi
+          if [[ "${sonar_snapshot_available}" == "true" ]]; then
+            python3 Tools/release/capture-quality-snapshot.py \
+              --repo "${GITHUB_REPOSITORY}" \
+              --commit "${PUBLISH_SHA}" \
+              --release-kind "${quality_release_kind}" > "${quality_snapshot}"
+          else
+            printf '::warning title=SonarQube unavailable::The release quality snapshot omits SonarQube-derived metrics because the API preflight did not succeed within five seconds.\n'
+            cat > "${quality_snapshot}" <<'EOF'
+          ## Quality Snapshot
+
+          SonarQube was unavailable during promotion, so this release omits
+          SonarQube-derived metrics. Applicable CI checks and CodeQL completed
+          successfully for this source revision.
+          EOF
+          fi
           release_notes_args+=(--quality-snapshot "${quality_snapshot}")
           python3 Tools/release/release-notes.py "${release_notes_args[@]}" > "${notes}"
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -263,9 +263,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("Current build VHS recording is missing", workflow)
         self.assertIn('--current-asset "${{ steps.lane.outputs.demo_asset }}"', workflow)
         tape = (ROOT / "docs" / "container-compose-demo.tape").read_text(encoding="utf-8")
-        self.assertIn("up --dry-run --wait", tape)
-        self.assertIn("ps --dry-run", tape)
-        self.assertIn("down --dry-run --volumes --remove-orphans", tape)
+        self.assertIn("up --wait", tape)
+        self.assertIn("stats --no-stream", tape)
+        self.assertIn("ps", tape)
+        self.assertIn("down --volumes --remove-orphans", tape)
+        self.assertNotIn("--dry-run", tape)
         self.assertIn(
             "releases/download/current/container-compose-demo-current.gif",
             readme,
@@ -285,6 +287,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('quality_release_kind="current"', workflow)
         self.assertIn('quality_release_kind="stable"', workflow)
         self.assertIn('--release-kind "${quality_release_kind}"', workflow)
+        self.assertIn('nc -z -w 5 sonarcloud.io 443', workflow)
+        self.assertIn('curl --location --silent --show-error --connect-timeout 3 --max-time 5', workflow)
+        self.assertIn('SonarQube was unavailable during promotion', workflow)
         self.assertIn('python3 Tools/release/release-notes.py "${release_notes_args[@]}"', workflow)
         self.assertNotIn("quality_snapshot_args", workflow)
 


### PR DESCRIPTION
Prevents current/stable release publication from waiting for a SonarQube analysis when the same five-second TCP/API preflight that CI uses reports the service unavailable.

The release notes explicitly state that SonarQube-derived metrics were omitted; applicable CI and CodeQL remain required. Also updates the VHS release-policy test for the real startup/stats tape.