### PR TITLE
docs: route container family API references

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ When installed correctly, `container help` lists `compose` under `PLUGINS`.
 
 ## Documentation
 
-- [Container documentation portal](https://stephenlclarke.github.io/container-compose/): browse the unified DocC portal for `container-compose`, `container`, `containerization`, and `container-k8s`, plus the builder shim's project documentation.
-- [container-compose API reference](https://stephenlclarke.github.io/container-compose/documentation/composecore/): browse the Compose plugin API reference generated from the Swift source and published automatically from `main`.
+- [Container developer API collection](https://stephenlclarke.github.io/api/): browse the unified documentation for `container-engine-api`, `container`, `containerization`, `container-k8s`, `container-builder-shim`, and `container-compose`.
+- [container-compose API reference](https://stephenlclarke.github.io/api/container-compose/): browse the Compose plugin API reference generated from the Swift source.
 - [INSTALL.md](INSTALL.md): install, upgrade, verify, uninstall, recover bad installs, and diagnose runtime issues.
 - [BUILD.md](BUILD.md): build, test, package, validate parity, and promote the current build to a stable release, including the weekly minor-release scheduler and manual major-release dispatch.
 - [DESIGN.md](DESIGN.md): understand the Swift/Go boundary and runtime adapter ownership.

--- a/Sources/ComposeCore/ComposeCore.docc/Container.md
+++ b/Sources/ComposeCore/ComposeCore.docc/Container.md
@@ -10,5 +10,5 @@ The runtime and command-line foundation that `container-compose` extends with Do
 @Image(source: "Containerization-Logo.png", alt: "The container project logo: a three-row service panel.")
 
 - [Repository](https://github.com/stephenlclarke/container)
-- [Hosted API reference](https://stephenlclarke.github.io/container-compose/container/documentation/)
+- [Stephen fork API reference](https://stephenlclarke.github.io/api/container/)
 - [Apple upstream API reference](https://apple.github.io/container/documentation/)

--- a/Sources/ComposeCore/ComposeCore.docc/ContainerBuilderShim.md
+++ b/Sources/ComposeCore/ComposeCore.docc/ContainerBuilderShim.md
@@ -2,4 +2,6 @@
 
 The BuildKit bridge that connects the host-side runtime to containerized image builds.
 
-- [Repository](https://github.com/stephenlclarke/container-builder-shim)
+- [Stephen fork](https://github.com/stephenlclarke/container-builder-shim)
+- [Fork developer guide](https://stephenlclarke.github.io/api/container-builder-shim/)
+- [Apple upstream repository](https://github.com/apple/container-builder-shim)

--- a/Sources/ComposeCore/ComposeCore.docc/ContainerEngineAPI.md
+++ b/Sources/ComposeCore/ComposeCore.docc/ContainerEngineAPI.md
@@ -1,0 +1,6 @@
+# container-engine-api
+
+The runtime-neutral Docker-compatible Engine transport, routing, provider-session, and Unix HTTP service layer shared by container developer tools.
+
+- [Repository](https://github.com/stephenlclarke/container-engine-api)
+- [Hosted API reference](https://stephenlclarke.github.io/api/container-engine-api/)

--- a/Sources/ComposeCore/ComposeCore.docc/ContainerK8s.md
+++ b/Sources/ComposeCore/ComposeCore.docc/ContainerK8s.md
@@ -3,4 +3,4 @@
 The Kubernetes development-cluster plugin for the `container` command-line interface.
 
 - [Repository](https://github.com/stephenlclarke/container-k8s)
-- [Hosted API reference](https://stephenlclarke.github.io/container-compose/k8s/documentation/)
+- [Hosted API reference](https://stephenlclarke.github.io/api/container-k8s/)

--- a/Sources/ComposeCore/ComposeCore.docc/ContainerProjects.md
+++ b/Sources/ComposeCore/ComposeCore.docc/ContainerProjects.md
@@ -5,19 +5,22 @@
   @PageImage(purpose: card, source: "container-compose-docc-card.png", alt: "The container project family illustration: a light-blue octopus beside a frosted three-row container service panel.")
 }
 
-This is the central API documentation site for the `container` project family. It hosts the Swift API references for the runtime, Containerization library, Kubernetes plugin, and Compose plugin under one GitHub Pages domain. The BuildKit shim is written in Go, so this portal provides its project and architecture documentation rather than a Swift DocC API reference.
+The [container developer API collection](https://stephenlclarke.github.io/api/) publishes documentation generated from Stephen's Engine transport, runtime, Containerization, Kubernetes, builder-shim, and Compose forks under one GitHub Pages namespace. Fork DocC is the primary reference; Apple upstream DocC or source repositories remain linked on the relevant project pages for comparison. Each source repository owns its documentation build, while the user-site workflow assembles the validated outputs into one atomic deployment.
 
 ## API References
 
-- [container-compose](https://stephenlclarke.github.io/container-compose/documentation/composecore/)
-- [container](https://stephenlclarke.github.io/container-compose/container/documentation/)
-- [containerization](https://stephenlclarke.github.io/container-compose/containerization/documentation/)
-- [container-k8s](https://stephenlclarke.github.io/container-compose/k8s/documentation/)
+- [container-engine-api](https://stephenlclarke.github.io/api/container-engine-api/)
+- [container](https://stephenlclarke.github.io/api/container/)
+- [containerization](https://stephenlclarke.github.io/api/containerization/)
+- [container-k8s](https://stephenlclarke.github.io/api/container-k8s/)
+- [container-builder-shim](https://stephenlclarke.github.io/api/container-builder-shim/)
+- [container-compose](https://stephenlclarke.github.io/api/container-compose/)
 
 ## Topics
 
 ### Runtime and Libraries
 
+- <doc:ContainerEngineAPI>
 - <doc:Container>
 - <doc:Containerization>
 

--- a/Sources/ComposeCore/ComposeCore.docc/Containerization.md
+++ b/Sources/ComposeCore/ComposeCore.docc/Containerization.md
@@ -10,5 +10,5 @@ The Swift library that provides the container and image primitives used by the r
 @Image(source: "Containerization-Logo.png", alt: "The Containerization project logo: a three-row service panel.")
 
 - [Repository](https://github.com/stephenlclarke/containerization)
-- [Hosted API reference](https://stephenlclarke.github.io/container-compose/containerization/documentation/)
+- [Stephen fork API reference](https://stephenlclarke.github.io/api/containerization/)
 - [Apple upstream API reference](https://apple.github.io/containerization/documentation/)


### PR DESCRIPTION
Turns the Compose DocC landing page into a route map for the six-project container API collection, with fork documentation first and Apple upstream references retained secondarily.