### PR TITLE
chore(upstream): classify release test isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ orchestration and maps supported Compose behavior to the matched runtime stack.
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 2 August 2026 snapshot, the three support forks are **509 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 11 August 2026 snapshot, the three support forks are **849 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 136 ahead** at [`4d49879df7da`](https://github.com/stephenlclarke/containerization/commit/4d49879df7da26cf38d7e7fe5b464952133f977b).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 339 ahead** at [`d7806cd2a7a1`](https://github.com/stephenlclarke/container/commit/d7806cd2a7a1f95d8457d0d33d42de7025706f8e).
-> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 34 ahead** at [`61832d4ca917`](https://github.com/stephenlclarke/container-builder-shim/commit/61832d4ca91715180a84dec0eab091170174c43c).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 190 ahead** at [`7e4f5152e960`](https://github.com/stephenlclarke/containerization/commit/7e4f5152e9606a34a92c34186eb94f7cd37c134f).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 620 ahead** at [`0e22d5eb3e5f`](https://github.com/stephenlclarke/container/commit/0e22d5eb3e5f6b1b40428e214a29de54552b3e0a).
+> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 39 ahead** at [`cb2adb124158`](https://github.com/stephenlclarke/container-builder-shim/commit/cb2adb12415828033dccf76730db6915548dc7c4).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >
 > What looks like a local Compose change can therefore require coordinated conflict resolution, pin updates, builds, tests, packaging, and release validation across the entire stack. The pinned revisions must move together.

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c",
-      "forkHead": "93ede1b94d8dfcf0cd821f1b3d7246e2c5de7d83",
+      "forkHead": "0e22d5eb3e5f6b1b40428e214a29de54552b3e0a",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -419,7 +419,8 @@
             "ff08b876ab1f87934aa8d2853b921e0ba8590b7b",
             "02ea71e158c93e8faf43bdb6460d14bd0747ade0",
             "cef184de20206027b4c29a0c988173dfc7331157",
-            "6e9bdba61e7db7c2861e0c3544eb56c49c883938"
+            "6e9bdba61e7db7c2861e0c3544eb56c49c883938",
+            "0e22d5eb3e5f6b1b40428e214a29de54552b3e0a"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c` | `93ede1b94d8dfcf0cd821f1b3d7246e2c5de7d83` | 0 | 619 | 559 |
+| `container` | `ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c` | `0e22d5eb3e5f6b1b40428e214a29de54552b3e0a` | 0 | 620 | 560 |
 | `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `7e4f5152e9606a34a92c34186eb94f7cd37c134f` | 0 | 190 | 156 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `cb2adb12415828033dccf76730db6915548dc7c4` | 0 | 39 | 33 |
-| **Total** | | | **0** | **848** | **748** |
+| **Total** | | | **0** | **849** | **749** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 531 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 532 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -137,13 +137,12 @@ patch-unique non-merge classification count and disposition totals remain
 unchanged.
 
 The 11 August 2026 maintenance refresh advances the Container fork through
-`93ede1b94d8d` and classifies three independently reviewed release repairs as
+`0e22d5eb3e5f` and classifies four independently reviewed release repairs as
 support maintenance: isolated init-bootstrap application and log roots,
-explicit HTTPS for programmatic bootstrap image pulls, and retained init
-archive loading during clean release validation. Exact-head CodeQL, signature,
-Linux workload, build, documentation, package, and project-test checks passed
-before the merge. These commits do not add a temporary upstream port or a
-Compose-owned policy surface.
+explicit HTTPS for programmatic bootstrap image pulls, retained init archive
+loading during clean release validation, and deterministic help-path health
+tests that cannot discover plugins from an installed release candidate. These
+commits do not add a temporary upstream port or a Compose-owned policy surface.
 
 The registry records fork ownership; it does not promote a runtime or Compose
 stack pin. The generated Container dependency commits


### PR DESCRIPTION
## Summary
- classify Container `0e22d5eb3e5f` as reviewed support maintenance
- refresh exact fork heads and README divergence metrics
- unblock the strict stable-release upstream gate

## Verification
- `make readme-upstream-metrics-check`
- `make fork-classifications-check`
- `make upstream-divergence-release-check`
- `python3 -m unittest Tools.ci.test_upstream_divergence_report`
- `git diff --check`

Release-Note: none