### PR TITLE
docs(network): record container-facing DNS blocker

### DIFF
--- a/docs/upstream/apple-container/ISSUE-network-aliases.md
+++ b/docs/upstream/apple-container/ISSUE-network-aliases.md
@@ -1,4 +1,4 @@
-# Feature request: network attachment aliases
+# Feature request: container-facing DNS for network attachment aliases
 
 ## Feature or enhancement request details
 
@@ -23,9 +23,23 @@ networks:
   backend: {}
 ```
 
-`apple/container` already allocates a hostname for each network attachment and resolves that hostname through the network service. It does not currently expose additional typed attachment aliases, so a Compose plugin cannot represent common service-discovery names without rewriting Compose files.
+`apple/container` now has an alias-registration proposal in
+[apple/container#1815](https://github.com/apple/container/pull/1815):
+`AttachmentOptions.aliases` records extra names in the per-network attachment
+registry. That is the right lower-level data model, but it is not enough for
+Compose parity because service containers cannot query the registry.
 
-Per JLogan's guidance in [apple/container#1769](https://github.com/apple/container/pull/1769#issuecomment-4780439328), this Apple-facing slice should stay focused on network attachment alias storage and lookup. Compose owns `networks.<name>.aliases`, legacy `links`, selected network restrictions, and Docker-compatible validation messaging.
+[apple/container#1813](https://github.com/apple/container/pull/1813) confirms
+the remaining platform constraint. It added forwarding and request-context
+groundwork but deliberately does not start a container-facing listener:
+wildcard UDP/53 conflicts with `mDNSResponder`, while binding the reported
+vmnet gateway address fails with `EADDRNOTAVAIL` even when the vmnet DNS proxy
+is disabled.
+
+Compose owns `networks.<name>.aliases`, legacy `links`, selected network
+restrictions, and Docker-compatible validation messaging. Apple owns a
+supported path from a service container's DNS request to its source network's
+attachment registry.
 
 Relevant references:
 
@@ -36,19 +50,34 @@ Relevant references:
 
 ## Proposed behavior
 
-- Add attachment `aliases` alongside the existing attachment hostname.
-- Validate aliases with the same RFC1123 hostname rules used by explicit hostnames when Apple accepts direct user input for this field.
-- Resolve aliases through the existing network lookup path.
-- Preserve existing persisted network attachment decoding by defaulting missing aliases to an empty list.
-- Keep multi-network attach/connect, DNSRR, fixed IPs, and Compose service policy out of this change.
+- Keep the existing `AttachmentOptions.aliases` groundwork.
+- Expose a platform-supported resolver endpoint or DNS interception mechanism
+  that receives requests from vmnet-backed service containers without binding
+  wildcard port 53.
+- Propagate source interface/network context to the network lookup path, so
+  names are resolved in the correct attachment registry.
+- Resolve an attachment hostname and its aliases over that container-facing
+  path, then remove the answer after the attachment is released.
+- Keep Compose syntax, service policy, DNSRR/VIP behavior, fixed IPs, and
+  multi-network attach/connect out of this runtime change.
 
 ## Minimal example
 
 Expected behavior:
 
-- The created container receives its normal network attachment.
-- Peers on the same `apple/container` network can resolve `api.internal` to the same address as the attachment hostname.
+- The created container receives its normal network attachment and aliases.
+- A peer on the same `apple/container` network resolves `api.internal` to the
+  same address as the attachment hostname through its configured DNS path.
+- A peer attached only to a different network does not receive that answer.
 - Existing callers that omit aliases preserve current behavior.
+
+## Design boundary
+
+Do not accept a host-loopback-only server or a listener that races
+`mDNSResponder` as a solution. The vmnet helper needs a supported endpoint
+provided by vmnet, packet interception, or another macOS networking facility.
+The existing gateway bind experiments prove that changing Compose or adding
+another `--network` parser cannot close this gap.
 
 ## Code of Conduct
 

--- a/docs/upstream/apple-container/PR-network-aliases.md
+++ b/docs/upstream/apple-container/PR-network-aliases.md
@@ -1,19 +1,28 @@
-# Pull request: add network attachment aliases
+# Handoff PR: add container-facing DNS for network attachment aliases
 
 ## Type of Change
 
 - [ ] Bug fix
-- [x] New feature
+- [ ] New feature
 - [ ] Breaking change
 - [x] Documentation update
 
 ## Motivation and Context
 
-Docker exposes network-scoped aliases as a container network attachment primitive. Compose service `networks.<name>.aliases` depends on that primitive, and Docker documents that aliases are resolved only on the network where the container is connected.
+Docker exposes network-scoped aliases as a container network attachment
+primitive. [apple/container#1815](https://github.com/apple/container/pull/1815)
+already supplies that storage and allocator primitive. The remaining failure
+is that service containers have no supported DNS route to the allocator.
 
-This change adds the generic runtime surface to `apple/container` without adding Compose-specific behavior. The current `container-compose` implementation maps its single-network Compose alias subset onto this primitive; multi-network attach/connect and service DNS policy remain separate networking gaps.
+[apple/container#1813](https://github.com/apple/container/pull/1813) tested
+the obvious listener designs and deliberately leaves listener startup out:
+wildcard UDP/53 races with `mDNSResponder`, and a listener bound to the vmnet
+gateway fails with `EADDRNOTAVAIL`, including after disabling the vmnet DNS
+proxy. This handoff asks for the smallest Apple-owned mechanism that can
+actually receive service DNS traffic and retain source-network context.
 
-Following JLogan's guidance in [apple/container#1769](https://github.com/apple/container/pull/1769#issuecomment-4780439328), the durable upstream ask is the typed attachment alias primitive. Docker/Compose network syntax stays in `container-compose`; any local `--network ...,alias=...` parser is only a bridge for the current command-vector create path.
+Docker/Compose network syntax stays in `container-compose`. No Compose-facing
+parser or policy belongs in this Apple change.
 
 References:
 
@@ -24,25 +33,42 @@ References:
 
 ## Commit Tracking
 
-- Container code commit: `cf5e8d1` in `stephenlclarke/container` (`feat(network): add attachment aliases`).
-- Lower runtime code commit: not required.
-- Compose mapping code commit: `0905db9` in `stephenlclarke/container-compose` (`feat(network): map compose network aliases`), not part of this Apple PR.
+- Alias-registration groundwork: `cf5e8d1` in `stephenlclarke/container`
+  (`feat(network): add attachment aliases`) and upstream
+  [apple/container#1815](https://github.com/apple/container/pull/1815).
+- DNS groundwork: [apple/container#1813](https://github.com/apple/container/pull/1813).
+- No new fork commit is proposed until maintainers identify the supported
+  vmnet-facing endpoint. The failed gateway-bind experiment is documented
+  upstream and should not be replaced with a local-only workaround.
 
 ## Implementation Details
 
-- Added `aliases` to `AttachmentOptions` and `Attachment`, with backward-compatible decoding that treats missing aliases as `[]`.
-- Added a network XPC `aliases` payload for allocation requests.
-- Extended `AttachmentAllocator` to reserve hostname and alias names for the same address index and release them together.
-- Updated container create validation so alias collisions fail before runtime resources are created.
-- Passed aliases from create options through to runtime attachment allocation.
-- The local fork also carried repeatable `alias=<name>` parsing on the `--network` attachment option and command-reference updates so the existing command-vector create path could validate the primitive; an upstream PR should drop or soften that bridge if maintainers prefer typed-only configuration.
+The Apple implementation should be limited to the runtime plumbing:
+
+1. Obtain a supported vmnet or macOS networking endpoint for DNS traffic from
+   guest service containers; do not bind wildcard port 53.
+2. Pass the ingress interface/network identity into the DNS handler and
+   attachment lookup.
+3. Resolve the existing hostname and alias entries from that network only,
+   preserving allocator cleanup semantics.
+4. Add an integration test that creates two real service containers and
+   resolves both the primary hostname and alias from the peer's configured DNS
+   path.
+
+The resolver should support both UDP and TCP if the selected platform endpoint
+requires it. The exact listener/packet-interception API is intentionally left
+to Apple maintainers because the known direct socket binds are not viable.
 
 ## Compatibility Notes
 
-- Existing persisted attachments that do not contain `aliases` continue to decode successfully.
-- Existing `--network <name>`, `--network <name>,mac=...`, and `--network <name>,mtu=...` forms keep their current behavior.
-- Alias names currently participate in the same uniqueness model as hostnames because the existing network lookup API is hostname-based and not source-network-scoped. Docker permits ambiguous alias sharing, but this smaller primitive is intentionally stricter until the DNS service can express network-scoped multi-answer behavior.
-- This does not add multi-network connect/disconnect, fixed IPs, service-name DNS for replicas, DNSRR, legacy links, or Compose-specific alias selection.
+- Existing persisted attachments that omit `aliases` continue to decode
+  successfully.
+- Existing attachment CLI forms retain their current behavior.
+- Alias names currently participate in a hostname-like uniqueness model. The
+  source-network-aware resolver is the prerequisite for Docker-compatible
+  shared aliases and multi-network behavior.
+- This does not add multi-network connect/disconnect, fixed IPs, service-name
+  DNS for replicas, DNSRR, legacy links, or Compose-specific alias selection.
 
 ## Testing
 
@@ -53,8 +79,12 @@ References:
 Focused validation:
 
 ```sh
-swift test --filter 'ParserTest/testParseNetworkWithAliases|ParserTest/testParseNetworkDeduplicatesAliases|ParserTest/testParseNetworkEmptyAlias|AttachmentConfigurationTest|AttachmentAllocatorTest/testLookupAllocatedAlias|AttachmentAllocatorTest/testAliasConflictThrows|AttachmentAllocatorTest/testHostnameCannotReuseExistingAlias|AttachmentAllocatorTest/testDuplicateAliasMapsToSingleAllocation|AttachmentAllocatorTest/testDeallocateRemovesAliases'
+swift test --filter 'AttachmentAllocatorTest|ForwardingResolverTest|CompositeResolverTest'
 ```
+
+The change is incomplete until a vmnet-backed integration test demonstrates
+peer resolution. Allocator and host-loopback tests alone are not acceptance
+evidence.
 
 Additional local checks:
 

--- a/docs/upstream/container-compose/ISSUE-network-aliases.md
+++ b/docs/upstream/container-compose/ISSUE-network-aliases.md
@@ -36,11 +36,36 @@ References:
 
 `container-compose` validates alias syntax and attachment ownership, then rejects every valid network-alias request before resource creation. The runtime can register aliases on repeated `--network` attachment arguments, and plain multi-network attachments are supported at container creation on macOS 26+. However, it configures service containers with only the first attachment gateway as their nameserver and has no container-facing DNS listener to resolve the registry entries. Passing the arguments through would therefore advertise a feature that peers cannot use.
 
+This is now verified against the active upstream work, rather than an assumed
+missing API:
+
+- [apple/container#1815](https://github.com/apple/container/pull/1815) adds
+  the correct narrow alias-registration primitive, but explicitly does not
+  make aliases resolvable from containers.
+- [apple/container#1813](https://github.com/apple/container/pull/1813) adds
+  forwarding and request-context groundwork, but intentionally does not start
+  a listener. A wildcard UDP/53 listener races with `mDNSResponder`; binding a
+  listener to the vmnet gateway failed with `EADDRNOTAVAIL`, both with the
+  vmnet DNS proxy enabled and disabled.
+
+The Compose-side rejection is therefore deliberate and must remain until the
+runtime can prove an end-to-end peer lookup. It also keeps `compose run
+--use-aliases` correctly marked partial rather than exposing a no-op flag.
+
 ## Likely owner
 
 both
 
-`apple/container` owns the missing container-facing DNS listener and source-network routing model. `container-compose` owns Compose model validation and the early, explicit unsupported error.
+`apple/container` owns the missing container-facing DNS listener and
+source-network routing model. `container-compose` owns Compose model
+validation and the early, explicit unsupported error.
+
+The smallest useful Apple-facing primitive is **not** another Compose parser
+or an alias-only API. It is a supported way for the vmnet-backed runtime to
+receive DNS requests from a service container, identify the originating
+network, and answer them from that network's attachment registry. Whether
+that is a vmnet-provided host-bindable endpoint, DNS interception, or a
+platform-supported mDNSResponder integration is an Apple runtime decision.
 
 ## Minimal example
 
@@ -65,6 +90,20 @@ Current behavior with the fork-backed runtime:
 - `container-compose` rejects this project before creating networks, volumes, or containers.
 - `apple/container` can register `api.internal` in its per-network registry but cannot answer that lookup from a service container.
 - Plain multi-network attachment creation is supported; all alias behavior remains blocked until `apple/container` exposes a container-facing DNS listener with source-network-aware routing.
+
+## Acceptance evidence for a future Compose slice
+
+Do not enable alias rendering based only on API shape or unit tests. The
+runtime handoff must demonstrate all of the following with a real vmnet-backed
+network:
+
+1. A peer container resolves an attachment hostname and an alias over the
+   network DNS path.
+2. The lookup is scoped to the peer's source network, including a container
+   with more than one attachment.
+3. The resolver's startup does not bind wildcard port 53 or interfere with
+   `mDNSResponder`.
+4. Alias teardown removes the answer after a container is removed.
 
 ## Code of Conduct and documentation
 

--- a/docs/upstream/container-compose/PR-network-aliases.md
+++ b/docs/upstream/container-compose/PR-network-aliases.md
@@ -1,23 +1,38 @@
-# Pull Request
+# Handoff: unblock Compose network aliases with container-facing DNS
 
 ## Summary
 
-- Map Compose network aliases to the plugin-owned network-alias projection for the single-network local subset.
-- Validate alias names and alias network ownership before side effects.
-- Document the remaining multi-network/DNS parity gaps.
+- Keep Compose network aliases and `run --use-aliases` explicitly unavailable
+  until they work for peer containers.
+- Hand off the smallest runtime primitive needed to unblock the feature.
+- Record why the existing alias-registration work is necessary but not
+  sufficient.
 
 ## Type of Change
 
 - [ ] Bug fix
-- [x] New feature
+- [ ] New feature
 - [ ] Breaking change
 - [x] Documentation update
 
 ## Motivation and Context
 
-Docker Compose supports service network aliases as network-scoped DNS names. The plugin previously rejected the whole surface because released upstream `apple/container` did not expose attachment aliases.
+Docker Compose supports service network aliases as network-scoped DNS names.
+The local `apple/container` fork and upstream
+[apple/container#1815](https://github.com/apple/container/pull/1815) provide
+the required alias-registration data model, but that does not make an alias
+resolvable by another service container.
 
-The local container fork now adds a generic network attachment alias primitive with `AttachmentOptions.aliases`. This plugin change keeps Compose policy in `container-compose`: it only maps aliases when the service has exactly one attached network, validates the aliases with Docker-compatible RFC1123 hostname rules, and leaves multi-network alias parity blocked until the runtime exposes richer networking behavior. The current live execution path still renders repeatable `container run/create --network <name>,alias=<value>` through the command-vector bridge while typed service creation is being wired.
+The Compose mapping that formerly rendered `--network ...,alias=...` has been
+intentionally disabled. `container-compose` now fails before side effects,
+because live service containers point at their attachment gateway and the
+runtime has no listener that can answer its attachment registry. Retaining the
+rejection avoids claiming a feature that cannot work end to end.
+
+The next implementation belongs in `apple/container`: expose a
+container-facing DNS path that carries source-network context into the
+existing attachment lookup. This is deliberately an Apple-shaped runtime
+handoff, not a request to add Compose syntax to Apple code.
 
 References:
 
@@ -25,32 +40,50 @@ References:
 - Docker `network connect --alias`: <https://docs.docker.com/reference/cli/docker/network/connect/>
 - Docker networking overview: <https://docs.docker.com/engine/network/>
 - Runtime handoff files: `docs/upstream/apple-container/ISSUE-network-aliases.md` and `docs/upstream/apple-container/PR-network-aliases.md`
+- [apple/container#1813](https://github.com/apple/container/pull/1813), which
+  records that binding a listener to the vmnet gateway currently fails with
+  `EADDRNOTAVAIL`
 - Related apple/container networking discussions: [apple/container#1283](https://github.com/apple/container/issues/1283), [apple/container#457](https://github.com/apple/container/issues/457), [apple/container#456](https://github.com/apple/container/issues/456), [apple/container#500](https://github.com/apple/container/issues/500), [apple/container#1320](https://github.com/apple/container/issues/1320), [apple/container#282](https://github.com/apple/container/issues/282)
 
 ## Commit Tracking
 
-- Compose code commit: `0905db9` (`feat(network): map compose network aliases`)
-- Container code commit: `cf5e8d1` in `stephenlclarke/container` (`feat(network): add attachment aliases`)
-- Lower runtime code commit: not required
+- Historical Compose mapping commit: `0905db9` (`feat(network): map compose
+  network aliases`); it is not enabled because peer resolution is absent.
+- Alias-registration commit: `cf5e8d1` in `stephenlclarke/container`
+  (`feat(network): add attachment aliases`).
+- Current upstream equivalents: [apple/container#1813](https://github.com/apple/container/pull/1813) and [apple/container#1815](https://github.com/apple/container/pull/1815).
+- No new fork commit is proposed until Apple identifies a supported vmnet DNS
+  attachment point. A listener that happens to bind locally would be an
+  unsupported and fragile workaround.
 
 ## Implementation Details
 
-- Replaced the blanket network-alias rejection with `validateNetworkAliasSupport(service:networks:)`.
-- Added shared RFC1123 hostname canonicalization for hostname-like Compose fields.
-- Added `networkAliasValues(service:network:)` to validate, canonicalize, and de-duplicate aliases before rendering.
-- Built alias projections for the single network attachment.
-- Appended aliases to the single `--network` attachment argument before MAC and MTU options in the current command-vector bridge.
-- Added positive `up` and one-off `run` tests for alias rendering.
-- Added negative tests for invalid aliases and aliases declared on unattached networks.
-- Updated `STATUS.md` and relevant project docs.
+The proposed runtime change must:
+
+1. Receive peer DNS traffic through a platform-supported vmnet mechanism
+   without binding wildcard port 53 or racing `mDNSResponder`.
+2. Carry the source interface/network through the DNS request to the network
+   service, so the same alias can be resolved only in the originating
+   network's registry.
+3. Answer attachment hostnames and aliases using the existing allocator data,
+   including cleanup after detach/remove.
+4. Offer an integration test with real service containers, not only allocator
+   or host-loopback DNS tests.
+
+`container-compose` already validates aliases before it emits side effects and
+has regression tests that assert its explicit container-facing-DNS error for
+both `up` and `run --use-aliases`.
 
 ## Docker Compose Compatibility Notes
 
-- Supported with the current fork-backed runtime: aliases on exactly one service network, currently through the command-vector bridge.
-- Supported: alias rendering alongside single-network MAC and MTU options.
-- Remaining gap: Docker permits the same network-wide alias to be shared by multiple containers, with unspecified resolution. The local runtime currently keeps alias names unique because the existing lookup path is hostname-like and not source-network-scoped.
-- Remaining gap: aliases on services with multiple networks need `apple/container` multi-network attach/connect and source-network-aware DNS behavior.
-- Remaining gap: service-name DNS for scaled replicas, DNSRR/VIP endpoint behavior, fixed IPs, and Docker network namespace modes remain separate networking gaps.
+- Not supported today: Compose aliases and `run --use-aliases` remain partial
+  because peer containers cannot resolve registered names.
+- The alias data model is useful groundwork, but it currently uses a
+  hostname-like uniqueness model. Docker-compatible shared aliases and
+  multi-network behavior require the source-network-aware resolver proposed
+  above.
+- Service-name DNS for scaled replicas, DNSRR/VIP endpoint behavior, fixed
+  IPs, and Docker network namespace modes remain separate networking gaps.
 
 ## Testing
 
@@ -61,7 +94,7 @@ References:
 Focused validation:
 
 ```sh
-swift test --filter 'ComposeOrchestratorTests/upMapsNetworkAliasesToSingleNetworkAttachment|ComposeOrchestratorTests/upRejectsInvalidNetworkAliasesBeforeCreatingResources|ComposeOrchestratorTests/upRejectsAliasesOnUnattachedNetworksBeforeCreatingResources|ComposeOrchestratorTests/runMapsNetworkAliasesToSingleNetworkAttachment'
+swift test --filter 'ComposeOrchestratorTests/upRejectsNetworkAliasesUntilRuntimeExposesContainerFacingDNS|ComposeOrchestratorTests/runUseAliasesRejectsNetworkAliasesUntilRuntimeExposesContainerFacingDNS'
 ```
 
 Additional local checks:


### PR DESCRIPTION
## Summary
- Correct the stale alias handoff: registration exists, but service containers cannot resolve aliases.
- Record upstream validation that direct vmnet gateway listener binds fail with EADDRNOTAVAIL and wildcard UDP/53 conflicts with mDNSResponder.
- Keep Compose aliases and run --use-aliases explicitly partial until a source-network-aware, container-facing DNS path is proven end to end.

## Validation
- swift test --disable-automatic-resolution --no-parallel --filter ComposeOrchestratorTests.upRejectsNetworkAliasesUntilRuntimeExposesContainerFacingDNS
- swift test --disable-automatic-resolution --no-parallel --filter ComposeOrchestratorTests.runUseAliasesRejectsNetworkAliasesUntilRuntimeExposesContainerFacingDNS
- make check
- git diff --check