### PR TITLE
feat(commit): support no-freeze live snapshots

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ed93bed0c99aedff422c387e8f508dff7d2a23524f6d1576df0145b146cda836",
+  "originHash" : "1cceebd21ded3ab07082cb9b08ca64c682f92335210dfbb0cc8951ff311d6bb6",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "c7c30f4a45d68bad46140d7c2b194a9beb6818a7"
+        "revision" : "f526f1feb8c5cffbca7714a7d9be2e6f4e2f6c81"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "c7c30f4a45d68bad46140d7c2b194a9beb6818a7",
+            revision: "f526f1feb8c5cffbca7714a7d9be2e6f4e2f6c81",
         ),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",

--- a/STATUS.md
+++ b/STATUS.md
@@ -35,8 +35,8 @@ Surface names follow the current Docker Docs [Compose file reference](https://do
 | Project discovery and source loading | ✅ Yes | Default local discovery, stdin, environment files, Git resources, and `oci://` project artifacts are implemented. Runtime-backed Compose file attributes are tracked separately below. |
 | Service attributes and runtime behavior | ⚠️ Partial | The complete grouped service surface is in [Service Attribute Surface](#service-attribute-surface), including details for every runtime-limited group. |
 | Dockerfile and build behavior | ⚠️ Partial | The complete instruction and Build Specification surface is in [Dockerfile And Build Surface](#dockerfile-and-build-surface); build-secret source and metadata shapes remain limited. |
-| CLI commands | ⚠️ Partial | 45 commands are ✅, 1 are ⚠️, and 0 are ❌. Every command is listed in [CLI Command Surface](#cli-command-surface). |
-| CLI long options | ⚠️ Partial | 261 documented long options are ✅, 2 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
+| CLI commands | ✅ Yes | 46 commands are ✅, 0 are ⚠️, and 0 are ❌. Every command is listed in [CLI Command Surface](#cli-command-surface). |
+| CLI long options | ✅ Yes | 262 documented long options are ✅, 1 are ⚠️, and 0 are ❌. Every option is listed in [CLI Option Surface](#cli-option-surface). |
 
 ## Compose File Surface
 
@@ -131,7 +131,7 @@ Docker Compose service attributes are grouped here by runtime behavior so every 
 | `bridge transformations list` | ✅ Yes | Local transformer images labelled `com.docker.compose.bridge=transformation` are listed in Docker-shaped table, JSON, and quiet modes. |
 | `bridge transformations ls` | ✅ Yes | Alias for `bridge transformations list`. |
 | `build` | ✅ Yes | Dockerfile/build parity is implemented for the supported build surface above. |
-| `commit` | ⚠️ Partial | Stopped service containers and running containers with the default `--pause=true` commit to OCI images through export, archive creation, and image load. The generated image preserves Docker `Healthcheck` metadata and effective Compose healthcheck overrides. The running path uses the generic live-export snapshot in the pinned `stephenlclarke/container` fork, which briefly freezes the root filesystem rather than pausing all processes. `--pause=false` remains unavailable because the backend cannot safely export a writable filesystem without that freeze. Omitted `--index` and `--index=0` use Docker Compose's default service-container selection. |
+| `commit` | ✅ Yes | Stopped service containers and running containers commit to OCI images through export, archive creation, and image load. The generated image preserves Docker `Healthcheck` metadata and effective Compose healthcheck overrides. The default `--pause=true` running path briefly freezes the root filesystem; `--pause=false` uses the generic best-effort APFS copy-on-write snapshot in the pinned `stephenlclarke/container` fork and leaves the filesystem writable. Omitted `--index` and `--index=0` use Docker Compose's default service-container selection. |
 | `config` | ✅ Yes | Compose project rendering and config query options are implemented. |
 | `convert` | ✅ Yes | Docker Compose's config-compatible model conversion projections are implemented for the documented local output modes. |
 | `cp` | ✅ Yes | Local-to-service, service-to-local, service-to-service, stdin tar archive, and stdout tar archive copies are implemented, including archive, follow-link, replica-index, and one-off-container modes. |
@@ -187,7 +187,7 @@ A ✅ option means the flag itself is parsed and mapped for the current command 
 | `bridge transformations list` options | ✅ Yes | ✅ `--dry-run`, ✅ `--format`, ✅ `--quiet`. |
 | `bridge transformations ls` options | ✅ Yes | ✅ `--dry-run`, ✅ `--format`, ✅ `--quiet`. |
 | `build` options | ✅ Yes | ✅ `--build-arg`, ✅ `--builder`, ✅ `--check`, ✅ `--dry-run`, ✅ `--memory`, ✅ `--no-cache`, ✅ `--print`, ✅ `--provenance`, ✅ `--pull`, ✅ `--push`, ✅ `--quiet`, ✅ `--sbom`, ✅ `--ssh`, ✅ `--with-dependencies`. |
-| `commit` options | ⚠️ Partial | ✅ `--author`, ✅ `--change`, ✅ `--dry-run`, ✅ `--index`, ✅ `--message`, ⚠️ `--pause`: the default uses a brief filesystem-consistent live snapshot for running containers; `--pause=false` is unavailable. |
+| `commit` options | ✅ Yes | ✅ `--author`, ✅ `--change`, ✅ `--dry-run`, ✅ `--index`, ✅ `--message`, ✅ `--pause`: the default uses a brief filesystem-consistent live snapshot for running containers; `--pause=false` uses a best-effort no-freeze snapshot. |
 | `config` options | ✅ Yes | ✅ `--dry-run`, ✅ `--environment`, ✅ `--format`, ✅ `--hash`, ✅ `--images`, ✅ `--lock-image-digests`, ✅ `--models`, ✅ `--networks`, ✅ `--no-consistency`, ✅ `--no-env-resolution`, ✅ `--no-interpolate`, ✅ `--no-normalize`, ✅ `--no-path-resolution`, ✅ `--output`, ✅ `--profiles`, ✅ `--quiet`, ✅ `--resolve-image-digests`, ✅ `--services`, ✅ `--variables`, ✅ `--volumes`. |
 | `convert` options | ✅ Yes | ✅ `--dry-run`, ✅ `--format`, ✅ `--hash`, ✅ `--images`, ✅ `--no-consistency`, ✅ `--no-interpolate`, ✅ `--no-normalize`, ✅ `--output`, ✅ `--profiles`, ✅ `--quiet`, ✅ `--resolve-image-digests`, ✅ `--services`, ✅ `--volumes`. |
 | `cp` options | ✅ Yes | ✅ `--all`, ✅ `--archive`, ✅ `--dry-run`, ✅ `--follow-link`, ✅ `--index`. |
@@ -227,7 +227,6 @@ Released Apple `container` compatibility is not a supported-lane functionality g
 
 ## Remaining Gap Focus
 
-- There are no remaining red CLI command or long-option surfaces.
-- The remaining orange command surface is `commit`; `commit --pause=false` needs a safe no-freeze writable-filesystem snapshot. Its table row above describes the exact supported subset.
+- All documented CLI commands are green. The `run --use-aliases` long option remains partial pending container-facing DNS support.
 - Runtime-primitive blockers include vendor/native GPU passthrough, multiple GPUs, arbitrary macOS hardware passthrough, external config/secret lookup, generic service endpoint `driver_opts`, and non-GPU Deploy device/generic reservations.
 - When touching slow runtime paths, keep first-frame progress rendering covered so local `container compose` runs do not appear to hang before visible output.

--- a/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
@@ -41,8 +41,10 @@ public extension ComposeOrchestrator {
         try await exporter.exportContainer(id: containerID, output: export.output, live: live)
     }
 
-    /// Creates an image from a service container filesystem, taking a brief
-    /// filesystem-consistent snapshot when the selected container is running.
+    /// Creates an image from a service container filesystem.
+    ///
+    /// Running containers use a filesystem-consistent snapshot by default;
+    /// `--pause=false` takes a best-effort no-freeze snapshot instead.
     func commit(
         project: ComposeProject,
         serviceName: String,
@@ -72,7 +74,23 @@ public extension ComposeOrchestrator {
         guard let container = try await discoveryManager.getContainer(id: containerID) else {
             throw ComposeError.invalidProject("service '\(service.name)' container '\(containerID)' does not exist")
         }
-        let live = try commitUsesLiveExport(container, service: service, pause: commit.pause)
+        try await writeCommitImage(
+            project: project,
+            service: service,
+            options: commit,
+            container: container,
+        )
+    }
+
+    /// Exports a container root filesystem and writes it as a Compose image archive.
+    func writeCommitImage(
+        project: ComposeProject,
+        service: ComposeService,
+        options commit: ComposeCommitOptions,
+        container: ComposeContainerSummary,
+    ) async throws {
+        let live = try commitUsesLiveExport(container, service: service)
+        let noFreeze = live && !commit.pause
         let baseImageMetadata = await commitBaseImageMetadata(project: project, service: service)
         let healthCheck = try commitImageHealthCheck(
             service: service,
@@ -90,7 +108,12 @@ public extension ComposeOrchestrator {
 
         let rootfs = tempDirectory.appendingPathComponent("rootfs.tar")
         let archive = tempDirectory.appendingPathComponent("image.tar")
-        try await exporter.exportContainer(id: containerID, output: rootfs.path, live: live)
+        try await exporter.exportContainer(
+            id: container.id,
+            output: rootfs.path,
+            live: live,
+            noFreeze: noFreeze,
+        )
         try ComposeCommitImageArchive.write(
             rootfsArchive: rootfs,
             output: archive,
@@ -183,21 +206,15 @@ public extension ComposeOrchestrator {
         return args
     }
 
-    /// Chooses a stopped-rootfs export or a consistent snapshot for a running service.
+    /// Chooses a stopped-rootfs export or a live snapshot for a running service.
     func commitUsesLiveExport(
         _ container: ComposeContainerSummary,
         service: ComposeService,
-        pause: Bool,
     ) throws -> Bool {
         switch container.status.lowercased() {
         case "created", "dead", "exited", "stopped":
             return false
         case "running":
-            guard pause else {
-                throw ComposeError.unsupported(
-                    "commit: service '\(service.name)' container '\(container.id)' is running; --pause=false is unavailable because the runtime cannot safely export a writable filesystem without a brief filesystem freeze. Omit --pause=false (the default takes a filesystem-consistent live snapshot) or stop the service container before committing.",
-                )
-            }
             return true
         default:
             throw ComposeError.unsupported(

--- a/Sources/ComposeCore/ContainerFilesystemAdapter.swift
+++ b/Sources/ComposeCore/ContainerFilesystemAdapter.swift
@@ -187,9 +187,17 @@ extension ContainerCopying {
 /// Direct apple/container API used for service container filesystem exports.
 public protocol ContainerExporting: Sendable {
     /// Exports `id` as a tar archive to `output`, or streams the archive to
-    /// stdout when `output` is nil. `live` asks the runtime to take a
-    /// filesystem-consistent snapshot of a running container.
-    func exportContainer(id: String, output: String?, live: Bool) async throws
+    /// stdout when `output` is nil. `live` asks the runtime to take a snapshot
+    /// of a running container. `noFreeze` opts into a best-effort snapshot that
+    /// leaves the guest filesystem writable.
+    func exportContainer(id: String, output: String?, live: Bool, noFreeze: Bool) async throws
+}
+
+public extension ContainerExporting {
+    /// Exports a container with the runtime's default snapshot behavior.
+    func exportContainer(id: String, output: String?, live: Bool) async throws {
+        try await exportContainer(id: id, output: output, live: live, noFreeze: false)
+    }
 }
 
 /// `ContainerClient`-backed copier for real service container file copies.
@@ -303,8 +311,8 @@ public struct ContainerClientExporter: ContainerExporting {
         _ = Self.isStateless
     }
 
-    /// Exports through `ContainerClient.export(id:archive:live:)`.
-    public func exportContainer(id: String, output: String?, live: Bool) async throws {
+    /// Exports through `ContainerClient.export(id:archive:live:noFreeze:)`.
+    public func exportContainer(id: String, output: String?, live: Bool, noFreeze: Bool) async throws {
         let client = ContainerClient()
         let tempDirectory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
@@ -313,7 +321,7 @@ public struct ContainerClientExporter: ContainerExporting {
         }
 
         let archive = tempDirectory.appendingPathComponent("archive.tar")
-        try await client.export(id: id, archive: archive, live: live)
+        try await client.export(id: id, archive: archive, live: live, noFreeze: noFreeze)
 
         if let output {
             try FileManager.default.moveItem(at: archive, to: Self.outputURL(output))

--- a/Sources/ComposePlugin/ComposeCLIHelp.swift
+++ b/Sources/ComposePlugin/ComposeCLIHelp.swift
@@ -86,7 +86,7 @@ enum ComposeCLIHelp {
                     commandPath: commandPath(from: key),
                     support: support.label,
                     color: support.color,
-                    detail: supportDetailByCommand[key]
+                    detail: nil
                 )
             }
             .sorted { $0.commandPath.lexicographicallyPrecedes($1.commandPath) }
@@ -304,7 +304,7 @@ enum ComposeCLIHelp {
         "bridge transformations list": .supported,
         "bridge transformations ls": .supported,
         "build": .supported,
-        "commit": .partiallySupported,
+        "commit": .supported,
         "config": .supported,
         "convert": .supported,
         "cp": .supported,
@@ -338,10 +338,6 @@ enum ComposeCLIHelp {
         "volumes": .supported,
         "wait": .supported,
         "watch": .supported,
-    ]
-
-    private static let supportDetailByCommand: [String: String] = [
-        "commit": "Stopped containers and running containers with default --pause=true can be committed; the running path uses a brief filesystem freeze. --pause=false remains unavailable because a writable filesystem cannot be exported safely without that freeze.",
     ]
 
     private static let supportByOption: [String: [String: SupportLevel]] = [
@@ -429,7 +425,7 @@ enum ComposeCLIHelp {
             "--dry-run": .supported,
             "--index": .supported,
             "--message": .supported,
-            "--pause": .partiallySupported,
+            "--pause": .supported,
         ],
         "config": [
             "--dry-run": .supported,
@@ -726,7 +722,7 @@ enum ComposeCLIHelp {
             rendered = insertSupportLine(
                 into: rendered,
                 support: support,
-                detail: supportDetailByCommand[commandPath.joined(separator: " ")],
+                detail: nil,
                 useANSI: useANSI
             )
         }
@@ -1311,7 +1307,7 @@ enum ComposeCLIHelp {
               --dry-run          Execute command in dry run mode
               --index int        index of the container if service has multiple replicas.
           -m, --message string   Commit message
-          -p, --pause            Use a filesystem-consistent snapshot for a running container (default true). This briefly freezes its filesystem; --pause=false is unavailable.
+          -p, --pause            Use a filesystem-consistent snapshot for a running container (default true). Set --pause=false for a best-effort snapshot without freezing its filesystem.
         """,
         "config": """
         Usage:  container compose config [OPTIONS] [SERVICE...]

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -1955,7 +1955,7 @@ struct Attach: AsyncParsableCommand, ComposeProjectCommand {
     }
 }
 
-/// Implements `compose commit` for stopped containers and default live snapshots.
+/// Implements `compose commit` for stopped containers and live snapshots.
 struct Commit: AsyncParsableCommand, ComposeProjectCommand {
     static let configuration = CommandConfiguration(commandName: "commit", abstract: "Create an image from a service container.")
     @OptionGroup var global: GlobalOptions
@@ -1970,7 +1970,7 @@ struct Commit: AsyncParsableCommand, ComposeProjectCommand {
     @Flag(
         name: .customLong("pause"),
         inversion: .prefixedNo,
-        help: "Use a filesystem-consistent snapshot for a running container. --pause=false is unavailable because it cannot safely export a writable filesystem."
+        help: "Use a filesystem-consistent snapshot for a running container (default true). Set --pause=false for a best-effort snapshot without freezing its filesystem."
     )
     var pause = true
     @Argument(help: "Service name.")

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTests.swift
@@ -21572,6 +21572,7 @@ struct ComposeOrchestratorTests {
         #expect(exports.first?.id == "demo-api-1")
         #expect(exports.first?.output?.hasSuffix("/rootfs.tar") == true)
         #expect(exports.first?.live == true)
+        #expect(exports.first?.noFreeze == false)
         let imageRequests = await imageManager.requests
         #expect(imageRequests.count == 2)
         #expect(imageRequests.first == .metadata("example/api"))
@@ -21582,8 +21583,8 @@ struct ComposeOrchestratorTests {
         }
     }
 
-    @Test("commit rejects running service containers when pause is disabled")
-    func commitRejectsRunningServiceContainersWhenPauseIsDisabled() async throws {
+    @Test("commit takes a no-freeze live snapshot when pause is disabled")
+    func commitTakesNoFreezeLiveSnapshotWhenPauseIsDisabled() async throws {
         let exporter = RecordingContainerExporter(archiveData: try rootfsArchiveData())
         let imageManager = RecordingContainerImageManager()
         let discoveryManager = RecordingContainerDiscoveryManager(containers: [
@@ -21601,21 +21602,19 @@ struct ComposeOrchestratorTests {
             $0.imageManager = imageManager
         })
 
-        do {
-            try await orchestrator.commit(project: project, serviceName: "api", options: ComposeCommitOptions {
-                $0.pause = false
-            })
-            Issue.record("Expected running commit with --pause=false to fail")
-        } catch let error as ComposeError {
-            #expect(error == .unsupported("commit: service 'api' container 'demo-api-1' is running; --pause=false is unavailable because the runtime cannot safely export a writable filesystem without a brief filesystem freeze. Omit --pause=false (the default takes a filesystem-consistent live snapshot) or stop the service container before committing."))
-        } catch {
-            Issue.record("Unexpected error: \(error)")
-        }
+        try await orchestrator.commit(project: project, serviceName: "api", options: ComposeCommitOptions {
+            $0.pause = false
+        })
 
         #expect(await discoveryManager.listRequests == [true])
         #expect(await discoveryManager.getRequests == ["demo-api-1"])
-        #expect(await exporter.requests.isEmpty)
-        #expect(await imageManager.requests.isEmpty)
+        let exports = await exporter.requests
+        #expect(exports.count == 1)
+        #expect(exports.first?.id == "demo-api-1")
+        #expect(exports.first?.output?.hasSuffix("/rootfs.tar") == true)
+        #expect(exports.first?.live == true)
+        #expect(exports.first?.noFreeze == true)
+        #expect((await imageManager.requests).count == 2)
     }
 
     @Test("commit image archive applies Docker change instructions")
@@ -26557,6 +26556,7 @@ private struct ContainerExportRequest: Equatable {
     var id: String
     var output: String?
     var live: Bool = false
+    var noFreeze: Bool = false
 }
 
 private enum ContainerCopyRequest: Equatable {
@@ -28286,8 +28286,8 @@ private actor RecordingContainerExporter: ContainerExporting {
         storage
     }
 
-    func exportContainer(id: String, output: String?, live: Bool) async throws {
-        storage.append(ContainerExportRequest(id: id, output: output, live: live))
+    func exportContainer(id: String, output: String?, live: Bool, noFreeze: Bool) async throws {
+        storage.append(ContainerExportRequest(id: id, output: output, live: live, noFreeze: noFreeze))
         if let failure {
             throw failure
         }

--- a/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
+++ b/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
@@ -95,33 +95,16 @@ struct ComposeCLIHelpTests {
         }
     }
 
-    @Test("partially supported commands explain their remaining gap")
-    func partiallySupportedCommandsExplainTheirRemainingGap() throws {
+    @Test("all command support entries are fully supported")
+    func allCommandSupportEntriesAreFullySupported() throws {
         let partialCommands = ComposeCLIHelp.commandSupportSnapshots
             .filter { $0.support == "partially supported" }
-
-        for command in partialCommands {
-            let detail = try #require(command.detail)
-            let help = try #require(ComposeCLIHelp.helpText(commandPath: command.commandPath))
-
-            #expect(!detail.isEmpty)
-            #expect(help.contains("Limitations: \(detail)"))
-        }
-    }
-
-    @Test("partial commands expose command-level parity limitations")
-    func partialCommandsExposeCommandLevelParityLimitations() throws {
         let commitHelp = try #require(ComposeCLIHelp.commandHelpText(command: "commit"))
-        let copyHelp = try #require(ComposeCLIHelp.commandHelpText(command: "cp"))
-        let publishHelp = try #require(ComposeCLIHelp.commandHelpText(command: "publish"))
 
-        #expect(commitHelp.contains("Support: \u{001B}[38;5;208mpartially supported\u{001B}[0m"))
-        #expect(commitHelp.contains("running containers with default --pause=true can be committed"))
-        #expect(commitHelp.contains("\u{001B}[38;5;208m--pause\u{001B}[0m"))
-        #expect(copyHelp.contains("Support: \u{001B}[32msupported\u{001B}[0m"))
-        #expect(!copyHelp.contains("Limitations:"))
-        #expect(publishHelp.contains("Support: \u{001B}[32msupported\u{001B}[0m"))
-        #expect(!publishHelp.contains("Limitations:"))
+        #expect(partialCommands.isEmpty)
+        #expect(commitHelp.contains("Support: \u{001B}[32msupported\u{001B}[0m"))
+        #expect(commitHelp.contains("best-effort snapshot"))
+        #expect(commitHelp.contains("\u{001B}[32m--pause\u{001B}[0m"))
     }
 
     @Test("every documented command option is covered by a parse representative")
@@ -1203,6 +1186,9 @@ struct ComposeCLIHelpTests {
                 #expect(command.pause)
                 #expect(command.service == "api")
                 #expect(command.reference == "example/api:snapshot")
+
+                let noPause = try Commit.parse(["--no-pause", "api"])
+                #expect(!noPause.pause)
             }),
             (["config"], [
                 "--dry-run", "--environment", "--format", "--hash", "--images", "--lock-image-digests", "--models", "--networks",

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "8189ee401dbd50d72935729625de4e1ed883a4f0",
+      "ref": "f526f1feb8c5cffbca7714a7d9be2e6f4e2f6c81",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

- pin the Compose runtime to the forked container no-freeze live-snapshot API
- support `compose commit --pause=false` for running services using a best-effort APFS copy-on-write snapshot
- mark the complete commit surface supported while retaining the separate `run --use-aliases` DNS limitation
- update checked-in stack release metadata to the matched container commit

## Validation

- `make test` (968 Swift tests across 17 suites plus Go tests)
- `make lint`
- `make stack-consistency`
- `swiftformat --lint --swift-version 6.2` on changed Swift files
- `swiftlint lint --strict --quiet` on changed Swift files
- `markdownlint STATUS.md`
- `hawkeye check --fail-if-unknown`
- rendered `container compose commit --help`

The matching Apple-shaped fork PR was merged only to `stephenlclarke/container`; no Apple remote was modified.