### PR TITLE
fix(release): shorten Current demo app root

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -969,14 +969,30 @@ jobs:
           acquire_container_runtime_lock
 
           demo_root="${RUNNER_TEMP}/current-build-demo"
-          demo_app_root="${demo_root}/app"
+          # Darwin AF_UNIX paths are bounded. Keep the launchd-visible app root
+          # short and real (not a symlink): launchd resolves service plists and
+          # the runtime rejects symlinked persisted-state roots. Package and
+          # install artifacts remain beneath the runner's managed temp path.
+          demo_app_root="/tmp/cc-current-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           demo_output=".build/current-demo/${DEMO_ASSET}"
           tape="${RUNNER_TEMP}/container-compose-current-demo.tape"
+
+          remove_demo_app_root() {
+            case "${demo_app_root}" in
+              /tmp/cc-current-[0-9]*-[0-9]*) ;;
+              *)
+                printf 'refusing to remove unexpected Current demo app root: %s\n' "${demo_app_root}" >&2
+                return 1
+                ;;
+            esac
+            rm -rf -- "${demo_app_root}"
+          }
 
           cleanup() {
             if [[ -n "${container_binary:-}" ]]; then
               "${container_binary}" system stop || true
             fi
+            remove_demo_app_root
           }
           trap cleanup EXIT
 
@@ -989,9 +1005,11 @@ jobs:
             container system stop || true
           fi
           bash Tools/release/wait-for-container-system-stop.sh
+          remove_demo_app_root
           rm -rf "${demo_root}"
 
           mkdir -p "${demo_root}/libexec/container-plugins"
+          mkdir -p "${demo_app_root}"
           mkdir -p "$(dirname "${demo_output}")"
           tar -xzf "${RUNTIME_ARCHIVE}" -C "${demo_root}"
           tar -xzf "${PLUGIN_ARCHIVE}" -C "${demo_root}/libexec/container-plugins"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -429,6 +429,22 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertIn('export CONTAINER_INSTALL_ROOT="${demo_root}"', workflow)
         self.assertIn('export CONTAINER_APP_ROOT="${demo_app_root}"', workflow)
+        self.assertIn(
+            'demo_app_root="/tmp/cc-current-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+            workflow,
+        )
+        self.assertIn('mkdir -p "${demo_app_root}"', workflow)
+        self.assertIn('remove_demo_app_root() {', workflow)
+        self.assertIn('/tmp/cc-current-[0-9]*-[0-9]*)', workflow)
+        self.assertIn('rm -rf -- "${demo_app_root}"', workflow)
+        self.assertNotIn('ln -s "${demo_app_storage}"', workflow)
+        longest_run_id = str(2**64 - 1)
+        longest_attempt = str(2**32 - 1)
+        provider_socket = (
+            f"/tmp/cc-current-{longest_run_id}-{longest_attempt}"
+            "/engine-provider/provider.sock"
+        )
+        self.assertLess(len(os.fsencode(provider_socket)), 104)
         self.assertIn('trap cleanup EXIT', workflow)
         self.assertIn('"${container_binary}" system stop || true', workflow)
         self.assertIn('"${demo_root}/bin/container" system stop || true', workflow)


### PR DESCRIPTION
## Summary

- keep the Current demo's launchd-visible app root below Darwin's AF_UNIX path limit
- use a real, run-unique short `/tmp` app root because launchd resolves service plists and the runtime rejects symlinked persisted-state roots
- retain package and install artifacts beneath the runner-managed temporary directory
- bound cleanup to the exact `/tmp/cc-current-<run>-<attempt>` pattern and fail closed for unexpected paths
- add a worst-case run-ID regression assertion for `engine-provider/provider.sock`

## Hosted failure addressed

Current run 31351999570 built and Developer-ID-verified both matched runtime and release packages, then the live VHS proof timed out because `container-apiserver` repeatedly exited with `invalid provider Unix socket path`. The generated socket pathname was 125 bytes.

## Proof

- targeted release policy test passed
- `make stack-consistency` passed
- `make check` passed (197 release tests, 101 CI tests, parity, neutrality and registry checks)
- signed commit `1c36c1fbc3fa07fa52f3e2d70dccde0b02ba9cff`