### PR TITLE
docs(upstream): classify stable container pin

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "af405ffd5a4d8e9ec872bc15351af41130c39b94",
-      "forkHead": "de749397e6d9be93061c094705a0deedae46fc61",
+      "forkHead": "d0777a8314b26a2c9311719081ad4da34c097560",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -412,7 +412,8 @@
             "522a2b37281c4bffd4cb7c0fd270c5477b99c3bf",
             "6d21802536ba16df4d824e5b7030f11f6d638a92",
             "42bc06ebeee2defdc707ca0a13f333f316081eb0",
-            "6320cf8203a8544bb049ef030f7be569748dc667"
+            "6320cf8203a8544bb049ef030f7be569748dc667",
+            "d0777a8314b26a2c9311719081ad4da34c097560"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `af405ffd5a4d8e9ec872bc15351af41130c39b94` | `de749397e6d9be93061c094705a0deedae46fc61` | 0 | 605 | 552 |
+| `container` | `af405ffd5a4d8e9ec872bc15351af41130c39b94` | `d0777a8314b26a2c9311719081ad4da34c097560` | 0 | 606 | 553 |
 | `containerization` | `b9c65e59b284c182c22d88b1f895a138b5fca1a9` | `7e4e1a61d58164ae48ce7e444a268e7d03373a50` | 0 | 184 | 153 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `cb2adb12415828033dccf76730db6915548dc7c4` | 0 | 39 | 33 |
-| **Total** | | | **0** | **828** | **738** |
+| **Total** | | | **0** | **829** | **739** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 521 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 522 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -124,6 +124,9 @@ disposition was inferred for a new commit, and no published history was
 rewritten.
 
 The registry records fork ownership; it does not promote a runtime or Compose
-stack pin. Release promotion must continue through the exact stack references,
-normal signed commits, and the full linked-stack gates without rewriting
-published history.
+stack pin. The generated Container dependency commit
+`d0777a8314b26a2c9311719081ad4da34c097560` was inspected as release
+maintenance because it only advances the exact Containerization revision.
+Release promotion must continue through the exact stack references, normal
+signed commits, and the full linked-stack gates without rewriting published
+history.


### PR DESCRIPTION
Classifies the generated Container dependency pin commit required by the stable 0.10.2 promotion.

Validation:
- `make fork-classifications-check`
- `markdownlint docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md`
- `python3 -m unittest Tools.ci.test_upstream_divergence_report`

The commit is support maintenance only: it advances the exact Containerization revision and adds no runtime functionality.

Release-Note: none