### PR TITLE
fix(release): pin dynamic containerization manifests

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -199,7 +199,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("Release-Note: none", runtime_pin)
         self.assertIn("sync_container_package_pin", self.script)
 
-    def test_containerization_pin_supports_literal_and_named_revisions(self) -> None:
+    def test_containerization_pin_supports_literal_named_and_dynamic_revisions(self) -> None:
         revision = "a" * 40
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -233,6 +233,39 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             named_text = named_manifest.read_text(encoding="utf-8")
             self.assertIn(f'let containerizationRevision = "{revision}"', named_text)
             self.assertIn("revision: containerizationRevision", named_text)
+
+            dynamic = root / "container-dynamic"
+            dynamic.mkdir()
+            dynamic_manifest = dynamic / "Package.swift"
+            dynamic_manifest.write_text(
+                textwrap.dedent(
+                    """\
+                    import Foundation
+                    import PackageDescription
+
+                    let containerizationRevision = "old"
+                    let scSource =
+                        ProcessInfo.processInfo.environment["CONTAINERIZATION_SOURCE"]
+                        ?? "stephenlclarke/containerization"
+                    let scRef =
+                        ProcessInfo.processInfo.environment["CONTAINERIZATION_REF"]
+                        ?? containerizationRevision
+                    let containerizationDependency: Package.Dependency = .package(
+                        url: "https://github.com/\\(scSource).git",
+                        revision: scRef
+                    )
+                    """
+                ),
+                encoding="utf-8",
+            )
+            dynamic_result = self.run_release_function(
+                root,
+                f"update_containerization_package_pin container-dynamic {revision} 0",
+            )
+            self.assertEqual(dynamic_result.returncode, 0, dynamic_result.stderr)
+            dynamic_text = dynamic_manifest.read_text(encoding="utf-8")
+            self.assertIn(f'let containerizationRevision = "{revision}"', dynamic_text)
+            self.assertIn("revision: scRef", dynamic_text)
 
             literal = root / "container-compose"
             literal.mkdir()

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -972,11 +972,30 @@ updated, direct_count = dependency_pattern.subn(
     text,
     count=1,
 )
-constant_dependency = re.search(
+literal_constant_dependency = re.search(
     r'\.package\(\s*url:\s*"https://github.com/stephenlclarke/containerization\.git"\s*,\s*'
     r"revision:\s*containerizationRevision\s*,?\s*\)",
     text,
     re.MULTILINE,
+)
+dynamic_source = re.search(
+    r'let\s+scSource\s*=(?:(?!\nlet\s).)*"stephenlclarke/containerization"',
+    text,
+    re.MULTILINE | re.DOTALL,
+)
+dynamic_ref = re.search(
+    r"let\s+scRef\s*=(?:(?!\n(?:let|var)\s).)*containerizationRevision",
+    text,
+    re.MULTILINE | re.DOTALL,
+)
+dynamic_dependency = re.search(
+    r'\.package\(\s*url:\s*"https://github.com/\\\(scSource\)\.git"\s*,\s*'
+    r"revision:\s*scRef\s*,?\s*\)",
+    text,
+    re.MULTILINE,
+)
+constant_dependency = literal_constant_dependency or (
+    dynamic_source and dynamic_ref and dynamic_dependency
 )
 constant_pattern = re.compile(
     r'^(let\s+containerizationRevision\s*=\s*")[^"]*(")',


### PR DESCRIPTION
## Summary
- recognize the current environment-resolved containerization dependency shape
- update its checked-in exact revision during stable promotion
- retain support for literal and named revision manifests

## Verification
- focused dynamic/literal/named pin test
- 70 release-control tests
- full `make check` (197 release, 101 CI, parity/neutrality/stack/registry)