### PR TITLE
chore(upstream): classify inspect fixture fix

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c",
-      "forkHead": "0e22d5eb3e5f6b1b40428e214a29de54552b3e0a",
+      "forkHead": "ee54d15ec41978de9ca0a8c62d26b1df3b177f63",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -420,7 +420,8 @@
             "02ea71e158c93e8faf43bdb6460d14bd0747ade0",
             "cef184de20206027b4c29a0c988173dfc7331157",
             "6e9bdba61e7db7c2861e0c3544eb56c49c883938",
-            "0e22d5eb3e5f6b1b40428e214a29de54552b3e0a"
+            "0e22d5eb3e5f6b1b40428e214a29de54552b3e0a",
+            "8ed263286b7c1981ede1014f329cb9e1c57c69f0"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- advance the reviewed Container fork head to the verified PR #103 merge
- classify the test-harness projection decoder as support maintenance
- restore the strict 561/561 fork-only commit classification gate

## Validation
- `make fork-classifications-check`
- `python3 -m unittest Tools.ci.test_upstream_divergence_report`
- `python3 -m json.tool docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json`
- `git diff --check`