### PR TITLE
docs(upstream): record maintenance publication evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 SHELL := /bin/bash
 .SHELLFLAGS := -euo pipefail -c
 .DEFAULT_GOAL := all
-.PHONY: upstream-divergence-report upstream-divergence-check upstream-divergence-release-check docs serve-docs
+.PHONY: upstream-divergence-report upstream-divergence-check upstream-divergence-release-check readme-upstream-metrics-update readme-upstream-metrics-check docs serve-docs
 
 SWIFT ?= swift
 SWIFT_RESOLVED_FLAGS ?= --disable-automatic-resolution
@@ -1562,6 +1562,12 @@ upstream-divergence-check:
 
 upstream-divergence-release-check:
 	$(PYTHON) Tools/ci/upstream-divergence-report.py --fetch --strict --require-upstream-current --output .build/reports/upstream-divergence.md --json-output .build/reports/upstream-divergence.json
+
+readme-upstream-metrics-update:
+	$(PYTHON) Tools/ci/update-readme-upstream-metrics.py --fetch
+
+readme-upstream-metrics-check:
+	$(PYTHON) Tools/ci/update-readme-upstream-metrics.py --fetch --check
 
 docs:
 	@printf 'Building DocC API documentation...\n'

--- a/README.md
+++ b/README.md
@@ -33,14 +33,16 @@ orchestration and maps supported Compose behavior to the matched runtime stack.
 > [!WARNING]
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 26 July 2026 snapshot, the three support forks are **445 commits ahead of Apple upstream**:
+> <!-- upstream-metrics:start -->
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 27 July 2026 snapshot, the three support forks are **463 commits ahead of Apple upstream**:
 >
 > - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 127 ahead** at [`164088e02e16`](https://github.com/stephenlclarke/containerization/commit/164088e02e16ed80e536d0c59822b09931d213df).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 285 ahead** at [`221fafc24ebd`](https://github.com/stephenlclarke/container/commit/221fafc24ebd19502f4553e0b5d38c14be3f2b22).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 303 ahead** at [`5796a79ee3e5`](https://github.com/stephenlclarke/container/commit/5796a79ee3e59c16098d086278c072740d519ee8).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 33 ahead** at [`f97cddf5b3aa`](https://github.com/stephenlclarke/container-builder-shim/commit/f97cddf5b3aae2426a094613793c11c41b1d2e53).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >
 > What looks like a local Compose change can therefore require coordinated conflict resolution, pin updates, builds, tests, packaging, and release validation across the entire stack. The pinned revisions must move together.
+> <!-- upstream-metrics:end -->
 >
 > Apple's [#1769 proposal](https://github.com/apple/container/pull/1769) and [stated direction](https://github.com/apple/container/pull/1769#issuecomment-4781645360) are that Docker CLI compatibility is **NOT** a project objective, because of UX, naming, and maintenance trade-offs; its preferred route is Docker CLI access through [Socktainer](https://github.com/socktainer/socktainer) and a separate API bridge or service plugin. The missing primitives and fixes may therefore remain long-lived fork responsibilities rather than work Apple adopts upstream.
 

--- a/Tools/ci/test_update_readme_upstream_metrics.py
+++ b/Tools/ci/test_update_readme_upstream_metrics.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("update-readme-upstream-metrics.py")
+SPEC = importlib.util.spec_from_file_location("update_readme_upstream_metrics", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+updater = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = updater
+SPEC.loader.exec_module(updater)
+
+
+class UpdateReadmeUpstreamMetricsTests(unittest.TestCase):
+    def metrics(self) -> list[updater.ReadmeMetric]:
+        return [
+            updater.ReadmeMetric("containerization", 0, 2, "abc123456789", "abc12345"),
+            updater.ReadmeMetric("container", 1, 3, "def123456789", "def12345"),
+            updater.ReadmeMetric("container-builder-shim", 0, 5, "fed123456789", "fed12345"),
+        ]
+
+    def test_renders_metrics_with_total_and_commit_links(self) -> None:
+        rendered = updater.render_metrics_section(self.metrics(), "27 July 2026")
+
+        self.assertIn("27 July 2026 snapshot", rendered)
+        self.assertIn("**10 commits ahead of Apple upstream**", rendered)
+        self.assertIn("**1 behind, 3 ahead**", rendered)
+        self.assertIn("https://github.com/stephenlclarke/container/commit/def123456789", rendered)
+        self.assertIn(updater.BEGIN_MARKER, rendered)
+        self.assertIn(updater.END_MARKER, rendered)
+
+    def test_replaces_legacy_unmarked_metrics_block(self) -> None:
+        readme = "\n".join(
+            [
+                "> [!WARNING]",
+                ">",
+                "> What started as a 'fun' implementation and old text.",
+                ">",
+                "> - [`container`](https://example.invalid): **0 behind, 1 ahead** at [`old`](https://example.invalid).",
+                ">",
+                "> What looks like a local Compose change can therefore require old work.",
+                ">",
+                "> Apple's [#1769 proposal](https://github.com/apple/container/pull/1769) continues.",
+                "",
+            ]
+        )
+        replacement = updater.render_metrics_section(self.metrics(), "27 July 2026")
+
+        updated = updater.replace_metrics_section(readme, replacement)
+
+        self.assertIn("**10 commits ahead of Apple upstream**", updated)
+        self.assertIn("> Apple's [#1769 proposal]", updated)
+        self.assertNotIn("old text", updated)
+
+    def test_replaces_marked_metrics_block(self) -> None:
+        replacement = updater.render_metrics_section(self.metrics(), "27 July 2026")
+        readme = (
+            "before\n"
+            f"> {updater.BEGIN_MARKER}\n"
+            "> stale\n"
+            f"> {updater.END_MARKER}\n"
+            "after\n"
+        )
+
+        updated = updater.replace_metrics_section(readme, replacement)
+
+        self.assertTrue(updated.startswith("before\n"))
+        self.assertIn("**10 commits ahead of Apple upstream**", updated)
+        self.assertTrue(updated.endswith("after\n"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/update-readme-upstream-metrics.py
+++ b/Tools/ci/update-readme-upstream-metrics.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Update README fork-divergence metrics from local stack repositories."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+import textwrap
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_REPO_ROOT = ROOT.parent
+DEFAULT_README = ROOT / "README.md"
+BEGIN_MARKER = "<!-- upstream-metrics:start -->"
+END_MARKER = "<!-- upstream-metrics:end -->"
+DISPLAY_ORDER = ("containerization", "container", "container-builder-shim")
+REPOSITORY_URLS = {
+    "containerization": "https://github.com/stephenlclarke/containerization",
+    "container": "https://github.com/stephenlclarke/container",
+    "container-builder-shim": "https://github.com/stephenlclarke/container-builder-shim",
+}
+
+
+@dataclass(frozen=True)
+class ReadmeMetric:
+    name: str
+    behind: int
+    ahead: int
+    commit_hash: str
+    short: str
+
+
+def load_divergence_reporter() -> Any:
+    module_path = Path(__file__).with_name("upstream-divergence-report.py")
+    spec = importlib.util.spec_from_file_location("upstream_divergence_report", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load {module_path}")
+    reporter = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = reporter
+    spec.loader.exec_module(reporter)
+    return reporter
+
+
+def snapshot_date(now: datetime | None = None) -> str:
+    current = now or datetime.now()
+    return f"{current.day} {current.strftime('%B')} {current.year}"
+
+
+def collect_metrics(repo_root: Path, fetch: bool) -> list[ReadmeMetric]:
+    reporter = load_divergence_reporter()
+    report = reporter.build_report(repo_root, fetch, 0, reporter.DEFAULT_REPOS)
+    by_name = {repo.name: repo for repo in report.repositories}
+    metrics: list[ReadmeMetric] = []
+    for name in DISPLAY_ORDER:
+        repo = by_name[name]
+        if repo.errors:
+            raise RuntimeError(f"{name}: {'; '.join(repo.errors)}")
+        if repo.fork is None:
+            raise RuntimeError(f"{name}: missing fork head")
+        metrics.append(
+            ReadmeMetric(
+                name=name,
+                behind=repo.fork_to_upstream.behind,
+                ahead=repo.fork_to_upstream.ahead,
+                commit_hash=repo.fork.hash,
+                short=repo.fork.hash[:12],
+            )
+        )
+    return metrics
+
+
+def render_metrics_section(metrics: Sequence[ReadmeMetric], date_text: str) -> str:
+    total_ahead = sum(metric.ahead for metric in metrics)
+    lines = [
+        f"> {BEGIN_MARKER}",
+        "> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. "
+        f"At the {date_text} snapshot, the three support forks are **{total_ahead} commits ahead of Apple upstream**:",
+        ">",
+    ]
+    for metric in metrics:
+        repo_url = REPOSITORY_URLS[metric.name]
+        lines.append(
+            f"> - [`{metric.name}`]({repo_url}): **{metric.behind} behind, {metric.ahead} ahead** "
+            f"at [`{metric.short}`]({repo_url}/commit/{metric.commit_hash})."
+        )
+    lines.extend(
+        [
+            "> - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.",
+            ">",
+            "> What looks like a local Compose change can therefore require coordinated conflict resolution, pin updates, builds, tests, packaging, and release validation across the entire stack. The pinned revisions must move together.",
+            f"> {END_MARKER}",
+            ">",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def replace_metrics_section(readme: str, replacement: str) -> str:
+    start = readme.find(f"> {BEGIN_MARKER}")
+    end = readme.find(f"> {END_MARKER}")
+    if start != -1 and end != -1 and end > start:
+        end_line = readme.find("\n", end)
+        if end_line == -1:
+            end_line = len(readme)
+        else:
+            end_line += 1
+        if readme.startswith(">\n", end_line):
+            end_line += 2
+        return readme[:start] + replacement + readme[end_line:]
+
+    legacy_start = readme.find("> What started as a 'fun' implementation")
+    legacy_end = readme.find("> Apple's [#1769 proposal]", legacy_start)
+    if legacy_start == -1 or legacy_end == -1:
+        raise ValueError("could not find README upstream metrics section")
+    return readme[:legacy_start] + replacement + readme[legacy_end:]
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=DEFAULT_REPO_ROOT)
+    parser.add_argument("--readme", type=Path, default=DEFAULT_README)
+    parser.add_argument("--date", default=snapshot_date())
+    parser.add_argument("--fetch", action="store_true")
+    parser.add_argument("--check", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    metrics = collect_metrics(args.repo_root.expanduser(), args.fetch)
+    replacement = render_metrics_section(metrics, args.date)
+    readme_path = args.readme.expanduser()
+    current = readme_path.read_text(encoding="utf-8")
+    updated = replace_metrics_section(current, replacement)
+    if args.check:
+        if updated != current:
+            print(
+                textwrap.dedent(
+                    f"""\
+                    {readme_path} upstream metrics are stale.
+                    Run: python3 Tools/ci/update-readme-upstream-metrics.py --fetch
+                    """
+                ).strip(),
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+    readme_path.write_text(updated, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/upstream/container-compose/HANDOFF-upstream-maintenance-20260727.md
+++ b/docs/upstream/container-compose/HANDOFF-upstream-maintenance-20260727.md
@@ -1,0 +1,311 @@
+# Cross-MBP handoff: upstream maintenance
+
+Updated: 2026-07-27 10:40 BST
+
+## Stop point
+
+The source changes for this slice are merged. Exact-main validation and
+documentation are still running, the `current` prerelease has not yet moved to
+the merge, and the final documentation/Slack closeout has not been completed.
+Do not begin the next parity slice until these publication gates are closed.
+
+The durable goal remains:
+
+> Complete every macOS-feasible Container Compose parity phase 1 through 6 in
+> order, with Apple-shaped fork commits, unit and Docker Compose V2 parity
+> coverage, current documentation, Sonar cleanup, main publication, slice
+> prereleases, and `-+-` stable releases at phase boundaries.
+
+The user waived only the soak gate.
+
+## Workflow rules to retain
+
+- Implement macOS-hosted functionality only. Include Linux guest behavior that
+  can be exercised through the macOS runtime; skip Windows-only work.
+- Prefer Compose-layer abstractions and minimally invasive, independently
+  useful Apple-fork commits.
+- Use signed Conventional Commits. Do not use `codex` in a branch name, commit
+  subject, or pull-request title.
+- Request an exact-head `@codex review` before merge. Respond directly to each
+  actionable `chatgpt-codex-connector[bot]` comment and resolve its thread.
+- Immediately before every merge, run the thread-aware review fetcher:
+
+  ```sh
+  review_script="/Users/sclarke/.codex/plugins/cache/"
+  review_script="${review_script}openai-curated-remote/github/"
+  review_script="${review_script}0.1.8-2841cf9749ae/skills/"
+  review_script="${review_script}gh-address-comments/scripts/fetch_comments.py"
+  GH_REPO=<owner/repo> python3 "${review_script}" <pr-number>
+  ```
+
+- Send detailed Slack START and END messages for every slice to
+  `xyzzytools.slack.com#codex`, channel ID `C0B1RNM8ZJ5`.
+- Immediately before each Slack send, fully reread the Slack, outgoing-message,
+  and Slack Markdown skill files under the installed Slack plugin.
+- The README VHS source must visibly type commands and show their real output.
+  It must contain no `Replay` or `Marker` directives.
+- Preserve dirty primary worktrees and use isolated worktrees.
+- Push each completed slice to `main`, publish its prerelease, and run/fix
+  Sonar before moving beyond a phase boundary.
+
+## Slice notification
+
+Slack START was already sent and must not be duplicated:
+
+<https://xyzzytools.slack.com/archives/C0B1RNM8ZJ5/p1785127242796979>
+
+The final slice END is still required after all gates and release verification
+complete. A stop/handoff update is expected when this checkpoint is pushed.
+
+## Runtime fork result
+
+Repository: `stephenlclarke/container`
+
+Temporary worktree:
+
+`/tmp/container-upstream-2022.QpmflP/worktree`
+
+PR:
+[stephenlclarke/container#30](https://github.com/stephenlclarke/container/pull/30)
+
+Reviewed feature head:
+
+`281208b1a8db06c92348afdeb1c163e043637c16`
+
+Merged runtime main:
+
+`5796a79ee3e59c16098d086278c072740d519ee8`
+
+The merge tree exactly matches the reviewed head. Hosted run
+[30249659444](https://github.com/stephenlclarke/container/actions/runs/30249659444)
+passed signatures, build, package, and project tests. All five actionable
+connector threads have direct responses and are resolved. The exact-head
+connector review reported no major issue.
+
+The eleven independently useful signed implementation commits are enumerated
+in
+[PR-upstream-maintenance-20260727.md](PR-upstream-maintenance-20260727.md).
+They cover compiled ignore globs, hashed context membership, concurrent stats,
+off-lock sizing, ordered/failure-safe init bootstrap, isolated volume prune,
+Unicode-sensitive glob semantics, partial-bootstrap cleanup, active-runtime
+reuse, snapshot-consistent volume usage, and isolated integration bootstrap
+configuration.
+
+Runtime validation:
+
+- 1,148 unit tests in 134 suites
+- 39.27% unit line coverage
+- 293 concurrent plus 87 serial source-matched integration scenarios
+- 51.56% combined runtime coverage
+- 62 strict Docker Compose V2 5.3.1 parity assertions
+
+## Compose result
+
+Repository: `stephenlclarke/container-compose`
+
+Temporary worktree:
+
+`/tmp/container-compose-upstream-audit.Vx0u4E/worktree`
+
+Implementation branch:
+
+`chore/upstream-audit-20260727`
+
+Issue:
+[stephenlclarke/container-compose#165](https://github.com/stephenlclarke/container-compose/issues/165)
+
+PR:
+[stephenlclarke/container-compose#166](https://github.com/stephenlclarke/container-compose/pull/166)
+
+Reviewed PR head:
+
+`eb6ac58ec3cdc90e47f6f88e346a5038691964c1`
+
+Merged Compose main:
+
+`4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`
+
+The merge tree exactly matches the reviewed head. The signed Compose commits
+are:
+
+- `6cae9a84deee2b13eecfeb1efbf83ad2c98f88a9` — remove oversized
+  release-only dependency caches
+- `e45240b718bf88a709e4fbb7056dfa0af4a1811e` — initial reviewed runtime
+  pin
+- `c9a343f0d658dbb576c52a33e1ea97f3130bc730` — pin merged runtime
+  `5796a79ee3e59c16098d086278c072740d519ee8`
+- `c28b0fe3ba3aba1c353a80d9678329c16755f79d` — refresh upstream audit and
+  handoffs
+- `eb6ac58ec3cdc90e47f6f88e346a5038691964c1` — link issue #165
+
+Local exact-pin validation:
+
+- `HAWKEYE_AUTO_INSTALL=1 make ci`: green
+- 1,249 Swift tests in 41 suites
+- Swift coverage 92.81%
+- Go coverage 89.88%
+- 175 release-policy tests
+- stack consistency, formatting/lint, licenses, JSON, and archive verifier:
+  green
+- seven immutable upstream PR archive refs verified live
+- Docker Compose V2 5.3.1 parity: 62 strict assertions
+- README tape: 16 `Type`, 16 `Enter`, 14 live waits/screens, zero `Replay`,
+  and zero `Marker`
+
+PR #166 hosted evidence:
+
+- CI
+  [30251651045](https://github.com/stephenlclarke/container-compose/actions/runs/30251651045):
+  green
+- CodeQL
+  [30251651099](https://github.com/stephenlclarke/container-compose/actions/runs/30251651099):
+  green
+- Quality
+  [30251651067](https://github.com/stephenlclarke/container-compose/actions/runs/30251651067):
+  green, including Swift ASan
+- Documentation
+  [30251651028](https://github.com/stephenlclarke/container-compose/actions/runs/30251651028):
+  green
+- immutable archive verification
+  [30251651053](https://github.com/stephenlclarke/container-compose/actions/runs/30251651053):
+  green
+- exact-head connector review: no major issues and zero review threads
+
+## Exact-main work in flight
+
+All runs target exact merge
+`4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`.
+
+- CI
+  [30253458586](https://github.com/stephenlclarke/container-compose/actions/runs/30253458586):
+  in progress in `Run coverage gate`
+- CodeQL
+  [30253458549](https://github.com/stephenlclarke/container-compose/actions/runs/30253458549):
+  green
+- Quality
+  [30253458554](https://github.com/stephenlclarke/container-compose/actions/runs/30253458554):
+  green
+- Documentation
+  [30253458571](https://github.com/stephenlclarke/container-compose/actions/runs/30253458571):
+  in progress in `Build static API documentation`
+- immutable archive verification
+  [30253458622](https://github.com/stephenlclarke/container-compose/actions/runs/30253458622):
+  green
+
+CI must finish coverage, CLI smoke, and an exact-revision Sonar scan. Its
+successful completion automatically starts the `Prebuilt Binaries` workflow.
+Do not dispatch a duplicate package run while the automatic run is viable.
+
+The `current` prerelease is still the previous publication:
+
+- target:
+  `e0e076c930e15828cd4d94f4d312a72ab8283846`
+- published: 2026-07-27 04:35:15 UTC
+- release:
+  <https://github.com/stephenlclarke/container-compose/releases/tag/current>
+
+It is not evidence for this slice.
+
+## Required closeout on the replacement MBP
+
+1. Fetch `origin` and confirm `main` still contains
+   `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`.
+2. Monitor exact-main runs `30253458586` and `30253458571`; confirm all five
+   workflows above finish green.
+3. Inspect CI `30253458586` and require the `SonarQube scan` step to pass.
+4. Query SonarCloud project `stephenlclarke_container-compose2` and require:
+   - analysis revision equal to exact validated main;
+   - quality gate `OK`;
+   - zero unresolved issues;
+   - zero unresolved security hotspots;
+   - A reliability, security, and maintainability ratings.
+5. Find the automatic `Prebuilt Binaries` run created from CI `30253458586`
+   and wait for it to finish.
+6. Compare its Package timings with baseline run `30235634675`:
+   - old SwiftPM cache transfer: 10m00s / 2,134,173,923 bytes;
+   - old `setup-go` cache path: 19m19s / 1,624,881,811-byte attempted restore.
+7. Verify the refreshed `current` prerelease:
+   - exact target commit;
+   - prerelease, not draft;
+   - seven assets;
+   - both checksum sidecars;
+   - both GitHub attestations;
+   - Homebrew tap commit and matched formula version;
+   - release-highlight JSON and quality snapshot;
+   - live GIF metadata/hash and the tape instruction counts above.
+8. Update these checked-in documents with the actual evidence:
+   - this handoff;
+   - `PR-upstream-maintenance-20260727.md`;
+   - `PR-release-dependency-cache-overhead.md`.
+9. Commit the evidence as a signed documentation commit on
+   `docs/upstream-maintenance-closeout-20260727`, push it, open a PR, obtain an
+   exact-head connector review, run the thread-aware fetcher, and merge.
+10. If the docs-only merge becomes newer than the released target, dispatch
+    full CI for exact final `main` and republish `current` from that exact
+    revision. Do not leave the mutable prerelease behind final `main`.
+11. Refresh this handoff with final run, Sonar, release, tap, GIF, and Slack END
+    identities.
+12. Fully reread the Slack skills, send the detailed slice END, then begin a
+    new slice only after a new Slack START.
+
+## Upstream state at merge
+
+Freshly fetched Apple/fork baselines:
+
+- `apple/container`: Apple
+  `d1d763530df3c6a326dbae7f0c0a59a335808045`; fork
+  `5796a79ee3e59c16098d086278c072740d519ee8`; Apple-only 0; fork-only
+  non-merge 276
+- `apple/containerization`: Apple
+  `74ace148ded72f7bb3c878b142e4962ae668adf4`; fork
+  `164088e02e16ed80e536d0c59822b09931d213df`; Apple-only 0; fork-only
+  non-merge 110
+- `apple/container-builder-shim`: Apple
+  `267b5ab98e1d7db7d98af98bdc90578bf5fd3192`; fork
+  `f97cddf5b3aae2426a094613793c11c41b1d2e53`; Apple-only 0; fork-only
+  non-merge 28
+
+No open Dependabot/Renovate PR existed in the runtime, containerization,
+builder-shim, Compose, or tap repositories.
+
+Stephen-authored Apple proposals had no requested author change:
+
+- `apple/container#1934`
+- `apple/container#1935`
+- `apple/container#1965`
+- `apple/containerization#799`
+
+Recheck all remotes, bot PRs, authored proposals, and connector comments after
+moving hosts; this snapshot is not a substitute for a fresh audit.
+
+## Worktrees and shared-runtime boundary
+
+Preserve these user changes:
+
+- `/Users/sclarke/github/container-compose`
+  - modified `Package.resolved`
+  - untracked `Packages/`
+- `/Users/sclarke/github/containerization`
+  - untracked `.vscode/`
+
+Do not clean, reset, overwrite, or fold them into this slice.
+
+The previous MBP shared its global Container service with a devcontainer
+session. Immediately before PR #166 merged, all visible devcontainer BuildKit
+containers were stopped. Once devcontainer work runs on a different MBP, that
+local service conflict is removed, but still inspect the service before any
+runtime install, stop, reset, or live parity run.
+
+## Next parity blockers
+
+Do not start these until this slice is fully published and closed:
+
+1. Drain package-compatibility preflight stdout/stderr concurrently so a full
+   child pipe cannot deadlock.
+2. Preserve inherited OCI `VOLUME` declarations in `compose commit`.
+3. Replace archive-mode `compose cp` host staging with direct runtime streams
+   so ownership metadata can be preserved.
+
+Continue the ordered inventory in
+`docs/reviews/CONTAINER-STACK-CRITICAL-REVIEW-2026-07-24.md` after these three
+confirmed P1 items.

--- a/docs/upstream/container-compose/HANDOFF-upstream-maintenance-20260727.md
+++ b/docs/upstream/container-compose/HANDOFF-upstream-maintenance-20260727.md
@@ -1,13 +1,17 @@
 # Cross-MBP handoff: upstream maintenance
 
-Updated: 2026-07-27 10:40 BST
+Updated: 2026-07-27 11:56 BST
 
 ## Stop point
 
-The source changes for this slice are merged. Exact-main validation and
-documentation are still running, the `current` prerelease has not yet moved to
-the merge, and the final documentation/Slack closeout has not been completed.
-Do not begin the next parity slice until these publication gates are closed.
+The source changes for this slice are merged and the exact-main publication
+gates have closed green. The mutable `current` prerelease now points at the
+merge, the package artefacts and Homebrew formulas are aligned, and SonarCloud
+has indexed the exact revision.
+
+The remaining closeout work is documentation review/merge and the final Slack
+END notification. Do not begin the next parity slice until that closeout is
+complete.
 
 The durable goal remains:
 
@@ -171,14 +175,15 @@ PR #166 hosted evidence:
   green
 - exact-head connector review: no major issues and zero review threads
 
-## Exact-main work in flight
+## Exact-main publication evidence
 
 All runs target exact merge
 `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`.
 
 - CI
   [30253458586](https://github.com/stephenlclarke/container-compose/actions/runs/30253458586):
-  in progress in `Run coverage gate`
+  green. `Run coverage gate`, `Run built CLI smoke`, and `SonarQube scan`
+  passed. The `SonarQube scan` step ran from 09:48:54 to 09:49:50 UTC.
 - CodeQL
   [30253458549](https://github.com/stephenlclarke/container-compose/actions/runs/30253458549):
   green
@@ -187,66 +192,93 @@ All runs target exact merge
   green
 - Documentation
   [30253458571](https://github.com/stephenlclarke/container-compose/actions/runs/30253458571):
-  in progress in `Build static API documentation`
+  green
 - immutable archive verification
   [30253458622](https://github.com/stephenlclarke/container-compose/actions/runs/30253458622):
   green
 
-CI must finish coverage, CLI smoke, and an exact-revision Sonar scan. Its
-successful completion automatically starts the `Prebuilt Binaries` workflow.
-Do not dispatch a duplicate package run while the automatic run is viable.
+The automatic `Prebuilt Binaries` workflow from CI finished green:
 
-The `current` prerelease is still the previous publication:
+- [30255646679](https://github.com/stephenlclarke/container-compose/actions/runs/30255646679),
+  event `workflow_run`, head
+  `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`
+- Package job [89943524792](https://github.com/stephenlclarke/container-compose/actions/runs/30255646679/job/89943524792):
+  14m18s total, from 09:51:06 to 10:05:24 UTC
+- Compared with baseline package run
+  [30235634675](https://github.com/stephenlclarke/container-compose/actions/runs/30235634675),
+  the SwiftPM package cache restore step was removed and the Go setup cache was
+  disabled. Baseline package duration was 43m01s, including a 10m00s
+  2,134,173,923-byte SwiftPM cache transfer and a 19m19s
+  1,624,881,811-byte Go cache restore attempt. Current `Set up Go` completed in
+  0s, `Build matched runtime package` completed in 2m50s, `Build release
+  package` completed in 2m31s, and the live VHS recording completed in 6m38s.
+
+SonarCloud project `stephenlclarke_container-compose2` is aligned:
+
+- latest analysis: `2026-07-27T09:49:07+0000`
+- revision: `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`
+- quality gate: `OK`
+- unresolved issues: 0
+- unresolved security hotspots: 0
+- reliability, security, and maintainability ratings: A
+- bugs, vulnerabilities, code smells, and security hotspots: 0
+
+The refreshed `current` prerelease is valid slice evidence:
 
 - target:
-  `e0e076c930e15828cd4d94f4d312a72ab8283846`
-- published: 2026-07-27 04:35:15 UTC
+  `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`
+- published: 2026-07-27 10:05:13 UTC
 - release:
   <https://github.com/stephenlclarke/container-compose/releases/tag/current>
+- prerelease: true
+- draft: false
+- seven release assets:
+  - `container-compose-demo-current.gif`,
+    GitHub asset digest
+    `sha256:a7e2821befbd1be4c6a2c7e0d807322aa18dd76d240d62233b32620dd2a9840a`
+  - `container-compose-plugin-current-4fe88b796fe2-arm64.tar.gz`,
+    GitHub asset digest and checked artefact SHA-256
+    `cc51d5dea4feabf84a66fc024a22b067b61a307f078bf23a48fa3ea1d32771ac`
+  - `container-compose-plugin-current-4fe88b796fe2-arm64.tar.gz.sha256`
+  - `container-current-4fe88b796fe2-arm64.tar.gz`,
+    GitHub asset digest and checked artefact SHA-256
+    `64b47eb5377b7f60c70381008510656d2a88dee1b4c625e349da2eba6ab840b2`
+  - `container-current-4fe88b796fe2-arm64.tar.gz.sha256`
+  - `quality-snapshot-current.svg`,
+    GitHub asset digest
+    `sha256:cdc66f407cc8c883bf09e1b4efcad056908e577354a47611d36119e337dcbcf5`
+  - `release-highlights-current-4fe88b796fe2.json`,
+    GitHub asset digest
+    `sha256:2fd2a2ca64f2cce34d5abc20892d0284ea469c6a7d4748ab0a5a0f05c1a444bb`
+- checksum sidecars verified locally with `shasum -a 256 -c`
+- both package attestations verified locally with `gh attestation verify` after
+  selecting the keyring-backed GitHub token:
+  - `container-compose-plugin-current-4fe88b796fe2-arm64.tar.gz`
+  - `container-current-4fe88b796fe2-arm64.tar.gz`
+- Homebrew tap commit
+  `5d53619c83bd8a2b1b47638d8d99d0c817d1ed17` updates
+  `container-current.rb` and `container-compose-current.rb` to
+  `current.895.4fe88b796fe2`, with matched asset names and SHA-256 values
+- downloaded release-highlight JSON contains the expected top-level keys:
+  `base`, `components`, `composeVersion`, `head`, `highlights`,
+  `releaseLabel`, `releaseTag`, and `schemaVersion`
+- downloaded live GIF is GIF89a, 1600 x 720, 3,306,908 bytes, SHA-256
+  `a7e2821befbd1be4c6a2c7e0d807322aa18dd76d240d62233b32620dd2a9840a`
+- checked-in README tape contains 16 `Type`, 16 `Enter`, 14 `Wait+Screen`,
+  zero `Replay`, and zero `Marker` directives
 
-It is not evidence for this slice.
+## Remaining closeout
 
-## Required closeout on the replacement MBP
-
-1. Fetch `origin` and confirm `main` still contains
-   `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`.
-2. Monitor exact-main runs `30253458586` and `30253458571`; confirm all five
-   workflows above finish green.
-3. Inspect CI `30253458586` and require the `SonarQube scan` step to pass.
-4. Query SonarCloud project `stephenlclarke_container-compose2` and require:
-   - analysis revision equal to exact validated main;
-   - quality gate `OK`;
-   - zero unresolved issues;
-   - zero unresolved security hotspots;
-   - A reliability, security, and maintainability ratings.
-5. Find the automatic `Prebuilt Binaries` run created from CI `30253458586`
-   and wait for it to finish.
-6. Compare its Package timings with baseline run `30235634675`:
-   - old SwiftPM cache transfer: 10m00s / 2,134,173,923 bytes;
-   - old `setup-go` cache path: 19m19s / 1,624,881,811-byte attempted restore.
-7. Verify the refreshed `current` prerelease:
-   - exact target commit;
-   - prerelease, not draft;
-   - seven assets;
-   - both checksum sidecars;
-   - both GitHub attestations;
-   - Homebrew tap commit and matched formula version;
-   - release-highlight JSON and quality snapshot;
-   - live GIF metadata/hash and the tape instruction counts above.
-8. Update these checked-in documents with the actual evidence:
-   - this handoff;
-   - `PR-upstream-maintenance-20260727.md`;
-   - `PR-release-dependency-cache-overhead.md`.
-9. Commit the evidence as a signed documentation commit on
+1. Commit this evidence as a signed documentation commit on
    `docs/upstream-maintenance-closeout-20260727`, push it, open a PR, obtain an
    exact-head connector review, run the thread-aware fetcher, and merge.
-10. If the docs-only merge becomes newer than the released target, dispatch
-    full CI for exact final `main` and republish `current` from that exact
-    revision. Do not leave the mutable prerelease behind final `main`.
-11. Refresh this handoff with final run, Sonar, release, tap, GIF, and Slack END
-    identities.
-12. Fully reread the Slack skills, send the detailed slice END, then begin a
-    new slice only after a new Slack START.
+2. If the docs-only merge becomes newer than the released target, dispatch full
+   CI for exact final `main` and republish `current` from that exact revision.
+   Do not leave the mutable prerelease behind final `main`.
+3. Refresh this handoff with final run, Sonar, release, tap, GIF, and Slack END
+   identities.
+4. Fully reread the Slack skills, send the detailed slice END, then begin a new
+   slice only after a new Slack START.
 
 ## Upstream state at merge
 
@@ -280,15 +312,10 @@ moving hosts; this snapshot is not a substitute for a fresh audit.
 
 ## Worktrees and shared-runtime boundary
 
-Preserve these user changes:
-
-- `/Users/sclarke/github/container-compose`
-  - modified `Package.resolved`
-  - untracked `Packages/`
-- `/Users/sclarke/github/containerization`
-  - untracked `.vscode/`
-
-Do not clean, reset, overwrite, or fold them into this slice.
+The replacement MBP now has `/Users/sclarke/github/container-compose` clean on
+this closeout branch after fast-forwarding `main`. `/Users/sclarke/github/homebrew-tap`
+was also fast-forwarded cleanly to the published formula commit above. Continue
+to inspect status before any runtime install, reset, or live parity run.
 
 The previous MBP shared its global Container service with a devcontainer
 session. Immediately before PR #166 merged, all visible devcontainer BuildKit

--- a/docs/upstream/container-compose/PR-release-dependency-cache-overhead.md
+++ b/docs/upstream/container-compose/PR-release-dependency-cache-overhead.md
@@ -61,15 +61,50 @@ The Go cache failed authentication after receiving about 1.29 GB; the build
 then succeeded. This makes the no-cache behavior directly equivalent to the
 successful portion of the observed run.
 
+## Publication comparison
+
+Exact-main Current run
+[`30255646679`](https://github.com/stephenlclarke/container-compose/actions/runs/30255646679)
+published merge `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4` successfully.
+
+| Step | Duration | Cache transfer |
+| --- | ---: | ---: |
+| Cache SwiftPM build artifacts | removed | none |
+| Build matched runtime package | 2m 50s | none |
+| Set up Go | 0s | none; `setup-go` cache disabled |
+| Build release package | 2m 31s | none |
+| Generate Current build VHS recording | 6m 38s | none |
+| Package job total | 14m 18s | none from the removed release caches |
+
+The baseline package job took 43m 01s. The Current job that contains this
+change avoided the prior 2,134,173,923-byte SwiftPM cache transfer and the
+1,624,881,811-byte Go cache restore attempt while preserving the same release
+authority, package, attestation, Homebrew, and live VHS stages.
+
+The refreshed `current` prerelease is not a draft, is marked prerelease, targets
+`4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`, and was published at
+2026-07-27 10:05:13 UTC. Both package archives have verified SHA-256 sidecars
+and locally verified GitHub attestations:
+
+- `container-compose-plugin-current-4fe88b796fe2-arm64.tar.gz`:
+  `cc51d5dea4feabf84a66fc024a22b067b61a307f078bf23a48fa3ea1d32771ac`
+- `container-current-4fe88b796fe2-arm64.tar.gz`:
+  `64b47eb5377b7f60c70381008510656d2a88dee1b4c625e349da2eba6ab840b2`
+
+Homebrew tap commit
+`5d53619c83bd8a2b1b47638d8d99d0c817d1ed17` updates
+`container-current.rb` and `container-compose-current.rb` to
+`current.895.4fe88b796fe2` with the matching asset names and SHA-256 values.
+
 ## Compatibility and risk
 
 - The clean job already checks out every exact source revision and SwiftPM
   resolves from tracked manifests.
 - `setup-go` still installs/selects the version pinned by `go.mod`; only its
   cache restore/save behavior changes.
-- Cold build duration can vary, so the next Current run is the authoritative
-  end-to-end timing. The change removes a deterministic 3.76 GB transfer
-  obligation observed to exceed the builds it was intended to accelerate.
+- Cold build duration can vary, but the exact-main Current run confirms the
+  release path no longer pays the deterministic 3.76 GB transfer obligation
+  observed to exceed the builds it was intended to accelerate.
 - CI, CodeQL, Quality, and stable-gate caches are unchanged.
 - Archive contents, checksums, attestations, formulae, and release identity are
   unchanged.
@@ -80,5 +115,5 @@ successful portion of the observed run.
 - [x] Focused workflow-policy tests
 - [x] YAML parse and actionlint
 - [x] Complete release test suite
-- [ ] Pull-request checks and connector review
-- [ ] Exact-main Current publication and timing comparison
+- [x] Pull-request checks and connector review
+- [x] Exact-main Current publication and timing comparison

--- a/docs/upstream/container-compose/PR-upstream-maintenance-20260727.md
+++ b/docs/upstream/container-compose/PR-upstream-maintenance-20260727.md
@@ -112,7 +112,35 @@ reviewed exact final runtime head `281208b1a8` with no major issue. Runtime
 hosted run
 [30249659444](https://github.com/stephenlclarke/container/actions/runs/30249659444)
 then passed signatures, build, package, and project tests before merge.
-Compose hosted checks and SonarCloud remain publication gates.
+Exact-main Compose publication gates are complete:
+
+- CI
+  [30253458586](https://github.com/stephenlclarke/container-compose/actions/runs/30253458586):
+  green, including coverage, built CLI smoke, and `SonarQube scan`
+- CodeQL
+  [30253458549](https://github.com/stephenlclarke/container-compose/actions/runs/30253458549):
+  green
+- Quality
+  [30253458554](https://github.com/stephenlclarke/container-compose/actions/runs/30253458554):
+  green
+- Documentation
+  [30253458571](https://github.com/stephenlclarke/container-compose/actions/runs/30253458571):
+  green
+- Verify Upstream PR Archives
+  [30253458622](https://github.com/stephenlclarke/container-compose/actions/runs/30253458622):
+  green
+- Prebuilt Binaries
+  [30255646679](https://github.com/stephenlclarke/container-compose/actions/runs/30255646679):
+  green, publishing `current` at
+  `4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`
+
+SonarCloud analysis `2026-07-27T09:49:07+0000` covers exact revision
+`4fe88b796fe2b4b3008ccc7da8d284cedd4235c4`, quality gate `OK`, zero
+unresolved issues, zero unresolved security hotspots, and A reliability,
+security, and maintainability ratings. The refreshed `current` prerelease is
+not a draft, has seven assets, verified checksum sidecars, locally verified
+GitHub attestations for both package archives, and matching Homebrew tap commit
+`5d53619c83bd8a2b1b47638d8d99d0c817d1ed17`.
 
 ## Compatibility and risk
 
@@ -138,5 +166,5 @@ Compose hosted checks and SonarCloud remain publication gates.
 - [x] Complete Compose release-policy tests
 - [x] Exact final-head connector review
 - [x] Docker Compose v5.3.1 live parity
-- [ ] Hosted CI, CodeQL, Quality, documentation, and SonarCloud
-- [ ] Signed prerelease and typed/live VHS evidence
+- [x] Hosted CI, CodeQL, Quality, documentation, and SonarCloud
+- [x] Signed prerelease and typed/live VHS evidence


### PR DESCRIPTION
## Summary

- record exact-main workflow, SonarCloud, release, attestation, Homebrew, and live GIF evidence for the upstream maintenance slice
- close the cache-overhead timing comparison against baseline run 30235634675
- update the README upstream divergence metrics to the current 27 July 2026 fork heads
- add `Tools/ci/update-readme-upstream-metrics.py` plus Makefile targets to update or check those metrics automatically
- keep the handoff blocked only on docs review/merge and Slack END closeout

## Validation

- `python3 Tools/ci/update-readme-upstream-metrics.py --fetch --check`
- `python3 -m unittest Tools.ci.test_update_readme_upstream_metrics Tools.ci.test_upstream_divergence_report`
- `python3 -m py_compile Tools/ci/*.py`
- `python3 -m unittest discover Tools/ci`
- `markdownlint README.md docs/upstream/container-compose/HANDOFF-upstream-maintenance-20260727.md docs/upstream/container-compose/PR-upstream-maintenance-20260727.md docs/upstream/container-compose/PR-release-dependency-cache-overhead.md`
- `git diff --check`
- Verified exact-main runs 30253458586, 30253458549, 30253458554, 30253458571, and 30253458622 are green
- Verified Prebuilt Binaries run 30255646679 is green and published `current` at 4fe88b796fe2b4b3008ccc7da8d284cedd4235c4
- Verified SonarCloud revision, quality gate, zero unresolved issues, zero unresolved hotspots, and A ratings
- Verified release assets, checksum sidecars, package attestations, Homebrew formula refs, GIF metadata, and tape counts