### PR TITLE
chore(release): prepare stable 0.10.2 stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ DOCS_OUTPUT_DIR ?= _site
 DOCS_SERVER_DIR ?= _serve
 DOCS_HOSTING_BASE_PATH ?= container-compose
 DOCS_SCRATCH_PATH ?= .build/docc
-COMPOSE_VERSION ?= 0.10.1
+COMPOSE_VERSION ?= 0.10.2
 CONTAINER_COMPOSE_SOURCE ?= $(shell $(PYTHON) -c 'import subprocess; result = subprocess.run(["git", "remote", "get-url", "origin"], capture_output=True, text=True); url = result.stdout.strip() if result.returncode == 0 else ""; url = url[len("git@github.com:"):] if url.startswith("git@github.com:") else url; url = url[len("https://github.com/"):] if url.startswith("https://github.com/") else url; url = url[:-4] if url.endswith(".git") else url; print(url)')
 CONTAINER_COMPOSE_BRANCH ?= $(shell git branch --show-current 2>/dev/null || git rev-parse --short HEAD)
 CONTAINER_COMPOSE_LANE ?= $(shell $(PYTHON) -c 'branch = "$(CONTAINER_COMPOSE_BRANCH)"; print("main" if branch == "main" else "release" if branch == "release" or branch.startswith("release-") else "detached" if branch in ("", "HEAD") else "development")')
@@ -459,16 +459,16 @@ cli-smoke-built:
 	.build/debug/compose --ansi never version >/dev/null
 	.build/debug/compose version --dry-run >/dev/null
 	version_short_output="$$(".build/debug/compose" version --short)"; \
-	[[ "$$version_short_output" == "0.10.1" ]]; \
+	[[ "$$version_short_output" == "0.10.2" ]]; \
 	version_pretty_output="$$(".build/debug/compose" version)"; \
-	[[ "$$version_pretty_output" == *"container-compose 0.10.1"* ]]; \
+	[[ "$$version_pretty_output" == *"container-compose 0.10.2"* ]]; \
 	[[ "$$version_pretty_output" == *"container:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"containerization:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"compose-go: $(COMPOSE_GO_VERSION)"* ]]; \
 	[[ "$$version_pretty_output" == *"runtime-capability-schema: 1"* ]]; \
 	[[ "$$version_pretty_output" == *"runtime-capability: io.github.stephenlclarke.container.compose.archive-copy.v1"* ]]; \
 	version_json_output="$$(".build/debug/compose" version --format json)"; \
-	[[ "$$version_json_output" == *'"version":"0.10.1"'* ]]; \
+	[[ "$$version_json_output" == *'"version":"0.10.2"'* ]]; \
 	[[ "$$version_json_output" == *'"containerSource":"stephenlclarke/container"'* ]]; \
 	[[ "$$version_json_output" == *'"containerRef":"$(CONTAINER_REF)"'* ]]; \
 	[[ "$$version_json_output" == *'"containerDistribution":"custom"'* ]]; \
@@ -478,16 +478,16 @@ cli-smoke-built:
 	[[ "$$version_json_output" == *'"runtimeCapabilitySchemaVersion":1'* ]]; \
 	[[ "$$version_json_output" == *'"runtimeCapabilities":["io.github.stephenlclarke.container.compose.archive-copy.v1"'* ]]; \
 	version_short_format_output="$$(".build/debug/compose" version -f json)"; \
-	[[ "$$version_short_format_output" == *'"version":"0.10.1"'* ]]; \
+	[[ "$$version_short_format_output" == *'"version":"0.10.2"'* ]]; \
 	version_compact_format_output="$$(".build/debug/compose" version -fjson)"; \
-	[[ "$$version_compact_format_output" == *'"version":"0.10.1"'* ]]; \
+	[[ "$$version_compact_format_output" == *'"version":"0.10.2"'* ]]; \
 	package_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$package_tmp"' EXIT; \
 	mkdir -p "$$package_tmp/compose/bin" "$$package_tmp/compose/resources" "$$package_tmp/bin"; \
 	cp .build/debug/compose "$$package_tmp/compose/bin/compose"; \
 	cp "$(PLUGIN_ICON)" "$$package_tmp/compose/resources/container-compose-icon.png"; \
 	test -f "$$package_tmp/compose/resources/container-compose-icon.png"; \
-	printf '%s\n' '{"version":"0.10.1","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
+	printf '%s\n' '{"version":"0.10.2","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
 	ln -s ../compose/bin/compose "$$package_tmp/bin/container-compose"; \
 	packaged_version_output="$$(cd /tmp && "$$package_tmp/bin/container-compose" version --format json)"; \
 	[[ "$$packaged_version_output" == *'"branch":"symlink-smoke"'* ]]; \
@@ -511,7 +511,7 @@ cli-smoke-built:
 	[[ "$$compat_output" == *"https://github.com/stephenlclarke/container-compose/blob/main/INSTALL.md"* ]]; \
 	service_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$service_tmp"' EXIT; \
-	printf '%s\n' '{"version":"0.10.1","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
+	printf '%s\n' '{"version":"0.10.2","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
 	printf '%s\n' '#!/usr/bin/env bash' 'if [[ "$$*" == "system version --format json" ]]; then' '  printf '\''[{"appName":"container","buildType":"release","commit":"matched-container","containerization":"stephenlclarke/containerization@matched-containerization","distribution":"custom","runtimeCapabilitySchemaVersion":1,"runtimeCapabilities":["io.github.stephenlclarke.container.compose.archive-copy.v1","io.github.stephenlclarke.container.compose.build-extensions.v1","io.github.stephenlclarke.container.compose.create-configuration.v1","io.github.stephenlclarke.container.compose.image-filesystem.v1","io.github.stephenlclarke.container.compose.lifecycle.v1","io.github.stephenlclarke.container.compose.observation.v1"],"source":"stephenlclarke/container","version":"homebrew-main"}]\n'\''' '  exit 0' 'fi' 'if [[ "$$*" == "system status" ]]; then' '  printf '\''apiserver is not running and not registered with launchd\n'\'' >&2' '  exit 1' 'fi' 'exit 2' > "$$service_tmp/container"; \
 	chmod +x "$$service_tmp/container"; \
 	set +e; \
@@ -746,7 +746,7 @@ cli-smoke-built:
 	printf 'services:\n  api:\n    image: alpine\n    build:\n      context: ./api\n    volumes:\n      - ./src:/src\n' > "$$tmpdir/relative-paths.yml"; \
 	printf 'services:\n  api:\n    image: alpine\n    depends_on:\n      - missing\n' > "$$tmpdir/missing-dependency.yml"; \
 	version_compact_global_output="$$(".build/debug/compose" -pcompact -f"$$tmpdir/compose.yml" version --short)"; \
-	[[ "$$version_compact_global_output" == "0.10.1" ]]; \
+	[[ "$$version_compact_global_output" == "0.10.2" ]]; \
 	config_output="$$(".build/debug/compose" -f "$$tmpdir/compose.yml" config)"; \
 	[[ "$$config_output" == *"name: \"demo\""* ]]; \
 	[[ "$$config_output" == *"services:"* ]]; \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "09469d366e300b38f851093b9a298dd024074119094d0ac981a9e84ffe5a29e9",
+  "originHash" : "1b5424bf26905371b9637ad36a2e3f60a1092673b6ac89eb8b36adbc7b845ba0",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "08f5e39ebcd70b0b6d7a5445d7b268e5be196167"
+        "revision" : "d0777a8314b26a2c9311719081ad4da34c097560"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "7f62f5b940630811573a34f70cdd6f3fa11d014d"
+        "revision" : "7e4e1a61d58164ae48ce7e444a268e7d03373a50"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1b5424bf26905371b9637ad36a2e3f60a1092673b6ac89eb8b36adbc7b845ba0",
+  "originHash" : "dbe841e01db3981df32e826f93c9aed67a9ccbe0010d8a220e2908eb6fb4a8bc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "d0777a8314b26a2c9311719081ad4da34c097560"
+        "revision" : "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "7e4e1a61d58164ae48ce7e444a268e7d03373a50"
+        "revision" : "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "08f5e39ebcd70b0b6d7a5445d7b268e5be196167",
+        revision: "d0777a8314b26a2c9311719081ad4da34c097560",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "7f62f5b940630811573a34f70cdd6f3fa11d014d",
+        revision: "7e4e1a61d58164ae48ce7e444a268e7d03373a50",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "d0777a8314b26a2c9311719081ad4da34c097560",
+        revision: "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "7e4e1a61d58164ae48ce7e444a268e7d03373a50",
+        revision: "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2",
     )
 }()
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -29,7 +29,7 @@ private let composePluginVersionNumber = composeBuildInfo.version
 private let composePluginVersionString = "container-compose \(composePluginVersionNumber)"
 
 struct ComposeBuildInfo: Codable {
-    var version: String = "0.10.1"
+    var version: String = "0.10.2"
     var source: String = "unspecified"
     var branch: String = "unspecified"
     var lane: String = "unspecified"
@@ -120,7 +120,7 @@ struct ComposeBuildInfo: Codable {
             declaredSource: environment["CONTAINERIZATION_SOURCE"]
         )
         return ComposeBuildInfo(
-            version: "0.10.1",
+            version: "0.10.2",
             source: remoteSource(root: root),
             branch: branch,
             lane: lane(for: branch),

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "08f5e39ebcd70b0b6d7a5445d7b268e5be196167",
+      "ref": "d0777a8314b26a2c9311719081ad4da34c097560",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -10,21 +10,12 @@
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
         "tag": "current-30784216505-806feb1c9cc1"
       },
-      "ref": "806feb1c9cc1fe9f183c0c7c123f6b63db4ebf64",
+      "ref": "cb2adb12415828033dccf76730db6915548dc7c4",
       "repository": "stephenlclarke/container-builder-shim"
     },
-    "container-engine-api": {
-      "ref": "5e6e24d017691596783515285e1ff56d29701235",
-      "repository": "stephenlclarke/container-engine-api",
-      "version": "0.2.3"
-    },
     "containerization": {
-      "ref": "7f62f5b940630811573a34f70cdd6f3fa11d014d",
+      "ref": "7e4e1a61d58164ae48ce7e444a268e7d03373a50",
       "repository": "stephenlclarke/containerization"
-    },
-    "devcontainer": {
-      "ref": "d57c2b689857a4832f7dbc8affca57f749fe155f",
-      "repository": "stephenlclarke/devcontainer"
     }
   },
   "schemaVersion": 1

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "d0777a8314b26a2c9311719081ad4da34c097560",
+      "ref": "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "7e4e1a61d58164ae48ce7e444a268e7d03373a50",
+      "ref": "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "af405ffd5a4d8e9ec872bc15351af41130c39b94",
-      "forkHead": "d0777a8314b26a2c9311719081ad4da34c097560",
+      "forkHead": "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -413,7 +413,8 @@
             "6d21802536ba16df4d824e5b7030f11f6d638a92",
             "42bc06ebeee2defdc707ca0a13f333f316081eb0",
             "6320cf8203a8544bb049ef030f7be569748dc667",
-            "d0777a8314b26a2c9311719081ad4da34c097560"
+            "d0777a8314b26a2c9311719081ad4da34c097560",
+            "bb6c2dc6f17d1e3e865719654bf9af0f1d1fabc7"
           ]
         },
         {
@@ -635,7 +636,7 @@
     },
     "containerization": {
       "upstreamHead": "b9c65e59b284c182c22d88b1f895a138b5fca1a9",
-      "forkHead": "7e4e1a61d58164ae48ce7e444a268e7d03373a50",
+      "forkHead": "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -740,7 +741,9 @@
             "d6322d3993d7bf735c637661955f3d84788b3386",
             "6a1370e463d664df8806d90ce25766714352395e",
             "310932e22db081b6a2722bc4277ab49a137aec74",
-            "1cec7943eacf89bc4d395954759dd8cf44f5fb11"
+            "1cec7943eacf89bc4d395954759dd8cf44f5fb11",
+            "febf53bc4a961c2f51c0321708e1ba7f09c34866",
+            "81522ed80496580d82a246a3810c6d37540c1748"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- prepare container-compose `0.10.2`
- pin Container `a58312fec3fd` and Containerization `1a124ec2d7b2` atomically
- retain builder `cb2adb124158` and refresh the release stack manifest
- classify the new fork-maintenance commits for the strict upstream-divergence gate

## Verification
- `make fork-classifications-check`
- `make check` (197 release tests, 101 CI tests, parity/reliability/neutrality/stack checks)
- Containerization integration: 176 passed, 2 skipped
- Container: 2,216 tests

Apple remotes remain read-only; this branch targets only Stephen-owned forks.