### PR TITLE
Align final Container stack heads and release ledger

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbe841e01db3981df32e826f93c9aed67a9ccbe0010d8a220e2908eb6fb4a8bc",
+  "originHash" : "8f03f38eb432bc4e6008ca7bf61ea3b743da99f621a0828ae06d43f06a53de4c",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "c07f1e8d77abc75d157072ae50cef9a275f282fc"
+        "revision" : "5264919268322aa86c58e01038011964c6caec82"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "c16095c4c9b9cd2b3d05bd1de06626e5cbe0a118"
+        "revision" : "c07f1e8d77abc75d157072ae50cef9a275f282fc"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2"
+        "revision" : "7e4f5152e9606a34a92c34186eb94f7cd37c134f"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42"
+        "revision" : "c16095c4c9b9cd2b3d05bd1de06626e5cbe0a118"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "c07f1e8d77abc75d157072ae50cef9a275f282fc",
+        revision: "5264919268322aa86c58e01038011964c6caec82",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "c16095c4c9b9cd2b3d05bd1de06626e5cbe0a118",
+        revision: "c07f1e8d77abc75d157072ae50cef9a275f282fc",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2",
+        revision: "7e4f5152e9606a34a92c34186eb94f7cd37c134f",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42",
+        revision: "c16095c4c9b9cd2b3d05bd1de06626e5cbe0a118",
     )
 }()
 

--- a/Sources/ComposeContainerRuntime/ContainerImageLiveAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerImageLiveAdapter.swift
@@ -149,7 +149,7 @@ public struct ContainerImageLiveAPIClient: ContainerImageAPIClienting {
         let image = try await ClientImage.pull(
             reference: reference,
             platform: platform,
-            scheme: .auto,
+            scheme: .https,
             containerSystemConfig: config,
             progressUpdate: nil,
         )
@@ -161,7 +161,7 @@ public struct ContainerImageLiveAPIClient: ContainerImageAPIClienting {
         let config = try await ConfigurationLoader.load()
         let platform = try Self.defaultPlatform()
         let image = try await ClientImage.get(reference: reference, containerSystemConfig: config)
-        try await image.push(platform: platform, scheme: .auto, containerSystemConfig: config, progressUpdate: nil)
+        try await image.push(platform: platform, scheme: .https, containerSystemConfig: config, progressUpdate: nil)
         return image.reference
     }
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "c07f1e8d77abc75d157072ae50cef9a275f282fc",
+      "ref": "5264919268322aa86c58e01038011964c6caec82",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42",
+      "ref": "c07f1e8d77abc75d157072ae50cef9a275f282fc",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2",
+      "ref": "7e4f5152e9606a34a92c34186eb94f7cd37c134f",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -3,8 +3,8 @@
   "reviewedAt": "2026-08-10",
   "repositories": {
     "container": {
-      "upstreamHead": "497465635a7b31f28558e104342433052a16c395",
-      "forkHead": "c07f1e8d77abc75d157072ae50cef9a275f282fc",
+      "upstreamHead": "ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c",
+      "forkHead": "5264919268322aa86c58e01038011964c6caec82",
       "slices": [
         {
           "id": "container-support-maintenance",

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -3,8 +3,8 @@
   "reviewedAt": "2026-08-10",
   "repositories": {
     "container": {
-      "upstreamHead": "af405ffd5a4d8e9ec872bc15351af41130c39b94",
-      "forkHead": "a58312fec3fd8a16c7e79a00cb359d0bf2d50f42",
+      "upstreamHead": "497465635a7b31f28558e104342433052a16c395",
+      "forkHead": "c07f1e8d77abc75d157072ae50cef9a275f282fc",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -414,7 +414,9 @@
             "42bc06ebeee2defdc707ca0a13f333f316081eb0",
             "6320cf8203a8544bb049ef030f7be569748dc667",
             "d0777a8314b26a2c9311719081ad4da34c097560",
-            "bb6c2dc6f17d1e3e865719654bf9af0f1d1fabc7"
+            "bb6c2dc6f17d1e3e865719654bf9af0f1d1fabc7",
+            "809a6d2f43b4643ae0ddb9929d1cbd7eabe60614",
+            "ff08b876ab1f87934aa8d2853b921e0ba8590b7b"
           ]
         },
         {
@@ -635,8 +637,8 @@
       ]
     },
     "containerization": {
-      "upstreamHead": "b9c65e59b284c182c22d88b1f895a138b5fca1a9",
-      "forkHead": "1a124ec2d7b2e05cb6a6885ff60ca3c2208798c2",
+      "upstreamHead": "5427fd21ded4b84034126caef5b3182900b4776d",
+      "forkHead": "7e4f5152e9606a34a92c34186eb94f7cd37c134f",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -743,7 +745,8 @@
             "310932e22db081b6a2722bc4277ab49a137aec74",
             "1cec7943eacf89bc4d395954759dd8cf44f5fb11",
             "febf53bc4a961c2f51c0321708e1ba7f09c34866",
-            "81522ed80496580d82a246a3810c6d37540c1748"
+            "81522ed80496580d82a246a3810c6d37540c1748",
+            "58d9a836b28cfbb055ce537a619a03aa662c9f6e"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `497465635a7b31f28558e104342433052a16c395` | `c07f1e8d77abc75d157072ae50cef9a275f282fc` | 0 | 613 | 556 |
+| `container` | `ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c` | `5264919268322aa86c58e01038011964c6caec82` | 0 | 615 | 556 |
 | `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `7e4f5152e9606a34a92c34186eb94f7cd37c134f` | 0 | 190 | 156 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `cb2adb12415828033dccf76730db6915548dc7c4` | 0 | 39 | 33 |
-| **Total** | | | **0** | **842** | **745** |
+| **Total** | | | **0** | **844** | **745** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -124,11 +124,17 @@ disposition was inferred for a new commit, and no published history was
 rewritten.
 
 The 10 August 2026 incremental refresh advances Apple `container` through
-`497465635a7b`, Apple `containerization` through `5427fd21ded4`, and adds three
+`ff5aa8a03b7d`, Apple `containerization` through `5427fd21ded4`, and adds three
 reviewed support-maintenance commits: the bounded Container test-process exit
 wait, Container's exact Containerization dependency pin, and the bounded
 Containerization CodeQL build timeout. No generic-runtime, temporary-port, or
 rejected-policy classification changed in this refresh.
+
+The final Container refresh also incorporates Apple's volume-name validation
+at `ff5aa8a03b7d` and the signed conflict resolution at `e2378a25873a`. Both
+are upstream or merge history, so the graph-ahead count increases while the
+patch-unique non-merge classification count and disposition totals remain
+unchanged.
 
 The registry records fork ownership; it does not promote a runtime or Compose
 stack pin. The generated Container dependency commits

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `af405ffd5a4d8e9ec872bc15351af41130c39b94` | `d0777a8314b26a2c9311719081ad4da34c097560` | 0 | 606 | 553 |
-| `containerization` | `b9c65e59b284c182c22d88b1f895a138b5fca1a9` | `7e4e1a61d58164ae48ce7e444a268e7d03373a50` | 0 | 184 | 153 |
+| `container` | `497465635a7b31f28558e104342433052a16c395` | `c07f1e8d77abc75d157072ae50cef9a275f282fc` | 0 | 613 | 556 |
+| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `7e4f5152e9606a34a92c34186eb94f7cd37c134f` | 0 | 190 | 156 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `cb2adb12415828033dccf76730db6915548dc7c4` | 0 | 39 | 33 |
-| **Total** | | | **0** | **829** | **739** |
+| **Total** | | | **0** | **842** | **745** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 522 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 528 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -123,10 +123,18 @@ were assigned to support maintenance. No temporary port or rejected-policy
 disposition was inferred for a new commit, and no published history was
 rewritten.
 
+The 10 August 2026 incremental refresh advances Apple `container` through
+`497465635a7b`, Apple `containerization` through `5427fd21ded4`, and adds three
+reviewed support-maintenance commits: the bounded Container test-process exit
+wait, Container's exact Containerization dependency pin, and the bounded
+Containerization CodeQL build timeout. No generic-runtime, temporary-port, or
+rejected-policy classification changed in this refresh.
+
 The registry records fork ownership; it does not promote a runtime or Compose
-stack pin. The generated Container dependency commit
-`d0777a8314b26a2c9311719081ad4da34c097560` was inspected as release
-maintenance because it only advances the exact Containerization revision.
+stack pin. The generated Container dependency commits
+`d0777a8314b26a2c9311719081ad4da34c097560` and
+`ff08b876ab1f87934aa8d2853b921e0ba8590b7b` were inspected as release
+maintenance because they only advance exact Containerization revisions.
 Release promotion must continue through the exact stack references, normal
 signed commits, and the full linked-stack gates without rewriting published
 history.


### PR DESCRIPTION
## Summary
- integrate Apple Container main through ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c
- pin Container to verified protected-main merge 5264919268322aa86c58e01038011964c6caec82
- pin Containerization to verified protected-main merge 7e4f5152e9606a34a92c34186eb94f7cd37c134f
- refresh exact stack refs and the reviewed fork-classification ledger

## Container proof
- PR #100 exact signed integration head e2378a25873a60468c5a1cd77753aebbbaf47413
- hosted signatures, Linux workloads, full build/test, and CodeQL all green
- protected-main merge 5264919268322aa86c58e01038011964c6caec82 has the expected c07f1e8d/e2378a25 parents and a valid GitHub signature
- focused Container API service suite: 301 tests in 37 suites passed
- make check passed

## Compose proof
- swift package resolve
- make fork-classifications-check
- CONTAINER_STACK_REPO=/Users/sclarke/github/container make stack-consistency
- make check: 197 release-tool tests, 101 CI-tool tests, parity/reliability suites, registry and neutrality gates passed
- exact source surface before the metadata-only final pin: 1,375 Swift tests passed (1,349 executed, 26 intentional live-runtime skips), plus Go tests/build and CLI smoke
- 745 classified patch-unique non-merge commits across a graph-ahead total of 844
- signed final pin commit 662d381072ee1f53af1c6517fd150f857f17e710, GitHub verification valid

Full hosted Compose checks remain required before merge.

## Upstream API repair
- replace removed Container registry scheme auto-selection with explicit HTTPS for pull and push
- focused runtime adapter suite: 24 tests passed