### PR TITLE
chore(release): promote 0.10.0 source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ DOCS_OUTPUT_DIR ?= _site
 DOCS_SERVER_DIR ?= _serve
 DOCS_HOSTING_BASE_PATH ?= container-compose
 DOCS_SCRATCH_PATH ?= .build/docc
-COMPOSE_VERSION ?= 0.9.0
+COMPOSE_VERSION ?= 0.10.0
 CONTAINER_COMPOSE_SOURCE ?= $(shell $(PYTHON) -c 'import subprocess; result = subprocess.run(["git", "remote", "get-url", "origin"], capture_output=True, text=True); url = result.stdout.strip() if result.returncode == 0 else ""; url = url[len("git@github.com:"):] if url.startswith("git@github.com:") else url; url = url[len("https://github.com/"):] if url.startswith("https://github.com/") else url; url = url[:-4] if url.endswith(".git") else url; print(url)')
 CONTAINER_COMPOSE_BRANCH ?= $(shell git branch --show-current 2>/dev/null || git rev-parse --short HEAD)
 CONTAINER_COMPOSE_LANE ?= $(shell $(PYTHON) -c 'branch = "$(CONTAINER_COMPOSE_BRANCH)"; print("main" if branch == "main" else "release" if branch == "release" or branch.startswith("release-") else "detached" if branch in ("", "HEAD") else "development")')
@@ -356,14 +356,14 @@ cli-smoke-built:
 	.build/debug/compose --ansi never version >/dev/null
 	.build/debug/compose version --dry-run >/dev/null
 	version_short_output="$$(".build/debug/compose" version --short)"; \
-	[[ "$$version_short_output" == "0.9.0" ]]; \
+	[[ "$$version_short_output" == "0.10.0" ]]; \
 	version_pretty_output="$$(".build/debug/compose" version)"; \
-	[[ "$$version_pretty_output" == *"container-compose 0.9.0"* ]]; \
+	[[ "$$version_pretty_output" == *"container-compose 0.10.0"* ]]; \
 	[[ "$$version_pretty_output" == *"container:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"containerization:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"compose-go: $(COMPOSE_GO_VERSION)"* ]]; \
 	version_json_output="$$(".build/debug/compose" version --format json)"; \
-	[[ "$$version_json_output" == *'"version":"0.9.0"'* ]]; \
+	[[ "$$version_json_output" == *'"version":"0.10.0"'* ]]; \
 	[[ "$$version_json_output" == *'"containerSource":"stephenlclarke/container"'* ]]; \
 	[[ "$$version_json_output" == *'"containerRef":"$(CONTAINER_REF)"'* ]]; \
 	[[ "$$version_json_output" == *'"containerDistribution":"custom"'* ]]; \
@@ -371,16 +371,16 @@ cli-smoke-built:
 	[[ "$$version_json_output" == *'"containerizationDistribution":"custom"'* ]]; \
 	[[ "$$version_json_output" == *'"composeGoVersion":"$(COMPOSE_GO_VERSION)"'* ]]; \
 	version_short_format_output="$$(".build/debug/compose" version -f json)"; \
-	[[ "$$version_short_format_output" == *'"version":"0.9.0"'* ]]; \
+	[[ "$$version_short_format_output" == *'"version":"0.10.0"'* ]]; \
 	version_compact_format_output="$$(".build/debug/compose" version -fjson)"; \
-	[[ "$$version_compact_format_output" == *'"version":"0.9.0"'* ]]; \
+	[[ "$$version_compact_format_output" == *'"version":"0.10.0"'* ]]; \
 	package_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$package_tmp"' EXIT; \
 	mkdir -p "$$package_tmp/compose/bin" "$$package_tmp/compose/resources" "$$package_tmp/bin"; \
 	cp .build/debug/compose "$$package_tmp/compose/bin/compose"; \
 	cp "$(PLUGIN_ICON)" "$$package_tmp/compose/resources/container-compose-icon.png"; \
 	test -f "$$package_tmp/compose/resources/container-compose-icon.png"; \
-	printf '%s\n' '{"version":"0.9.0","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
+	printf '%s\n' '{"version":"0.10.0","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
 	ln -s ../compose/bin/compose "$$package_tmp/bin/container-compose"; \
 	packaged_version_output="$$(cd /tmp && "$$package_tmp/bin/container-compose" version --format json)"; \
 	[[ "$$packaged_version_output" == *'"branch":"symlink-smoke"'* ]]; \
@@ -404,7 +404,7 @@ cli-smoke-built:
 	[[ "$$compat_output" == *"https://github.com/stephenlclarke/container-compose/blob/main/INSTALL.md"* ]]; \
 	service_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$service_tmp"' EXIT; \
-	printf '%s\n' '{"version":"0.9.0","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
+	printf '%s\n' '{"version":"0.10.0","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
 	printf '%s\n' '#!/usr/bin/env bash' 'if [[ "$$*" == "system version --format json" ]]; then' '  printf '\''[{"appName":"container","buildType":"release","commit":"matched-container","containerization":"stephenlclarke/containerization@matched-containerization","distribution":"custom","source":"stephenlclarke/container","version":"homebrew-main"}]\n'\''' '  exit 0' 'fi' 'if [[ "$$*" == "system status" ]]; then' '  printf '\''apiserver is not running and not registered with launchd\n'\'' >&2' '  exit 1' 'fi' 'exit 2' > "$$service_tmp/container"; \
 	chmod +x "$$service_tmp/container"; \
 	set +e; \
@@ -637,7 +637,7 @@ cli-smoke-built:
 	printf 'services:\n  api:\n    image: alpine\n    build:\n      context: ./api\n    volumes:\n      - ./src:/src\n' > "$$tmpdir/relative-paths.yml"; \
 	printf 'services:\n  api:\n    image: alpine\n    depends_on:\n      - missing\n' > "$$tmpdir/missing-dependency.yml"; \
 	version_compact_global_output="$$(".build/debug/compose" -pcompact -f"$$tmpdir/compose.yml" version --short)"; \
-	[[ "$$version_compact_global_output" == "0.9.0" ]]; \
+	[[ "$$version_compact_global_output" == "0.10.0" ]]; \
 	config_output="$$(".build/debug/compose" -f "$$tmpdir/compose.yml" config)"; \
 	[[ "$$config_output" == *"name: \"demo\""* ]]; \
 	[[ "$$config_output" == *"services:"* ]]; \

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -29,7 +29,7 @@ private let composePluginVersionNumber = composeBuildInfo.version
 private let composePluginVersionString = "container-compose \(composePluginVersionNumber)"
 
 private struct ComposeBuildInfo: Codable {
-    var version: String = "0.9.0"
+    var version: String = "0.10.0"
     var source: String = "unspecified"
     var branch: String = "unspecified"
     var lane: String = "unspecified"
@@ -104,7 +104,7 @@ private struct ComposeBuildInfo: Codable {
         let root = git(["rev-parse", "--show-toplevel"]) ?? FileManager.default.currentDirectoryPath
         let branch = git(["branch", "--show-current"], root: root) ?? "unspecified"
         return ComposeBuildInfo(
-            version: "0.9.0",
+            version: "0.10.0",
             source: remoteSource(root: root),
             branch: branch,
             lane: lane(for: branch),


### PR DESCRIPTION
Promotes the container-compose source candidate for 0.10.0.

Validation:
- The hosted Stable Release Gate must pass before stable package publication.
- The promoted main tree must match this candidate before tagging.
- Apple upstream remotes remain read-only; only stephenlclarke-owned remotes are push targets.

Candidate:
- container-compose: aa8313a07fbefed6ced7ef1e44e8bc6b435a0f44