### PR TITLE
fix(ci): preserve Sonar retry budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,7 +416,9 @@ jobs:
           steps.sonar_api.outputs.available == 'true' &&
           steps.sonar_install.outcome == 'success'
         continue-on-error: true
-        timeout-minutes: 10
+        # make sonar-scan permits three 300-second quality-gate waits plus
+        # scanner work and two 20-second retry delays.
+        timeout-minutes: 25
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_QUALITYGATE_WAIT: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.heavy == 'true'
     runs-on: macos-26
-    timeout-minutes: 75
+    # Cover the 45-minute validation/coverage budget, 10-minute CLI smoke,
+    # 25-minute Sonar retry budget, and dependency/setup overhead.
+    timeout-minutes: 105
     steps:
       - name: Checkout container-compose
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/BUILD.md
+++ b/BUILD.md
@@ -429,8 +429,9 @@ exists from `make ci`, run only the scanner with:
 SONAR_BRANCH=main make sonar-scan
 ```
 
-Local scans do not wait for the quality gate by default. Set
-`SONAR_QUALITYGATE_WAIT=true` when the token can read quality-gate status.
+Local scans do not wait for the quality gate by default. Set `SONAR_QUALITYGATE_WAIT=true` when the token can read quality-gate status.
+
+Main-branch CI keeps the scanner's three-attempt fail-closed policy and gives the step enough time for all three 300-second quality-gate waits, scanner work, and retry delays. A reachable SonarCloud service therefore still blocks CI when every attempt fails, without an outer workflow timeout killing a valid later attempt.
 
 ## Maintenance
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -431,7 +431,7 @@ SONAR_BRANCH=main make sonar-scan
 
 Local scans do not wait for the quality gate by default. Set `SONAR_QUALITYGATE_WAIT=true` when the token can read quality-gate status.
 
-Main-branch CI keeps the scanner's three-attempt fail-closed policy and gives the step enough time for all three 300-second quality-gate waits, scanner work, and retry delays. A reachable SonarCloud service therefore still blocks CI when every attempt fails, without an outer workflow timeout killing a valid later attempt.
+Main-branch CI keeps the scanner's three-attempt fail-closed policy and gives the step enough time for all three 300-second quality-gate waits, scanner work, and retry delays. The enclosing runtime-validation job separately covers its 45-minute coverage gate, 10-minute CLI smoke, 25-minute Sonar budget, and dependency/setup overhead. A reachable SonarCloud service therefore still blocks CI when every attempt fails, without either workflow timeout killing a valid later attempt.
 
 ## Maintenance
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -689,6 +689,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("needs.analyze.result", codeql)
         self.assertIn("needs.analyze-skipped.result", codeql)
 
+    def test_main_sonar_step_preserves_the_complete_retry_budget(self) -> None:
+        ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        sonar = ci[
+            ci.index("- name: SonarQube scan") : ci.index(
+                "- name: Enforce SonarQube failures when the service is available"
+            )
+        ]
+        self.assertIn("continue-on-error: true", sonar)
+        self.assertIn("timeout-minutes: 25", sonar)
+        self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)
+        self.assertIn("run: make sonar-scan", sonar)
+
     def test_stable_package_requires_candidate_bound_release_authority(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         authority = workflow[

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -691,11 +691,17 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_main_sonar_step_preserves_the_complete_retry_budget(self) -> None:
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
+        runtime_job = ci[
+            ci.index("  validate_runtime:") : ci.index(
+                "    steps:", ci.index("  validate_runtime:")
+            )
+        ]
         sonar = ci[
             ci.index("- name: SonarQube scan") : ci.index(
                 "- name: Enforce SonarQube failures when the service is available"
             )
         ]
+        self.assertIn("timeout-minutes: 105", runtime_job)
         self.assertIn("continue-on-error: true", sonar)
         self.assertIn("timeout-minutes: 25", sonar)
         self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)

--- a/docs/upstream/container-compose/ISSUE-154.md
+++ b/docs/upstream/container-compose/ISSUE-154.md
@@ -1,0 +1,38 @@
+# Sonar retry policy exceeds its workflow timeout
+
+## I have done the following
+
+- [x] I searched the existing issues.
+- [x] I reproduced the issue using the `main` branch.
+
+## Steps to reproduce
+
+1. Run exact-main CI while SonarCloud takes longer than 300 seconds to process
+   an uploaded analysis.
+2. Observe `make sonar-scan` start its configured second of three attempts
+   after the first quality-gate wait expires.
+3. Observe GitHub Actions terminate the SonarQube step at its independent
+   ten-minute timeout before the retry policy can finish.
+
+Exact source [`eabc04736d83bf62c06781ee4b0cf2d612c40af2`](https://github.com/stephenlclarke/container-compose/commit/eabc04736d83bf62c06781ee4b0cf2d612c40af2) reproduced the mismatch twice in [CI run 30204614991](https://github.com/stephenlclarke/container-compose/actions/runs/30204614991). Both attempts uploaded the exact revision successfully. The retry passed all 1,224 Swift tests in 41 suites with 92.66% Swift line coverage and 89.88% Go statement coverage before SonarCloud's processing wait timed out.
+
+## Problem description
+
+The scanner target permits three attempts. Each attempt can spend 300 seconds waiting for the quality gate, in addition to scanner analysis and upload time, and the target waits 20 seconds between attempts. The workflow instead allows only ten minutes for the complete target. That outer deadline cannot represent the retry policy it invokes, so a reachable but delayed SonarCloud service can kill a valid later attempt and block exact-main prerelease publication for the wrong reason.
+
+The workflow step needs a 25-minute budget that covers the three waits, scanner work, and both retry delays. The existing API-aware enforcement step must remain unchanged: if SonarCloud is reachable and every scanner attempt fails, CI must still fail closed.
+
+## Environment
+
+- **OS**: macOS 26 GitHub-hosted runner
+- **Container**:
+  `221fafc24ebd19502f4553e0b5d38c14be3f2b22`
+- **Containerization**:
+  `164088e02e16ed80e536d0c59822b09931d213df`
+- **container-compose**:
+  `eabc04736d83bf62c06781ee4b0cf2d612c40af2`
+
+## Code of Conduct
+
+- [x] I agree to follow this project's Code of Conduct.
+- [x] I removed secrets and private data from this report.

--- a/docs/upstream/container-compose/ISSUE-154.md
+++ b/docs/upstream/container-compose/ISSUE-154.md
@@ -20,7 +20,7 @@ Exact source [`eabc04736d83bf62c06781ee4b0cf2d612c40af2`](https://github.com/ste
 
 The scanner target permits three attempts. Each attempt can spend 300 seconds waiting for the quality gate, in addition to scanner analysis and upload time, and the target waits 20 seconds between attempts. The workflow instead allows only ten minutes for the complete target. That outer deadline cannot represent the retry policy it invokes, so a reachable but delayed SonarCloud service can kill a valid later attempt and block exact-main prerelease publication for the wrong reason.
 
-The workflow step needs a 25-minute budget that covers the three waits, scanner work, and both retry delays. The existing API-aware enforcement step must remain unchanged: if SonarCloud is reachable and every scanner attempt fails, CI must still fail closed.
+The workflow step needs a 25-minute budget that covers the three waits, scanner work, and both retry delays. Its enclosing job also needs enough time for the earlier 45-minute coverage gate, 10-minute CLI smoke, Sonar budget, and dependency/setup overhead; a 105-minute job budget preserves all of those declared limits. The existing API-aware enforcement step must remain unchanged: if SonarCloud is reachable and every scanner attempt fails, CI must still fail closed.
 
 ## Environment
 

--- a/docs/upstream/container-compose/PR-155.md
+++ b/docs/upstream/container-compose/PR-155.md
@@ -22,12 +22,14 @@ Proposed in [#155](https://github.com/stephenlclarke/container-compose/pull/155)
 
 The Sonar target permits three attempts, each with a 300-second quality-gate wait, plus 20-second retry delays. Its GitHub Actions step allowed only ten minutes total. When SonarCloud accepted the exact revision but delayed processing, attempt one exhausted its wait and the outer deadline killed attempt two before the configured policy could finish.
 
-This change raises only the outer workflow budget to 25 minutes. It does not skip Sonar, weaken quality-gate waiting, change retry count, or change the following API-aware enforcement step.
+This change raises the scanner step budget to 25 minutes and the enclosing runtime-validation job budget to 105 minutes. It does not skip Sonar, weaken quality-gate waiting, change retry count, or change the following API-aware enforcement step.
 
 ## Implementation Details
 
 - `.github/workflows/ci.yml` budgets 25 minutes for `make sonar-scan`, covering
-  three 300-second waits, scanner work, and two 20-second delays.
+  three 300-second waits, scanner work, and two 20-second delays; the
+  105-minute job budget also covers the earlier 45-minute coverage gate,
+  10-minute CLI smoke, and dependency/setup overhead.
 - `Tools/release/test_container_stack_release.py` locks the fail-closed scan
   shape and the 25-minute budget.
 - `BUILD.md` records the main-branch timing and enforcement contract.

--- a/docs/upstream/container-compose/PR-155.md
+++ b/docs/upstream/container-compose/PR-155.md
@@ -1,4 +1,4 @@
-# Pull Request
+# Pull request: preserve the complete Sonar retry budget
 
 ## Summary
 
@@ -18,6 +18,8 @@
 
 Closes [#154](https://github.com/stephenlclarke/container-compose/issues/154).
 
+Proposed in [#155](https://github.com/stephenlclarke/container-compose/pull/155).
+
 The Sonar target permits three attempts, each with a 300-second quality-gate wait, plus 20-second retry delays. Its GitHub Actions step allowed only ten minutes total. When SonarCloud accepted the exact revision but delayed processing, attempt one exhausted its wait and the outer deadline killed attempt two before the configured policy could finish.
 
 This change raises only the outer workflow budget to 25 minutes. It does not skip Sonar, weaken quality-gate waiting, change retry count, or change the following API-aware enforcement step.
@@ -29,6 +31,9 @@ This change raises only the outer workflow budget to 25 minutes. It does not ski
 - `Tools/release/test_container_stack_release.py` locks the fail-closed scan
   shape and the 25-minute budget.
 - `BUILD.md` records the main-branch timing and enforcement contract.
+- Signed implementation:
+  [`2f6fa78422533aab644e8cce5c8817233591c6b6`](https://github.com/stephenlclarke/container-compose/commit/2f6fa78422533aab644e8cce5c8817233591c6b6),
+  `fix(ci): preserve Sonar retry budget`.
 
 ## Testing
 

--- a/docs/upstream/container-compose/PR-sonarqube-scan-timeout-budget.md
+++ b/docs/upstream/container-compose/PR-sonarqube-scan-timeout-budget.md
@@ -1,0 +1,65 @@
+# Pull Request
+
+## Summary
+
+- Give exact-main Sonar analysis enough outer workflow time to complete all
+  three configured scanner attempts.
+- Retain the existing reachable-service fail-closed enforcement.
+- Add a workflow-policy regression test and document the timing contract.
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [x] Documentation update
+
+## Motivation and Context
+
+Closes [#154](https://github.com/stephenlclarke/container-compose/issues/154).
+
+The Sonar target permits three attempts, each with a 300-second quality-gate wait, plus 20-second retry delays. Its GitHub Actions step allowed only ten minutes total. When SonarCloud accepted the exact revision but delayed processing, attempt one exhausted its wait and the outer deadline killed attempt two before the configured policy could finish.
+
+This change raises only the outer workflow budget to 25 minutes. It does not skip Sonar, weaken quality-gate waiting, change retry count, or change the following API-aware enforcement step.
+
+## Implementation Details
+
+- `.github/workflows/ci.yml` budgets 25 minutes for `make sonar-scan`, covering
+  three 300-second waits, scanner work, and two 20-second delays.
+- `Tools/release/test_container_stack_release.py` locks the fail-closed scan
+  shape and the 25-minute budget.
+- `BUILD.md` records the main-branch timing and enforcement contract.
+
+## Testing
+
+- [x] `python3 Tools/release/test_container_stack_release.py` (62 tests)
+- [x] `make check` (189 Python tests plus release, consistency, license, format,
+  YAML, shell, and Markdown checks)
+- [ ] Exact-head pull-request checks
+- [ ] Exact-main CI with a passed SonarQube scan
+- [ ] Exact-main Sonar analysis revision and quality gate
+
+Docker Compose V2 and live Apple-runtime integration are not applicable to this CI-only timing correction. The preceding CC-001 source change retains its existing strict Docker Compose V2 and source-matched macOS runtime evidence.
+
+## Compatibility
+
+No Compose model, CLI, runtime, package, or Apple primitive changes. Successful fast Sonar scans are unchanged. Delayed scans can now consume the retry policy the Makefile already promises.
+
+## Remaining Risks
+
+- A SonarCloud incident that outlasts every configured attempt still fails
+  exact-main CI while the API remains reachable, by design.
+- The longest failure path can now consume up to 25 minutes instead of being
+  killed at ten minutes.
+
+## container-compose Checks
+
+- [x] `BUILD.md` and the handoff documents are current; `STATUS.md` needs no
+  change because Compose support does not change.
+- [x] This pull request is focused on one issue.
+- [x] The CI failure and exact-main run are linked in the issue handoff.
+- [x] Conventional Commit and pull request title will be used.
+- [x] This internal-only change will use `Release-Note: none`.
+- [x] No upstream source change is imported.
+- [x] The commit will be signed.
+- [x] No credentials or private data are included.


### PR DESCRIPTION
## Summary

- Give exact-main Sonar analysis enough outer workflow time to complete all three configured scanner attempts.
- Give the enclosing runtime-validation job enough time for coverage, CLI smoke, Sonar, and setup budgets.
- Retain the existing reachable-service fail-closed enforcement.
- Add a workflow-policy regression test and document the timing contract.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

Closes #154.

The Sonar target permits three attempts, each with a 300-second quality-gate wait, plus 20-second retry delays. Its GitHub Actions step allowed only ten minutes total. When SonarCloud accepted the exact revision but delayed processing, attempt one exhausted its wait and the outer deadline killed attempt two before the configured policy could finish.

The scanner step now has 25 minutes and the enclosing runtime-validation job has 105 minutes. The job budget covers the earlier 45-minute coverage gate, 10-minute CLI smoke, Sonar budget, and dependency/setup overhead. The change does not skip Sonar, weaken quality-gate waiting, change retry count, or change the following API-aware enforcement step.

## Implementation Details

- `.github/workflows/ci.yml` budgets 25 minutes for `make sonar-scan` and 105 minutes for the enclosing job.
- `Tools/release/test_container_stack_release.py` locks both budgets and the fail-closed scan shape.
- `BUILD.md` records the main-branch timing and enforcement contract.
- Signed implementation commits:
  - [`2f6fa784`](https://github.com/stephenlclarke/container-compose/commit/2f6fa78422533aab644e8cce5c8817233591c6b6), `fix(ci): preserve Sonar retry budget`.
  - [`088fd2d0`](https://github.com/stephenlclarke/container-compose/commit/088fd2d0e85e4474b87152bdbe13822e12153755), `fix(ci): preserve runtime validation budget`.

## Testing

- [x] `python3 Tools/release/test_container_stack_release.py` (62 tests)
- [x] `make check` (189 Python tests plus release, consistency, license, format, YAML, shell, and Markdown checks)
- [x] Exact-head pull-request CI and CodeQL passed before the job-budget review follow-up
- [ ] Exact-head checks after the job-budget follow-up
- [ ] Exact-main CI with a passed SonarQube scan
- [ ] Exact-main Sonar analysis revision and quality gate

Docker Compose V2 and live Apple-runtime integration are not applicable to this CI-only timing correction. The preceding CC-001 source change retains its existing strict Docker Compose V2 and source-matched macOS runtime evidence.

## Compatibility

No Compose model, CLI, runtime, package, or Apple primitive changes. Successful fast Sonar scans are unchanged. Delayed scans can now consume the retry policy the Makefile already promises.

## Remaining Risks

- A SonarCloud incident that outlasts every configured attempt still fails exact-main CI while the API remains reachable, by design.
- The longest failure path can now use the declared 25-minute scanner budget; the enclosing job can run up to 105 minutes.

## container-compose Checks

- [x] `BUILD.md` and the handoff documents are current; `STATUS.md` needs no change because Compose support does not change.
- [x] This pull request is focused on one issue.
- [x] The CI failure and exact-main run are linked in the issue handoff.
- [x] Conventional Commit and pull request title are used.
- [x] This internal-only change uses `Release-Note: none`.
- [x] No upstream source change is imported.
- [x] Commits are signed.
- [x] No credentials or private data are included.
- [x] The connector P1 was answered directly, fixed, and resolved.