### PR TITLE
chore(upstream): classify CoreDNS resolver fix

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "875d80ba07fdcc3aac138ed7fc56643d71aaf860",
-      "forkHead": "55275d93a7f1fa2116524128043837f99551f767",
+      "forkHead": "59690f21f26a1418d95603c03506937bd0b6f1bd",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -425,7 +425,8 @@
             "b49b37ea8d832495447f9387e26ea7dcadd24183",
             "5b59927f999158e794c43e7734aaac2a6d7112f5",
             "925341c2d91d31a324ab3b518339d47fa4f08a8c",
-            "55275d93a7f1fa2116524128043837f99551f767"
+            "55275d93a7f1fa2116524128043837f99551f767",
+            "3cab6712ac077eda6d44267f3dc01b3dbd4b17b1"
           ]
         },
         {


### PR DESCRIPTION
## Summary
- advance the reviewed Container fork head to the merged CoreDNS repair
- classify `3cab6712` as support maintenance

## Verification
- `make fork-classifications-check`
- `git diff --check`

This is the single metadata update required by the fail-closed 0.11.0 release alignment gate.