### PR TITLE
fix(release): ignore mutable runtime package tag

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1140,7 +1140,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.run_command("git", "-C", str(updater), "tag", "--no-sign", "-f", "current")
             self.run_command("git", "-C", str(updater), "push", "origin", "+refs/tags/current")
 
-            result = self.run_release_function(root / "github", "fetch_release_remote container-compose")
+            result = self.run_release_function(
+                root / "github",
+                "fetch_release_remote container-compose",
+                shell="/bin/bash",
+            )
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("refreshing mutable current tag", result.stdout)
@@ -1701,6 +1705,7 @@ gh() {
         root: Path,
         function_call: str,
         shell_setup: str | None = None,
+        shell: str = "bash",
     ) -> subprocess.CompletedProcess[str]:
         lines = [
             "set -euo pipefail",
@@ -1717,7 +1722,7 @@ gh() {
         command = "\n".join(lines)
         environment = self.non_interactive_environment()
         return subprocess.run(
-            ["bash", "-c", command],
+            [shell, "-c", command],
             capture_output=True,
             text=True,
             check=False,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1115,6 +1115,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)
         self.assertIn("+refs/tags/current:refs/tags/current", self.script)
+        self.assertIn("^refs/tags/homebrew-main", self.script)
         self.assertNotIn("fetch --prune --tags --force", self.script)
 
     def test_git_fixtures_never_launch_an_editor(self) -> None:
@@ -1148,6 +1149,70 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "git", "ls-remote", "--tags", "--refs", str(remote), "refs/tags/current"
             ).stdout.split()[0]
             self.assertEqual(local_current, remote_current)
+
+    def test_release_fetch_excludes_mutable_homebrew_main_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote = root / "remote.git"
+            local = root / "github" / "container"
+            self.run_command("git", "init", "--bare", str(remote))
+            local.parent.mkdir(parents=True)
+            self.run_command("git", "init", "-b", "main", str(local))
+            self.configure_repo(local)
+            self.run_command("git", "-C", str(local), "remote", "add", "fork", str(remote))
+            self.commit_file(local, "README.md", "base\n", "chore: initial runtime")
+            self.run_command("git", "-C", str(local), "tag", "--no-sign", "homebrew-main")
+            self.run_command(
+                "git",
+                "-C",
+                str(local),
+                "push",
+                "-u",
+                "fork",
+                "main",
+                "refs/tags/homebrew-main",
+            )
+            local_tag = self.git(local, "rev-parse", "refs/tags/homebrew-main")
+
+            updater = root / "updater"
+            self.run_command("git", "clone", "--branch", "main", str(remote), str(updater))
+            self.configure_repo(updater)
+            self.commit_file(updater, "CURRENT.md", "current\n", "chore: advance runtime")
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+            self.run_command(
+                "git",
+                "-C",
+                str(updater),
+                "tag",
+                "--no-sign",
+                "-f",
+                "homebrew-main",
+            )
+            self.run_command(
+                "git",
+                "-C",
+                str(updater),
+                "push",
+                "origin",
+                "+refs/tags/homebrew-main",
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "fetch_release_remote container",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(self.git(local, "rev-parse", "refs/tags/homebrew-main"), local_tag)
+            remote_tag = self.run_command(
+                "git",
+                "ls-remote",
+                "--tags",
+                "--refs",
+                str(remote),
+                "refs/tags/homebrew-main",
+            ).stdout.split()[0]
+            self.assertNotEqual(local_tag, remote_tag)
 
     def test_release_helper_reconstructs_an_unpublished_prepared_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -1231,7 +1296,6 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_release_helper_does_not_refresh_legacy_mutable_package_pointers(self) -> None:
         self.assertNotIn("+refs/tags/homebrew-main:refs/tags/homebrew-main", self.script)
-        self.assertNotIn("legacy mutable pointer", self.script)
         self.assertNotIn("fetch --prune --tags --force", self.script)
 
     def test_equivalent_squash_promotion_aligns_local_main(self) -> None:

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -433,12 +433,21 @@ refresh_mutable_current_tag() {
 
 fetch_release_remote() {
   local repo="$1" path remote url fallback_url
+  local tag_exclusions=()
   path="$(repo_path "${repo}")"
   remote="$(push_remote "${repo}")"
   url="$(git -C "${path}" remote get-url "${remote}")"
+  if [[ "${repo}" == "${CONTAINER_REPO}" ]]; then
+    # The legacy Homebrew lane retargets this pointer on every runtime build.
+    # Stable release preparation does not consume it, so exclude it while
+    # fetching immutable package and semantic tags.
+    tag_exclusions+=("^refs/tags/homebrew-main")
+  fi
 
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run: git -C %s fetch --prune --tags %s\n' "${path}" "${remote}"
+    printf 'would run: git -C %s fetch --prune --tags %s' "${path}" "${remote}"
+    printf ' %s' "${tag_exclusions[@]}"
+    printf '\n'
     return 0
   fi
 
@@ -449,16 +458,20 @@ fetch_release_remote() {
   fi
 
   refresh_mutable_current_tag "${repo}" "${path}" "${remote}"
-  printf '+ git -C %s fetch --prune --tags %s\n' "${path}" "${remote}"
-  if git -C "${path}" fetch --prune --tags "${remote}"; then
+  printf '+ git -C %s fetch --prune --tags %s' "${path}" "${remote}"
+  printf ' %s' "${tag_exclusions[@]}"
+  printf '\n'
+  if git -C "${path}" fetch --prune --tags "${remote}" "${tag_exclusions[@]}"; then
     return 0
   fi
 
   if fallback_url="$(stephen_https_url "${url}")"; then
     printf 'fetch from %s failed for %s; switching %s to %s and retrying\n' "${url}" "${repo}" "${remote}" "${fallback_url}" >&2
     git -C "${path}" remote set-url "${remote}" "${fallback_url}"
-    printf '+ git -C %s fetch --prune --tags %s\n' "${path}" "${remote}"
-    git -C "${path}" fetch --prune --tags "${remote}"
+    printf '+ git -C %s fetch --prune --tags %s' "${path}" "${remote}"
+    printf ' %s' "${tag_exclusions[@]}"
+    printf '\n'
+    git -C "${path}" fetch --prune --tags "${remote}" "${tag_exclusions[@]}"
     return 0
   fi
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -433,20 +433,21 @@ refresh_mutable_current_tag() {
 
 fetch_release_remote() {
   local repo="$1" path remote url fallback_url
-  local tag_exclusions=()
+  local fetch_args=()
   path="$(repo_path "${repo}")"
   remote="$(push_remote "${repo}")"
   url="$(git -C "${path}" remote get-url "${remote}")"
+  fetch_args=(git -C "${path}" fetch --prune --tags "${remote}")
   if [[ "${repo}" == "${CONTAINER_REPO}" ]]; then
     # The legacy Homebrew lane retargets this pointer on every runtime build.
     # Stable release preparation does not consume it, so exclude it while
     # fetching immutable package and semantic tags.
-    tag_exclusions+=("^refs/tags/homebrew-main")
+    fetch_args+=("^refs/tags/homebrew-main")
   fi
 
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run: git -C %s fetch --prune --tags %s' "${path}" "${remote}"
-    printf ' %s' "${tag_exclusions[@]}"
+    printf 'would run:'
+    printf ' %s' "${fetch_args[@]}"
     printf '\n'
     return 0
   fi
@@ -458,20 +459,20 @@ fetch_release_remote() {
   fi
 
   refresh_mutable_current_tag "${repo}" "${path}" "${remote}"
-  printf '+ git -C %s fetch --prune --tags %s' "${path}" "${remote}"
-  printf ' %s' "${tag_exclusions[@]}"
+  printf '+'
+  printf ' %s' "${fetch_args[@]}"
   printf '\n'
-  if git -C "${path}" fetch --prune --tags "${remote}" "${tag_exclusions[@]}"; then
+  if "${fetch_args[@]}"; then
     return 0
   fi
 
   if fallback_url="$(stephen_https_url "${url}")"; then
     printf 'fetch from %s failed for %s; switching %s to %s and retrying\n' "${url}" "${repo}" "${remote}" "${fallback_url}" >&2
     git -C "${path}" remote set-url "${remote}" "${fallback_url}"
-    printf '+ git -C %s fetch --prune --tags %s' "${path}" "${remote}"
-    printf ' %s' "${tag_exclusions[@]}"
+    printf '+'
+    printf ' %s' "${fetch_args[@]}"
     printf '\n'
-    git -C "${path}" fetch --prune --tags "${remote}" "${tag_exclusions[@]}"
+    "${fetch_args[@]}"
     return 0
   fi
 


### PR DESCRIPTION
## Summary

- exclude the retargeted `homebrew-main` runtime tag from stable-release fetches
- continue fetching immutable package and semantic tags normally
- cover the stale-local/advanced-remote tag case with a real Git fixture

## Root cause

The `0.10.1` maintenance promotion stopped before source changes because `git fetch --prune --tags fork` refused to overwrite the runtime repository’s legacy mutable `homebrew-main` tag. Stable release preparation does not consume that pointer.

## Validation

- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- focused release regression tests
- `HAWKEYE_AUTO_INSTALL=1 make check`
- `HAWKEYE_AUTO_INSTALL=1 make ci`
- exact blocked-path fetch probe against `/Users/sclarke/github/container`
- `git diff --check`