### PR TITLE
chore(upstream): classify init bootstrap repairs

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-08-10",
+  "reviewedAt": "2026-08-11",
   "repositories": {
     "container": {
       "upstreamHead": "ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c",
-      "forkHead": "5264919268322aa86c58e01038011964c6caec82",
+      "forkHead": "93ede1b94d8dfcf0cd821f1b3d7246e2c5de7d83",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -416,7 +416,10 @@
             "d0777a8314b26a2c9311719081ad4da34c097560",
             "bb6c2dc6f17d1e3e865719654bf9af0f1d1fabc7",
             "809a6d2f43b4643ae0ddb9929d1cbd7eabe60614",
-            "ff08b876ab1f87934aa8d2853b921e0ba8590b7b"
+            "ff08b876ab1f87934aa8d2853b921e0ba8590b7b",
+            "02ea71e158c93e8faf43bdb6460d14bd0747ade0",
+            "cef184de20206027b4c29a0c988173dfc7331157",
+            "6e9bdba61e7db7c2861e0c3544eb56c49c883938"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 10 August 2026
+Updated: 11 August 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c` | `5264919268322aa86c58e01038011964c6caec82` | 0 | 615 | 556 |
+| `container` | `ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c` | `93ede1b94d8dfcf0cd821f1b3d7246e2c5de7d83` | 0 | 619 | 559 |
 | `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `7e4f5152e9606a34a92c34186eb94f7cd37c134f` | 0 | 190 | 156 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `cb2adb12415828033dccf76730db6915548dc7c4` | 0 | 39 | 33 |
-| **Total** | | | **0** | **844** | **745** |
+| **Total** | | | **0** | **848** | **748** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 528 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 531 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -135,6 +135,15 @@ at `ff5aa8a03b7d` and the signed conflict resolution at `e2378a25873a`. Both
 are upstream or merge history, so the graph-ahead count increases while the
 patch-unique non-merge classification count and disposition totals remain
 unchanged.
+
+The 11 August 2026 maintenance refresh advances the Container fork through
+`93ede1b94d8d` and classifies three independently reviewed release repairs as
+support maintenance: isolated init-bootstrap application and log roots,
+explicit HTTPS for programmatic bootstrap image pulls, and retained init
+archive loading during clean release validation. Exact-head CodeQL, signature,
+Linux workload, build, documentation, package, and project-test checks passed
+before the merge. These commits do not add a temporary upstream port or a
+Compose-owned policy surface.
 
 The registry records fork ownership; it does not promote a runtime or Compose
 stack pin. The generated Container dependency commits


### PR DESCRIPTION
## What changed

- advance the reviewed Container fork head to the exact PR #101 merge
- classify its three patch-unique init-bootstrap repairs as `support-maintenance`
- refresh the documented graph and disposition totals

## Why

The stable-release upstream-divergence guard correctly stopped because the three newly merged Container repairs were not yet present in the reviewed fork-classification registry. They are release/system maintenance fixes, not temporary Apple ports or Compose-owned policy.

## Validation

- `python3 -m json.tool docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json`
- `python3 Tools/ci/test_upstream_divergence_report.py` (11 tests)
- `make upstream-divergence-release-check`
- `git diff --check`

Container PR #101 passed exact-head CodeQL, signature, Linux workload, build/docs/package, and project-test checks before merge.