### PR TITLE
feat(attach): enable interactive stream reattachment

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f3b7961638a999748fd7ce9439288150a1e0c607c73fdf20690a107c3a0a2249",
+  "originHash" : "d163f29daa055fc70cc10de293516e407fc966cfa0c059b989b63bdee95a2ffa",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "8189ee401dbd50d72935729625de4e1ed883a4f0"
+        "revision" : "872fc44e959a7c4a35e265954b388fe273164b76"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "8189ee401dbd50d72935729625de4e1ed883a4f0",
+            revision: "872fc44e959a7c4a35e265954b388fe273164b76",
         ),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",

--- a/STATUS.md
+++ b/STATUS.md
@@ -123,7 +123,7 @@ Docker Compose service attributes are grouped here by runtime behavior so every 
 | `alpha dry-run` | ✅ Yes | Experimental `alpha dry-run -- COMMAND` wraps the requested Compose command with root `--dry-run` while preserving project/global options. |
 | `alpha scale` | ✅ Yes | Experimental `alpha scale` is implemented as an alias for the stable `scale` command. |
 | `alpha watch` | ✅ Yes | Experimental `alpha watch` is implemented as an alias for the stable `watch` command. |
-| `attach` | ⚠️ Partial | `--no-stdin` output-follow attach is implemented; default interactive reattach and detach-key handling need the runtime primitive tracked by [apple/container#378](https://github.com/apple/container/issues/378). |
+| `attach` | ⚠️ Partial | Interactive init-process stream reattachment and `--sig-proxy` are implemented through the forked runtime primitive tracked by [apple/container#378](https://github.com/apple/container/issues/378); output-only attach continues to follow persisted logs. Custom `--detach-keys` remains the only command gap because a terminal session needs a cancellable wait path before it can safely disconnect without stopping the service. |
 | `bridge` | ✅ Yes | The complete Compose Bridge CLI runtime is implemented for the `stephenlclarke` runtime lane. |
 | `bridge convert` | ✅ Yes | Models include image ports, published target ports, and text or binary config and secret content; Kubernetes, Helm, custom templates, repeated transformations, and empty-output current-directory mode run through local transformer images. |
 | `bridge transformations` | ✅ Yes | Bridge transformation image management is implemented. |
@@ -179,7 +179,7 @@ A ✅ option means the flag itself is parsed and mapped for the current command 
 | `alpha dry-run` options | ✅ Yes | ✅ `--dry-run`: accepted and implied for the wrapped command. |
 | `alpha scale` options | ✅ Yes | ✅ `--dry-run`, ✅ `--no-deps`. |
 | `alpha watch` options | ✅ Yes | ✅ `--dry-run`, ✅ `--no-up`, ✅ `--quiet`. |
-| `attach` options | ⚠️ Partial | ✅ `--dry-run`, ✅ `--index`, ✅ `--no-stdin`, ✅ `--sig-proxy`; ⚠️ `--detach-keys`: parsed and documented, but output-only attach ignores detach keys because interactive reattach is not exposed by the runtime. |
+| `attach` options | ⚠️ Partial | ✅ `--dry-run`, ✅ `--index`, ✅ `--no-stdin`, ✅ `--sig-proxy`; ⚠️ `--detach-keys`: parsed and documented, ignored for output-only attach, and rejected for interactive attach until a safe terminal-session disconnect path exists. |
 | `bridge` options | ✅ Yes | ✅ `--dry-run`. |
 | `bridge convert` options | ✅ Yes | ✅ `--dry-run`, ✅ `--output`, ✅ `--templates`, ✅ `--transformation`. |
 | `bridge transformations` options | ✅ Yes | ✅ `--dry-run`. |
@@ -228,6 +228,6 @@ Released Apple `container` compatibility is not a supported-lane functionality g
 ## Remaining Gap Focus
 
 - There are no remaining red CLI command or long-option surfaces.
-- The remaining orange command surfaces are `attach` and `commit`; `attach` needs an interactive runtime stream reattach/multiplexer, while `commit --pause=false` needs a safe no-freeze writable-filesystem snapshot. Their table rows above describe the exact supported subset.
+- The remaining orange command surfaces are `attach` and `commit`; `attach` needs only safe custom detach-key handling over the existing interactive stream relay, while `commit --pause=false` needs a safe no-freeze writable-filesystem snapshot. Their table rows above describe the exact supported subset.
 - Runtime-primitive blockers include vendor/native GPU passthrough, multiple GPUs, arbitrary macOS hardware passthrough, external config/secret lookup, generic service endpoint `driver_opts`, and non-GPU Deploy device/generic reservations.
 - When touching slow runtime paths, keep first-frame progress rendering covered so local `container compose` runs do not appear to hang before visible output.

--- a/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
@@ -241,13 +241,19 @@ public extension ComposeOrchestrator {
         }
     }
 
-    /// Attaches to service output using the apple/container log stream.
+    /// Attaches to a service container through the runtime stream relay.
     func attach(project: ComposeProject, serviceName: String, options attach: ComposeAttachOptions) async throws {
         let proxySignals = try validateAttachOptions(attach)
         guard let service = project.services[serviceName] else {
             throw ComposeError.invalidProject("unknown service '\(serviceName)'")
         }
         let id = try await serviceContainerID(project: project, service: service, index: attach.index)
+        if !attach.noStdin {
+            let arguments = ["attach", "--sig-proxy=\(proxySignals ? "true" : "false")", id]
+            try await runContainer(arguments, inheritedIO: true)
+            return
+        }
+
         let args = ["logs", "--follow", id]
         let followLogs: @Sendable () async throws -> Void = {
             try await self.logManager.logs(

--- a/Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift
@@ -286,13 +286,10 @@ extension ComposeOrchestrator {
         }
     }
 
-    /// Validates that attach stays on the output-only log-follow path apple/container exposes today.
+    /// Validates Compose attach client options before selecting its stream path.
     func validateAttachOptions(_ attach: ComposeAttachOptions) throws -> Bool {
-        if !attach.noStdin, let detachKeys = attach.detachKeys, !detachKeys.isEmpty {
-            throw ComposeError.unsupported("attach --detach-keys: apple/container does not expose detach-key handling for interactive attach")
-        }
-        if !attach.noStdin {
-            throw ComposeError.unsupported("attach: apple/container does not expose stdin/stdout/stderr reattach for already-running service containers; use --no-stdin for output-only logs")
+        if !attach.noStdin, attach.detachKeys != nil {
+            throw ComposeError.unsupported("attach --detach-keys: interactive stream reattachment is available, but detach-key handling is not yet available")
         }
         let sigProxy = attach.sigProxy.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         switch sigProxy {

--- a/Sources/ComposePlugin/ComposeCLIHelp.swift
+++ b/Sources/ComposePlugin/ComposeCLIHelp.swift
@@ -341,7 +341,7 @@ enum ComposeCLIHelp {
     ]
 
     private static let supportDetailByCommand: [String: String] = [
-        "attach": "Output-only attach is supported; interactive stream reattachment and detach-key handling require additional runtime support.",
+        "attach": "Interactive stream reattachment and signal proxy are supported; custom detach-key handling is pending terminal-session support.",
         "commit": "Stopped containers and running containers with default --pause=true can be committed; the running path uses a brief filesystem freeze. --pause=false remains unavailable because a writable filesystem cannot be exported safely without that freeze.",
     ]
 
@@ -1274,7 +1274,7 @@ enum ComposeCLIHelp {
         Attach local standard input, output, and error streams to a service's running container
 
         Options:
-              --detach-keys string   Override the key sequence for detaching from a container. Ignored with --no-stdin output-only attach.
+              --detach-keys string   Override the key sequence for detaching from a container. Ignored with --no-stdin output-only attach; interactive handling is not yet available.
               --dry-run              Execute command in dry run mode
               --index int            index of the container if service has multiple replicas.
               --no-stdin             Do not attach STDIN

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -1925,21 +1925,21 @@ struct Scale: AsyncParsableCommand, ComposeProjectCommand {
     }
 }
 
-/// Implements output-only `compose attach` through the runtime log stream.
+/// Implements `compose attach` through the runtime stream relay or log stream.
 struct Attach: AsyncParsableCommand, ComposeProjectCommand {
     static let configuration = CommandConfiguration(commandName: "attach", abstract: "Attach to a service container.")
     @OptionGroup var global: GlobalOptions
-    @Flag(name: .customLong("no-stdin"), help: "Do not attach stdin. Required for the supported output-only log attach path.")
+    @Flag(name: .customLong("no-stdin"), help: "Do not attach stdin.")
     var noStdin = false
-    @Option(name: .customLong("detach-keys"), help: "Override detach key sequence. Ignored with --no-stdin output-only attach.")
+    @Option(name: .customLong("detach-keys"), help: "Override detach key sequence. Ignored with --no-stdin output-only attach; interactive handling is not yet available.")
     var detachKeys: String?
     @Option(name: .customLong("index"), help: "Target service container index.")
     var index = 1
-    @Option(name: .customLong("sig-proxy"), help: "Proxy signals to the service process for output-only attach.")
+    @Option(name: .customLong("sig-proxy"), help: "Proxy signals to the service process (default true).")
     var sigProxy = "true"
     @Argument(help: "Service name.")
     var service: String
-    /// Streams the selected service container output.
+    /// Attaches to the selected service container.
     func run() async throws {
         let loadedProject = try await project()
         try await orchestrator().attach(

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -20029,6 +20029,51 @@ struct ComposeOrchestratorTests {
         #expect(emitted.messages == ["attached"])
     }
 
+    @Test("attach interactive mode invokes the runtime attach relay")
+    func attachInteractiveModeInvokesRuntimeAttachRelay() async throws {
+        let runner = RecordingRunner()
+        let logManager = RecordingContainerLogManager()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api"),
+            ]
+        )
+
+        try await ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(),
+            logManager: logManager
+        ).attach(
+            project: project,
+            serviceName: "api",
+            options: ComposeAttachOptions()
+        )
+
+        #expect(runner.commands.map(\.arguments) == [["container", "attach", "--sig-proxy=true", "demo-api-1"]])
+        #expect(runner.commands.map(\.io) == [.inherited])
+        #expect(await logManager.requests.isEmpty)
+    }
+
+    @Test("attach interactive mode forwards disabled signal proxy")
+    func attachInteractiveModeForwardsDisabledSignalProxy() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api"),
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).attach(
+            project: project,
+            serviceName: "api",
+            options: ComposeAttachOptions { $0.sigProxy = "false" }
+        )
+
+        #expect(runner.commands.map(\.arguments) == [["container", "attach", "--sig-proxy=false", "demo-api-1"]])
+    }
+
     @Test("attach output-only mode proxies received signals by default")
     func attachOutputOnlyModeProxiesReceivedSignalsByDefault() async throws {
         let emitted = MessageRecorder()
@@ -20212,25 +20257,21 @@ struct ComposeOrchestratorTests {
         #expect(await logManager.requests.isEmpty)
     }
 
-    @Test("attach reports apple/container runtime gap for interactive options")
-    func attachReportsAppleContainerRuntimeGapForInteractiveOptions() async throws {
+    @Test("attach rejects the remaining custom detach-key gap")
+    func attachRejectsRemainingCustomDetachKeyGap() async throws {
         let cases: [(options: ComposeAttachOptions, error: ComposeError)] = [
-            (
-                ComposeAttachOptions(),
-                .unsupported("attach: apple/container does not expose stdin/stdout/stderr reattach for already-running service containers; use --no-stdin for output-only logs")
-            ),
             (
                 ComposeAttachOptions {
                     $0.sigProxy = "false"
                     $0.detachKeys = "ctrl-x"
                 },
-                .unsupported("attach --detach-keys: apple/container does not expose detach-key handling for interactive attach")
+                .unsupported("attach --detach-keys: interactive stream reattachment is available, but detach-key handling is not yet available")
             ),
             (
                 ComposeAttachOptions {
-                    $0.sigProxy = "false"
+                    $0.detachKeys = ""
                 },
-                .unsupported("attach: apple/container does not expose stdin/stdout/stderr reattach for already-running service containers; use --no-stdin for output-only logs")
+                .unsupported("attach --detach-keys: interactive stream reattachment is available, but detach-key handling is not yet available")
             ),
             (
                 ComposeAttachOptions {

--- a/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
+++ b/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
@@ -474,7 +474,8 @@ struct ComposeCLIHelpTests {
 
         #expect(help.contains("Support: \u{001B}[38;5;208mpartially supported\u{001B}[0m"))
         #expect(help.contains("\u{001B}[38;5;208m--detach-keys\u{001B}[0m"))
-        #expect(help.contains("Ignored with --no-stdin output-only attach."))
+        #expect(help.contains("Interactive stream reattachment and signal proxy are supported"))
+        #expect(help.contains("Ignored with --no-stdin output-only attach; interactive handling is not yet available."))
         #expect(help.contains("\u{001B}[32m--index\u{001B}[0m"))
         #expect(help.contains("\u{001B}[32m--no-stdin\u{001B}[0m"))
         #expect(help.contains("\u{001B}[32m--sig-proxy\u{001B}[0m"))


### PR DESCRIPTION
## What changed

- Pins Compose to the published `container` attach relay and signal-proxy implementation.
- Routes default `compose attach` through inherited terminal I/O; retains persisted-log following for `--no-stdin`.
- Keeps `--detach-keys` visibly partial and rejects every interactive use until safe terminal-session disconnect support exists.

## Why

This closes the default interactive attach gap without overstating unsupported detach-key behaviour.

## Validation

- `make test` (968 Swift tests plus Go normalizer tests)
- `make lint`
- `/Users/sclarke/.local/bin/hawkeye check --fail-if-unknown`
- `git diff --check`