### PR TITLE
fix(release): use Swift 6.3 compatible container

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,10 @@ jobs:
   build:
     name: Build DocC Site
     runs-on: macos-26
-    timeout-minutes: 45
+    # A cold SwiftPM/DocC build of the pinned runtime stack can exceed 45
+    # minutes on the hosted macOS image. Keep a bounded window that also
+    # covers that first-build case instead of cancelling healthy compiles.
+    timeout-minutes: 90
     steps:
       - name: Checkout container-compose
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "c7924e375d98d82af37902f4a0c310ee389eab97"
+        "revision" : "08f5e39ebcd70b0b6d7a5445d7b268e5be196167"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "c7924e375d98d82af37902f4a0c310ee389eab97",
+        revision: "08f5e39ebcd70b0b6d7a5445d7b268e5be196167",
     )
 }()
 

--- a/Tools/ci/test_documentation_workflow.py
+++ b/Tools/ci/test_documentation_workflow.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Regression tests for the documentation workflow."""
+
+import unittest
+from pathlib import Path
+
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "docs.yml"
+
+
+class DocumentationWorkflowTests(unittest.TestCase):
+    """DocC must have enough time for a cold pinned-stack build."""
+
+    def test_cold_docc_build_has_a_bounded_ninety_minute_window(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        build_job = workflow[workflow.index("  build:\n") : workflow.index("  upload-pages-artifact:\n")]
+
+        self.assertIn("    timeout-minutes: 90\n", build_job)
+        self.assertNotIn("    timeout-minutes: 45\n", build_job)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "c7924e375d98d82af37902f4a0c310ee389eab97",
+      "ref": "08f5e39ebcd70b0b6d7a5445d7b268e5be196167",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

- advance the matched Container runtime pin to signed commit `08f5e39e`
- keep `Package.swift`, `Package.resolved`, and `Tools/release/stack-refs.json` exact and consistent
- unblock Current packaging on the self-hosted Apple Swift 6.3.3 release runner

## Proof

- Container `swift build -c release --product container` passes on Apple Swift 6.3.3
- Container `swift test --filter ContainerTestSupportTests` passes (3 tests)
- Container `make check` passes
- Compose `make stack-consistency` passes
- Compose `make check` passes (196 release-tool tests, 100 CI-tool tests, and parity checks)
- commits `08f5e39e` and `adcb07a1` are signed

The exact-main Current workflow failed at `Build matched runtime package` because Swift 6.3.3 rejected a compile-time constant-false ternary in ContainerTestSupport. Container PR #96 fixes the source; this PR advances the coherent runtime pin. Merge this after Container #96.