### PR TITLE
fix(release): republish Current build metadata

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -918,7 +918,7 @@ jobs:
           git commit -m "chore(homebrew): update ${{ steps.lane.outputs.package_lane }} stack ${{ steps.lane.outputs.compose_version }}"
           git push
 
-      - name: Finalize current release pointer
+      - name: Publish Current build release
         if: steps.current-freshness.outputs.publish == 'true' && needs.resolve-publish-context.outputs.ref_type == 'branch'
         env:
           GH_TOKEN: ${{ github.token }}

--- a/BUILD.md
+++ b/BUILD.md
@@ -167,7 +167,7 @@ check on that tag commit; the package workflow requires that check, then repeats
 
 There are two package lanes, with no manual asset copying:
 
-- Every green `main` commit refreshes the explicit `current` tag and one mutable GitHub prerelease named **Current build**, plus the opt-in `container-current` / `container-compose-current` Homebrew pair.
+- Every successful CI run that originates from a push to `main` refreshes the explicit `current` tag and a newly published mutable GitHub prerelease named **Current build**, plus the opt-in `container-current` / `container-compose-current` Homebrew pair. A commit superseded before promotion is skipped so the subsequent successful run publishes the newest `main` head.
 - A semantic release is an immutable `x.y.z` tag and becomes Homebrew's default `container` / `container-compose` pair.
 
 `current` is deliberately an unsigned, movable pointer; signing it would make
@@ -186,9 +186,12 @@ release helper enforces these rules.
 
 Current publication is recoverable across GitHub and Homebrew: it stages
 immutable commit-identified archives on the existing Current prerelease, updates
-the matching Homebrew formula pair, and only then advances the mutable `current`
-tag and release notes. If a later phase fails, the preceding formula pair stays
-installable and rerunning the same publication resumes it.
+the matching Homebrew formula pair, then moves the mutable `current` tag and
+recreates the release object from those staged assets. Recreating the object
+makes GitHub's published time represent this Current build rather than the
+first build that used the `current` tag. If that final replacement is
+interrupted, rerunning the same publication recreates the release from the same
+candidate assets.
 
 ### Scheduled Stable Releases
 
@@ -218,8 +221,9 @@ Do not copy, rename, or edit the mutable GitHub **Current build** prerelease.
 It is an installable view of green `main`, not a stable release candidate asset.
 Promotion always rebuilds the exact tagged source into immutable stable assets,
 which is what keeps the semantic version, runtime pin, checksums, Homebrew
-formulae, and release notes deterministic. The current prerelease is updated
-in place before its tag moves, so it is never deleted and recreated.
+formulae, and release notes deterministic. The current prerelease is recreated
+by its workflow after the matching Homebrew formulae update, so its GitHub
+published time always identifies the build users are viewing.
 
 After `make release-plan` confirms the intended next version, promote the
 validated `main` source with one selector. The selector is resolved from the

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -125,8 +125,9 @@ esac
 #
 #   stage    upload immutable, commit-addressed assets while the existing tap
 #            formulae and current tag remain usable;
-#   finalize update the release notes and then advance the current tag, after
-#            the matching Homebrew formula pair has been committed.
+#   finalize advance the current tag, then replace the mutable release object
+#            after the matching Homebrew formula pair has been committed. This
+#            gives GitHub a publication timestamp for the build being released.
 #
 # GitHub releases and the Homebrew tap are separate repositories, so this is
 # not a distributed transaction. It does guarantee that an interrupted current
@@ -170,46 +171,6 @@ if [[ -n "${RELEASE_EXTRA_ASSETS_FILE:-}" ]]; then
   done < "${RELEASE_EXTRA_ASSETS_FILE}"
 fi
 
-if [[ "${published_release_state}" == "exists" ]]; then
-  if [[ "${RELEASE_MUTABLE}" != "true" ]]; then
-    printf 'release %s already exists; published releases are immutable\n' \
-      "${RELEASE_TAG}" >&2
-    exit 1
-  fi
-
-  if [[ "${RELEASE_PHASE}" == "stage" ]]; then
-    "${GH}" release upload "${RELEASE_TAG}" "${release_assets[@]}" \
-      --repo "${RELEASE_REPOSITORY}" --clobber
-    exit 0
-  fi
-
-  "${GH}" release edit "${RELEASE_TAG}" \
-    --repo "${RELEASE_REPOSITORY}" \
-    --title "${RELEASE_TITLE}" \
-    --notes-file "${RELEASE_NOTES_FILE}" \
-    --target "${PUBLISH_SHA}" \
-    --prerelease
-
-  # `current` is a lightweight, mutable pointer. Explicitly disable signing so
-  # a developer-level tag.gpgSign setting cannot open an annotation editor.
-  "${GIT}" tag --no-sign --force "${RELEASE_TAG}" "${PUBLISH_SHA}"
-  "${GIT}" push --force origin "refs/tags/${RELEASE_TAG}"
-  exit 0
-fi
-
-if [[ "${PUBLISH_REF_TYPE}" == "branch" && "${RELEASE_PHASE}" == "finalize" ]]; then
-  printf 'cannot finalize current: release %s does not exist\n' "${RELEASE_TAG}" >&2
-  exit 1
-fi
-
-if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
-  # Create the explicit current tag before the first prerelease. This avoids a
-  # GitHub release with only an implicit target and makes the mutable lane
-  # visible and verifiable in the tag list from its first publication.
-  "${GIT}" tag --no-sign --force "${RELEASE_TAG}" "${PUBLISH_SHA}"
-  "${GIT}" push --force origin "refs/tags/${RELEASE_TAG}"
-fi
-
 create_args=(
   "${release_assets[@]}" \
   --repo "${RELEASE_REPOSITORY}"
@@ -223,4 +184,56 @@ else
 fi
 create_args+=("${release_flags[@]}")
 
-exec "${GH}" release create "${RELEASE_TAG}" "${create_args[@]}"
+move_current_tag() {
+  # `current` is a lightweight, mutable pointer. Explicitly disable signing so
+  # a developer-level tag.gpgSign setting cannot open an annotation editor.
+  "${GIT}" tag --no-sign --force "${RELEASE_TAG}" "${PUBLISH_SHA}"
+  "${GIT}" push --force origin "refs/tags/${RELEASE_TAG}"
+}
+
+create_release() {
+  "${GH}" release create "${RELEASE_TAG}" "${create_args[@]}"
+}
+
+if [[ "${published_release_state}" == "exists" ]]; then
+  if [[ "${RELEASE_MUTABLE}" != "true" ]]; then
+    printf 'release %s already exists; published releases are immutable\n' \
+      "${RELEASE_TAG}" >&2
+    exit 1
+  fi
+
+  if [[ "${RELEASE_PHASE}" == "stage" ]]; then
+    "${GH}" release upload "${RELEASE_TAG}" "${release_assets[@]}" \
+      --repo "${RELEASE_REPOSITORY}" --clobber
+    exit 0
+  fi
+
+  move_current_tag
+  # GitHub retains `published_at` when a release is edited. Delete only the
+  # mutable release object (not its source tag), then create it from the staged
+  # assets so the release page shows when this Current build was published.
+  "${GH}" release delete "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" --yes
+  create_release
+  # `--verify-tag` preserves the already-validated source tag; set the release
+  # target explicitly too, so GitHub's release metadata records the commit.
+  "${GH}" release edit "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" \
+    --target "${PUBLISH_SHA}" \
+    --prerelease
+  exit 0
+fi
+
+if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
+  # Create the explicit current tag before the first prerelease or a recovered
+  # finalization. This avoids an implicit target and keeps the lane verifiable.
+  move_current_tag
+fi
+
+create_release
+
+if [[ "${PUBLISH_REF_TYPE}" == "branch" && "${RELEASE_PHASE}" == "finalize" ]]; then
+  "${GH}" release edit "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" \
+    --target "${PUBLISH_SHA}" \
+    --prerelease
+fi

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -235,10 +235,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"', workflow)
         self.assertIn('highlights_asset="release-highlights-current-${short_sha}.json"', workflow)
         self.assertIn('RELEASE_PHASE="${release_phase}"', workflow)
-        self.assertIn("Finalize current release pointer", workflow)
+        self.assertIn("Publish Current build release", workflow)
         self.assertLess(
             workflow.index("Commit atomic Homebrew stack update"),
-            workflow.index("Finalize current release pointer"),
+            workflow.index("Publish Current build release"),
         )
         self.assertIn('RELEASE_MUTABLE="${release_mutable}"', workflow)
         self.assertIn("--delete-superseded-current-releases", workflow)
@@ -318,6 +318,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("workflow_run:", workflow)
         self.assertIn("branches:\n      - main", workflow)
+        self.assertIn("github.event.workflow_run.conclusion == 'success'", workflow)
+        self.assertIn('if [[ "${WORKFLOW_RUN_EVENT}" != "push" ]]', workflow)
+        self.assertIn('elif [[ "${WORKFLOW_RUN_HEAD_BRANCH}" == "main" ]]', workflow)
         self.assertIn("timeout-minutes: 120", workflow)
         self.assertIn("name: Cache SwiftPM build artifacts", workflow)
         self.assertIn("container-compose/.build", workflow)

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -147,9 +147,11 @@ main_finalize_calls="${temporary_directory}/main-finalize.calls"
 run_publisher branch exists "${main_finalize_calls}" "" finalize
 grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_finalize_calls}.git"
 grep -Fqx "push --force origin refs/tags/current" "${main_finalize_calls}.git"
-grep -Fqx "release edit current --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --target 0123456789012345678901234567890123456789 --prerelease" "${main_finalize_calls}"
-if grep -Eq 'release (create|upload|delete)' "${main_finalize_calls}"; then
-  printf 'current finalization unexpectedly changed release assets\n' >&2
+grep -Fqx "release delete current --repo stephenlclarke/container-compose --yes" "${main_finalize_calls}"
+grep -Fqx "release create current ${asset} ${checksum} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --verify-tag --prerelease --latest=false" "${main_finalize_calls}"
+grep -Fqx "release edit current --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --prerelease" "${main_finalize_calls}"
+if grep -Eq 'release upload' "${main_finalize_calls}" || grep -Fq -- '--cleanup-tag' "${main_finalize_calls}"; then
+  printf 'current finalization unexpectedly changed staged assets or removed the current tag\n' >&2
   exit 1
 fi
 
@@ -160,14 +162,11 @@ grep -Fqx "tag --no-sign --force current 012345678901234567890123456789012345678
 grep -Fqx "push --force origin refs/tags/current" "${main_create_calls}.git"
 
 main_missing_finalize_calls="${temporary_directory}/main-missing-finalize.calls"
-if run_publisher branch missing "${main_missing_finalize_calls}" "" finalize; then
-  printf 'current finalization unexpectedly created a missing release\n' >&2
-  exit 1
-fi
-if [[ -e "${main_missing_finalize_calls}" || -e "${main_missing_finalize_calls}.git" ]]; then
-  printf 'current finalization mutated a missing release\n' >&2
-  exit 1
-fi
+run_publisher branch missing "${main_missing_finalize_calls}" "" finalize
+grep -Fqx "release create current ${asset} ${checksum} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --verify-tag --prerelease --latest=false" "${main_missing_finalize_calls}"
+grep -Fqx "release edit current --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --prerelease" "${main_missing_finalize_calls}"
+grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_missing_finalize_calls}.git"
+grep -Fqx "push --force origin refs/tags/current" "${main_missing_finalize_calls}.git"
 
 runtime_asset="${temporary_directory}/container-release-arm64.tar.gz"
 runtime_checksum="${runtime_asset}.sha256"


### PR DESCRIPTION
## Summary
- recreate the mutable `current` GitHub release after its staged assets and Homebrew formulae are promoted
- preserve the `current` tag while giving every successful current build a fresh GitHub publication timestamp
- assert successful push-to-main CI authority and recovery when the release object is absent

## Validation
- `bash -n Tools/release/publish-github-release.sh Tools/release/test_publish_github_release.sh`
- `Tools/release/test_publish_github_release.sh`
- `python3 -m unittest discover -s Tools/release -p 'test_*.py'`\n- `actionlint .github/workflows/prebuilt-binaries.yml`\n- `markdownlint BUILD.md`\n- `git diff --check`