### PR TITLE
feat(parallel): complete independent engine scheduling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -385,7 +385,7 @@ cli-smoke-built:
 	[[ "$$root_help_output" == *"$${ansi_escape}[38;5;208mcommit$${ansi_escape}[0m"* ]]; \
 	[[ "$$root_help_output" == *"$${ansi_escape}[32mpause$${ansi_escape}[0m"* ]]; \
 	[[ "$$root_help_output" == *"$${ansi_escape}[32m--file$${ansi_escape}[0m"* ]]; \
-	[[ "$$root_help_output" == *"$${ansi_escape}[38;5;208m--parallel$${ansi_escape}[0m"* ]]; \
+	[[ "$$root_help_output" == *"$${ansi_escape}[32m--parallel$${ansi_escape}[0m"* ]]; \
 	plain_help_output="$$(".build/debug/compose" --ansi never --help)"; \
 	[[ "$$plain_help_output" == *"Support: supported | partially supported | not supported"* ]]; \
 	[[ "$$plain_help_output" != *"$${ansi_escape}["* ]]; \

--- a/STATUS.md
+++ b/STATUS.md
@@ -36,7 +36,7 @@ Surface names follow the current Docker Docs [Compose file reference](https://do
 | Service attributes and runtime behavior | ⚠️ Partial | The complete grouped service surface is in [Service Attribute Surface](#service-attribute-surface), including details for every runtime-limited group. |
 | Dockerfile and build behavior | ⚠️ Partial | The complete instruction and Build Specification surface is in [Dockerfile And Build Surface](#dockerfile-and-build-surface); build-secret source and metadata shapes remain limited. |
 | CLI commands | ⚠️ Partial | 44 commands are ✅, 2 are ⚠️, and 0 are ❌. Every command is listed in [CLI Command Surface](#cli-command-surface). |
-| CLI long options | ⚠️ Partial | 259 documented long options are ✅, 4 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
+| CLI long options | ⚠️ Partial | 260 documented long options are ✅, 3 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
 
 ## Compose File Surface
 
@@ -174,7 +174,7 @@ A ✅ option means the flag itself is parsed and mapped for the current command 
 
 | Option Surface | Parity | Details |
 | --- | --- | --- |
-| Root options | ⚠️ Partial | ✅ `--all-resources`: selected-service `config` and `convert` output keeps unreferenced top-level networks, volumes, configs, and secrets, ✅ `--ansi`, ✅ `--compatibility`: uses Docker Compose legacy underscore separators for generated service and one-off container names, ✅ `--dry-run`, ✅ `--env-file`, ✅ `--file`, ✅ `--profile`, ✅ `--progress`, ✅ `--project-directory`, ✅ `--project-name`, ✅ `--verbose`; ⚠️ `--parallel`: caps repeated `pull` and `push` image operations while dependency-sensitive orchestration stays ordered. |
+| Root options | ✅ Yes | ✅ `--all-resources`: selected-service `config` and `convert` output keeps unreferenced top-level networks, volumes, configs, and secrets, ✅ `--ansi`, ✅ `--compatibility`: uses Docker Compose legacy underscore separators for generated service and one-off container names, ✅ `--dry-run`, ✅ `--env-file`, ✅ `--file`, ✅ `--parallel` and `COMPOSE_PARALLEL_LIMIT`: limit independent pull, push, and build engine operations, with `-1` as the unlimited default; dependency-sensitive lifecycle orchestration remains ordered, ✅ `--profile`, ✅ `--progress`, ✅ `--project-directory`, ✅ `--project-name`, ✅ `--verbose`. |
 | `alpha` options | ✅ Yes | ✅ `--dry-run`. |
 | `alpha dry-run` options | ✅ Yes | ✅ `--dry-run`: accepted and implied for the wrapped command. |
 | `alpha scale` options | ✅ Yes | ✅ `--dry-run`, ✅ `--no-deps`. |

--- a/Sources/ComposeCore/ComposeExecutionOptions.swift
+++ b/Sources/ComposeCore/ComposeExecutionOptions.swift
@@ -214,6 +214,27 @@ public struct ComposeExecutionOptions {
         self.maxParallelism = maxParallelism
     }
 
+    /// Resolves Docker Compose's root parallelism controls.
+    ///
+    /// An explicit `--parallel` value wins over `COMPOSE_PARALLEL_LIMIT`.
+    /// Docker Compose uses `-1` when neither control is supplied, which means
+    /// that independent engine calls are not locally capped.
+    public static func effectiveParallelism(
+        explicit: Int?,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+    ) throws -> Int {
+        if let explicit {
+            return try validateParallelism(explicit, source: "--parallel")
+        }
+        guard let configured = environment["COMPOSE_PARALLEL_LIMIT"] else {
+            return -1
+        }
+        guard let limit = Int(configured.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            throw ComposeError.invalidProject("COMPOSE_PARALLEL_LIMIT must be -1 or a positive integer")
+        }
+        return try validateParallelism(limit, source: "COMPOSE_PARALLEL_LIMIT")
+    }
+
     public init(dryRun: Bool = false, emit: @escaping @Sendable (String) -> Void) {
         self.init(
             dryRun: dryRun,
@@ -333,6 +354,14 @@ public struct ComposeExecutionOptions {
         ProcessInfo.processInfo.environment["CONTAINER_BIN"]
             ?? ProcessInfo.processInfo.environment["CONTAINER_COMPOSE_CONTAINER"]
             ?? "container"
+    }
+
+    /// Validates the values accepted by Docker Compose's parallelism controls.
+    private static func validateParallelism(_ value: Int, source: String) throws -> Int {
+        guard value == -1 || value > 0 else {
+            throw ComposeError.invalidProject("\(source) must be -1 or a positive integer")
+        }
+        return value
     }
 
     public static func defaultInitImage() -> String? {

--- a/Sources/ComposeCore/ComposeOrchestratorBuildAndImages.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorBuildAndImages.swift
@@ -152,18 +152,11 @@ extension ComposeOrchestrator {
                 throw ComposeError.invalidProject("unknown service '\(name)'")
             }
             visiting.insert(name)
-            if includeRuntimeDependencies {
-                for (dependency, metadata) in serviceDependencies(service) {
-                    if metadata.required == false, project.services[dependency] == nil {
-                        continue
-                    }
-                    try visit(dependency)
-                }
-            }
-            for dependency in try buildAdditionalContextServiceNames(build: service.build) {
-                guard project.services[dependency] != nil else {
-                    throw ComposeError.invalidProject("build additional_contexts references unknown service '\(dependency)'")
-                }
+            for dependency in try buildServiceDependencies(
+                project: project,
+                service: service,
+                includeRuntimeDependencies: includeRuntimeDependencies,
+            ) {
                 try visit(dependency)
             }
             visiting.remove(name)
@@ -176,6 +169,64 @@ extension ComposeOrchestrator {
             try visit(name)
         }
         return ordered
+    }
+
+    /// Returns build-order dependencies for one service.
+    func buildServiceDependencies(
+        project: ComposeProject,
+        service: ComposeService,
+        includeRuntimeDependencies: Bool,
+    ) throws -> [String] {
+        var names = Set<String>()
+        if includeRuntimeDependencies {
+            for (dependency, metadata) in serviceDependencies(service) {
+                if metadata.required == false, project.services[dependency] == nil {
+                    continue
+                }
+                names.insert(dependency)
+            }
+        }
+        for dependency in try buildAdditionalContextServiceNames(build: service.build) {
+            guard project.services[dependency] != nil else {
+                throw ComposeError.invalidProject("build additional_contexts references unknown service '\(dependency)'")
+            }
+            names.insert(dependency)
+        }
+        return names.sorted()
+    }
+
+    /// Groups independently buildable services into dependency-safe layers.
+    func buildServiceLayers(
+        project: ComposeProject,
+        services: [ComposeService],
+        includeRuntimeDependencies: Bool,
+    ) throws -> [[ComposeService]] {
+        let buildServices = services.filter { $0.build != nil }
+        let buildServiceNames = Set(buildServices.map(\.name))
+        let servicesByName = Dictionary(uniqueKeysWithValues: buildServices.map { ($0.name, $0) })
+        var dependencies = [String: Set<String>]()
+        for service in buildServices {
+            dependencies[service.name] = Set(try buildServiceDependencies(
+                project: project,
+                service: service,
+                includeRuntimeDependencies: includeRuntimeDependencies,
+            )).intersection(buildServiceNames)
+        }
+
+        var remaining = buildServiceNames
+        var completed = Set<String>()
+        var layers = [[ComposeService]]()
+        while !remaining.isEmpty {
+            let ready = remaining.filter { dependencies[$0, default: []].isSubset(of: completed) }.sorted()
+            guard !ready.isEmpty else {
+                let names = remaining.sorted().joined(separator: ", ")
+                throw ComposeError.invalidProject("build dependency cycle involving \(names)")
+            }
+            layers.append(ready.compactMap { servicesByName[$0] })
+            remaining.subtract(ready)
+            completed.formUnion(ready)
+        }
+        return layers
     }
 
     /// Resolves Compose `dockerfile` relative to the build context for apple/container.

--- a/Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift
@@ -243,20 +243,52 @@ public extension ComposeOrchestrator {
             try options.emit(renderBuildBakeFile(project: project, services: services, options: build))
             return
         }
-        for service in services where service.build != nil {
-            if build.quiet || options.dryRun {
-                try await buildService(project: project, service: service, options: build)
-            } else {
-                try await options.progress.activityWithExternalOutput("Building \(service.name)") {
-                    try await buildService(project: project, service: service, options: build)
+        let layers = try buildServiceLayers(
+            project: project,
+            services: services,
+            includeRuntimeDependencies: build.withDependencies,
+        )
+        let concurrentProject = ConcurrentEngineOperationValue(value: project)
+        let concurrentOptions = ConcurrentEngineOperationValue(value: build)
+        for layer in layers {
+            guard let limit = try engineOperationParallelLimit(operationCount: layer.count) else {
+                for service in layer {
+                    try await buildAndPushService(
+                        project: project,
+                        service: service,
+                        options: build,
+                    )
                 }
+                continue
             }
-            if build.push, !build.check, let image = service.image {
-                if options.dryRun {
-                    try await runContainer(["image", "push", image])
-                } else {
-                    try await imageManager.pushImage(image, emit: options.emit)
-                }
+            try await runBoundedEngineOperations(layer, limit: limit) { [self, concurrentProject, concurrentOptions] service in
+                try await buildAndPushService(
+                    project: concurrentProject.value,
+                    service: service,
+                    options: concurrentOptions.value,
+                )
+            }
+        }
+    }
+
+    /// Builds one service and performs its requested post-build push.
+    private func buildAndPushService(
+        project: ComposeProject,
+        service: ComposeService,
+        options buildOptions: ComposeBuildOptions,
+    ) async throws {
+        if buildOptions.quiet || options.dryRun {
+            try await buildService(project: project, service: service, options: buildOptions)
+        } else {
+            try await options.progress.activityWithExternalOutput("Building \(service.name)") {
+                try await buildService(project: project, service: service, options: buildOptions)
+            }
+        }
+        if buildOptions.push, !buildOptions.check, let image = service.image {
+            if options.dryRun {
+                try await runContainer(["image", "push", image])
+            } else {
+                try await imageManager.pushImage(image, emit: options.emit)
             }
         }
     }

--- a/Sources/ComposeCore/ComposeOrchestratorParallelism.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorParallelism.swift
@@ -17,15 +17,15 @@
 import Foundation
 
 extension ComposeOrchestrator {
-    /// Runs image operations sequentially by default, or with the Docker
-    /// Compose-compatible explicit `--parallel` limit when requested.
+    /// Runs independent image operations using Docker Compose's effective
+    /// parallelism limit.
     func runImageOperations(
         _ images: [String],
         progressMessage: String,
         quiet: Bool,
         operation: @escaping @Sendable (_ image: String, _ quiet: Bool) async throws -> Void,
     ) async throws {
-        guard let limit = try imageOperationParallelLimit(operationCount: images.count) else {
+        guard let limit = try engineOperationParallelLimit(operationCount: images.count) else {
             for image in images {
                 try await operation(image, quiet)
             }
@@ -33,20 +33,24 @@ extension ComposeOrchestrator {
         }
 
         try await progressActivity(progressMessage, quiet: quiet) {
-            try await runBoundedImageOperations(images, limit: limit) { image in
+            try await runBoundedEngineOperations(images, limit: limit) { image in
                 try await operation(image, true)
             }
         }
     }
 
-    /// Returns the effective bounded parallelism for image operations.
-    func imageOperationParallelLimit(operationCount: Int) throws -> Int? {
-        guard let requested = options.maxParallelism else {
-            return nil
-        }
-        guard requested == -1 || requested > 0 else {
-            throw ComposeError.invalidProject("--parallel must be -1 or a positive integer")
-        }
+    /// Returns the effective parallelism for independent engine operations.
+    ///
+    /// A `nil` return value preserves deterministic handling for dry runs,
+    /// single-operation batches, and an explicit limit of one.
+    func engineOperationParallelLimit(
+        operationCount: Int,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+    ) throws -> Int? {
+        let requested = try ComposeExecutionOptions.effectiveParallelism(
+            explicit: options.maxParallelism,
+            environment: environment,
+        )
         guard !options.dryRun, operationCount > 1 else {
             return nil
         }
@@ -56,35 +60,47 @@ extension ComposeOrchestrator {
         return requested > 1 ? min(requested, operationCount) : nil
     }
 
-    private func runBoundedImageOperations(
-        _ images: [String],
+    /// Executes values with a bounded task group while preserving cancellation.
+    func runBoundedEngineOperations<Value>(
+        _ values: [Value],
         limit: Int,
-        operation: @escaping @Sendable (String) async throws -> Void,
+        operation: @escaping @Sendable (Value) async throws -> Void,
     ) async throws {
-        var iterator = images.makeIterator()
+        var iterator = values.makeIterator()
         try await withThrowingTaskGroup(of: Void.self) { group in
             var activeTasks = 0
             for _ in 0 ..< limit {
-                guard let image = iterator.next() else {
+                guard let value = iterator.next() else {
                     break
                 }
                 activeTasks += 1
+                let concurrentValue = ConcurrentEngineOperationValue(value: value)
                 group.addTask {
-                    try await operation(image)
+                    try await operation(concurrentValue.value)
                 }
             }
 
             while activeTasks > 0 {
                 try await group.next()
                 activeTasks -= 1
-                guard let image = iterator.next() else {
+                guard let value = iterator.next() else {
                     continue
                 }
                 activeTasks += 1
+                let concurrentValue = ConcurrentEngineOperationValue(value: value)
                 group.addTask {
-                    try await operation(image)
+                    try await operation(concurrentValue.value)
                 }
             }
         }
     }
+}
+
+/// Carries an immutable value into an independent engine-operation task.
+///
+/// Compose models are copied before scheduling and never mutated while their
+/// task group is running. The wrapper confines that audited assumption to the
+/// parallel scheduler instead of marking the broad normalized model Sendable.
+struct ConcurrentEngineOperationValue<Value>: @unchecked Sendable {
+    let value: Value
 }

--- a/Sources/ComposeCore/ProcessRunner.swift
+++ b/Sources/ComposeCore/ProcessRunner.swift
@@ -504,11 +504,31 @@ public struct RecordedCommand: Equatable, Sendable {
 
 /// Test runner that records invocations and returns queued responses.
 public final class RecordingRunner: CommandRunning, @unchecked Sendable {
-    public private(set) var commands: [RecordedCommand] = []
-    public var responses: [CommandResult]
+    private let lock = NSLock()
+    private var commandStorage: [RecordedCommand] = []
+    private var responseStorage: [CommandResult]
+
+    public var commands: [RecordedCommand] {
+        lock.lock()
+        defer { lock.unlock() }
+        return commandStorage
+    }
+
+    public var responses: [CommandResult] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return responseStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            responseStorage = newValue
+        }
+    }
 
     public init(responses: [CommandResult] = []) {
-        self.responses = responses
+        responseStorage = responses
     }
 
     /// Records a command and returns the next queued response, or success.
@@ -519,16 +539,17 @@ public final class RecordingRunner: CommandRunning, @unchecked Sendable {
         environment: [String: String]?,
         io: CommandIO
     ) async throws -> CommandResult {
-        commands.append(RecordedCommand(
-            executable: executable,
-            arguments: arguments,
-            workingDirectory: workingDirectory,
-            environment: environment,
-            io: io
-        ))
-        if !responses.isEmpty {
-            return responses.removeFirst()
+        lock.withLock {
+            commandStorage.append(RecordedCommand(
+                executable: executable,
+                arguments: arguments,
+                workingDirectory: workingDirectory,
+                environment: environment,
+                io: io
+            ))
+            return responseStorage.isEmpty
+                ? CommandResult(status: 0, stdout: "", stderr: "")
+                : responseStorage.removeFirst()
         }
-        return CommandResult(status: 0, stdout: "", stderr: "")
     }
 }

--- a/Sources/ComposePlugin/ComposeCLIHelp.swift
+++ b/Sources/ComposePlugin/ComposeCLIHelp.swift
@@ -353,7 +353,7 @@ enum ComposeCLIHelp {
             "--dry-run": .supported,
             "--env-file": .supported,
             "--file": .supported,
-            "--parallel": .partiallySupported,
+            "--parallel": .supported,
             "--profile": .supported,
             "--progress": .supported,
             "--project-directory": .supported,
@@ -1083,7 +1083,7 @@ enum ComposeCLIHelp {
           --dry-run                    Execute command in dry run mode
           --env-file stringArray       Specify an alternate environment file
       -f, --file stringArray           Compose configuration files
-          --parallel int               Control max parallelism for image operations; -1 for unlimited
+          --parallel int               Control max parallelism, -1 for unlimited
           --profile stringArray        Specify a profile to enable
           --progress string            Set type of progress output (auto, tty, plain, json, quiet)
           --project-directory string   Specify an alternate working directory

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -376,7 +376,7 @@ struct GlobalOptions: ParsableArguments {
     @Flag(name: .customLong("compatibility"), help: "Run compose in backward compatibility mode.")
     var compatibility: Bool = false
 
-    @Option(name: .customLong("parallel"), help: "Control max parallel image operations.")
+    @Option(name: .customLong("parallel"), help: "Control max parallelism, -1 for unlimited.")
     var parallel: Int?
 
     @Flag(name: .customLong("dry-run"), help: "Print container commands instead of running them.")

--- a/Tests/ComposeCoreTests/ComposeExecutionOptionsTests.swift
+++ b/Tests/ComposeCoreTests/ComposeExecutionOptionsTests.swift
@@ -33,6 +33,42 @@ struct ComposeExecutionOptionsTests {
     }
 
     @Test
+    func `parallelism defaults to unlimited when no control is configured`() throws {
+        #expect(try ComposeExecutionOptions.effectiveParallelism(explicit: nil, environment: [:]) == -1)
+    }
+
+    @Test
+    func `explicit parallelism overrides the environment`() throws {
+        #expect(try ComposeExecutionOptions.effectiveParallelism(
+            explicit: 2,
+            environment: ["COMPOSE_PARALLEL_LIMIT": "4"],
+        ) == 2)
+    }
+
+    @Test
+    func `parallelism uses the environment when the option is absent`() throws {
+        #expect(try ComposeExecutionOptions.effectiveParallelism(
+            explicit: nil,
+            environment: ["COMPOSE_PARALLEL_LIMIT": "3"],
+        ) == 3)
+    }
+
+    @Test
+    func `parallelism rejects an invalid environment value`() {
+        do {
+            _ = try ComposeExecutionOptions.effectiveParallelism(
+                explicit: nil,
+                environment: ["COMPOSE_PARALLEL_LIMIT": "0"],
+            )
+            Issue.record("Expected invalid COMPOSE_PARALLEL_LIMIT failure")
+        } catch let error as ComposeError {
+            #expect(error == .invalidProject("COMPOSE_PARALLEL_LIMIT must be -1 or a positive integer"))
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+        }
+    }
+
+    @Test
     func `dynamic host port allocation supports wildcard UDP and bracketed IPv6`() throws {
         let wildcardUDPPort = try ComposeExecutionOptions.defaultHostPortAllocator(
             hostAddress: nil,

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -2411,12 +2411,14 @@ struct ComposeOrchestratorTests {
         )
 
         let commands = runner.commands.map(\.arguments)
-        #expect(commands[0].containsSequence(["container", "build", "--tag", "example/api"]))
-        #expect(commands[0].last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("api").standardizedFileURL.path)
-        #expect(commands[1].containsSequence(["container", "build", "--tag", "demo_worker:latest"]))
-        #expect(commands[1].last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("worker").standardizedFileURL.path)
-        #expect(commands[2].starts(with: ["container", "create", "--name", "demo-api-1"]))
-        #expect(commands[3].starts(with: ["container", "create", "--name", "demo-worker-1"]))
+        let apiBuild = try #require(commands.first { $0.containsSequence(["container", "build", "--tag", "example/api"]) })
+        let workerBuild = try #require(commands.first { $0.containsSequence(["container", "build", "--tag", "demo_worker:latest"]) })
+        let firstCreateIndex = try #require(commands.firstIndex { $0.starts(with: ["container", "create"]) })
+        #expect(apiBuild.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("api").standardizedFileURL.path)
+        #expect(workerBuild.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("worker").standardizedFileURL.path)
+        #expect(commands[..<firstCreateIndex].allSatisfy { $0.starts(with: ["container", "build"]) })
+        #expect(commands.contains { $0.starts(with: ["container", "create", "--name", "demo-api-1"]) })
+        #expect(commands.contains { $0.starts(with: ["container", "create", "--name", "demo-worker-1"]) })
         #expect(await discoveryManager.getRequests == ["demo-api-1", "demo-worker-1"])
     }
 
@@ -12328,40 +12330,115 @@ struct ComposeOrchestratorTests {
         try await orchestrator.pull(project: project, services: ["api", "worker"])
         try await orchestrator.push(project: project, services: ["api", "worker"])
 
-        #expect(runner.commands[0].arguments.containsSequence(["container", "build", "--tag", "example/api:latest"]))
-        #expect(runner.commands[0].arguments.filter { $0 == "example/api:latest" }.count == 1)
-        #expect(runner.commands[0].arguments.containsSequence(["--tag", "example/api:dev"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--tag", "example/api:test"]))
-        #expect(runner.commands[0].arguments.containsSequence([
+        let apiCommand = try #require(runner.commands.first { command in
+            command.arguments.containsSequence(["container", "build", "--tag", "example/api:latest"])
+        }?.arguments)
+        let workerCommand = try #require(runner.commands.first { command in
+            command.arguments.containsSequence(["container", "build", "--tag", "demo_worker:latest"])
+        }?.arguments)
+        #expect(apiCommand.filter { $0 == "example/api:latest" }.count == 1)
+        #expect(apiCommand.containsSequence(["--tag", "example/api:dev"]))
+        #expect(apiCommand.containsSequence(["--tag", "example/api:test"]))
+        #expect(apiCommand.containsSequence([
             "--file",
             URL(fileURLWithPath: project.workingDirectory, isDirectory: true)
                 .appendingPathComponent("api/Containerfile")
                 .standardizedFileURL
                 .path,
         ]))
-        #expect(runner.commands[0].arguments.containsSequence(["--target", "runtime"]))
-        #expect(runner.commands[0].arguments.contains("--no-cache"))
-        #expect(runner.commands[0].arguments.contains("--pull"))
-        #expect(runner.commands[0].arguments.containsSequence(["--platform", "linux/amd64"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--platform", "linux/arm64"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--cache-in", "type=registry,ref=example/api:cache"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--cache-out", "type=local,dest=.cache"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--label", "build.label=true"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--label", "org.opencontainers.image.title=api"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--secret", "id=file_token,src=./token.txt"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--secret", "id=npm_token,env=NPM_TOKEN"]))
-        #expect(runner.commands[0].arguments.containsSequence(["--provenance", "mode=min"]))
-        #expect(!runner.commands[0].arguments.contains("--sbom"))
-        #expect(runner.commands[0].arguments.containsSequence(["--build-arg", "VERSION=1"]))
-        #expect(runner.commands[0].arguments.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("api").standardizedFileURL.path)
-        #expect(runner.commands[1].arguments.containsSequence(["--tag", "demo_worker:latest"]))
-        #expect(runner.commands[1].arguments.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("worker").standardizedFileURL.path)
+        #expect(apiCommand.containsSequence(["--target", "runtime"]))
+        #expect(apiCommand.contains("--no-cache"))
+        #expect(apiCommand.contains("--pull"))
+        #expect(apiCommand.containsSequence(["--platform", "linux/amd64"]))
+        #expect(apiCommand.containsSequence(["--platform", "linux/arm64"]))
+        #expect(apiCommand.containsSequence(["--cache-in", "type=registry,ref=example/api:cache"]))
+        #expect(apiCommand.containsSequence(["--cache-out", "type=local,dest=.cache"]))
+        #expect(apiCommand.containsSequence(["--label", "build.label=true"]))
+        #expect(apiCommand.containsSequence(["--label", "org.opencontainers.image.title=api"]))
+        #expect(apiCommand.containsSequence(["--secret", "id=file_token,src=./token.txt"]))
+        #expect(apiCommand.containsSequence(["--secret", "id=npm_token,env=NPM_TOKEN"]))
+        #expect(apiCommand.containsSequence(["--provenance", "mode=min"]))
+        #expect(!apiCommand.contains("--sbom"))
+        #expect(apiCommand.containsSequence(["--build-arg", "VERSION=1"]))
+        #expect(apiCommand.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("api").standardizedFileURL.path)
+        #expect(workerCommand.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("worker").standardizedFileURL.path)
         #expect(runner.commands.count == 2)
         #expect(await imageManager.requests == [
             .pull("example/api:latest"),
             .push("example/api:latest"),
         ])
         #expect(emitted.messages == ["example/api:latest"])
+    }
+
+    @Test("build honors the configured parallel engine call limit")
+    func buildHonorsConfiguredParallelEngineCallLimit() async throws {
+        let runner = DelayedBuildRunner(delay: .milliseconds(50))
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api:latest") {
+                    $0.build = ComposeBuild(context: "api")
+                },
+                "cache": composeService(name: "cache", image: "example/cache:latest") {
+                    $0.build = ComposeBuild(context: "cache")
+                },
+                "worker": composeService(name: "worker", image: "example/worker:latest") {
+                    $0.build = ComposeBuild(context: "worker")
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(maxParallelism: 2),
+        ).build(
+            project: project,
+            options: ComposeBuildOptions {
+                $0.quiet = true
+            },
+        )
+
+        #expect(await runner.commands.count == 3)
+        #expect(await runner.maximumActiveOperations == 2)
+    }
+
+    @Test("build layers additional context dependencies before dependents")
+    func buildLayersAdditionalContextDependenciesBeforeDependents() async throws {
+        let runner = DelayedBuildRunner(delay: .milliseconds(50))
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api:latest") {
+                    $0.build = ComposeBuild(contexts: ComposeBuild.Contexts(
+                        context: "api",
+                        additionalContexts: ["base": "service:base"],
+                    ))
+                },
+                "base": composeService(name: "base", image: "example/base:latest") {
+                    $0.build = ComposeBuild(context: "base")
+                },
+                "worker": composeService(name: "worker", image: "example/worker:latest") {
+                    $0.build = ComposeBuild(context: "worker")
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(maxParallelism: 2),
+        ).build(
+            project: project,
+            options: ComposeBuildOptions {
+                $0.quiet = true
+            },
+        )
+
+        let commands = await runner.commands
+        let targets = commands.compactMap(\.last)
+        let baseIndex = try #require(targets.firstIndex { $0.hasSuffix("/base") })
+        let apiIndex = try #require(targets.firstIndex { $0.hasSuffix("/api") })
+        #expect(baseIndex < apiIndex)
+        #expect(await runner.maximumActiveOperations == 2)
     }
 
     @Test("build resolves Dockerfile relative to build context")
@@ -12484,8 +12561,8 @@ struct ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
-    @Test("pull include deps with missing policy pulls dependency images first")
-    func pullIncludeDepsWithMissingPolicyPullsDependencyImagesFirst() async throws {
+    @Test("pull include deps selects dependency images with the missing policy")
+    func pullIncludeDepsWithMissingPolicySelectsDependencyImages() async throws {
         let imageManager = RecordingContainerImageManager()
         let project = composeProject(
             name: "demo",
@@ -12512,10 +12589,10 @@ struct ComposeOrchestratorTests {
             }
         )
 
-        #expect(await imageManager.requests == [
-            .pullMissing("example/db:latest"),
-            .pullMissing("example/api:latest"),
-        ])
+        let requests = await imageManager.requests
+        #expect(requests.count == 2)
+        #expect(requests.contains(.pullMissing("example/db:latest")))
+        #expect(requests.contains(.pullMissing("example/api:latest")))
     }
 
     @Test("pull ignore buildable skips services with build sections")
@@ -12567,10 +12644,10 @@ struct ComposeOrchestratorTests {
             }
         )
 
-        #expect(await imageManager.requests == [
-            .pull("example/api:latest"),
-            .pull("example/worker:latest"),
-        ])
+        let requests = await imageManager.requests
+        #expect(requests.count == 2)
+        #expect(requests.contains(.pull("example/api:latest")))
+        #expect(requests.contains(.pull("example/worker:latest")))
     }
 
     @Test("pull honors configured parallel image operation limit")
@@ -12603,6 +12680,30 @@ struct ComposeOrchestratorTests {
         #expect(requests.contains(.pull("example/cache:latest")))
         #expect(requests.contains(.pull("example/worker:latest")))
         #expect(await concurrency.maximumActiveOperations == 2)
+    }
+
+    @Test("pull defaults to unlimited independent engine operations")
+    func pullDefaultsToUnlimitedParallelImageOperations() async throws {
+        let concurrency = OperationConcurrencyRecorder(delay: .milliseconds(50))
+        let imageManager = RecordingContainerImageManager(onPullImage: { _ in
+            await concurrency.recordOperation()
+        })
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api:latest"),
+                "db": composeService(name: "db", image: "example/db:latest"),
+                "worker": composeService(name: "worker", image: "example/worker:latest"),
+            ]
+        )
+
+        try await ComposeOrchestrator(
+            dependencies: orchestratorDependencies {
+                $0.imageManager = imageManager
+            }
+        ).pull(project: project, options: ComposePullOptions())
+
+        #expect(await concurrency.maximumActiveOperations == 3)
     }
 
     @Test("pull rejects invalid parallelism before side effects")
@@ -12659,8 +12760,8 @@ struct ComposeOrchestratorTests {
         #expect(await imageManager.requests.isEmpty)
     }
 
-    @Test("push include deps pushes dependency images first")
-    func pushIncludeDepsPushesDependencyImagesFirst() async throws {
+    @Test("push include deps selects dependency images")
+    func pushIncludeDepsSelectsDependencyImages() async throws {
         let imageManager = RecordingContainerImageManager()
         let project = composeProject(
             name: "demo",
@@ -12687,10 +12788,10 @@ struct ComposeOrchestratorTests {
             }
         )
 
-        #expect(await imageManager.requests == [
-            .push("example/db:latest"),
-            .push("example/api:latest"),
-        ])
+        let requests = await imageManager.requests
+        #expect(requests.count == 2)
+        #expect(requests.contains(.push("example/db:latest")))
+        #expect(requests.contains(.push("example/api:latest")))
     }
 
     @Test("push quiet suppresses emitted pushed references")
@@ -12746,10 +12847,10 @@ struct ComposeOrchestratorTests {
             }
         )
 
-        #expect(await imageManager.requests == [
-            .push("example/api:latest"),
-            .push("example/worker:latest"),
-        ])
+        let requests = await imageManager.requests
+        #expect(requests.count == 2)
+        #expect(requests.contains(.push("example/api:latest")))
+        #expect(requests.contains(.push("example/worker:latest")))
     }
 
     @Test("push honors unlimited parallel image operations")
@@ -28221,6 +28322,40 @@ private actor OperationConcurrencyRecorder {
         maximum = max(maximum, activeOperations)
         try? await Task.sleep(for: delay)
         activeOperations -= 1
+    }
+}
+
+private actor DelayedBuildRunner: CommandRunning {
+    private let delay: Duration
+    private var activeOperations = 0
+    private var maximum = 0
+    private var storedCommands: [[String]] = []
+
+    init(delay: Duration) {
+        self.delay = delay
+    }
+
+    var commands: [[String]] {
+        storedCommands
+    }
+
+    var maximumActiveOperations: Int {
+        maximum
+    }
+
+    func run(
+        _ executable: String,
+        _ arguments: [String],
+        workingDirectory: URL?,
+        environment: [String: String]?,
+        io: CommandIO,
+    ) async throws -> CommandResult {
+        activeOperations += 1
+        maximum = max(maximum, activeOperations)
+        try? await Task.sleep(for: delay)
+        storedCommands.append(arguments)
+        activeOperations -= 1
+        return .success
     }
 }
 

--- a/docs/upstream/container-compose/ISSUE-compose-parallel-image-operations.md
+++ b/docs/upstream/container-compose/ISSUE-compose-parallel-image-operations.md
@@ -1,21 +1,23 @@
-# Support root `--parallel` for image operations
+# Support root `--parallel` for independent engine operations
 
 ## Summary
 
-`container compose --parallel N pull` and `container compose --parallel N push` should honor Docker Compose's global parallelism flag for repeated image work instead of accepting the option as parser-only compatibility.
+`container compose --parallel N` and `COMPOSE_PARALLEL_LIMIT` should honor Docker Compose's global parallelism controls for independent engine work instead of accepting the option as parser-only compatibility.
 
-Docker Compose treats `--parallel` as a root option. `container-compose` already parsed it, but help marked it unsupported and orchestration ignored the value. That made large image pull/push batches slower than necessary and left users with a misleading accepted-but-unused flag.
+Docker Compose treats `--parallel` as a root option. `container-compose` already parsed it, but help marked it only partially supported and orchestration did not cover builds or the environment equivalent. That left users with a misleadingly narrow compatibility surface.
 
 ## Acceptance Criteria
 
 - `container compose --parallel 2 pull` runs at most two image pull operations concurrently.
 - `container compose --parallel -1 push` runs selected image push operations without a local cap.
+- Independent build services run concurrently by default while `service:` additional contexts and `--with-dependencies` retain dependency-safe ordering.
+- `COMPOSE_PARALLEL_LIMIT` supplies the limit when the flag is absent; an explicit `--parallel` value wins.
 - `container compose --parallel 0 pull` rejects the value before side effects.
 - Dry-run output remains deterministic and ordered.
-- Build, create, start, and dependency-sensitive reconciliation remain ordered until their dependency and progress semantics are explicitly reviewed.
-- Root help marks `--parallel` as partially supported and describes the image-operation scope.
-- Focused tests cover bounded pull concurrency, unlimited push concurrency, invalid values, and help status.
+- Create, start, and dependency-sensitive lifecycle reconciliation remain ordered until their dependency and progress semantics are explicitly reviewed.
+- Root help marks `--parallel` as supported and describes its Docker-compatible scope.
+- Focused tests cover bounded pull/build concurrency, unlimited defaults, environment precedence, build dependency layers, invalid values, and help status.
 
 ## Notes
 
-This is a Compose-side scheduling improvement. It does not require new Apple runtime APIs because it uses the existing image manager pull/push operations. Broader lifecycle parallelism remains intentionally out of scope until the service dependency graph, progress output, and runtime reconciliation ordering can be changed without surprising users.
+This is a Compose-side scheduling improvement. It does not require new Apple runtime APIs: pull/push use the existing image manager operations, and builds invoke independent existing `container build` operations. Build layers retain `service:` additional-context and requested runtime build dependencies before their consumers run. Broader lifecycle parallelism remains intentionally out of scope until the service dependency graph, progress output, and runtime reconciliation ordering can be changed without surprising users.

--- a/docs/upstream/container-compose/PR-compose-parallel-image-operations.md
+++ b/docs/upstream/container-compose/PR-compose-parallel-image-operations.md
@@ -1,11 +1,11 @@
-# Support `--parallel` image pull and push
+# Support `--parallel` independent image and build operations
 
 ## Summary
 
-- Thread the parsed root `--parallel` value into `ComposeExecutionOptions`.
-- Add a bounded image-operation helper that defaults to ordered execution, honors positive limits, treats `-1` as uncapped, and rejects zero or other invalid negative values.
-- Apply the helper to repeated `pull` and `push` image operations while preserving ordered dry-run output.
-- Mark root `--parallel` as partially supported in help and document the exact scope.
+- Resolve `--parallel` and `COMPOSE_PARALLEL_LIMIT` into Docker Compose's unlimited-by-default behavior, with the explicit option taking precedence.
+- Add a bounded engine-operation helper that honors positive limits, treats `-1` as uncapped, and rejects zero or other invalid negative values.
+- Apply it to repeated `pull` and `push` image operations and dependency-safe layers of independent builds while preserving ordered dry-run output.
+- Mark root `--parallel` as supported in help and document the exact scope.
 
 ## Type of Change
 
@@ -16,24 +16,26 @@
 
 ## Motivation and Context
 
-The CLI parser accepted Docker Compose's root `--parallel` option, but orchestration ignored it and help correctly showed it as unsupported. This change closes the safe image-operation portion of that compatibility gap without changing dependency-sensitive service scheduling.
+The CLI parser accepted Docker Compose's root `--parallel` option, but orchestration only partially used it and its environment equivalent was absent. This change closes the safe independent-engine-operation portion of that compatibility gap without changing dependency-sensitive service lifecycle scheduling.
 
-The implementation deliberately keeps dry-run output, builds, creates, starts, and lifecycle reconciliation ordered. Build planning depends on service-context build ordering, and service lifecycle parallelism needs a separate dependency-graph review.
+The implementation deliberately keeps dry-run output, creates, starts, and lifecycle reconciliation ordered. Build planning first forms dependency-safe layers: a service referenced through `additional_contexts: service:name`, or selected through `--with-dependencies`, completes before its consumer; unrelated services in a layer can run concurrently. Service lifecycle parallelism still needs a separate dependency-graph review.
 
 ## Implementation Details
 
-- Added `ComposeExecutionOptions.maxParallelism`.
-- Added `runImageOperations` to choose ordered execution by default and bounded task groups only when `--parallel` is explicitly set and useful.
+- Added `ComposeExecutionOptions.maxParallelism` resolution for `COMPOSE_PARALLEL_LIMIT`, with an explicit option taking precedence and `-1` as the default.
+- Added a bounded independent-engine-operation scheduler for image and build work.
 - Suppressed per-image spinner ownership inside the parallel path and used one aggregate progress activity for the batch.
 - Updated `pull` and `push` to precompute selected image references and run them through the helper.
-- Updated help prose and support metadata from unsupported to partially supported.
+- Added build dependency layers that preserve `additional_contexts: service:name` and `--with-dependencies` order while scheduling independent builds.
+- Updated help prose and support metadata to supported.
 
 ## Docker Compose Compatibility Notes
 
 Supported:
 
-- Positive `--parallel` values cap concurrent repeated image pulls and pushes.
-- `--parallel -1` removes the local cap for repeated image pulls and pushes.
+- Positive `--parallel` values cap concurrent repeated image pulls, pushes, and builds.
+- `--parallel -1` removes the local cap for independent image pulls, pushes, and builds; it is also the default when no flag or environment value is supplied.
+- `COMPOSE_PARALLEL_LIMIT` supplies the cap if `--parallel` is absent.
 - Invalid values fail before image side effects.
 
 Remaining gap:
@@ -49,7 +51,7 @@ Remaining gap:
 Focused validation:
 
 ```bash
-swift test --disable-automatic-resolution --filter 'pullHonorsConfiguredParallelImageOperationLimit|pullRejectsInvalidParallelismBeforeSideEffects|pushHonorsUnlimitedParallelImageOperations|ComposeCLIHelpTests'
+swift test --disable-automatic-resolution --filter 'ComposeExecutionOptionsTests|pullHonorsConfiguredParallelImageOperationLimit|buildHonorsConfiguredParallelEngineCallLimit|buildLayersAdditionalContextDependenciesBeforeDependents|ComposeCLIHelpTests'
 ```
 
 Broader local gate:


### PR DESCRIPTION
## Summary
- apply Docker Compose parallel defaults and COMPOSE_PARALLEL_LIMIT precedence
- schedule independent builds while retaining build dependency layers
- mark the root option supported and make concurrent test recording safe

## Validation
- swift test --disable-automatic-resolution --no-parallel
- make check
- make cli-smoke