### PR TITLE
fix(release): stage exact Current init image

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -959,6 +959,8 @@ jobs:
         if: needs.resolve-publish-context.outputs.ref_type == 'branch'
         env:
           DEMO_ASSET: ${{ steps.lane.outputs.demo_asset }}
+          DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: f9c25b9e801470fe65ecdce845f82ecd16b5200fddf4163cd73a8e505c6879cd
           PLUGIN_ARCHIVE: ${{ runner.temp }}/${{ steps.lane.outputs.asset }}
           RUNTIME_ARCHIVE: ${{ steps.runtime-package.outputs.local_asset }}
         shell: bash
@@ -1018,8 +1020,32 @@ jobs:
           test -x "${container_binary}"
           test -x "${demo_root}/libexec/container-plugins/compose/bin/compose"
 
+          if [[ -z "${DEMO_INIT_IMAGE_ARCHIVE}" || ! -f "${DEMO_INIT_IMAGE_ARCHIVE}" ]]; then
+            printf 'matched Current demo init-image archive is unavailable: %s\n' \
+              "${DEMO_INIT_IMAGE_ARCHIVE:-<unset>}" >&2
+            exit 1
+          fi
+          actual_init_image_sha256="$(shasum -a 256 "${DEMO_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')"
+          if [[ "${actual_init_image_sha256}" != "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" ]]; then
+            printf 'matched Current demo init-image archive digest mismatch (expected %s, got %s)\n' \
+              "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" "${actual_init_image_sha256}" >&2
+            exit 1
+          fi
+
+          demo_init_image_archive="/tmp/cc-current-init-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.oci.tar"
+          rm -f "${demo_init_image_archive}"
+          cp "${DEMO_INIT_IMAGE_ARCHIVE}" "${demo_init_image_archive}"
+          trap 'rm -f "${demo_init_image_archive}"' EXIT
+          staged_init_image_sha256="$(shasum -a 256 "${demo_init_image_archive}" | awk '{print $1}')"
+          if [[ "${staged_init_image_sha256}" != "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" ]]; then
+            printf 'staged Current demo init-image archive digest mismatch (expected %s, got %s)\n' \
+              "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" "${staged_init_image_sha256}" >&2
+            exit 1
+          fi
+
           export CONTAINER_INSTALL_ROOT="${demo_root}"
           export CONTAINER_APP_ROOT="${demo_app_root}"
+          export CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE="${demo_init_image_archive}"
           export PATH="${demo_root}/bin:${PATH}"
 
           # VHS itself is the fail-closed runtime gate. It types every command

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -430,6 +430,38 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('export CONTAINER_INSTALL_ROOT="${demo_root}"', workflow)
         self.assertIn('export CONTAINER_APP_ROOT="${demo_app_root}"', workflow)
         self.assertIn(
+            "DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}",
+            workflow,
+        )
+        self.assertIn(
+            "DEMO_INIT_IMAGE_ARCHIVE_SHA256: "
+            "f9c25b9e801470fe65ecdce845f82ecd16b5200fddf4163cd73a8e505c6879cd",
+            workflow,
+        )
+        self.assertIn(
+            'actual_init_image_sha256="$(shasum -a 256 '
+            '\"${DEMO_INIT_IMAGE_ARCHIVE}\" | awk \'{print $1}\')"',
+            workflow,
+        )
+        self.assertIn(
+            'demo_init_image_archive="/tmp/cc-current-init-'
+            '${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.oci.tar"',
+            workflow,
+        )
+        self.assertIn(
+            'cp "${DEMO_INIT_IMAGE_ARCHIVE}" "${demo_init_image_archive}"',
+            workflow,
+        )
+        self.assertIn(
+            'staged_init_image_sha256="$(shasum -a 256 '
+            '\"${demo_init_image_archive}\" | awk \'{print $1}\')"',
+            workflow,
+        )
+        self.assertIn(
+            'export CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE="${demo_init_image_archive}"',
+            workflow,
+        )
+        self.assertIn(
             'demo_app_root="/tmp/cc-current-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
             workflow,
         )
@@ -468,6 +500,16 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("docs/container-compose-demo.tape", workflow)
         self.assertIn("VHS itself is the fail-closed runtime gate", workflow)
         self.assertIn("bash Tools/release/record-vhs-live-demo.sh", workflow)
+        tape = (ROOT / "docs/container-compose-demo.tape").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(
+            tape.count(
+                "--init-image-archive "
+                "$CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE"
+            ),
+            2,
+        )
         self.assertNotIn("record_monitoring_stack_transcript", workflow)
         self.assertNotIn("demo_transcript", workflow)
         self.assertNotIn("current-build-demo-transcript", workflow)

--- a/docs/container-compose-demo.tape
+++ b/docs/container-compose-demo.tape
@@ -17,7 +17,7 @@ Type "cd $CONTAINER_COMPOSE_DEMO_ROOT || exit 1"
 Enter
 Sleep 2s
 
-Type "(container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --enable-kernel-install --timeout 60 || { sleep 5; container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --enable-kernel-install --timeout 60; }) && container system status"
+Type "(container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60 || { sleep 5; container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60; }) && container system status"
 Enter
 Wait+Screen@180s /status +running/
 Sleep 2s


### PR DESCRIPTION
## Summary

- make the Current VHS gate boot the matched packaged runtime without GHCR credentials by importing an immutable, exact-ref OCI vminit archive
- verify the retained SSD source archive and its short `/tmp` staged copy against SHA-256 `f9c25b9e801470fe65ecdce845f82ecd16b5200fddf4163cd73a8e505c6879cd`
- pass the staged archive to both fail-closed `container system start` attempts in the typed VHS demo

## Proof

- signed head: `c335eb9b956ef56a776f9bfad38a455ce8aca0f2`
- local matched packaged-runtime boot: `start_status=0`, `status=running`, Container Engine gateway running
- exact imported ref: `ghcr.io/stephenlclarke/containerization/vminit:7f62f5b940630811573a34f70cdd6f3fa11d014d`
- `make check` (197 release tests, 101 CI tests, parity, runtime neutrality, stack consistency, handoff registry)

## Release impact

This repairs the last Current-only blocker exposed after the short app-root fix. The gate remains fail closed if the repository variable is unset, the source archive differs, the staged copy differs, runtime startup fails, or VHS does not observe a running system.