### PR TITLE
docs: add devcontainer to API collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ When installed correctly, `container help` lists `compose` under `PLUGINS`.
 
 ## Documentation
 
-- [Container developer API collection](https://stephenlclarke.github.io/api/): browse the unified documentation for `container-engine-api`, `container`, `containerization`, `container-k8s`, `container-builder-shim`, and `container-compose`.
+- [Container developer API collection](https://stephenlclarke.github.io/api/): browse the unified documentation for `container-engine-api`, `container`, `containerization`, `container-k8s`, `container-builder-shim`, `container-compose`, and `devcontainer`.
 - [container-compose API reference](https://stephenlclarke.github.io/api/container-compose/): browse the Compose plugin API reference generated from the Swift source.
 - [INSTALL.md](INSTALL.md): install, upgrade, verify, uninstall, recover bad installs, and diagnose runtime issues.
 - [BUILD.md](BUILD.md): build, test, package, validate parity, and promote the current build to a stable release, including the weekly minor-release scheduler and manual major-release dispatch.

--- a/Sources/ComposeCore/ComposeCore.docc/ContainerProjects.md
+++ b/Sources/ComposeCore/ComposeCore.docc/ContainerProjects.md
@@ -5,7 +5,7 @@
   @PageImage(purpose: card, source: "container-compose-docc-card.png", alt: "The container project family illustration: a light-blue octopus beside a frosted three-row container service panel.")
 }
 
-The [container developer API collection](https://stephenlclarke.github.io/api/) publishes documentation generated from Stephen's Engine transport, runtime, Containerization, Kubernetes, builder-shim, and Compose forks under one GitHub Pages namespace. Fork DocC is the primary reference; Apple upstream DocC or source repositories remain linked on the relevant project pages for comparison. Each source repository owns its documentation build, while the user-site workflow assembles the validated outputs into one atomic deployment.
+The [container developer API collection](https://stephenlclarke.github.io/api/) publishes documentation generated from Stephen's Engine transport, runtime, Containerization, Kubernetes, builder-shim, Compose, and Dev Container repositories under one GitHub Pages namespace. Fork DocC is the primary reference; Apple upstream DocC or source repositories remain linked on the relevant project pages for comparison. Each source repository owns its documentation build, while the user-site workflow assembles the validated outputs into one atomic deployment.
 
 ## API References
 
@@ -15,6 +15,7 @@ The [container developer API collection](https://stephenlclarke.github.io/api/) 
 - [container-k8s](https://stephenlclarke.github.io/api/container-k8s/)
 - [container-builder-shim](https://stephenlclarke.github.io/api/container-builder-shim/)
 - [container-compose](https://stephenlclarke.github.io/api/container-compose/)
+- [devcontainer](https://stephenlclarke.github.io/api/devcontainer/)
 
 ## Topics
 
@@ -28,3 +29,7 @@ The [container developer API collection](https://stephenlclarke.github.io/api/) 
 
 - <doc:ContainerK8s>
 - <doc:ContainerBuilderShim>
+
+### Developer Environments
+
+- <doc:DevContainer>

--- a/Sources/ComposeCore/ComposeCore.docc/DevContainer.md
+++ b/Sources/ComposeCore/ComposeCore.docc/DevContainer.md
@@ -1,0 +1,7 @@
+# devcontainer
+
+A VS Code-compatible Dev Container implementation for Apple's container runtime, built on the shared Engine API and container project family.
+
+- [Repository](https://github.com/stephenlclarke/devcontainer)
+- [Hosted API reference](https://stephenlclarke.github.io/api/devcontainer/)
+- [Dev Container specification and tools](https://containers.dev/)


### PR DESCRIPTION
## What changed

- add `devcontainer` to the Container Projects portal and API route list
- add a focused Dev Container project page
- update the README collection inventory

## Why

The Compose DocC portal is the navigation map for the broader container project family and needs to include the Dev Container layer.

## Validation

- `make docs` generated 2,574 files and included the new Dev Container article
- `markdownlint` on the changed documentation
- `git diff --check`