### PR TITLE
chore(upstream): classify Apple documentation merge

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -3,8 +3,8 @@
   "reviewedAt": "2026-08-11",
   "repositories": {
     "container": {
-      "upstreamHead": "ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c",
-      "forkHead": "4dc78993a2b4fcdcebb7a01475fe51362d9cdff0",
+      "upstreamHead": "875d80ba07fdcc3aac138ed7fc56643d71aaf860",
+      "forkHead": "50b1eff7f6a25bee5f8ff1ef576a32297045aeb4",
       "slices": [
         {
           "id": "container-support-maintenance",

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `ff5aa8a03b7d49fdf5ab1fc3cb76b4d13eadce3c` | `0e22d5eb3e5f6b1b40428e214a29de54552b3e0a` | 0 | 620 | 560 |
+| `container` | `875d80ba07fdcc3aac138ed7fc56643d71aaf860` | `50b1eff7f6a25bee5f8ff1ef576a32297045aeb4` | 0 | 626 | 562 |
 | `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `7e4f5152e9606a34a92c34186eb94f7cd37c134f` | 0 | 190 | 156 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `cb2adb12415828033dccf76730db6915548dc7c4` | 0 | 39 | 33 |
-| **Total** | | | **0** | **849** | **749** |
+| **Total** | | | **0** | **855** | **751** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 532 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 534 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |


### PR DESCRIPTION
## Summary
- advance the reviewed Apple Container baseline to documentation refactor `875d80ba`
- bind the fork classification registry to verified Container main `50b1eff7`
- refresh the human-readable baseline totals (626 fork-ahead commits; 562 classified non-merge patches)

## Validation
- `python3 Tools/ci/test_upstream_divergence_report.py` (11/11)
- `env HAWKEYE_AUTO_INSTALL=1 make fmt`
- `make fork-classifications-check`
- `git diff --check`

The strict registry reports `current` with 562/562 commits classified and zero errors.