### PR TITLE
Classify the release integration boundary fix

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c",
-      "forkHead": "ee54d15ec41978de9ca0a8c62d26b1df3b177f63",
+      "forkHead": "4dc78993a2b4fcdcebb7a01475fe51362d9cdff0",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -421,7 +421,8 @@
             "cef184de20206027b4c29a0c988173dfc7331157",
             "6e9bdba61e7db7c2861e0c3544eb56c49c883938",
             "0e22d5eb3e5f6b1b40428e214a29de54552b3e0a",
-            "8ed263286b7c1981ede1014f329cb9e1c57c69f0"
+            "8ed263286b7c1981ede1014f329cb9e1c57c69f0",
+            "b49b37ea8d832495447f9387e26ea7dcadd24183"
           ]
         },
         {


### PR DESCRIPTION
Records Container merge `4dc78993a2b4fcdcebb7a01475fe51362d9cdff0` as the exact fork head and classifies its signed patch commit `b49b37ea8d832495447f9387e26ea7dcadd24183` as support maintenance.

Validation:
- `make fork-classifications-check`
- `git diff --check`
- signed commit verification