### PR TITLE
fix(release): keep package graph path-based

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -888,15 +888,9 @@ jobs:
             printf 'local_asset=%s\n' "${runtime_local_asset}"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Use checked-out container dependency
-        run: Tools/ci/use-stack-container.sh ../container
-        working-directory: container-compose
-
-      - name: Use checked-out containerization dependency
-        if: steps.stack-refs.outputs.containerization_ref != ''
-        run: Tools/ci/use-stack-containerization.sh ../containerization
-        working-directory: container-compose
-
+      # The Makefile passes these sibling checkouts to Package.swift as local
+      # path dependencies. Do not also `swift package edit` them: mixing edit
+      # state with manifest paths makes SwiftPM exhaust graph resolution.
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -693,6 +693,19 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("cache: false", setup_go)
         self.assertNotIn("cache-dependency-path:", setup_go)
 
+    def test_package_build_uses_manifest_paths_without_swiftpm_edits(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        package_build = workflow[
+            workflow.index("- name: Verify containerization dependency ref") : workflow.index(
+                "- name: Build release package"
+            )
+        ]
+
+        self.assertNotIn("use-stack-container.sh", package_build)
+        self.assertNotIn("use-stack-containerization.sh", package_build)
+        self.assertIn("- name: Checkout container dependency", workflow)
+        self.assertIn("- name: Checkout containerization dependency", workflow)
+
     def test_stable_and_current_release_authority_select_main_ci(self) -> None:
         stable_gate = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
         package = PACKAGE_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- stop mixing `swift package edit` state with the local dependency paths already supplied by the release Makefile
- keep the checked-out, immutable Container and Containerization sources as manifest path dependencies
- add a regression assertion covering the release workflow

## Failure proof

Exact-main Current run `31349881577` passed `Build matched runtime package`, then failed `Build release package` with SwiftPM exhausting graph resolution for the local `container` and `containerization` dependencies.

## Local proof

Reproduced the failure against Container `08f5e39e` and Containerization `c5773696` using the workflow's edit/build sequence. Repeating the exact release build without the redundant edits completed all 1,057 actions and linked `compose` successfully.

Also passed:

- targeted release workflow regression test
- `make stack-consistency`
- `make check` (197 release tests, 101 CI tests, parity tests, runtime neutrality, handoff registry)

Signed head: `cb3b97e49d9e9145b6f7b127245b0eac84cb86e7`