### PR TITLE
feat(attach): support custom detach keys

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d163f29daa055fc70cc10de293516e407fc966cfa0c059b989b63bdee95a2ffa",
+  "originHash" : "ed93bed0c99aedff422c387e8f508dff7d2a23524f6d1576df0145b146cda836",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "872fc44e959a7c4a35e265954b388fe273164b76"
+        "revision" : "c7c30f4a45d68bad46140d7c2b194a9beb6818a7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "872fc44e959a7c4a35e265954b388fe273164b76",
+            revision: "c7c30f4a45d68bad46140d7c2b194a9beb6818a7",
         ),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",

--- a/STATUS.md
+++ b/STATUS.md
@@ -35,8 +35,8 @@ Surface names follow the current Docker Docs [Compose file reference](https://do
 | Project discovery and source loading | ✅ Yes | Default local discovery, stdin, environment files, Git resources, and `oci://` project artifacts are implemented. Runtime-backed Compose file attributes are tracked separately below. |
 | Service attributes and runtime behavior | ⚠️ Partial | The complete grouped service surface is in [Service Attribute Surface](#service-attribute-surface), including details for every runtime-limited group. |
 | Dockerfile and build behavior | ⚠️ Partial | The complete instruction and Build Specification surface is in [Dockerfile And Build Surface](#dockerfile-and-build-surface); build-secret source and metadata shapes remain limited. |
-| CLI commands | ⚠️ Partial | 44 commands are ✅, 2 are ⚠️, and 0 are ❌. Every command is listed in [CLI Command Surface](#cli-command-surface). |
-| CLI long options | ⚠️ Partial | 260 documented long options are ✅, 3 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
+| CLI commands | ⚠️ Partial | 45 commands are ✅, 1 are ⚠️, and 0 are ❌. Every command is listed in [CLI Command Surface](#cli-command-surface). |
+| CLI long options | ⚠️ Partial | 261 documented long options are ✅, 2 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
 
 ## Compose File Surface
 
@@ -123,7 +123,7 @@ Docker Compose service attributes are grouped here by runtime behavior so every 
 | `alpha dry-run` | ✅ Yes | Experimental `alpha dry-run -- COMMAND` wraps the requested Compose command with root `--dry-run` while preserving project/global options. |
 | `alpha scale` | ✅ Yes | Experimental `alpha scale` is implemented as an alias for the stable `scale` command. |
 | `alpha watch` | ✅ Yes | Experimental `alpha watch` is implemented as an alias for the stable `watch` command. |
-| `attach` | ⚠️ Partial | Interactive init-process stream reattachment and `--sig-proxy` are implemented through the forked runtime primitive tracked by [apple/container#378](https://github.com/apple/container/issues/378); output-only attach continues to follow persisted logs. Custom `--detach-keys` remains the only command gap because a terminal session needs a cancellable wait path before it can safely disconnect without stopping the service. |
+| `attach` | ✅ Yes | Interactive init-process stream reattachment, `--sig-proxy`, and Docker-compatible `--detach-keys` are implemented through the forked runtime primitive tracked by [apple/container#378](https://github.com/apple/container/issues/378); output-only attach continues to follow persisted logs. |
 | `bridge` | ✅ Yes | The complete Compose Bridge CLI runtime is implemented for the `stephenlclarke` runtime lane. |
 | `bridge convert` | ✅ Yes | Models include image ports, published target ports, and text or binary config and secret content; Kubernetes, Helm, custom templates, repeated transformations, and empty-output current-directory mode run through local transformer images. |
 | `bridge transformations` | ✅ Yes | Bridge transformation image management is implemented. |
@@ -179,7 +179,7 @@ A ✅ option means the flag itself is parsed and mapped for the current command 
 | `alpha dry-run` options | ✅ Yes | ✅ `--dry-run`: accepted and implied for the wrapped command. |
 | `alpha scale` options | ✅ Yes | ✅ `--dry-run`, ✅ `--no-deps`. |
 | `alpha watch` options | ✅ Yes | ✅ `--dry-run`, ✅ `--no-up`, ✅ `--quiet`. |
-| `attach` options | ⚠️ Partial | ✅ `--dry-run`, ✅ `--index`, ✅ `--no-stdin`, ✅ `--sig-proxy`; ⚠️ `--detach-keys`: parsed and documented, ignored for output-only attach, and rejected for interactive attach until a safe terminal-session disconnect path exists. |
+| `attach` options | ✅ Yes | ✅ `--detach-keys`: forwarded to the interactive runtime stream relay and ignored for output-only attach, ✅ `--dry-run`, ✅ `--index`, ✅ `--no-stdin`, ✅ `--sig-proxy`. |
 | `bridge` options | ✅ Yes | ✅ `--dry-run`. |
 | `bridge convert` options | ✅ Yes | ✅ `--dry-run`, ✅ `--output`, ✅ `--templates`, ✅ `--transformation`. |
 | `bridge transformations` options | ✅ Yes | ✅ `--dry-run`. |
@@ -228,6 +228,6 @@ Released Apple `container` compatibility is not a supported-lane functionality g
 ## Remaining Gap Focus
 
 - There are no remaining red CLI command or long-option surfaces.
-- The remaining orange command surfaces are `attach` and `commit`; `attach` needs only safe custom detach-key handling over the existing interactive stream relay, while `commit --pause=false` needs a safe no-freeze writable-filesystem snapshot. Their table rows above describe the exact supported subset.
+- The remaining orange command surface is `commit`; `commit --pause=false` needs a safe no-freeze writable-filesystem snapshot. Its table row above describes the exact supported subset.
 - Runtime-primitive blockers include vendor/native GPU passthrough, multiple GPUs, arbitrary macOS hardware passthrough, external config/secret lookup, generic service endpoint `driver_opts`, and non-GPU Deploy device/generic reservations.
 - When touching slow runtime paths, keep first-frame progress rendering covered so local `container compose` runs do not appear to hang before visible output.

--- a/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
@@ -249,7 +249,11 @@ public extension ComposeOrchestrator {
         }
         let id = try await serviceContainerID(project: project, service: service, index: attach.index)
         if !attach.noStdin {
-            let arguments = ["attach", "--sig-proxy=\(proxySignals ? "true" : "false")", id]
+            var arguments = ["attach", "--sig-proxy=\(proxySignals ? "true" : "false")"]
+            if let detachKeys = attach.detachKeys, !detachKeys.isEmpty {
+                arguments.append("--detach-keys=\(detachKeys)")
+            }
+            arguments.append(id)
             try await runContainer(arguments, inheritedIO: true)
             return
         }

--- a/Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift
@@ -288,9 +288,6 @@ extension ComposeOrchestrator {
 
     /// Validates Compose attach client options before selecting its stream path.
     func validateAttachOptions(_ attach: ComposeAttachOptions) throws -> Bool {
-        if !attach.noStdin, attach.detachKeys != nil {
-            throw ComposeError.unsupported("attach --detach-keys: interactive stream reattachment is available, but detach-key handling is not yet available")
-        }
         let sigProxy = attach.sigProxy.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         switch sigProxy {
         case "true", "1", "yes":

--- a/Sources/ComposePlugin/ComposeCLIHelp.swift
+++ b/Sources/ComposePlugin/ComposeCLIHelp.swift
@@ -296,7 +296,7 @@ enum ComposeCLIHelp {
         "alpha dry-run": .supported,
         "alpha scale": .supported,
         "alpha watch": .supported,
-        "attach": .partiallySupported,
+        "attach": .supported,
         "bridge": .supported,
         "bridge convert": .supported,
         "bridge transformations": .supported,
@@ -341,7 +341,6 @@ enum ComposeCLIHelp {
     ]
 
     private static let supportDetailByCommand: [String: String] = [
-        "attach": "Interactive stream reattachment and signal proxy are supported; custom detach-key handling is pending terminal-session support.",
         "commit": "Stopped containers and running containers with default --pause=true can be committed; the running path uses a brief filesystem freeze. --pause=false remains unavailable because a writable filesystem cannot be exported safely without that freeze.",
     ]
 
@@ -376,7 +375,7 @@ enum ComposeCLIHelp {
             "--quiet": .supported,
         ],
         "attach": [
-            "--detach-keys": .partiallySupported,
+            "--detach-keys": .supported,
             "--dry-run": .supported,
             "--index": .supported,
             "--no-stdin": .supported,
@@ -1274,7 +1273,7 @@ enum ComposeCLIHelp {
         Attach local standard input, output, and error streams to a service's running container
 
         Options:
-              --detach-keys string   Override the key sequence for detaching from a container. Ignored with --no-stdin output-only attach; interactive handling is not yet available.
+              --detach-keys string   Override the key sequence for detaching from a container. Ignored with --no-stdin output-only attach.
               --dry-run              Execute command in dry run mode
               --index int            index of the container if service has multiple replicas.
               --no-stdin             Do not attach STDIN

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -1931,7 +1931,7 @@ struct Attach: AsyncParsableCommand, ComposeProjectCommand {
     @OptionGroup var global: GlobalOptions
     @Flag(name: .customLong("no-stdin"), help: "Do not attach stdin.")
     var noStdin = false
-    @Option(name: .customLong("detach-keys"), help: "Override detach key sequence. Ignored with --no-stdin output-only attach; interactive handling is not yet available.")
+    @Option(name: .customLong("detach-keys"), help: "Override detach key sequence. Ignored with --no-stdin output-only attach.")
     var detachKeys: String?
     @Option(name: .customLong("index"), help: "Target service container index.")
     var index = 1

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -5195,10 +5195,10 @@ struct ComposeOrchestratorTests {
 
         let buildCommands = runner.commands.map(\.arguments).filter { $0.starts(with: ["container", "build"]) }
         #expect(buildCommands.count == 2)
-        #expect(buildCommands[0].containsSequence(["--tag", "example/api"]))
-        #expect(buildCommands[0].last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("api").standardizedFileURL.path)
-        #expect(buildCommands[1].containsSequence(["--tag", "demo_worker:latest"]))
-        #expect(buildCommands[1].last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("worker").standardizedFileURL.path)
+        let apiCommand = try #require(buildCommands.first { $0.containsSequence(["--tag", "example/api"]) })
+        let workerCommand = try #require(buildCommands.first { $0.containsSequence(["--tag", "demo_worker:latest"]) })
+        #expect(apiCommand.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("api").standardizedFileURL.path)
+        #expect(workerCommand.last == URL(fileURLWithPath: project.workingDirectory, isDirectory: true).appendingPathComponent("worker").standardizedFileURL.path)
         #expect(await discoveryManager.getRequests == ["demo-api-1", "demo-worker-1"])
     }
 
@@ -20074,6 +20074,25 @@ struct ComposeOrchestratorTests {
         #expect(runner.commands.map(\.arguments) == [["container", "attach", "--sig-proxy=false", "demo-api-1"]])
     }
 
+    @Test("attach interactive mode forwards custom detach keys")
+    func attachInteractiveModeForwardsCustomDetachKeys() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": ComposeService(name: "api", image: "example/api"),
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner).attach(
+            project: project,
+            serviceName: "api",
+            options: ComposeAttachOptions { $0.detachKeys = "ctrl-x,x" }
+        )
+
+        #expect(runner.commands.map(\.arguments) == [["container", "attach", "--sig-proxy=true", "--detach-keys=ctrl-x,x", "demo-api-1"]])
+    }
+
     @Test("attach output-only mode proxies received signals by default")
     func attachOutputOnlyModeProxiesReceivedSignalsByDefault() async throws {
         let emitted = MessageRecorder()
@@ -20257,22 +20276,9 @@ struct ComposeOrchestratorTests {
         #expect(await logManager.requests.isEmpty)
     }
 
-    @Test("attach rejects the remaining custom detach-key gap")
-    func attachRejectsRemainingCustomDetachKeyGap() async throws {
+    @Test("attach validates signal-proxy before runtime commands")
+    func attachValidatesSignalProxyBeforeRuntimeCommands() async throws {
         let cases: [(options: ComposeAttachOptions, error: ComposeError)] = [
-            (
-                ComposeAttachOptions {
-                    $0.sigProxy = "false"
-                    $0.detachKeys = "ctrl-x"
-                },
-                .unsupported("attach --detach-keys: interactive stream reattachment is available, but detach-key handling is not yet available")
-            ),
-            (
-                ComposeAttachOptions {
-                    $0.detachKeys = ""
-                },
-                .unsupported("attach --detach-keys: interactive stream reattachment is available, but detach-key handling is not yet available")
-            ),
             (
                 ComposeAttachOptions {
                     $0.noStdin = true

--- a/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
+++ b/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
@@ -30,7 +30,7 @@ struct ComposeCLIHelpTests {
         #expect(help.contains("\u{001B}[32msupported\u{001B}[0m"))
         #expect(help.contains("\u{001B}[38;5;208mpartially supported\u{001B}[0m"))
         #expect(help.contains("\u{001B}[31mnot supported\u{001B}[0m"))
-        #expect(help.contains("\u{001B}[38;5;208mattach\u{001B}[0m"))
+        #expect(help.contains("\u{001B}[32mattach\u{001B}[0m"))
         #expect(help.contains("\u{001B}[32m--progress\u{001B}[0m"))
         #expect(help.contains("\u{001B}[32m--verbose\u{001B}[0m"))
     }
@@ -468,14 +468,13 @@ struct ComposeCLIHelpTests {
         #expect(help.contains("Use --sbom=false to explicitly disable."))
     }
 
-    @Test("attach signal proxy option is shown as supported")
-    func attachSignalProxyOptionIsShownAsSupported() throws {
+    @Test("attach options are shown as supported")
+    func attachOptionsAreShownAsSupported() throws {
         let help = try #require(ComposeCLIHelp.commandHelpText(command: "attach"))
 
-        #expect(help.contains("Support: \u{001B}[38;5;208mpartially supported\u{001B}[0m"))
-        #expect(help.contains("\u{001B}[38;5;208m--detach-keys\u{001B}[0m"))
-        #expect(help.contains("Interactive stream reattachment and signal proxy are supported"))
-        #expect(help.contains("Ignored with --no-stdin output-only attach; interactive handling is not yet available."))
+        #expect(help.contains("Support: \u{001B}[32msupported\u{001B}[0m"))
+        #expect(help.contains("\u{001B}[32m--detach-keys\u{001B}[0m"))
+        #expect(help.contains("Ignored with --no-stdin output-only attach."))
         #expect(help.contains("\u{001B}[32m--index\u{001B}[0m"))
         #expect(help.contains("\u{001B}[32m--no-stdin\u{001B}[0m"))
         #expect(help.contains("\u{001B}[32m--sig-proxy\u{001B}[0m"))


### PR DESCRIPTION
## Summary
- pin Compose to the detach-key runtime primitive in `stephenlclarke/container`
- forward non-empty `compose attach --detach-keys` values for interactive streams while retaining the default runtime sequence for an empty value
- mark attach and its option as supported in the rendered help and parity ledger
- remove an order-sensitive parallel-build assertion exposed during review

## Validation
- `make test` (969 Swift tests and Compose normalizer Go tests)
- `make lint`
- `hawkeye check --fail-if-unknown`
- `swift run compose attach --help`
- `git diff --check`