### PR TITLE
refactor(build): resolve Phase 5 Sonar findings

### DIFF
--- a/Sources/ComposeCore/ComposeOrchestratorBuildSecrets.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorBuildSecrets.swift
@@ -89,8 +89,7 @@ extension ComposeOrchestrator {
             var materialized: [ComposeBuildSecret] = []
             for (index, item) in resolved.enumerated() {
                 let secret = item.secret
-                switch item.source {
-                case let .external(name):
+                if case let .external(name) = item.source {
                     let contents: Data
                     do {
                         contents = try await secretReader.readSecret(name: name)
@@ -107,7 +106,7 @@ extension ComposeOrchestrator {
                         permissions: 0o400,
                     ).write()
                     materialized.append(ComposeBuildSecret(id: secret.id, file: file.path))
-                default:
+                } else {
                     materialized.append(normalizedBuildSecret(secret, source: item.source))
                 }
             }
@@ -134,15 +133,13 @@ extension ComposeOrchestrator {
             .appendingPathComponent("dry-run", isDirectory: true)
         return ComposeMaterializedBuildSecrets(
             secrets: resolved.enumerated().map { index, item in
-                switch item.source {
-                case .external:
-                    ComposeBuildSecret(
+                if case .external = item.source {
+                    return ComposeBuildSecret(
                         id: item.secret.id,
                         file: directory.appendingPathComponent("secret-\(index)").path,
                     )
-                default:
-                    normalizedBuildSecret(item.secret, source: item.source)
                 }
+                return normalizedBuildSecret(item.secret, source: item.source)
             },
             directory: nil,
         )

--- a/docs/upstream/container-compose/ISSUE-sonarqube-phase5-cleanup.md
+++ b/docs/upstream/container-compose/ISSUE-sonarqube-phase5-cleanup.md
@@ -1,0 +1,41 @@
+# Resolve the Phase 5 SonarQube findings
+
+## Problem
+
+The exact `main` SonarCloud analysis for Phase 5 release-control commit
+`caa6ce5b595073521c03ab7ae0abc87a84e6e257` passed its quality gate, but
+reported two open `swift:S1301` maintainability findings in
+`ComposeOrchestratorBuildSecrets.swift`. Both findings identify a `switch`
+whose only specialized branch handles an external build secret and whose
+fallback handles every non-external source.
+
+The branches are already owned by the Compose layer and have complete behavior
+coverage for live materialization, file and environment fallback, failed-build
+cleanup, and dry-run projection. No Apple runtime primitive or fork change is
+needed.
+
+## Acceptance criteria
+
+- Replace each single-case `switch` with a behavior-equivalent conditional.
+- Keep external secret bytes invocation-private and preserve `0400`
+  permissions, cleanup, dry-run behavior, and normalized non-external sources.
+- Keep the change in `ComposeCore`; do not change a public model, SPI, runtime
+  fork, or command-line surface.
+- Pass the focused external-build-secret tests and the complete local quality
+  gate.
+- Pass exact-revision hosted CI, CodeQL, and SonarCloud with no unresolved
+  Sonar issues.
+- Publish and verify the exact-revision Current prerelease before Phase 6.
+
+## Implementation
+
+Signed commit `d6318ec967a4a01c014f7542eabeb11fade18cb8`
+(`refactor(build): simplify external secret branches`) contains the two
+Compose-only refactors. The paired pull-request handoff records the code map,
+tests, and post-merge evidence.
+
+## Compatibility
+
+This is a source-equivalent maintainability refactor. The Docker Compose v2
+external-build-secret parity contract and the stable `0.10.0` release remain
+unchanged. No Apple-facing pull request is required.

--- a/docs/upstream/container-compose/PR-sonarqube-phase5-cleanup.md
+++ b/docs/upstream/container-compose/PR-sonarqube-phase5-cleanup.md
@@ -7,6 +7,8 @@ SonarCloud with equivalent pattern-matching conditionals. The code remains
 entirely in the Compose layer, preserves every secret-lifetime invariant, and
 does not require an Apple runtime change.
 
+Review: [stephenlclarke/container-compose#146](https://github.com/stephenlclarke/container-compose/pull/146)
+
 ## Constructible commit
 
 - `d6318ec967a4a01c014f7542eabeb11fade18cb8`

--- a/docs/upstream/container-compose/PR-sonarqube-phase5-cleanup.md
+++ b/docs/upstream/container-compose/PR-sonarqube-phase5-cleanup.md
@@ -1,0 +1,62 @@
+# Pull request: resolve the Phase 5 SonarQube findings
+
+## Summary
+
+Replace the two single-case external-build-secret switches reported by
+SonarCloud with equivalent pattern-matching conditionals. The code remains
+entirely in the Compose layer, preserves every secret-lifetime invariant, and
+does not require an Apple runtime change.
+
+## Constructible commit
+
+- `d6318ec967a4a01c014f7542eabeb11fade18cb8`
+  `refactor(build): simplify external secret branches`
+
+The implementation commit is signed and independently constructible. This
+documentation commit is intentionally separate.
+
+## Code map
+
+- `Sources/ComposeCore/ComposeOrchestratorBuildSecrets.swift`
+  - uses `if case let .external` while materializing live build secrets;
+  - uses `if case .external` while projecting dry-run paths;
+  - retains the existing normalization fallback for file and environment
+    sources.
+- `Tests/ComposeCoreTests/ComposeOrchestratorTests.swift`
+  - existing focused tests cover live materialization, `0400` permissions,
+    successful cleanup, cleanup after engine failure, dry-run behavior, and
+    unavailable external resources;
+  - the ordinary build test covers file and environment fallback.
+
+## Verification
+
+```sh
+swift test --filter \
+  'ComposeCoreTests\.ComposeOrchestratorTests/build(MaterializesExternalSecretsOnlyForEngineInvocation|RemovesExternalSecretFilesAfterEngineFailure|DryRunNeitherReadsNorWritesExternalSecrets)'
+make check
+git diff --check
+```
+
+Focused verification passed locally with three tests in one suite.
+`make check` also passed, including 167 release-controller tests, 14 CI-helper
+tests, coverage policy, stack consistency, release consistency, and
+credential scanning. Hosted checks, the exact-revision Sonar result, Current
+publication, and live Docker Compose v2 parity are promotion requirements and
+will be recorded here before the phase handoff.
+
+## Compatibility and risk
+
+The refactor changes control-flow spelling only. It does not change normalized
+Compose data, filesystem paths, secure-store reads, secret contents,
+permissions, cleanup, engine arguments, or dry-run output. The stable
+`0.10.0` artifacts remain immutable. No Apple-facing pull request is required.
+
+## Review checklist
+
+- [x] The signed implementation commit is identified.
+- [x] Live and dry-run external-secret branches retain focused unit coverage.
+- [x] File and environment fallback behavior remains covered.
+- [x] Complete local quality gate passes.
+- [ ] Hosted CI and CodeQL pass for the exact revision.
+- [ ] Exact-revision SonarCloud quality gate passes with zero open issues.
+- [ ] Current prerelease and Docker Compose v2 parity are verified.


### PR DESCRIPTION
## Summary

- replace two single-case external build-secret switches with behavior-equivalent pattern-matching conditionals
- preserve live materialization, cleanup, dry-run projection, and non-external normalization in the Compose layer
- add exact constructible-commit ISSUE and PR handoff documentation

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Internal maintainability refactor

## Motivation and Context

The exact Phase 5 main analysis passed its quality gate but reported two swift:S1301 findings in ComposeOrchestratorBuildSecrets.swift. This narrowly resolves both findings without changing an Apple primitive, public API, runtime fork, command surface, or stable 0.10.0 artifact.

## Testing

- [x] Tested locally
- [x] Existing focused unit tests cover every affected branch
- [x] Added/updated docs
- [x] Three focused external-build-secret tests pass
- [x] make check passes, including 167 release tests and 14 CI-helper tests
- [x] git diff --check passes

## container-compose Checks

- [x] I updated docs/upstream for the quality handoff.
- [x] This pull request is focused on one coherent quality change.
- [x] Runtime, release, security, upstream-import, or cross-repository stack changes have review notes and CI attached to this pull request.
- [x] I used Conventional Commits in commit messages and the pull request title.
- [x] Release-Note: none
- [x] No upstream reference is required because this is Compose-owned quality cleanup.
- [x] I signed my commits with a GitHub-supported signature method.
- [x] I removed credentials, tokens, private keys, personal data, and private registry details from code, tests, logs, and screenshots.

## Handoff

- Implementation: d6318ec967a4a01c014f7542eabeb11fade18cb8
- Issue handoff: docs/upstream/container-compose/ISSUE-sonarqube-phase5-cleanup.md
- PR handoff: docs/upstream/container-compose/PR-sonarqube-phase5-cleanup.md
- Phase 6 remains blocked until hosted CI, CodeQL, exact-revision Sonar zero issues, Current publication, and Docker Compose v2 parity all pass.