### PR TITLE
docs: remove duplicate DocC artwork

### DIFF
--- a/Sources/ComposeCore/ComposeCore.docc/ComposeCore.md
+++ b/Sources/ComposeCore/ComposeCore.docc/ComposeCore.md
@@ -7,8 +7,6 @@
 
 Parse, normalize, and execute Compose projects with the `container` runtime.
 
-@Image(source: "container-compose-docc-card.png", alt: "The container-compose DocC illustration: a light-blue octopus beside a frosted three-row container service panel.")
-
 ## Overview
 
 `ComposeCore` is the reusable Swift library behind the `compose` container plugin. It models Compose configuration, prepares runtime-neutral service execution plans, and orchestrates them through `ComposeRuntimeSPI` providers. The plugin supplies the [`container`](https://github.com/apple/container)-backed provider.

--- a/Sources/ComposeCore/ComposeCore.docc/Container.md
+++ b/Sources/ComposeCore/ComposeCore.docc/Container.md
@@ -7,8 +7,6 @@
 
 The runtime and command-line foundation that `container-compose` extends with Docker Compose compatibility.
 
-@Image(source: "Containerization-Logo.png", alt: "The container project logo: a three-row service panel.")
-
 - [Repository](https://github.com/stephenlclarke/container)
 - [Stephen fork API reference](https://stephenlclarke.github.io/api/container/)
 - [Apple upstream API reference](https://apple.github.io/container/documentation/)

--- a/Sources/ComposeCore/ComposeCore.docc/Containerization.md
+++ b/Sources/ComposeCore/ComposeCore.docc/Containerization.md
@@ -7,8 +7,6 @@
 
 The Swift library that provides the container and image primitives used by the runtime stack.
 
-@Image(source: "Containerization-Logo.png", alt: "The Containerization project logo: a three-row service panel.")
-
 - [Repository](https://github.com/stephenlclarke/containerization)
 - [Stephen fork API reference](https://stephenlclarke.github.io/api/containerization/)
 - [Apple upstream API reference](https://apple.github.io/containerization/documentation/)


### PR DESCRIPTION
## Summary

- remove the redundant inline artwork from the ComposeCore, container, and containerization overview content
- retain DocC page icon and card metadata for the header and navigation surfaces
- preserve links to Stephen fork API references and Apple upstream documentation

## Validation

- markdownlint on the three changed DocC Markdown files
- scripts/make-docs.sh /tmp/container-compose-icon-qa api/container-compose
- verified the generated render JSON has no inline image blocks on all three routes
- verified the pages in the assembled local Pages site