### PR TITLE
chore: refresh upstreams and pin reviewed runtime

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -630,34 +630,6 @@ jobs:
             exit 1
           fi
 
-      - name: Compute SwiftPM cache fingerprint
-        id: swiftpm-cache
-        shell: bash
-        run: |
-          set -euo pipefail
-          {
-            swift --version 2>&1
-            printf 'container_ref=%s\n' "${{ steps.container-ref.outputs.ref }}"
-            printf 'containerization_ref=%s\n' "${{ steps.stack-refs.outputs.containerization_ref }}"
-            shasum -a 256 container-compose/Package.swift container-compose/Package.resolved
-            shasum -a 256 container/Package.swift container/Package.resolved
-            if [[ -f containerization/Package.swift ]]; then
-              shasum -a 256 containerization/Package.swift containerization/Package.resolved
-            fi
-          } | shasum -a 256 | awk '{ printf "fingerprint=%s\n", $1 }' >> "$GITHUB_OUTPUT"
-
-      - name: Cache SwiftPM build artifacts
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
-        with:
-          path: |
-            container-compose/.build
-            container/.build
-            containerization/.build
-            ~/Library/Caches/org.swift.swiftpm
-          key: ${{ runner.os }}-${{ runner.arch }}-macos26-stack-swiftpm-v1-${{ steps.swiftpm-cache.outputs.fingerprint }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-macos26-stack-swiftpm-v1-
-
       - name: Require the hosted release authority
         env:
           GH_TOKEN: ${{ github.token }}
@@ -793,7 +765,7 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: container-compose/Tools/compose-normalizer/go.mod
-          cache-dependency-path: container-compose/Tools/compose-normalizer/go.sum
+          cache: false
 
       - name: Build release package
         run: make package-release PLUGIN_ARCHIVE="${RUNNER_TEMP}/${{ steps.lane.outputs.asset }}"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "2a0e32acbf01afbc8985a0a3785b3c33d8723871"
+        "revision" : "5796a79ee3e59c16098d086278c072740d519ee8"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b920c1e637ca129f54498ed6cba10983ecc7dab29b2dcd07efd2eac3e5abd940",
+  "originHash" : "9c85b89b1d29958a9fcc12d842bf8a8796a552e2182f010cf214d92e08765ff9",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "221fafc24ebd19502f4553e0b5d38c14be3f2b22"
+        "revision" : "2a0e32acbf01afbc8985a0a3785b3c33d8723871"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "2a0e32acbf01afbc8985a0a3785b3c33d8723871",
+            revision: "5796a79ee3e59c16098d086278c072740d519ee8",
         ),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "221fafc24ebd19502f4553e0b5d38c14be3f2b22",
+            revision: "2a0e32acbf01afbc8985a0a3785b3c33d8723871",
         ),
         .package(
             url: "https://github.com/stephenlclarke/containerization.git",

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "221fafc24ebd19502f4553e0b5d38c14be3f2b22",
+      "ref": "2a0e32acbf01afbc8985a0a3785b3c33d8723871",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "2a0e32acbf01afbc8985a0a3785b3c33d8723871",
+      "ref": "5796a79ee3e59c16098d086278c072740d519ee8",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -669,11 +669,20 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('.event == "workflow_dispatch"', workflow)
         self.assertIn("Skipping current package for %s until successful exact-main CI", workflow)
         self.assertIn("timeout-minutes: 120", workflow)
-        self.assertIn("name: Cache SwiftPM build artifacts", workflow)
-        self.assertIn("container-compose/.build", workflow)
-        self.assertIn("container/.build", workflow)
         self.assertIn('.headBranch == "main"', workflow)
         self.assertIn('.status == "completed"', workflow)
+
+    def test_current_package_avoids_oversized_dependency_caches(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("name: Cache SwiftPM build artifacts", workflow)
+        self.assertNotIn("id: swiftpm-cache", workflow)
+        setup_go = workflow[
+            workflow.index("- name: Set up Go") : workflow.index(
+                "- name: Build release package"
+            )
+        ]
+        self.assertIn("cache: false", setup_go)
+        self.assertNotIn("cache-dependency-path:", setup_go)
 
     def test_stable_and_current_release_authority_select_main_ci(self) -> None:
         stable_gate = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")

--- a/docs/reviews/CONTAINER-STACK-CRITICAL-REVIEW-2026-07-24.md
+++ b/docs/reviews/CONTAINER-STACK-CRITICAL-REVIEW-2026-07-24.md
@@ -27,7 +27,7 @@ Docker Compose YAML integration, and no-surviving-process coverage.
 The largest engineering risk is now the runtime dependency model, not Compose
 file parsing. `ComposeRuntimeSPI` is presented as a clean provider boundary,
 but `ComposeCore` still imports and publicly exposes Apple package types. The
-three support forks contain 394 non-merge commits beyond current Apple
+three support forks contain 414 non-merge commits beyond current Apple
 upstream heads. That gives the project valuable capabilities, but creates a
 large review, release, and convergence burden.
 
@@ -78,6 +78,46 @@ Current Apple heads at the final source review were:
 | `apple/container` | `d1d763530df3c6a326dbae7f0c0a59a335808045` |
 | `apple/containerization` | `450d44ecb6d690b7a50250b87d4a40e467d805b8` |
 | `apple/container-builder-shim` | `267b5ab98e1d7db7d98af98bdc90578bf5fd3192` |
+
+### 27 July 2026 Maintenance Refresh
+
+Every configured Apple and Stephen-owned remote was fetched again before the
+maintenance slice. The supported fork mains contained every Apple main commit:
+
+| Repository | Apple main | Supported main | Apple-only | Fork-only |
+| --- | --- | --- | ---: | ---: |
+| `container` | `d1d7635` | `5796a79` | 0 | 276 |
+| `containerization` | `74ace14` | `164088e` | 0 | 110 |
+| `container-builder-shim` | `267b5ab` | `f97cddf` | 0 | 28 |
+
+The Compose and release-support repositories had no open Dependabot or
+Renovate pull requests. The four Stephen-authored Apple proposals remained
+mergeable with no requested author change:
+
+- `apple/container#1934`
+- `apple/container#1935`
+- `apple/container#1965`
+- `apple/containerization#799`
+
+The fork reproduced the four performance findings in
+`apple/container#2022`. Support PR
+[`stephenlclarke/container#30`](https://github.com/stephenlclarke/container/pull/30)
+keeps their corrections independently cherry-pickable, adds source-matched
+unit and integration evidence, and directly addresses every exact-head
+connector review thread. The long-line `logs -n` correctness case already
+passes, while `apple/container#2021` remains an Apple
+Virtualization.framework virtio-fs primitive and has no safe fork workaround.
+The reviewed head `281208b1a8` passed hosted build and tests and merged without
+tree changes as `5796a79ee3e59c16098d086278c072740d519ee8`.
+
+The release audit also found that Current restored a 2.13 GB SwiftPM cache and
+attempted a 1.62 GB Go cache before builds that completed in a few minutes.
+Signed Compose commit `6cae9a84` removes only those package-lane caches and
+retains validation-workflow caches.
+
+This refresh does not close the three confirmed release blockers in the
+executive verdict: compatibility-preflight pipe drainage, inherited commit
+volumes, and direct archive copy streaming remain required.
 
 All repositories were fetched with `git fetch --all --prune --no-tags`.
 The review covered:
@@ -535,8 +575,8 @@ debt at this snapshot. The fork-only surface is nevertheless large:
 
 | Fork | Behind Apple | Ahead of Apple | Non-merge ahead | Diff from Apple |
 | --- | ---: | ---: | ---: | --- |
-| `container` | 0 | 281 | 256 | 329 files, +30,184/-1,147 |
-| `containerization` | 0 | 126 | 110 | 110 files, +8,547/-505 |
+| `container` | 0 | 303 | 276 | 340 files, +31,154/-1,197 |
+| `containerization` | 0 | 127 | 110 | 110 files, +8,523/-492 |
 | `container-builder-shim` | 0 | 33 | 28 | 60 files, +2,533/-881 |
 
 This should be managed as an upstream-convergence programme:

--- a/docs/upstream/APPLE-UPSTREAM-REVIEW.md
+++ b/docs/upstream/APPLE-UPSTREAM-REVIEW.md
@@ -8,6 +8,24 @@ This is the current disposition of Apple work that affects the five-repository c
 - `apple/containerization`
 - `apple/container-builder-shim`
 
+## Fetched Main Baselines
+
+The 27 July 2026 refresh fetched every configured Apple and Stephen-owned
+remote before comparison. Each supported fork contains its complete Apple
+`main` history:
+
+| Repository | Apple `main` | Supported fork `main` | Apple-only commits |
+| --- | --- | --- | ---: |
+| `container` | `d1d763530df3c6a326dbae7f0c0a59a335808045` | `5796a79ee3e59c16098d086278c072740d519ee8` | 0 |
+| `containerization` | `74ace148ded72f7bb3c878b142e4962ae668adf4` | `164088e02e16ed80e536d0c59822b09931d213df` | 0 |
+| `container-builder-shim` | `267b5ab98e1d7db7d98af98bdc90578bf5fd3192` | `f97cddf5b3aae2426a094613793c11c41b1d2e53` | 0 |
+
+No Apple commit needed merging in this refresh. The runtime maintenance head
+`281208b1a8db06c92348afdeb1c163e043637c16` passed exact-head review and
+hosted checks, then merged without tree changes as
+`5796a79ee3e59c16098d086278c072740d519ee8`. The Compose and Homebrew support
+repositories also had no open dependency-bot pull requests.
+
 ## Open stephenlclarke Proposals
 
 | Pull request | Current purpose |
@@ -39,6 +57,10 @@ fails if any snapshot is deleted or retargeted.
 | `apple/container` | [IPv4 network address reservations](apple-container/PR-network-ipv4-reserved-addresses.md) carry validated generic reservations through persisted network configuration, helper startup, and attachment allocation. |
 | `apple/container` | [Numeric supplemental process groups](apple-container/PR-supplemental-groups.md) expose the runtime's existing typed GID support through the generic process CLI surface. |
 | `apple/container` | [Owned regular-file bind snapshots](apple-container/PR-file-mount-ownership.md) expose optional UID/GID mapping without mutating the host source. |
+| `apple/container` | [Compiled build glob caching](apple-container/PR-build-glob-cache.md) compiles each Docker ignore pattern once per context while retaining the existing Swift regex semantics. |
+| `apple/container` | [Hashed build-context membership](apple-container/PR-build-context-membership.md) uses the existing `Set<DirEntry>` contract instead of scanning it linearly for each archive candidate. |
+| `apple/container` | [Concurrent stats sampling](apple-container/PR-stats-concurrent-sampling.md) fans out independent runtime samples while preserving list order and failure semantics. |
+| `apple/container` | [Disk-usage lock scope](apple-container/PR-disk-usage-lock-scope.md) snapshots metadata under service locks and traverses resource trees on detached utility tasks. |
 | `apple/containerization` | [Fork CI validation](apple-containerization/PR-fork-ci-validation.md) runs supported checks in contributor forks while retaining official guest image and integration work. |
 | `apple/containerization` | [Additional guest interface addresses](apple-containerization/PR-additional-interface-addresses.md) configure generic supplemental IPv4/IPv6 CIDRs before link-up. |
 | `apple/containerization` | [Owned regular-file bind snapshots](apple-containerization/PR-file-mount-ownership.md) create private guest copies only when ownership metadata is requested. |
@@ -91,15 +113,18 @@ fails if any snapshot is deleted or retargeted.
 | Compose process-start observation | The exact-main SonarCloud analysis for child-process cancellation identified one undocumented no-op observer and two nested launch-observer closures. Compose-only correction `7939874a` names the private callback contract, invokes it through one helper outside the asynchronous continuation bodies, and explains the production no-op without changing launch or cancellation behavior. Follow-up merge `617c2036` passed exact-main analysis `fe1e52b4-9674-4da6-90f8-ce4b0155909d` with zero unresolved issues or hotspots. See [ISSUE-process-start-observer-maintainability.md](container-compose/ISSUE-process-start-observer-maintainability.md) and [PR-process-start-observer-maintainability.md](container-compose/PR-process-start-observer-maintainability.md). |
 | Current VHS runtime startup | The self-hosted Current release runner now requires the global Container launchd namespace to remain absent before recording, repeats that guard after a transport-only reset, and visibly types one bounded retry of the exact packaged-runtime start. This is Compose release-layer recovery for an XPC interruption after a long retained-runtime stop; it changes no Apple runtime source and introduces no Replay, Marker, or transcript path. Four signed commits merged as `4b4a4cff`; exact-main CI, CodeQL, and SonarCloud analysis `b31c11e9-089a-4c1e-b3c6-44967b74ad79` passed with zero unresolved issues or hotspots. Current run `30231378606` published matched checksummed and SLSA-attested archives plus a 303.92-second GIF whose commands and real output are live, with 16 `Type`, 16 `Enter`, 14 `Wait`, zero Replay, and zero Marker instructions. See [ISSUE-current-vhs-start-recovery.md](container-compose/ISSUE-current-vhs-start-recovery.md) and [PR-current-vhs-start-recovery.md](container-compose/PR-current-vhs-start-recovery.md). |
 | Current full-dispatch authority | A docs-only main merge requires explicit full-validation CI to establish runtime, coverage, and SonarCloud authority. Current's controller accepted that exact successful `workflow_dispatch`, but its independent package-time guard pre-filtered to push events and rejected the same run after cache restoration. Compose-only correction `c8524d36` accepts successful exact-main CI from the existing trusted `push` or `workflow_dispatch` set and continues to exclude all other events. See [ISSUE-current-dispatch-release-authority.md](container-compose/ISSUE-current-dispatch-release-authority.md) and [PR-current-dispatch-release-authority.md](container-compose/PR-current-dispatch-release-authority.md). |
+| Current dependency cache overhead | Current run `30235634675` spent 10 minutes restoring a 2.13 GB SwiftPM cache and 19 minutes 19 seconds attempting a 1.62 GB Go cache restore, versus 2 minutes 25 seconds and 2 minutes 17 seconds for the respective runtime and Compose builds. Compose-only correction `6cae9a84` removes the release SwiftPM cache and disables release `setup-go` caching while retaining all validation-workflow caches. See [ISSUE-release-dependency-cache-overhead.md](container-compose/ISSUE-release-dependency-cache-overhead.md) and [PR-release-dependency-cache-overhead.md](container-compose/PR-release-dependency-cache-overhead.md). |
 | [apple/container#1941](https://github.com/apple/container/issues/1941) | The supported fork ports the content-identical signal-name correction from [apple/container#1997](https://github.com/apple/container/pull/1997) in `bb2438c`, with regression coverage in `26cc778` and handoff details in [PR-1997.md](apple-container/PR-1997.md). Drop the port when Apple merges an equivalent fix. |
 | [apple/container#1967](https://github.com/apple/container/issues/1967) | The supported `LogFileOutput` already retains complete records across backward-read chunks. Explicit 3 KB and multi-record tests in `26cc778` cover the behavior proposed by [apple/container#2000](https://github.com/apple/container/pull/2000). |
 | [apple/container#2009](https://github.com/apple/container/issues/2009) | The supported init-process reattach path writes persistent sinks first and removes failed clients through `AttachableOutput`; `26cc778` proves later persistent writes continue. Apple main still needs its own reviewed fix. |
 | [apple/containerization#798](https://github.com/apple/containerization/pull/798) | Merged upstream. Its SwiftPM manifest correction is included in the current Apple baseline, so it no longer needs fork-side review or a local port. |
+| [apple/container#2021](https://github.com/apple/container/issues/2021) | Host disk-space retention after deleting guest files is owned by the macOS Virtualization.framework virtio-fs implementation and is released when the container stops. The supported stack must not add a divergent copy, remount, or guest-filesystem workaround for an Apple OS primitive. Track the upstream platform resolution. |
+| [apple/container#2022](https://github.com/apple/container/issues/2022) | The reported long-line `logs -n` correctness case passes on the installed supported runtime with a 2,001-byte first record and exact final three records. The four reported hot-path inefficiencies reproduce in the fork and are corrected as independent signed commits: glob cache `abab498f` plus Unicode-semantics correction `4436afe`, hashed context membership `41e31f7`, concurrent stats `600fde2`, and off-lock disk sizing `b15ac4a`. Review follow-up `c7d05f1` keeps active-volume accounting consistent with the sizing snapshot. Matching issue/PR handoffs are linked above. |
 
 ## Open Follow-up
 
 - Keep `apple/container#1934`, `#1935`, and `#1965`, `apple/containerization#799`, and `apple/container-builder-shim#87` open until Apple merges, replaces, or explicitly rejects their current changes.
-- The 26 July refresh found those four Stephen-authored Apple pull requests
+- The 27 July refresh found those four Stephen-authored Apple pull requests
   mergeable with no actionable author review. The account-wide connector
   audit also confirmed that every actionable connector thread has a Stephen
   response; historical merged threads remain open until their current-main

--- a/docs/upstream/PR-ARCHIVE.json
+++ b/docs/upstream/PR-ARCHIVE.json
@@ -15,14 +15,14 @@
       "upstream": "apple/container#1933"
     },
     {
-      "archiveRef": "refs/heads/upstream-pr-1934-25311b21bb46",
-      "commit": "25311b21bb469ac546a8a1f3c494d104d81a4dfe",
+      "archiveRef": "refs/heads/upstream-pr-1934-d5d73ef1a95c",
+      "commit": "d5d73ef1a95ca9f78ffa287b7c2e5204bfd9d569",
       "repository": "stephenlclarke/container",
       "upstream": "apple/container#1934"
     },
     {
-      "archiveRef": "refs/heads/upstream-pr-1935-fc55c18a9888",
-      "commit": "fc55c18a98883c578e57c6acc9b3042d743e004d",
+      "archiveRef": "refs/heads/upstream-pr-1935-f4f908606d4a",
+      "commit": "f4f908606d4a7693f9bfc958593f7671b35caa0f",
       "repository": "stephenlclarke/container",
       "upstream": "apple/container#1935"
     },

--- a/docs/upstream/apple-container/ISSUE-build-context-membership.md
+++ b/docs/upstream/apple-container/ISSUE-build-context-membership.md
@@ -1,0 +1,41 @@
+# Performance: build-context archive membership scans a set linearly
+
+## Summary
+
+`BuildFSSync.tar` stores selected build-context entries in a `Set<DirEntry>`,
+but its archive filter previously searched that set with a closure comparing
+`relativePath`. This discarded the set's hashed lookup and made each candidate
+membership check linear in the number of selected entries.
+
+This reproduces the second performance finding in
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Reproduction on macOS
+
+1. Create a build context with a large number of selected files.
+2. Run `container build`.
+3. Profile the archive filter in `BuildFSSync.tar`; each candidate iterates the
+   `Set` until a matching relative path is found.
+
+## Expected behavior
+
+Construct the equivalent `DirEntry` for each archive candidate and use native
+`Set.contains`, retaining the existing equality and hashing contract.
+
+## Ownership and boundary
+
+This is generic build-context archive construction in `apple/container`.
+Compose should continue to submit ordinary concurrent build requests without a
+second context index.
+
+## Commit tracking
+
+- `41e31f7fe34e4a6a99ed9dd29512fd99a2cbc074` —
+  `perf(build): use hashed context membership`.
+
+## Validation expectations
+
+- Preserve included, ignored, re-included, directory, and synthetic
+  Dockerfile behavior in the existing `BuildFSSyncTests`.
+- Run the complete Container unit and coverage gates.
+- Retain Docker Compose v2 build-context parity.

--- a/docs/upstream/apple-container/ISSUE-build-glob-cache.md
+++ b/docs/upstream/apple-container/ISSUE-build-glob-cache.md
@@ -1,0 +1,48 @@
+# Performance: build glob patterns are compiled for every candidate path
+
+## Summary
+
+`Globber.glob` converts a Docker ignore pattern into a regular expression and
+compiles that expression every time a candidate path is tested. A build context
+with many paths and patterns therefore repeats identical compilation work in
+the inner matching loop.
+
+This reproduces the first performance finding in
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Reproduction on macOS
+
+1. Create a build context containing many files and a `.dockerignore` with
+   several glob patterns.
+2. Run `container build`.
+3. Profile `Globber.glob`; the same translated expression is compiled for each
+   candidate tested against the pattern.
+
+## Expected behavior
+
+Each `Globber` instance should compile a source pattern at most once and reuse
+the same Foundation regular expression for subsequent whole-string matches,
+while retaining the existing Swift Regex validation.
+
+## Ownership and boundary
+
+This is generic build-context filtering in `apple/container`. The correction
+belongs in `Globber`; neither Compose nor the builder shim should maintain a
+parallel pattern cache.
+
+## Commit tracking
+
+- `abab498f01c4f7325c7b41ec8254a186640824f2` —
+  `perf(build): cache compiled glob patterns`.
+- `4436afea7c31a6a6a99e37ea7254465d333d9147` —
+  `fix(build): preserve cached glob semantics`.
+
+## Validation expectations
+
+- Preserve all existing Docker ignore matching cases, including invalid
+  patterns.
+- Preserve Foundation's composed and decomposed Unicode matching behavior.
+- Prove that repeated matches for one source pattern leave one cached compiled
+  expression.
+- Run the complete Container unit and coverage gates.
+- Retain Docker Compose v2 build-context parity.

--- a/docs/upstream/apple-container/ISSUE-disk-usage-lock-scope.md
+++ b/docs/upstream/apple-container/ISSUE-disk-usage-lock-scope.md
@@ -1,0 +1,53 @@
+# Performance: disk usage walks filesystems while service locks are held
+
+## Summary
+
+Container and volume disk-usage calculations previously traversed every
+resource directory while holding service locks. Volume sizing also nested its
+volume lock around a container-list lock. Large sparse or populated resource
+trees could therefore delay unrelated create, list, or lifecycle operations.
+
+This reproduces the fourth performance finding in
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Reproduction on macOS
+
+1. Create containers or volumes with large on-disk trees.
+2. Invoke `container system df`.
+3. Concurrently perform an operation requiring the container or volume service
+   lock.
+4. The operation waits for synchronous allocated-size traversal to complete.
+
+## Expected behavior
+
+Snapshot only the in-memory resource metadata under service locks, release the
+locks, and perform synchronous filesystem traversal on a utility-priority
+detached task. Derive active-volume accounting from the same validated path
+snapshot used for sizing so a concurrent attachment cannot make the active
+count exceed the total count. Preserve total, active, and reclaimable
+accounting.
+
+## Ownership and boundary
+
+This is generic macOS host storage accounting in the
+`ContainerAPIService`. Compose should not cache or recreate the runtime's disk
+usage model.
+
+## Commit tracking
+
+- `b15ac4aaf1ad7ce59a124c7e222a427565525d3a` —
+  `perf(storage): size resources outside service locks`.
+- `c7d05f1e3396436d96090dbffc8f8196d34f3c1d` —
+  `fix(storage): keep volume usage snapshots consistent`.
+
+## Validation expectations
+
+- Cover running and stopped container accounting with known on-disk payloads.
+- Cover active and unused volume accounting with known on-disk payloads.
+- Preserve the total metadata count while deriving active and reclaimable
+  counts from validated snapshotted paths when an invalid identifier is
+  skipped.
+- Cover a simulated post-snapshot volume attachment and prove active count
+  cannot exceed the snapshotted total.
+- Run the complete Container unit and coverage gates.
+- Confirm Compose v2 resource-model parity remains unchanged.

--- a/docs/upstream/apple-container/ISSUE-stats-concurrent-sampling.md
+++ b/docs/upstream/apple-container/ISSUE-stats-concurrent-sampling.md
@@ -1,0 +1,42 @@
+# Performance: container stats samples running containers serially
+
+## Summary
+
+`container stats` previously requested both samples one container at a time.
+Each slow runtime request therefore added directly to command latency even
+though containers are independent sampling targets.
+
+This reproduces the third performance finding in
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Reproduction on macOS
+
+1. Start several containers.
+2. Run a one-shot `container stats --no-stream`.
+3. Observe or profile the runtime requests; both the first and second sample
+   loops await every container serially.
+
+## Expected behavior
+
+Sample running containers concurrently while preserving list order and the
+existing failure behavior: omit a container whose first sample fails, and keep
+its first sample if only its second sample fails.
+
+## Ownership and boundary
+
+This is generic `container stats` command behavior in `apple/container`.
+Compose should consume the runtime's ordinary stats surface without adding
+runtime-specific fan-out.
+
+## Commit tracking
+
+- `600fde28de94093fc5a067e19a29358a9adcec9e` —
+  `perf(stats): sample containers concurrently`.
+
+## Validation expectations
+
+- Prove that more than one transform is active concurrently.
+- Prove deterministic input ordering after concurrent completion.
+- Prove that failed first samples are compacted.
+- Run the complete Container unit and coverage gates.
+- Confirm Compose v2 stats-model parity remains unchanged.

--- a/docs/upstream/apple-container/PR-build-context-membership.md
+++ b/docs/upstream/apple-container/PR-build-context-membership.md
@@ -1,0 +1,52 @@
+# Pull Request: use hashed build-context membership
+
+## Summary
+
+- Construct the existing `DirEntry` value for each archive candidate.
+- Use `Set<DirEntry>.contains` instead of a closure-based linear scan.
+- Preserve the existing `DirEntry` equality, hashing, and archive output.
+
+## Intended Review Delta
+
+Apply signed commit `41e31f7fe34e4a6a99ed9dd29512fd99a2cbc074`
+(`perf(build): use hashed context membership`) from
+`stephenlclarke/container`.
+
+The companion report is
+[ISSUE-build-context-membership.md](ISSUE-build-context-membership.md), and the
+originating upstream report is
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Code Map
+
+- `Sources/ContainerBuild/BuildFSSync.swift`: replaces the closure scan in the
+  tar filter with native hashed membership.
+
+## Validation
+
+```console
+swift test --disable-automatic-resolution --filter BuildFSSyncTests
+make coverage-unit
+make check
+CONTAINER_STACK_REPO=/absolute/path/to/container \
+  CONTAINERIZATION_INIT_SOURCE_PATH=/absolute/path/to/containerization \
+  make docker-compose-parity
+```
+
+The existing five focused `BuildFSSyncTests` pass with the hashed lookup.
+Complete coverage and Compose v2 parity are required before publication.
+
+## Compatibility and Risks
+
+- The constructed entry uses the same URL, directory flag, and relative path
+  represented by the selected set.
+- The change relies on the existing `DirEntry` `Hashable` contract instead of
+  adding a parallel path-only index.
+- Archive ordering and contents are unchanged.
+- No public API, Linux guest behavior, Windows path, or Compose-specific
+  primitive changes.
+
+## Handoff Status
+
+No Apple remote has been pushed. This two-line implementation remains a
+standalone reviewable commit.

--- a/docs/upstream/apple-container/PR-build-glob-cache.md
+++ b/docs/upstream/apple-container/PR-build-glob-cache.md
@@ -1,0 +1,64 @@
+# Pull Request: cache compiled build glob patterns
+
+## Summary
+
+- Cache translated Foundation regular expressions by their original Docker
+  ignore pattern for the lifetime of one `Globber`.
+- Use the cached expression directly for whole-string matching.
+- Preserve the existing Swift Regex validation, Foundation matching semantics,
+  pattern translation, and thrown-error behavior.
+
+## Intended Review Delta
+
+Apply signed commit `abab498f01c4f7325c7b41ec8254a186640824f2`
+(`perf(build): cache compiled glob patterns`) from
+`stephenlclarke/container`, followed by review correction
+`4436afea7c31a6a6a99e37ea7254465d333d9147`
+(`fix(build): preserve cached glob semantics`).
+
+The companion report is
+[ISSUE-build-glob-cache.md](ISSUE-build-glob-cache.md), and the originating
+upstream report is
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Code Map
+
+- `Sources/ContainerBuild/Globber.swift`: retains Swift Regex validation,
+  owns a pattern-to-`NSRegularExpression` cache, and reuses the Foundation
+  expression for matching.
+- `Tests/ContainerBuildTests/GlobberTests.swift`: verifies reuse across
+  multiple inputs, independence between distinct source patterns, and the
+  composed-versus-decomposed Unicode behavior.
+
+## Validation
+
+```console
+swift test --disable-automatic-resolution --filter TestGlobber
+make coverage-unit
+make check
+CONTAINER_STACK_REPO=/absolute/path/to/container \
+  CONTAINERIZATION_INIT_SOURCE_PATH=/absolute/path/to/containerization \
+  make docker-compose-parity
+```
+
+The focused `TestGlobber` suite passes all six test groups, including every
+existing parameterized matching and invalid-pattern case plus the cache-reuse
+and decomposed-Unicode regressions. Complete coverage and Compose v2 parity are
+required before publication.
+
+## Compatibility and Risks
+
+- Cache keys are the original patterns, so patterns with different spellings
+  do not accidentally share a translated expression.
+- Swift Regex still validates each translated pattern once, and the cached
+  Foundation expression retains the previous Unicode-scalar match behavior;
+  invalid patterns still throw.
+- The cache lifetime is one build-context globber and adds no global mutable
+  state.
+- No public API, Linux guest behavior, Windows path, or Compose-specific
+  primitive changes.
+
+## Handoff Status
+
+No Apple remote has been pushed. The commit is deliberately independent of the
+other performance findings in `apple/container#2022`.

--- a/docs/upstream/apple-container/PR-disk-usage-lock-scope.md
+++ b/docs/upstream/apple-container/PR-disk-usage-lock-scope.md
@@ -1,0 +1,72 @@
+# Pull Request: size resources outside service locks
+
+## Summary
+
+- Snapshot container and volume metadata while holding only the owning service
+  lock.
+- Remove the nested volume-lock/container-lock scope.
+- Traverse resource trees on utility-priority detached tasks after locks are
+  released.
+- Derive active-volume counts from the same validated path snapshot used for
+  filesystem sizing.
+- Preserve total, active, and reclaimable disk-usage accounting.
+
+## Intended Review Delta
+
+Apply these signed commits from `stephenlclarke/container` in order:
+
+1. `b15ac4aaf1ad7ce59a124c7e222a427565525d3a`
+   (`perf(storage): size resources outside service locks`).
+2. `c7d05f1e3396436d96090dbffc8f8196d34f3c1d`
+   (`fix(storage): keep volume usage snapshots consistent`).
+
+The companion report is
+[ISSUE-disk-usage-lock-scope.md](ISSUE-disk-usage-lock-scope.md), and the
+originating upstream report is
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Code Map
+
+- `Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift`:
+  snapshots identifier/status pairs and sizes validated paths off the actor.
+- `Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift`:
+  snapshots store and mount metadata separately, then sizes validated paths
+  off the actor and derives active count from that same path snapshot.
+- `Tests/ContainerAPIServiceTests/DiskUsageConcurrencyTests.swift`: covers
+  container and volume total, active, and reclaimable calculations against
+  real temporary directory payloads.
+
+## Validation
+
+```console
+swift test --disable-automatic-resolution --filter DiskUsageConcurrencyTests
+make coverage-unit
+make check
+CONTAINER_STACK_REPO=/absolute/path/to/container \
+  CONTAINERIZATION_INIT_SOURCE_PATH=/absolute/path/to/containerization \
+  make docker-compose-parity
+```
+
+The two focused disk-usage regressions pass using real allocated-size results,
+including a volume snapshot with fewer valid paths than total metadata entries.
+The complete unit coverage gate passes 1,148 tests in 134 suites with 39.27%
+line coverage. Compose v2 parity remains required before publication.
+
+## Compatibility and Risks
+
+- Total counts retain the metadata snapshot count even if an unsafe storage
+  name is skipped, matching existing behavior.
+- Running containers remain active; every other valid status remains
+  reclaimable.
+- Volume active count includes only mounted names present in the validated path
+  snapshot. A stale or later mount reference cannot make active count exceed
+  the snapshotted total.
+- Filesystem traversal is still exact and synchronous within its detached
+  utility task; only lock and actor occupancy change.
+- No public API, Linux guest behavior, Windows path, or Compose-specific
+  primitive changes.
+
+## Handoff Status
+
+No Apple remote has been pushed. The correction is isolated from the other
+performance findings in `apple/container#2022`.

--- a/docs/upstream/apple-container/PR-stats-concurrent-sampling.md
+++ b/docs/upstream/apple-container/PR-stats-concurrent-sampling.md
@@ -1,0 +1,56 @@
+# Pull Request: sample container stats concurrently
+
+## Summary
+
+- Fan out each stats sample across running containers with a Swift task group.
+- Restore deterministic container-list order using indexed results.
+- Preserve first-sample omission and second-sample fallback behavior.
+
+## Intended Review Delta
+
+Apply signed commit `600fde28de94093fc5a067e19a29358a9adcec9e`
+(`perf(stats): sample containers concurrently`) from
+`stephenlclarke/container`.
+
+The companion report is
+[ISSUE-stats-concurrent-sampling.md](ISSUE-stats-concurrent-sampling.md), and
+the originating upstream report is
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+
+## Code Map
+
+- `Sources/ContainerCommands/Container/ContainerStats.swift`: samples running
+  containers through one ordered concurrent compact-map helper.
+- `Tests/ContainerCommandsTests/ContainerStatsCommandTests.swift`: proves
+  actual overlap, stable order, and failed-result compaction.
+
+## Validation
+
+```console
+swift test --disable-automatic-resolution \
+  --filter ContainerStatsCommandTests
+make coverage-unit
+make check
+CONTAINER_STACK_REPO=/absolute/path/to/container \
+  CONTAINERIZATION_INIT_SOURCE_PATH=/absolute/path/to/containerization \
+  make docker-compose-parity
+```
+
+The focused concurrency regression passes and observes more than one active
+operation while returning the original successful-input order. Complete
+coverage and Compose v2 parity are required before publication.
+
+## Compatibility and Risks
+
+- Only snapshots with running status are scheduled, as before.
+- A failed first sample still removes that container from output.
+- A failed second sample still retains the first sample for both points.
+- Result ordering remains the order returned by the container list.
+- The runtime client already supports independent async requests; no server or
+  public API changes.
+- No Windows path or Linux guest behavior changes.
+
+## Handoff Status
+
+No Apple remote has been pushed. This change is independent of build and disk
+usage performance work from the same upstream report.

--- a/docs/upstream/container-compose/ISSUE-release-dependency-cache-overhead.md
+++ b/docs/upstream/container-compose/ISSUE-release-dependency-cache-overhead.md
@@ -1,0 +1,49 @@
+# Current packaging spends most of its build window restoring dependency caches
+
+## Problem
+
+Exact-main Current packaging run
+[`30235634675`](https://github.com/stephenlclarke/container-compose/actions/runs/30235634675)
+spent 10 minutes restoring a 2,134,173,923-byte SwiftPM cache before a
+2-minute-25-second matched-runtime build. Its `setup-go` step then spent
+19 minutes 19 seconds downloading a 1,624,881,811-byte cache, failed
+authentication after receiving about 1.29 GB, and built the Compose archive in
+2 minutes 17 seconds without that restored cache.
+
+The package job took 43 minutes. More than two thirds of the pre-publication
+window was cache transfer that did not establish release authority or improve
+the observed build enough to recover its cost.
+
+## Expected behavior
+
+- Build the exact matched Container and Compose packages from their immutable
+  clean checkouts.
+- Do not download or upload multi-gigabyte SwiftPM build trees in the release
+  job.
+- Install the pinned Go toolchain without restoring or saving the machine-wide
+  module/build cache.
+- Retain caching in validation workflows where repeated compilation can
+  amortize it; this correction is limited to package publication.
+
+## Ownership and boundary
+
+This is Compose release orchestration on the designated macOS runner. It
+changes no Apple source, package contents, runtime API, Docker Compose
+semantics, Windows path, or typed/live VHS behavior.
+
+## Resolution
+
+Signed commit `6cae9a84deee2b13eecfeb1efbf83ad2c98f88a9`
+(`perf(release): avoid oversized dependency caches`) removes the release-only
+SwiftPM cache action and sets `setup-go` to `cache: false`.
+
+## Acceptance
+
+- Workflow policy tests require the SwiftPM cache step and fingerprint to
+  remain absent.
+- Workflow policy tests require the release `setup-go` step to disable caching
+  and omit a dependency-cache path.
+- YAML parsing, actionlint, the complete release test suite, full CI,
+  SonarCloud, and Current publication pass.
+- The next exact-main Package job records the cache-free step timings for
+  comparison with run `30235634675`.

--- a/docs/upstream/container-compose/ISSUE-upstream-maintenance-20260727.md
+++ b/docs/upstream/container-compose/ISSUE-upstream-maintenance-20260727.md
@@ -1,0 +1,76 @@
+# Upstream maintenance refresh for 27 July 2026
+
+## Problem
+
+The supported stack must prove that every Apple-backed fork contains the
+complete current Apple `main` history before parity work continues. It must
+also review current upstream bug reports, dependency-bot proposals,
+Stephen-authored Apple pull requests, and actionable connector feedback.
+
+That evidence becomes stale whenever one repository advances independently.
+The consuming Compose revision can also remain pinned to an older runtime even
+after a fork-side correction is ready, causing validation to exercise the
+wrong source.
+
+## Expected behavior
+
+- Fetch every configured Apple and Stephen-owned remote with pruning.
+- Prove there are zero Apple-only `main` commits in each supported fork.
+- Import an Apple commit only when it is missing; never manufacture a
+  redundant merge.
+- Reproduce applicable upstream reports on macOS and keep each generic runtime
+  correction in an independently reviewable signed commit.
+- Preserve exact immutable references for open Stephen-authored Apple pull
+  requests and answer every actionable connector review.
+- Pin Compose manifests and release stack metadata to the exact reviewed
+  runtime.
+- Pass unit, coverage, full CI, SonarCloud, and Docker Compose v5.3.1 parity
+  before publishing the slice.
+
+Windows-only behavior and Linux-host implementation are outside this refresh.
+Linux guest behavior that is exercised by the macOS runtime remains in scope.
+
+## Reproduction and audit result
+
+The refresh fetched the three Apple-backed repositories and compared their
+Apple `main` history with the supported fork `main`:
+
+| Repository | Apple `main` | Fork baseline | Apple-only |
+| --- | --- | --- | ---: |
+| `container` | `d1d763530df3c6a326dbae7f0c0a59a335808045` | `5796a79ee3e59c16098d086278c072740d519ee8` | 0 |
+| `containerization` | `74ace148ded72f7bb3c878b142e4962ae668adf4` | `164088e02e16ed80e536d0c59822b09931d213df` | 0 |
+| `container-builder-shim` | `267b5ab98e1d7db7d98af98bdc90578bf5fd3192` | `f97cddf5b3aae2426a094613793c11c41b1d2e53` | 0 |
+
+No Apple commit was missing. The Compose and release-support repositories had
+no open Dependabot or Renovate pull request. The four open Stephen-authored
+Apple proposals were mergeable and had no requested author change.
+Runtime PR
+[stephenlclarke/container#30](https://github.com/stephenlclarke/container/pull/30)
+then merged the reviewed maintenance tree as
+`5796a79ee3e59c16098d086278c072740d519ee8`; the post-merge audit retained an
+Apple-only count of zero.
+
+The fork reproduced the four performance hot paths from
+[apple/container#2022](https://github.com/apple/container/issues/2022).
+The long-line log correctness case already passed. The disk-retention report
+in [apple/container#2021](https://github.com/apple/container/issues/2021)
+remains owned by the macOS Virtualization.framework virtio-fs primitive and
+has no safe fork-side workaround.
+
+## Ownership and boundary
+
+Generic runtime corrections belong in `stephenlclarke/container` and are
+documented as Apple-shaped handoffs. Exact dependency selection, release cache
+policy, parity orchestration, and aggregate evidence belong in
+`container-compose`. No Apple remote is modified by this work.
+
+## Acceptance
+
+- Re-fetch all upstreams immediately before publication and retain zero
+  Apple-only commits.
+- Run the Container unit and coverage gates plus focused bootstrap validation.
+- Run complete Compose CI and release-policy coverage.
+- Run live Docker Compose v5.3.1 parity against the exact supported stack.
+- Obtain an exact-head connector review and answer every actionable thread.
+- Publish a signed prerelease with current documentation and typed/live VHS
+  evidence.

--- a/docs/upstream/container-compose/PR-release-dependency-cache-overhead.md
+++ b/docs/upstream/container-compose/PR-release-dependency-cache-overhead.md
@@ -1,0 +1,84 @@
+# Pull request: avoid oversized release dependency caches
+
+## Summary
+
+- Remove the release job's exact/ref-fallback SwiftPM build-tree cache.
+- Disable the `setup-go` module/build cache in the release job.
+- Lock both decisions with workflow-policy regression coverage.
+- Keep source checkouts, authority checks, package commands, attestations,
+  Homebrew promotion, and typed/live VHS recording unchanged.
+
+## Intended review delta
+
+Apply signed implementation commit
+`6cae9a84deee2b13eecfeb1efbf83ad2c98f88a9`
+(`perf(release): avoid oversized dependency caches`) from
+`chore/upstream-audit-20260727`.
+
+The companion report is
+[ISSUE-release-dependency-cache-overhead.md](ISSUE-release-dependency-cache-overhead.md).
+
+## Code map
+
+- `.github/workflows/prebuilt-binaries.yml`: removes the SwiftPM cache
+  fingerprint/action and configures release `setup-go` with `cache: false`.
+- `Tools/release/test_container_stack_release.py`: requires those cache-free
+  release policies.
+
+## Validation
+
+```console
+python3 -m unittest \
+  Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_current_package_avoids_oversized_dependency_caches \
+  Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_current_package_workflow_only_follows_successful_main_ci
+ruby -ryaml -e \
+  'YAML.unsafe_load_file(".github/workflows/prebuilt-binaries.yml")'
+actionlint .github/workflows/prebuilt-binaries.yml
+python3 -m unittest discover Tools/release
+make ci
+git diff --check
+```
+
+The two focused workflow-policy tests, YAML load, and actionlint pass locally.
+The complete release suite passes 175 tests. Full CI passes 1,249 Swift tests
+in 41 suites with 92.81% Swift and 89.88% Go coverage. Pull-request-hosted
+checks remain required before merge.
+
+## Baseline evidence
+
+Current run
+[`30235634675`](https://github.com/stephenlclarke/container-compose/actions/runs/30235634675)
+recorded:
+
+| Step | Duration | Cache transfer |
+| --- | ---: | ---: |
+| Cache SwiftPM build artifacts | 10m 00s | 2,134,173,923 bytes |
+| Build matched runtime package | 2m 25s | none |
+| Set up Go | 19m 19s | 1,624,881,811-byte attempted restore |
+| Build release package | 2m 17s | none after the Go restore failed |
+
+The Go cache failed authentication after receiving about 1.29 GB; the build
+then succeeded. This makes the no-cache behavior directly equivalent to the
+successful portion of the observed run.
+
+## Compatibility and risk
+
+- The clean job already checks out every exact source revision and SwiftPM
+  resolves from tracked manifests.
+- `setup-go` still installs/selects the version pinned by `go.mod`; only its
+  cache restore/save behavior changes.
+- Cold build duration can vary, so the next Current run is the authoritative
+  end-to-end timing. The change removes a deterministic 3.76 GB transfer
+  obligation observed to exceed the builds it was intended to accelerate.
+- CI, CodeQL, Quality, and stable-gate caches are unchanged.
+- Archive contents, checksums, attestations, formulae, and release identity are
+  unchanged.
+
+## Checklist
+
+- [x] Signed Conventional implementation commit
+- [x] Focused workflow-policy tests
+- [x] YAML parse and actionlint
+- [x] Complete release test suite
+- [ ] Pull-request checks and connector review
+- [ ] Exact-main Current publication and timing comparison

--- a/docs/upstream/container-compose/PR-upstream-maintenance-20260727.md
+++ b/docs/upstream/container-compose/PR-upstream-maintenance-20260727.md
@@ -1,0 +1,140 @@
+# Pull request: refresh upstreams and publish reviewed runtime corrections
+
+## Summary
+
+- Record a complete zero-behind audit for all Apple-backed forks.
+- Correct four reproducible runtime hot paths from `apple/container#2022`.
+- Keep review follow-ups and bootstrap cleanup in focused signed runtime
+  commits.
+- Pin Compose to the exact reviewed runtime revision.
+- Remove oversized caches only from the release package lane.
+- Refresh current Apple proposal, connector, dependency-bot, validation, and
+  release evidence.
+
+The companion report is
+[ISSUE-upstream-maintenance-20260727.md](ISSUE-upstream-maintenance-20260727.md).
+
+## Intended review delta
+
+The Apple-shaped runtime changes are in
+[stephenlclarke/container#30](https://github.com/stephenlclarke/container/pull/30).
+Reviewed head `281208b1a8db06c92348afdeb1c163e043637c16` merged without
+tree changes as `5796a79ee3e59c16098d086278c072740d519ee8`.
+The independently useful implementation commits are:
+
+| Commit | Purpose |
+| --- | --- |
+| `abab498f01c4f7325c7b41ec8254a186640824f2` | Compile build ignore globs once. |
+| `41e31f7fe34e4a6a99ed9dd29512fd99a2cbc074` | Use hashed build-context membership. |
+| `600fde28de94093fc5a067e19a29358a9adcec9e` | Sample independent container stats concurrently. |
+| `b15ac4aaf1ad7ce59a124c7e222a427565525d3a` | Size resources outside service locks. |
+| `345ae6d50db8480b1f85a481b15a6d8c291fe6d3` | Install init only after runtime bootstrap. |
+| `d48a962c30b873d054345cbbb5856eb616e4f2ee` | Keep volume-prune failures isolated. |
+| `4436afea7c31a6a6a99e37ea7254465d333d9147` | Preserve Unicode-sensitive glob matching. |
+| `25bfef8c7f810aed0442d7214e2e9fd38f3bd89c` | Clean partial bootstrap state on failure. |
+| `98b3ae7db2d3dcfdcefd6e4eace5a65f850ac52e` | Reuse a healthy active runtime during install. |
+| `c7d05f1e3396436d96090dbffc8f8196d34f3c1d` | Keep volume-usage counts on one snapshot. |
+| `20e00d7b340b4a7daf730f505e6a3e80dc812ebc` | Isolate integration bootstrap configuration. |
+
+Documentation-only commits `a111a4e`, `1621722`, `c76ae6a`, `2a0e32a`, and
+`37fc529` provide aggregate and review-follow-up handoffs without changing
+runtime behavior. `281208b` records the final isolated-bootstrap correction.
+The commit-identity correction in `37fc529` ensures every referenced full hash
+resolves to the named commit.
+
+The Compose implementation commits are:
+
+| Commit | Purpose |
+| --- | --- |
+| `6cae9a84deee2b13eecfeb1efbf83ad2c98f88a9` | Avoid oversized release dependency caches. |
+| `e45240b718bf88a709e4fbb7056dfa0af4a1811e` | Initially pin manifests and stack metadata to reviewed production runtime `2a0e32a`. |
+| `c9a343f0d658dbb576c52a33e1ea97f3130bc730` | Pin all consuming identities to merged runtime `5796a79`. |
+
+## Code map
+
+### `stephenlclarke/container`
+
+- `Sources/ContainerBuild/BuildFSSync.swift`: compiled ignore-pattern cache.
+- `Sources/ContainerBuild/ContentStore.swift`: hashed context membership.
+- `Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift`:
+  concurrent stats and off-lock container sizing.
+- `Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift`:
+  isolated prune failures and snapshot-consistent off-lock volume sizing.
+- `scripts/install-init.sh`: ordered, failure-safe, active-runtime-aware
+  bootstrap.
+- `Makefile`: one configuration-isolated `init-block` invocation inside the
+  integration execution sequence.
+- Focused unit and shell tests cover each correction.
+
+### `container-compose`
+
+- `Package.swift` and `Package.resolved`: exact runtime dependency.
+- `Tools/release/stack-refs.json`: matching release source identity.
+- `.github/workflows/prebuilt-binaries.yml`: cache-free package lane.
+- `Tools/release/test_container_stack_release.py`: workflow-policy regression
+  coverage.
+- `docs/upstream/`: current audit, issue reports, Apple-shaped handoffs, and
+  immutable proposal references.
+
+## Validation
+
+```console
+# container
+make coverage-unit
+make test
+make check
+make test-install-init
+
+# container-compose
+python3 Tools/ci/check-stack-consistency.py
+HAWKEYE_AUTO_INSTALL=1 make ci
+CONTAINER_STACK_REPO=/absolute/path/to/container \
+  CONTAINERIZATION_STACK_REPO=/absolute/path/to/containerization \
+  CONTAINERIZATION_INIT_SOURCE_PATH=/absolute/path/to/containerization \
+  make docker-compose-parity
+```
+
+Container unit coverage passes 1,148 tests in 134 suites with 39.27% line
+coverage. Source-matched Container integration previously passed 293
+concurrent and 87 serial scenarios, and combined coverage reached 51.56%.
+The complete Compose release suite passes 175 tests. Full Compose CI passes
+1,249 Swift tests in 41 suites with 92.81% Swift and 89.88% Go coverage. The
+connector reviewed runtime production head `2a0e32acbf` and reported no major
+issue after every earlier actionable thread was answered and resolved. A later
+review identified that the integration bootstrap inherited developer
+configuration; `20e00d7` moves the sole invocation inside the isolated
+sequence and passes its scratch `XDG_CONFIG_HOME`, with a full-target Make
+dry-run regression. Docker Compose v5.3.1 parity passes all 62 strict
+assertions against the unchanged runtime production tree. The connector then
+reviewed exact final runtime head `281208b1a8` with no major issue. Runtime
+hosted run
+[30249659444](https://github.com/stephenlclarke/container/actions/runs/30249659444)
+then passed signatures, build, package, and project tests before merge.
+Compose hosted checks and SonarCloud remain publication gates.
+
+## Compatibility and risk
+
+- No public runtime API or Compose model contract changes.
+- Build glob semantics retain the existing Swift regex behavior, including
+  Unicode-sensitive matches.
+- Stats preserve input ordering and all-or-fail error semantics.
+- Storage counts retain their metadata total while active and reclaimable
+  values derive from one validated snapshot.
+- Bootstrap skips replacement only when the existing runtime is healthy and
+  bound to the requested application root.
+- The release change removes cache transfer only; package inputs, outputs,
+  checksums, attestations, and authority checks remain unchanged.
+- No Windows path or Linux-host implementation is added.
+
+## Checklist
+
+- [x] Every Apple-backed fork contains current Apple `main`
+- [x] Signed Conventional implementation commits
+- [x] Focused regression tests and unit coverage
+- [x] Apple-shaped issue and pull-request handoffs
+- [x] Exact Compose dependency and release stack pin
+- [x] Complete Compose release-policy tests
+- [x] Exact final-head connector review
+- [x] Docker Compose v5.3.1 live parity
+- [ ] Hosted CI, CodeQL, Quality, documentation, and SonarCloud
+- [ ] Signed prerelease and typed/live VHS evidence

--- a/docs/upstream/container-compose/PR-upstream-maintenance-20260727.md
+++ b/docs/upstream/container-compose/PR-upstream-maintenance-20260727.md
@@ -13,6 +13,8 @@
 
 The companion report is
 [ISSUE-upstream-maintenance-20260727.md](ISSUE-upstream-maintenance-20260727.md).
+Closes
+[stephenlclarke/container-compose#165](https://github.com/stephenlclarke/container-compose/issues/165).
 
 ## Intended review delta
 


### PR DESCRIPTION
# Pull request: refresh upstreams and publish reviewed runtime corrections

## Summary

- Record a complete zero-behind audit for all Apple-backed forks.
- Correct four reproducible runtime hot paths from `apple/container#2022`.
- Keep review follow-ups and bootstrap cleanup in focused signed runtime
  commits.
- Pin Compose to the exact reviewed runtime revision.
- Remove oversized caches only from the release package lane.
- Refresh current Apple proposal, connector, dependency-bot, validation, and
  release evidence.

The companion report is
[ISSUE-upstream-maintenance-20260727.md](ISSUE-upstream-maintenance-20260727.md).
Closes
[stephenlclarke/container-compose#165](https://github.com/stephenlclarke/container-compose/issues/165).

## Intended review delta

The Apple-shaped runtime changes are in
[stephenlclarke/container#30](https://github.com/stephenlclarke/container/pull/30).
Reviewed head `281208b1a8db06c92348afdeb1c163e043637c16` merged without
tree changes as `5796a79ee3e59c16098d086278c072740d519ee8`.
The independently useful implementation commits are:

| Commit | Purpose |
| --- | --- |
| `abab498f01c4f7325c7b41ec8254a186640824f2` | Compile build ignore globs once. |
| `41e31f7fe34e4a6a99ed9dd29512fd99a2cbc074` | Use hashed build-context membership. |
| `600fde28de94093fc5a067e19a29358a9adcec9e` | Sample independent container stats concurrently. |
| `b15ac4aaf1ad7ce59a124c7e222a427565525d3a` | Size resources outside service locks. |
| `345ae6d50db8480b1f85a481b15a6d8c291fe6d3` | Install init only after runtime bootstrap. |
| `d48a962c30b873d054345cbbb5856eb616e4f2ee` | Keep volume-prune failures isolated. |
| `4436afea7c31a6a6a99e37ea7254465d333d9147` | Preserve Unicode-sensitive glob matching. |
| `25bfef8c7f810aed0442d7214e2e9fd38f3bd89c` | Clean partial bootstrap state on failure. |
| `98b3ae7db2d3dcfdcefd6e4eace5a65f850ac52e` | Reuse a healthy active runtime during install. |
| `c7d05f1e3396436d96090dbffc8f8196d34f3c1d` | Keep volume-usage counts on one snapshot. |
| `20e00d7b340b4a7daf730f505e6a3e80dc812ebc` | Isolate integration bootstrap configuration. |

Documentation-only commits `a111a4e`, `1621722`, `c76ae6a`, `2a0e32a`, and
`37fc529` provide aggregate and review-follow-up handoffs without changing
runtime behavior. `281208b` records the final isolated-bootstrap correction.
The commit-identity correction in `37fc529` ensures every referenced full hash
resolves to the named commit.

The Compose implementation commits are:

| Commit | Purpose |
| --- | --- |
| `6cae9a84deee2b13eecfeb1efbf83ad2c98f88a9` | Avoid oversized release dependency caches. |
| `e45240b718bf88a709e4fbb7056dfa0af4a1811e` | Initially pin manifests and stack metadata to reviewed production runtime `2a0e32a`. |
| `c9a343f0d658dbb576c52a33e1ea97f3130bc730` | Pin all consuming identities to merged runtime `5796a79`. |

## Code map

### `stephenlclarke/container`

- `Sources/ContainerBuild/BuildFSSync.swift`: compiled ignore-pattern cache.
- `Sources/ContainerBuild/ContentStore.swift`: hashed context membership.
- `Sources/Services/ContainerAPIService/Server/Containers/ContainersService.swift`:
  concurrent stats and off-lock container sizing.
- `Sources/Services/ContainerAPIService/Server/Volumes/VolumesService.swift`:
  isolated prune failures and snapshot-consistent off-lock volume sizing.
- `scripts/install-init.sh`: ordered, failure-safe, active-runtime-aware
  bootstrap.
- `Makefile`: one configuration-isolated `init-block` invocation inside the
  integration execution sequence.
- Focused unit and shell tests cover each correction.

### `container-compose`

- `Package.swift` and `Package.resolved`: exact runtime dependency.
- `Tools/release/stack-refs.json`: matching release source identity.
- `.github/workflows/prebuilt-binaries.yml`: cache-free package lane.
- `Tools/release/test_container_stack_release.py`: workflow-policy regression
  coverage.
- `docs/upstream/`: current audit, issue reports, Apple-shaped handoffs, and
  immutable proposal references.

## Validation

```console
# container
make coverage-unit
make test
make check
make test-install-init

# container-compose
python3 Tools/ci/check-stack-consistency.py
HAWKEYE_AUTO_INSTALL=1 make ci
CONTAINER_STACK_REPO=/absolute/path/to/container \
  CONTAINERIZATION_STACK_REPO=/absolute/path/to/containerization \
  CONTAINERIZATION_INIT_SOURCE_PATH=/absolute/path/to/containerization \
  make docker-compose-parity
```

Container unit coverage passes 1,148 tests in 134 suites with 39.27% line
coverage. Source-matched Container integration previously passed 293
concurrent and 87 serial scenarios, and combined coverage reached 51.56%.
The complete Compose release suite passes 175 tests. Full Compose CI passes
1,249 Swift tests in 41 suites with 92.81% Swift and 89.88% Go coverage. The
connector reviewed runtime production head `2a0e32acbf` and reported no major
issue after every earlier actionable thread was answered and resolved. A later
review identified that the integration bootstrap inherited developer
configuration; `20e00d7` moves the sole invocation inside the isolated
sequence and passes its scratch `XDG_CONFIG_HOME`, with a full-target Make
dry-run regression. Docker Compose v5.3.1 parity passes all 62 strict
assertions against the unchanged runtime production tree. The connector then
reviewed exact final runtime head `281208b1a8` with no major issue. Runtime
hosted run
[30249659444](https://github.com/stephenlclarke/container/actions/runs/30249659444)
then passed signatures, build, package, and project tests before merge.
Compose hosted checks and SonarCloud remain publication gates.

## Compatibility and risk

- No public runtime API or Compose model contract changes.
- Build glob semantics retain the existing Swift regex behavior, including
  Unicode-sensitive matches.
- Stats preserve input ordering and all-or-fail error semantics.
- Storage counts retain their metadata total while active and reclaimable
  values derive from one validated snapshot.
- Bootstrap skips replacement only when the existing runtime is healthy and
  bound to the requested application root.
- The release change removes cache transfer only; package inputs, outputs,
  checksums, attestations, and authority checks remain unchanged.
- No Windows path or Linux-host implementation is added.

## Checklist

- [x] Every Apple-backed fork contains current Apple `main`
- [x] Signed Conventional implementation commits
- [x] Focused regression tests and unit coverage
- [x] Apple-shaped issue and pull-request handoffs
- [x] Exact Compose dependency and release stack pin
- [x] Complete Compose release-policy tests
- [x] Exact final-head connector review
- [x] Docker Compose v5.3.1 live parity
- [ ] Hosted CI, CodeQL, Quality, documentation, and SonarCloud
- [ ] Signed prerelease and typed/live VHS evidence
