### PR TITLE
Make provider publication evidence durable

### DIFF
--- a/docs/upstream/container-compose/PR-unconfigured-runtime-image-volume-provider.md
+++ b/docs/upstream/container-compose/PR-unconfigured-runtime-image-volume-provider.md
@@ -63,7 +63,7 @@ new volume-subpath source field. Its direct subpath failure is host/guest
 version skew, not a failure of this Compose change; the documented
 source-matched harness is the valid fork integration gate.
 
-## Publication evidence
+## Implementation publication evidence
 
 - Pull request
   [`stephenlclarke/container-compose#151`](https://github.com/stephenlclarke/container-compose/pull/151)
@@ -75,12 +75,14 @@ source-matched harness is the valid fork integration gate.
 - Exact-main CI, CodeQL, Quality, and Documentation workflows passed. The
   SonarCloud gate reported 0 issues with 82.6% overall and 82.5% new-code
   coverage.
-- The mutable `current` prerelease targets the signed exact-main commit and
-  contains seven release assets. Both primary archives match their SHA-256
-  sidecars and verify against GitHub artifact attestations.
-- Homebrew formulae `container-current` and `container-compose-current` are
-  installed at `current.882.8096c45a29d1`; the installed Compose provenance
-  reports commit `8096c45a29d180acdf85af0bb691e1eb567d0087`.
+- The implementation prerelease used the mutable `current` tag to target the
+  signed implementation merge and contained seven release assets. Both primary
+  archives matched their SHA-256 sidecars and verified against GitHub artifact
+  attestations.
+- Homebrew formulae `container-current` and `container-compose-current` were
+  installed and verified at `current.882.8096c45a29d1`; the installed Compose
+  provenance reported commit
+  `8096c45a29d180acdf85af0bb691e1eb567d0087`.
 - A post-install, post-reboot focused run repeated all 7 provider tests
   successfully. The installed strict parity run repeated the Docker Compose
   V2 reference and Apple host paths; its sole Apple failure was the documented


### PR DESCRIPTION
## Summary

- label the release evidence as the implementation publication record
- describe the mutable `current` tag and formula installation in historical tense
- prevent future prerelease movement from making the handoff appear stale

## Apple-shaped scope

This is a documentation-only durability correction. It changes no Compose behavior, Apple runtime API, platform branch, package content, or release policy.

## Handoff

- Issue: [`docs/upstream/container-compose/ISSUE-unconfigured-runtime-image-volume-provider.md`](https://github.com/stephenlclarke/container-compose/blob/docs/cc-001-historical-evidence/docs/upstream/container-compose/ISSUE-unconfigured-runtime-image-volume-provider.md)
- Pull-request handoff: [`docs/upstream/container-compose/PR-unconfigured-runtime-image-volume-provider.md`](https://github.com/stephenlclarke/container-compose/blob/docs/cc-001-historical-evidence/docs/upstream/container-compose/PR-unconfigured-runtime-image-volume-provider.md)
- Signed correction commit: [`e9ac2653`](https://github.com/stephenlclarke/container-compose/commit/e9ac2653)
- Implementation PR: #151
- Publication closeout PR: #152

## Validation

- `git diff --check`
- Markdown lint over every tracked Markdown file
- `ruby -c Tools/release/container-compose.rb.in`

## Checklist

- [x] Signed Conventional commit
- [x] Documentation-only delta
- [x] No volatile current-state assertion remains
- [x] Local documentation gates passed
- [ ] Pull-request checks passed
- [ ] Connector review completed
- [ ] Exact-main release republished after merge