### PR TITLE
chore(release): harden and prepare 0.11.0

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -170,14 +170,14 @@ counts from the Swift Testing log.
 
 ### Isolated macOS Runtime Ownership
 
-The default Container installation retains its stock launchd/Mach names, but an explicit validated `CONTAINER_SERVICE_NAMESPACE` now gives a candidate runtime its own API, Machine API, images, runtime, network, Engine, and public-socket ownership. `scripts/run-with-container-runtime.sh` derives a bounded namespace from its marker-protected candidate root and UID, verifies the namespace-derived socket before it starts services, and stops only that namespace. [RUNTIME-ISOLATED-PUBLIC-SOCKET-01](docs/parity/handoffs/RUNTIME-ISOLATED-PUBLIC-SOCKET-01.md) verifies one source-pinned public `docker version` lifecycle with the user-owned `devcontainer-engine` healthy before and after candidate cleanup.
+The default Container installation retains its stock launchd/Mach names, but an explicit validated `CONTAINER_SERVICE_NAMESPACE` now gives a candidate runtime its own API, Machine API, images, runtime, network, Engine, and public-socket ownership. `scripts/run-with-container-runtime.sh` derives a bounded namespace from its marker-protected candidate root, UID, and unique run identity, verifies the namespace-derived socket before it starts services, and stops only that namespace. Reusing one namespace after rebuilding the executable is unsupported. [RUNTIME-ISOLATED-PUBLIC-SOCKET-01](docs/parity/handoffs/RUNTIME-ISOLATED-PUBLIC-SOCKET-01.md) verifies one source-pinned public `docker version` lifecycle with the user-owned `devcontainer-engine` healthy before and after candidate cleanup.
 
 The default lock is `/tmp/container-compose-runtime-${UID}.lock`; `CONTAINER_RUNTIME_LOCK_FILE` changes it and `CONTAINER_RUNTIME_LOCK_TIMEOUT_SECONDS` changes the default 10,800-second wait. The helper uses `lockf` on macOS and the equivalent `flock` file-descriptor lock in Linux source-check runners. Every cooperating workflow on the host must use the same lock path. The lock remains required for legacy/default-namespace callers and controlled release workflows; it is no longer the only safety boundary for a correctly namespaced candidate. A unique per-job lock still defeats serialization for callers that share the default namespace.
 
 The parity harness also:
 
 - clears only a marker-protected `CONTAINER_RUNTIME_APP_ROOT`, retaining its kernel cache;
-- loads `CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE` when supplied, avoiding a cold source rebuild of the exact init image, or falls back to `CONTAINER_RUNTIME_INIT_BLOCK_REPO`;
+- verifies that `CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE`, when supplied, contains every reference in `CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES` plus the configured Compose alias at one digest before it touches the host runtime, then loads that archive or falls back to `CONTAINER_RUNTIME_INIT_BLOCK_REPO`;
 - starts the exact Container binary and requires a real `container list --all --format json` API round trip;
 - stops and restarts that exact runtime at most once after an XPC `Connection interrupted`/`Connection invalid` start or failed API-readiness round trip; and
 - always stops the matched runtime when the wrapped command exits.
@@ -380,8 +380,13 @@ Current source and package, every local and hosted release gate, a signed tag,
 and the paired Homebrew verification. It then blocks if a sibling fork is
 behind Apple upstream, requires `kern.hv_support=1`, bootstraps the matched
 stack tools, fetches the required `containerization` integration kernel when it
-is absent, and runs the full local `make release-gate`. The hosted gate
-then runs the `make release-gate-hosted` equivalent from its immutable
+is absent, and runs the full local `make release-gate` inside one fresh,
+marker-protected, uniquely namespaced runtime lifecycle. Nested runtime targets
+reuse that owner without stopping it, and exact-input sibling validation
+checkpoints under the release evidence directory are reused after an
+interrupted retry. An unpublished helper-generated candidate commit is likewise
+retained rather than recommitted with a new identity. The hosted gate then runs
+the `make release-gate-hosted` equivalent from its immutable
 release-control checkout against the immutable source, runtime, and tap
 checkouts before package publication. The helper waits up to three hours for
 that hosted gate, which exceeds its 120-minute workflow timeout; set

--- a/BUILD.md
+++ b/BUILD.md
@@ -177,6 +177,7 @@ The default lock is `/tmp/container-compose-runtime-${UID}.lock`; `CONTAINER_RUN
 The parity harness also:
 
 - clears only a marker-protected `CONTAINER_RUNTIME_APP_ROOT`, retaining its kernel cache;
+- redirects LLVM raw profiles into that marker-protected runtime root so instrumented test binaries cannot dirty source checkouts;
 - verifies that `CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE`, when supplied, contains every reference in `CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES` plus the configured Compose alias at one digest before it touches the host runtime, then loads that archive or falls back to `CONTAINER_RUNTIME_INIT_BLOCK_REPO`;
 - starts the exact Container binary and requires a real `container list --all --format json` API round trip;
 - stops and restarts that exact runtime at most once after an XPC `Connection interrupted`/`Connection invalid` start or failed API-readiness round trip; and

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7b5fceb244fa9b62d6f04df31a5a73befb8cbf29f2d5c863cfa760afb9b21a59",
+  "originHash" : "4f03ff1b11a5b5418b96f48ad9c95450f47be49ffae06278428b29e05df2effe",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "50b1eff7f6a25bee5f8ff1ef576a32297045aeb4"
+        "revision" : "59690f21f26a1418d95603c03506937bd0b6f1bd"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "50b1eff7f6a25bee5f8ff1ef576a32297045aeb4",
+        revision: "59690f21f26a1418d95603c03506937bd0b6f1bd",
     )
 }()
 

--- a/Tools/ci/container-runtime-lock.sh
+++ b/Tools/ci/container-runtime-lock.sh
@@ -21,6 +21,18 @@
 # services still occupy one launchd namespace for the current macOS user. Keep
 # every long-running repository workflow from stopping or replacing another
 # workflow's service while it owns that namespace.
+release_container_runtime_lock() {
+    local keeper_pid=${CONTAINER_RUNTIME_LOCK_KEEPER_PID:-}
+    if [[ -z "$keeper_pid" ]]; then
+        return
+    fi
+
+    kill "$keeper_pid" >/dev/null 2>&1 || true
+    wait "$keeper_pid" >/dev/null 2>&1 || true
+    unset CONTAINER_RUNTIME_LOCK_KEEPER_PID
+    unset CONTAINER_RUNTIME_LOCK_HELD
+}
+
 acquire_container_runtime_lock() {
     if [[ "${CONTAINER_RUNTIME_LOCK_HELD:-0}" == "1" ]]; then
         return
@@ -64,6 +76,20 @@ acquire_container_runtime_lock() {
             "$timeout_seconds" "$lock_file" >&2
         return 1
     fi
+
+    # Keep the lock descriptor in a dedicated shell rather than this runtime
+    # owner. Commands launched by the owner can start long-lived descendants
+    # (for example Chrome during VHS capture); those descendants must not keep
+    # the host-wide lock after the owner exits.
+    local lock_owner_pid=$$
+    (
+        trap 'exit 0' HUP INT TERM
+        while kill -0 "$lock_owner_pid" >/dev/null 2>&1; do
+            sleep 0.1
+        done
+    ) </dev/null >/dev/null 2>&1 &
+    CONTAINER_RUNTIME_LOCK_KEEPER_PID=$!
+    exec 9>&-
 
     export CONTAINER_RUNTIME_LOCK_HELD=1
     printf 'Acquired macOS Container runtime lock: %s\n' "$lock_file"

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -90,32 +90,65 @@ if [[ "${mode}" == "full" ]]; then
 fi
 
 checkpoint_directory=${CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR:-}
-validation_fingerprint=$(
-  {
-    printf 'mode=%s\n' "${mode}"
-    printf 'container_scratch_root=%s\n' "${container_scratch_root}"
-    printf 'containerization_targets=%s\n' "${containerization_targets[*]}"
-    printf 'container_targets=%s\n' "${container_targets[*]}"
-    printf 'required_init_references=%s\n' \
-      "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}"
-    printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
-    for path in "${compose_repo}" "${builder_repo}" "${containerization_repo}" \
-      "${container_repo}" "${homebrew_tap_repo}"; do
-      tree=$(git -C "${path}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
-      printf 'tree=%s:%s\n' "${path}" "${tree}"
-    done
-    if [[ -n "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" ]]; then
-      if [[ -f "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" ]]; then
-        printf 'init_archive=%s\n' \
-          "$(shasum -a 256 "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')"
-      else
-        printf 'init_archive=missing:%s\n' "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}"
+validation_fingerprint=""
+if [[ -n "${checkpoint_directory}" ]]; then
+  validation_fingerprint=$(
+    {
+      printf 'mode=%s\n' "${mode}"
+      printf 'container_scratch_root=%s\n' "${container_scratch_root}"
+      printf 'containerization_targets=%s\n' "${containerization_targets[*]}"
+      printf 'container_targets=%s\n' "${container_targets[*]}"
+      printf 'required_init_references=%s\n' \
+        "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}"
+      printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
+      for path in "${compose_repo}" "${builder_repo}" "${containerization_repo}" \
+        "${container_repo}" "${homebrew_tap_repo}"; do
+        tree=$(git -C "${path}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
+        printf 'tree=%s:%s\n' "${path}" "${tree}"
+      done
+      if [[ -n "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" ]]; then
+        if [[ -f "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" ]]; then
+          printf 'init_archive=%s\n' \
+            "$(shasum -a 256 "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')"
+        else
+          printf 'init_archive=missing:%s\n' "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}"
+        fi
       fi
-    fi
-    swift --version 2>/dev/null || true
-    uname -a
-  } | shasum -a 256 | awk '{print $1}'
-)
+      printf 'environment=PATH=%s\n' "${PATH}"
+      printf 'environment=DEVELOPER_DIR=%s\n' "${DEVELOPER_DIR:-}"
+      printf 'environment=SDKROOT=%s\n' "${SDKROOT:-}"
+      printf 'environment=CC=%s\n' "${CC:-}"
+      printf 'environment=CXX=%s\n' "${CXX:-}"
+      for tool_name in git make swift clang go ruby python3 docker hawkeye shellcheck xcodebuild; do
+        tool_path=$(command -v "${tool_name}" 2>/dev/null || true)
+        printf 'tool=%s:path=%s\n' "${tool_name}" "${tool_path:-missing}"
+        if [[ -n "${tool_path}" && -f "${tool_path}" ]]; then
+          printf 'tool=%s:sha256=%s\n' "${tool_name}" \
+            "$(shasum -a 256 "${tool_path}" | awk '{print $1}')"
+        fi
+        if [[ -z "${tool_path}" ]]; then
+          tool_version=missing
+        else
+          case "${tool_name}" in
+            go)
+              tool_version=$(go version 2>&1 || true)
+              ;;
+            xcodebuild)
+              tool_version=$(xcodebuild -version 2>&1 || true)
+              ;;
+            *)
+              tool_version=$("${tool_name}" --version 2>&1 || true)
+              ;;
+          esac
+        fi
+        printf 'tool=%s:version=%s\n' "${tool_name}" "${tool_version}"
+      done
+      printf 'docker:buildx=%s\n' "$(docker buildx version 2>&1 || true)"
+      printf 'docker:compose=%s\n' "$(docker compose version 2>&1 || true)"
+      uname -a
+    } | shasum -a 256 | awk '{print $1}'
+  )
+fi
 
 run_checkpointed() {
   local stage=$1
@@ -145,6 +178,9 @@ run_checkpointed() {
 }
 
 printf 'running %s stack release validation\n' "${mode}"
+if [[ -n "${checkpoint_directory}" ]]; then
+  printf 'stack validation exact-input fingerprint: %s\n' "${validation_fingerprint}"
+fi
 run_checkpointed builder \
   make -C "${builder_repo}" check-licenses vet lint coverage build
 run_checkpointed containerization \

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -89,15 +89,74 @@ if [[ "${mode}" == "full" ]]; then
   )
 fi
 
+checkpoint_directory=${CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR:-}
+validation_fingerprint=$(
+  {
+    printf 'mode=%s\n' "${mode}"
+    printf 'container_scratch_root=%s\n' "${container_scratch_root}"
+    printf 'containerization_targets=%s\n' "${containerization_targets[*]}"
+    printf 'container_targets=%s\n' "${container_targets[*]}"
+    printf 'required_init_references=%s\n' \
+      "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}"
+    printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
+    for path in "${compose_repo}" "${builder_repo}" "${containerization_repo}" \
+      "${container_repo}" "${homebrew_tap_repo}"; do
+      tree=$(git -C "${path}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
+      printf 'tree=%s:%s\n' "${path}" "${tree}"
+    done
+    if [[ -n "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" ]]; then
+      if [[ -f "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" ]]; then
+        printf 'init_archive=%s\n' \
+          "$(shasum -a 256 "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')"
+      else
+        printf 'init_archive=missing:%s\n' "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}"
+      fi
+    fi
+    swift --version 2>/dev/null || true
+    uname -a
+  } | shasum -a 256 | awk '{print $1}'
+)
+
+run_checkpointed() {
+  local stage=$1
+  shift
+  if [[ -z "${checkpoint_directory}" ]]; then
+    "$@"
+    return
+  fi
+
+  mkdir -p "${checkpoint_directory}"
+  local stamp="${checkpoint_directory}/${mode}-${stage}.sha256"
+  local expected="${validation_fingerprint}:${stage}"
+  local actual=""
+  if [[ -f "${stamp}" ]]; then
+    IFS= read -r actual <"${stamp}" || true
+  fi
+  if [[ "${actual}" == "${expected}" ]]; then
+    printf 'reusing exact-input validation checkpoint: %s\n' "${stage}"
+    return
+  fi
+
+  "$@"
+  local temporary_stamp
+  temporary_stamp=$(mktemp "${checkpoint_directory}/.${mode}-${stage}.XXXXXX")
+  printf '%s\n' "${expected}" >"${temporary_stamp}"
+  mv -f "${temporary_stamp}" "${stamp}"
+}
+
 printf 'running %s stack release validation\n' "${mode}"
-make -C "${builder_repo}" check-licenses vet lint coverage build
-make -C "${containerization_repo}" "${containerization_targets[@]}"
+run_checkpointed builder \
+  make -C "${builder_repo}" check-licenses vet lint coverage build
+run_checkpointed containerization \
+  make -C "${containerization_repo}" "${containerization_targets[@]}"
 # The outer stable gate may select an already-running isolated runtime for
 # Containerization's image build. Container's unit tests exercise their own
 # default namespace contract, so do not let that selector rewrite the expected
 # launchd labels and engine socket paths. The explicit APP_ROOT/LOG_ROOT make
 # arguments still isolate Container's VM-backed integration state.
-env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
-  CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" \
-  make -C "${container_repo}" "${container_make_args[@]}" "${container_targets[@]}"
-ruby -c "${homebrew_tap_repo}/Formula/container-compose.rb"
+run_checkpointed container \
+  env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
+    CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" \
+    make -C "${container_repo}" "${container_make_args[@]}" "${container_targets[@]}"
+run_checkpointed homebrew \
+  ruby -c "${homebrew_tap_repo}/Formula/container-compose.rb"

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -1086,12 +1086,23 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
 
 
 class ContainerRuntimeLockTest(unittest.TestCase):
+    @staticmethod
+    def independent_runtime_environment() -> dict[str, str]:
+        environment = os.environ.copy()
+        for variable in (
+            "CONTAINER_RUNTIME_LOCK_HELD",
+            "CONTAINER_RUNTIME_LOCK_KEEPER_PID",
+            "CONTAINER_RUNTIME_MANAGED",
+        ):
+            environment.pop(variable, None)
+        return environment
+
     def test_runtime_children_do_not_inherit_the_lock_descriptor(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
             lock_file = temporary_root / "runtime.lock"
             inherited_descriptor = temporary_root / "inherited-descriptor"
-            environment = os.environ.copy()
+            environment = self.independent_runtime_environment()
             environment.update(
                 {
                     "CONTAINER_RUNTIME_LOCK_FILE": str(lock_file),
@@ -1144,7 +1155,7 @@ class ContainerRuntimeLockTest(unittest.TestCase):
             holder_ready = temporary_root / "holder-ready"
             holder_release = temporary_root / "holder-release"
             contender_acquired = temporary_root / "contender-acquired"
-            environment = os.environ.copy()
+            environment = self.independent_runtime_environment()
             environment.update(
                 {
                     "CONTAINER_RUNTIME_LOCK_FILE": str(lock_file),

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -54,6 +54,8 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             "CONTAINERIZATION_INIT_BUILD_SCRATCH_ROOT",
             "CONTAINER_COMPOSE_INIT_IMAGE",
             "CONTAINER_RUNTIME_LOCK_FILE",
+            "CONTAINER_RUNTIME_LOCK_HELD",
+            "CONTAINER_RUNTIME_LOCK_KEEPER_PID",
         ):
             environment.pop(variable, None)
         return environment
@@ -800,6 +802,57 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
 
 
 class ContainerRuntimeLockTest(unittest.TestCase):
+    def test_runtime_children_do_not_inherit_the_lock_descriptor(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            lock_file = temporary_root / "runtime.lock"
+            inherited_descriptor = temporary_root / "inherited-descriptor"
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_LOCK_FILE": str(lock_file),
+                    "CONTAINER_RUNTIME_LOCK_TIMEOUT_SECONDS": "1",
+                }
+            )
+            holder_script = (
+                f'source "{LOCK_SCRIPT}"; '
+                "acquire_container_runtime_lock; "
+                f"/bin/bash -c 'if [[ -e /dev/fd/9 ]]; then "
+                f'touch "{inherited_descriptor}"; fi; sleep 2\' '
+                ">/dev/null 2>&1 &"
+            )
+            contender_script = (
+                f'source "{LOCK_SCRIPT}"; '
+                "acquire_container_runtime_lock; "
+                "release_container_runtime_lock"
+            )
+
+            holder = subprocess.run(
+                ["/bin/bash", "-c", holder_script],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(holder.returncode, 0, holder.stdout + holder.stderr)
+
+            started = time.monotonic()
+            contender = subprocess.run(
+                ["/bin/bash", "-c", contender_script],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            elapsed = time.monotonic() - started
+            self.assertEqual(
+                contender.returncode,
+                0,
+                contender.stdout + contender.stderr,
+            )
+            self.assertLess(elapsed, 1.0)
+            self.assertFalse(inherited_descriptor.exists())
+
     def test_serializes_independent_runtime_users(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -18,8 +18,11 @@
 from __future__ import annotations
 
 import hashlib
+import io
+import json
 import os
 import subprocess
+import tarfile
 import tempfile
 import time
 import unittest
@@ -54,6 +57,9 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             "CONTAINERIZATION_INIT_BUILD_SCRATCH_ROOT",
             "CONTAINER_COMPOSE_INIT_IMAGE",
             "CONTAINER_RUNTIME_LOCK_FILE",
+            "CONTAINER_RUNTIME_MANAGED",
+            "CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES",
+            "CONTAINER_RUNTIME_RUN_ID",
             "CONTAINER_RUNTIME_LOCK_HELD",
             "CONTAINER_RUNTIME_LOCK_KEEPER_PID",
         ):
@@ -79,6 +85,35 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             encoding="utf-8",
         )
         path.chmod(0o755)
+
+    @staticmethod
+    def create_oci_archive(
+        path: Path,
+        *references: str,
+        distinct_digests: bool = False,
+    ) -> None:
+        index = {
+            "schemaVersion": 2,
+            "manifests": [
+                {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "sha256:"
+                    + (f"{index:x}" * 64)[:64]
+                    if distinct_digests
+                    else "sha256:" + "0" * 64,
+                    "size": 0,
+                    "annotations": {
+                        "org.opencontainers.image.ref.name": reference,
+                    },
+                }
+                for index, reference in enumerate(references, start=1)
+            ],
+        }
+        payload = json.dumps(index).encode("utf-8")
+        with tarfile.open(path, "w") as archive:
+            member = tarfile.TarInfo("index.json")
+            member.size = len(payload)
+            archive.addfile(member, io.BytesIO(payload))
 
     @staticmethod
     def create_containerization_source(root: Path) -> tuple[Path, str]:
@@ -160,6 +195,70 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 self.assertIn(expected_error, result.stderr)
                 self.assertFalse(container_log.exists())
 
+    def test_preserves_nonempty_unmarked_runtime_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            app_root.mkdir()
+            sentinel = app_root / "user-data"
+            sentinel.write_text("preserve\n", encoding="utf-8")
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("refusing to clear unmarked", result.stderr)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve\n")
+
+    def test_preserves_runtime_root_with_invalid_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            app_root.mkdir()
+            marker = app_root / ".container-compose-runtime-root"
+            marker.write_text("not-owned\n", encoding="utf-8")
+            sentinel = app_root / "user-data"
+            sentinel.write_text("preserve\n", encoding="utf-8")
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("refusing to clear container runtime root with an invalid marker", result.stderr)
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "preserve\n")
+
     def test_scopes_candidate_namespace_and_exports_public_socket(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
@@ -172,6 +271,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             environment.update(
                 {
                     "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_RUN_ID": "candidate-test-run",
                     "CONTAINER_RUNTIME_LOCK_FILE": str(
                         temporary_root / "runtime.lock"
                     ),
@@ -203,7 +303,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             )
 
             namespace_digest = hashlib.sha256(
-                f"{app_root}:{os.getuid()}".encode("utf-8")
+                f"{app_root}:{os.getuid()}:candidate-test-run".encode("utf-8")
             ).hexdigest()[:24]
             namespace = (
                 "io.github.stephenlclarke.container-compose.runtime."
@@ -218,6 +318,45 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 [namespace, str(app_root), socket, f"unix://{socket}"],
             )
             self.assertIn("system start", container_log.read_text(encoding="utf-8"))
+
+    def test_repeated_runs_on_one_root_receive_different_default_namespaces(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            namespaces: list[str] = []
+            for run_number in range(2):
+                namespace_file = temporary_root / f"namespace-{run_number}"
+                environment = self.runtime_environment()
+                environment.update(
+                    {
+                        "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                        "CONTAINER_RUNTIME_LOCK_FILE": str(
+                            temporary_root / "runtime.lock"
+                        ),
+                        "CONTAINER_TEST_LOG": str(container_log),
+                        "NAMESPACE_FILE": str(namespace_file),
+                    }
+                )
+                result = subprocess.run(
+                    [
+                        str(SCRIPT),
+                        str(fake_container),
+                        "/bin/sh",
+                        "-c",
+                        'printf "%s\\n" "$CONTAINER_SERVICE_NAMESPACE" >"$NAMESPACE_FILE"',
+                    ],
+                    cwd=ROOT,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                namespaces.append(namespace_file.read_text(encoding="utf-8").strip())
+
+            self.assertNotEqual(namespaces[0], namespaces[1])
 
     def test_rejects_legacy_global_stop_helper_before_service_side_effects(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -657,7 +796,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             temporary_root = Path(temporary_directory)
             app_root = temporary_root / "app-root"
             init_archive = temporary_root / "vminit.tar"
-            init_archive.write_bytes(b"retained init image")
+            self.create_oci_archive(init_archive, DEFAULT_INIT_IMAGE)
             container_log = temporary_root / "container.log"
             fake_container = temporary_root / "container-cli"
             self.write_fake_container(fake_container)
@@ -697,6 +836,151 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             self.assertIn("--disable-kernel-install", starts[0])
             self.assertIn(f"--init-image-archive {init_archive}", starts[0])
             self.assertNotIn(f"image load --input {init_archive}", invocations)
+
+    def test_rejects_retained_archive_missing_any_required_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            init_archive = temporary_root / "vminit.tar"
+            immutable_reference = "ghcr.io/example/vminit:0123456789abcdef"
+            self.create_oci_archive(init_archive, DEFAULT_INIT_IMAGE)
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(init_archive),
+                    "CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES": immutable_reference,
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(immutable_reference, result.stderr)
+            self.assertFalse(container_log.exists())
+
+    def test_rejects_required_archive_references_with_different_digests(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            init_archive = temporary_root / "vminit.tar"
+            immutable_reference = "ghcr.io/example/vminit:0123456789abcdef"
+            self.create_oci_archive(
+                init_archive,
+                DEFAULT_INIT_IMAGE,
+                immutable_reference,
+                distinct_digests=True,
+            )
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(init_archive),
+                    "CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES": immutable_reference,
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("do not resolve to one digest", result.stderr)
+            self.assertFalse(container_log.exists())
+
+    def test_managed_runtime_does_not_restart_or_stop_its_owner(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            container_log = temporary_root / "container.log"
+            command_log = temporary_root / "command.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_MANAGED": "1",
+                    "CONTAINER_RUNTIME_RUN_ID": "outer-owner",
+                    "CONTAINER_TEST_LOG": str(container_log),
+                    "COMMAND_LOG": str(command_log),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT),
+                    str(fake_container),
+                    "/bin/sh",
+                    "-c",
+                    'printf "managed\\n" >"$COMMAND_LOG"',
+                ],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(command_log.read_text(encoding="utf-8"), "managed\n")
+            self.assertFalse(container_log.exists())
+
+    def test_api_round_trip_failure_blocks_the_candidate_command(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            container_log = temporary_root / "container.log"
+            command_marker = temporary_root / "command-ran"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(
+                fake_container,
+                body=(
+                    'if [[ "$*" == "list --all --format json" ]]; then\n'
+                    "  exit 23\n"
+                    "fi\n"
+                ),
+            )
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/touch", str(command_marker)],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse(command_marker.exists())
 
     def test_restarts_once_after_transient_xpc_start_failure(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,16 +1,16 @@
 {
   "components": {
     "container": {
-      "ref": "50b1eff7f6a25bee5f8ff1ef576a32297045aeb4",
+      "ref": "59690f21f26a1418d95603c03506937bd0b6f1bd",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
       "image": {
-        "digest": "sha256:6cfb001d6fcf46283526df084351c20fd77e473eabaa9bf55e9327cc1d882f0c",
+        "digest": "sha256:c29628471db683a53f4a75bcb759bb9147a65e097ede37c7dde05442afa7518c",
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
-        "tag": "current-30784216505-806feb1c9cc1"
+        "tag": "current-31545611348-88332c96705b"
       },
-      "ref": "cb2adb12415828033dccf76730db6915548dc7c4",
+      "ref": "88332c96705b024bbc5cd210642118ee82f8793d",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1050,15 +1050,33 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 tool = tools / name
                 tool.write_text(
                     "#!/usr/bin/env bash\n"
+                    "if [[ \"${1:-}\" == \"--version\" ]]; then\n"
+                    "  printf '%s version 1.0\\n' \"$(basename \"$0\")\"\n"
+                    "  exit 0\n"
+                    "fi\n"
                     "printf '%s:%s\\n' \"$(basename \"$0\")\" \"$*\" >> \"${STACK_VALIDATION_LOG:?}\"\n"
                     "printf 'bootstrap:%s\\n' \"${CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE:-}\" >> \"${STACK_VALIDATION_LOG:?}\"\n",
                     encoding="utf-8",
                 )
                 tool.chmod(0o755)
+            go_tool = tools / "go"
+            go_tool.write_text(
+                "#!/usr/bin/env bash\n"
+                "if [[ \"${1:-}\" == \"version\" ]]; then\n"
+                "  printf 'go version %s\\n' \"${FAKE_GO_VERSION:?}\"\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 64\n",
+                encoding="utf-8",
+            )
+            go_tool.chmod(0o755)
 
             environment = os.environ.copy()
             environment["PATH"] = f"{tools}{os.pathsep}{environment['PATH']}"
+            environment["BASH_ENV"] = "/dev/null"
+            environment["ENV"] = "/dev/null"
             environment["STACK_VALIDATION_LOG"] = str(log)
+            environment["FAKE_GO_VERSION"] = "go1.26.3"
             environment["CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"] = "/tmp/runtime-init.oci.tar"
             environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
                 root / "checkpoints"
@@ -1108,6 +1126,30 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "reusing exact-input validation checkpoint: containerization",
                 repeated_full.stdout,
+            )
+
+            environment["FAKE_GO_VERSION"] = "go1.26.4"
+            changed_toolchain = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+            )
+            self.assertEqual(changed_toolchain.returncode, 0, changed_toolchain.stderr)
+            changed_commands = log.read_text(encoding="utf-8")
+            self.assertEqual(
+                changed_commands.count(f"make:-C {builder}"),
+                2,
+                full.stdout
+                + repeated_full.stdout
+                + changed_toolchain.stdout
+                + changed_toolchain.stderr
+                + changed_commands,
+            )
+            self.assertNotIn(
+                "reusing exact-input validation checkpoint",
+                changed_toolchain.stdout,
             )
 
             log.unlink()
@@ -1295,9 +1337,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertLess(release.index("run_local_release_gate"), release.index("push_all_main"))
         self.assertIn('HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"', self.script)
         self.assertIn('"$(repo_path "container-builder-shim")"', self.script)
-        self.assertIn('make -C "$(repo_path "containerization")" fetch-default-kernel', self.script)
+        self.assertIn('containerization_path="$(repo_path "containerization")"', self.script)
+        self.assertIn('make -C "${containerization_path}" fetch-default-kernel', self.script)
         self.assertIn("one fresh marker-protected runtime lifecycle", self.script)
         self.assertIn("CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES", self.script)
+        self.assertIn("CONTAINER_RUNTIME_INIT_BLOCK_REPO", self.script)
+        self.assertIn("CONTAINERIZATION_INIT_SOURCE_PATH", self.script)
         self.assertIn("-u CONTAINER_RUNTIME_SERVICE_NAMESPACE", self.script)
 
     def test_stable_release_requires_intent_and_reviewed_sibling_mains(self) -> None:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -79,14 +79,15 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"', self.script)
         self.assertIn("CONTAINER_STACK_RELEASE_ROOT", self.script)
 
-    def test_release_helper_recovers_only_its_unpublished_candidate_before_readiness(self) -> None:
+    def test_release_helper_retains_only_its_unpublished_candidate_before_readiness(self) -> None:
         recovery = self.script[
             self.script.index("recover_unpublished_release_candidate() {") : self.script.index(
                 "# Print and optionally execute a command."
             )
         ]
         release = self.script[self.script.index("release_current_stack() {") :]
-        self.assertIn('git -C "${path}" reset --soft "${remote_head}"', recovery)
+        self.assertNotIn('git -C "${path}" reset --soft "${remote_head}"', recovery)
+        self.assertIn("retaining unpublished release candidate", recovery)
         self.assertNotIn("reset --hard", recovery)
         self.assertIn('"chore(release): prepare ${version}"', recovery)
         self.assertIn('"chore(deps): pin containerization "[0-9a-f]*', recovery)
@@ -1059,6 +1060,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             environment["PATH"] = f"{tools}{os.pathsep}{environment['PATH']}"
             environment["STACK_VALIDATION_LOG"] = str(log)
             environment["CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"] = "/tmp/runtime-init.oci.tar"
+            environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
+                root / "checkpoints"
+            )
             validation_paths = [
                 str(compose),
                 str(builder),
@@ -1091,6 +1095,20 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
             self.assertNotIn("CONCURRENT_TEST_SUITES=", full_commands)
             self.assertIn("bootstrap:/tmp/runtime-init.oci.tar", full_commands)
+
+            repeated_full = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+            )
+            self.assertEqual(repeated_full.returncode, 0, repeated_full.stderr)
+            self.assertEqual(log.read_text(encoding="utf-8"), full_commands)
+            self.assertIn(
+                "reusing exact-input validation checkpoint: containerization",
+                repeated_full.stdout,
+            )
 
             log.unlink()
             hosted = subprocess.run(
@@ -1278,6 +1296,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"', self.script)
         self.assertIn('"$(repo_path "container-builder-shim")"', self.script)
         self.assertIn('make -C "$(repo_path "containerization")" fetch-default-kernel', self.script)
+        self.assertIn("one fresh marker-protected runtime lifecycle", self.script)
+        self.assertIn("CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES", self.script)
+        self.assertIn("-u CONTAINER_RUNTIME_SERVICE_NAMESPACE", self.script)
 
     def test_stable_release_requires_intent_and_reviewed_sibling_mains(self) -> None:
         promotion = self.script[self.script.index("push_all_main() {") : self.script.index("# Require an executable command")]
@@ -1486,7 +1507,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             ).stdout.split()[0]
             self.assertNotEqual(local_tag, remote_tag)
 
-    def test_release_helper_reconstructs_an_unpublished_prepared_candidate(self) -> None:
+    def test_release_helper_retains_an_unpublished_prepared_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             _remote, local = self.create_compose_checkout(root)
@@ -1497,6 +1518,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "0.6.71\n",
                 "chore(release): prepare 0.6.71",
             )
+            candidate_head = self.git(local, "rev-parse", "main")
 
             result = self.run_release_function(
                 root / "github",
@@ -1504,11 +1526,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("reconstructing unpublished release candidate", result.stdout)
-            self.assertEqual(self.git(local, "rev-parse", "main"), remote_head)
-            self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "VERSION")
+            self.assertIn("retaining unpublished release candidate", result.stdout)
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
+            self.assertNotEqual(candidate_head, remote_head)
+            self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "")
 
-    def test_release_helper_reconstructs_an_atomic_stack_pin_candidate(self) -> None:
+    def test_release_helper_retains_an_atomic_stack_pin_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             _remote, local = self.create_compose_checkout(root)
@@ -1519,6 +1542,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "pinned stack\n",
                 "chore(deps): pin container stack 123456789abc abcdef123456",
             )
+            candidate_head = self.git(local, "rev-parse", "main")
 
             result = self.run_release_function(
                 root / "github",
@@ -1526,8 +1550,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertEqual(self.git(local, "rev-parse", "main"), remote_head)
-            self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "Package.swift")
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
+            self.assertNotEqual(candidate_head, remote_head)
+            self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "")
 
     def test_release_helper_refuses_to_reconstruct_an_unrelated_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -88,6 +88,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         release = self.script[self.script.index("release_current_stack() {") :]
         self.assertNotIn('git -C "${path}" reset --soft "${remote_head}"', recovery)
         self.assertIn("retaining unpublished release candidate", recovery)
+        self.assertIn("RECOVERED_UNPUBLISHED_RELEASE_BASE", recovery)
         self.assertNotIn("reset --hard", recovery)
         self.assertIn('"chore(release): prepare ${version}"', recovery)
         self.assertIn('"chore(deps): pin containerization "[0-9a-f]*', recovery)
@@ -1557,6 +1558,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             root = Path(directory)
             _remote, local = self.create_compose_checkout(root)
             remote_head = self.git(local, "rev-parse", "origin/main")
+            self.run_command(
+                "git", "-C", str(local), "tag", "--no-sign", "current", remote_head
+            )
             self.commit_file(
                 local,
                 "VERSION",
@@ -1567,11 +1571,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
             result = self.run_release_function(
                 root / "github",
-                "recover_unpublished_release_candidate 0.6.71",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "ensure_current_release_source_identity",
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("retaining unpublished release candidate", result.stdout)
+            self.assertIn("current tag targets published parent", result.stdout)
             self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
             self.assertNotEqual(candidate_head, remote_head)
             self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "")
@@ -1598,6 +1604,34 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
             self.assertNotEqual(candidate_head, remote_head)
             self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "")
+
+    def test_retained_candidate_rejects_current_from_any_commit_but_its_parent(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _remote, local = self.create_compose_checkout(root)
+            remote_head = self.git(local, "rev-parse", "origin/main")
+            self.commit_file(local, "STALE", "stale\n", "chore: stale current")
+            self.run_command(
+                "git", "-C", str(local), "tag", "--no-sign", "current"
+            )
+            self.run_command("git", "-C", str(local), "reset", "--hard", remote_head)
+            self.commit_file(
+                local,
+                "VERSION",
+                "0.6.71\n",
+                "chore(release): prepare 0.6.71",
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "ensure_current_release_source_identity",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("current tag targets", result.stderr)
 
     def test_release_helper_refuses_to_reconstruct_an_unrelated_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1409,6 +1409,20 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("sysctl -n kern.hv_support", self.script)
         self.assertIn("kern.hv_support=1", self.script)
 
+    def test_local_release_gate_keeps_llvm_profiles_out_of_source_checkouts(self) -> None:
+        local_gate = self.script[
+            self.script.index("run_local_release_gate() {") : self.script.index(
+                "# Verify that Apple remotes cannot be pushed"
+            )
+        ]
+        self.assertIn('profile_root="${runtime_parent}/profiles"', local_gate)
+        self.assertIn('mkdir -p "${profile_root}"', local_gate)
+        self.assertIn('LLVM_PROFILE_FILE="${profile_root}/%p-%m.profraw"', local_gate)
+        self.assertLess(
+            local_gate.index('profile_root="${runtime_parent}/profiles"'),
+            local_gate.index('"${path}/scripts/run-with-container-runtime.sh"'),
+        )
+
     def test_local_virtualization_preflight_requires_hardware_support(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -571,10 +571,11 @@ require_local_virtualization() {
 
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
-  local path repository container_path container_binary runtime_parent runtime_app_root
+  local path repository container_path containerization_path container_binary runtime_parent runtime_app_root
   local containerization_reference required_init_references status marker_value
   path="$(repo_path "${COMPOSE_REPO}")"
   container_path="$(repo_path "${CONTAINER_REPO}")"
+  containerization_path="$(repo_path "containerization")"
   if [[ ! -f "${HOMEBREW_TAP_REPO}/Formula/container-compose.rb" ]]; then
     printf 'Homebrew tap checkout is required at %s\n' "${HOMEBREW_TAP_REPO}" >&2
     exit 1
@@ -599,7 +600,7 @@ run_local_release_gate() {
       fi
     )
   done
-  run make -C "$(repo_path "containerization")" fetch-default-kernel
+  run make -C "${containerization_path}" fetch-default-kernel
   run make -C "${container_path}" container
   if [[ "${EXECUTE}" != "1" ]]; then
     printf 'would run the complete local gate inside one fresh marker-protected runtime lifecycle\n'
@@ -629,6 +630,8 @@ PY
     -u CONTAINER_RUNTIME_SERVICE_NAMESPACE -u CONTAINER_RUNTIME_RUN_ID \
     HAWKEYE_AUTO_INSTALL=1 \
     CONTAINER_RUNTIME_APP_ROOT="${runtime_app_root}" \
+    CONTAINER_RUNTIME_INIT_BLOCK_REPO="${container_path}" \
+    CONTAINERIZATION_INIT_SOURCE_PATH="${containerization_path}" \
     CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES="${required_init_references}" \
     CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR="${PARITY_EVIDENCE_DIR:-${path}/.build/release-evidence}/stack-validation" \
     "${path}/scripts/run-with-container-runtime.sh" "${container_binary}" \

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -360,7 +360,9 @@ PY
   fi
 }
 
-# Reconstruct a helper-created candidate after a local release gate fails before promotion.
+# Retain a helper-created candidate after a local release gate fails before
+# promotion. Recommitting an identical tree changes the reviewed candidate
+# identity on every retry and makes evidence impossible to bind reliably.
 recover_unpublished_release_candidate() {
   local version="$1" path remote local_head remote_head subject subjects
   path="$(repo_path "${COMPOSE_REPO}")"
@@ -400,8 +402,7 @@ recover_unpublished_release_candidate() {
     esac
   done <<<"${subjects}"
 
-  printf 'reconstructing unpublished release candidate from %s/main after an earlier local gate failure\n' "${remote}"
-  run git -C "${path}" reset --soft "${remote_head}"
+  printf 'retaining unpublished release candidate %s after an earlier local gate failure\n' "${local_head}"
 }
 
 # Print and optionally execute a command.
@@ -570,8 +571,10 @@ require_local_virtualization() {
 
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
-  local path repository
+  local path repository container_path container_binary runtime_parent runtime_app_root
+  local containerization_reference required_init_references status marker_value
   path="$(repo_path "${COMPOSE_REPO}")"
+  container_path="$(repo_path "${CONTAINER_REPO}")"
   if [[ ! -f "${HOMEBREW_TAP_REPO}/Formula/container-compose.rb" ]]; then
     printf 'Homebrew tap checkout is required at %s\n' "${HOMEBREW_TAP_REPO}" >&2
     exit 1
@@ -597,8 +600,51 @@ run_local_release_gate() {
     )
   done
   run make -C "$(repo_path "containerization")" fetch-default-kernel
-  run env HAWKEYE_AUTO_INSTALL=1 \
-    make -C "${path}" release-gate "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}"
+  run make -C "${container_path}" container
+  if [[ "${EXECUTE}" != "1" ]]; then
+    printf 'would run the complete local gate inside one fresh marker-protected runtime lifecycle\n'
+    return 0
+  fi
+
+  container_binary="${container_path}/bin/container"
+  if [[ ! -x "${container_binary}" ]]; then
+    printf 'local release gate did not produce an executable Container CLI: %s\n' \
+      "${container_binary}" >&2
+    exit 1
+  fi
+  containerization_reference="$(python3 - "${path}/Tools/release/stack-refs.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(manifest["components"]["containerization"]["ref"])
+PY
+)"
+  required_init_references="vminit:container-compose ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
+  runtime_parent="$(mktemp -d "${TMPDIR:-/tmp}/cc-release.XXXXXX")"
+  runtime_app_root="${runtime_parent}/app"
+  status=0
+  env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
+    -u CONTAINER_RUNTIME_SERVICE_NAMESPACE -u CONTAINER_RUNTIME_RUN_ID \
+    HAWKEYE_AUTO_INSTALL=1 \
+    CONTAINER_RUNTIME_APP_ROOT="${runtime_app_root}" \
+    CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES="${required_init_references}" \
+    CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR="${PARITY_EVIDENCE_DIR:-${path}/.build/release-evidence}/stack-validation" \
+    "${path}/scripts/run-with-container-runtime.sh" "${container_binary}" \
+    make -C "${path}" release-gate "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}" || status=$?
+
+  marker_value=""
+  if [[ -f "${runtime_app_root}/.container-compose-runtime-root" ]]; then
+    IFS= read -r marker_value <"${runtime_app_root}/.container-compose-runtime-root" || true
+  fi
+  if [[ "${marker_value}" == "container-compose isolated runtime state v1" ]]; then
+    find "${runtime_parent}" -depth -delete
+  else
+    printf 'refusing to remove release runtime root without its valid marker: %s\n' \
+      "${runtime_parent}" >&2
+  fi
+  return "${status}"
 }
 
 # Verify that Apple remotes cannot be pushed and stephenlclarke remotes are the target.

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -593,7 +593,7 @@ require_local_virtualization() {
 
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
-  local path repository container_path containerization_path container_binary runtime_parent runtime_app_root
+  local path repository container_path containerization_path container_binary runtime_parent runtime_app_root profile_root
   local containerization_reference required_init_references status marker_value
   path="$(repo_path "${COMPOSE_REPO}")"
   container_path="$(repo_path "${CONTAINER_REPO}")"
@@ -647,6 +647,8 @@ PY
   required_init_references="vminit:container-compose ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
   runtime_parent="$(mktemp -d "${TMPDIR:-/tmp}/cc-release.XXXXXX")"
   runtime_app_root="${runtime_parent}/app"
+  profile_root="${runtime_parent}/profiles"
+  mkdir -p "${profile_root}"
   status=0
   env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
     -u CONTAINER_RUNTIME_SERVICE_NAMESPACE -u CONTAINER_RUNTIME_RUN_ID \
@@ -656,6 +658,7 @@ PY
     CONTAINERIZATION_INIT_SOURCE_PATH="${containerization_path}" \
     CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES="${required_init_references}" \
     CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR="${PARITY_EVIDENCE_DIR:-${path}/.build/release-evidence}/stack-validation" \
+    LLVM_PROFILE_FILE="${profile_root}/%p-%m.profraw" \
     "${path}/scripts/run-with-container-runtime.sh" "${container_binary}" \
     make -C "${path}" release-gate "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}" || status=$?
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -206,6 +206,7 @@ RELEASE_INTENT="${CONTAINER_STACK_RELEASE_INTENT:-}"
 SECURITY_REASON="${CONTAINER_STACK_SECURITY_REASON:-}"
 MAINTENANCE_REASON="${CONTAINER_STACK_MAINTENANCE_REASON:-}"
 MILESTONE_SOAK_OVERRIDE_REASON="${CONTAINER_STACK_MILESTONE_SOAK_OVERRIDE_REASON:-}"
+RECOVERED_UNPUBLISHED_RELEASE_BASE=""
 readonly STABLE_CURRENT_SOAK_SECONDS=604800
 HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"
 REPOS=(
@@ -307,12 +308,37 @@ ensure_release_intent() {
   fi
 }
 
+# Require Current to identify local main, or the published parent of the exact
+# helper-created candidate retained for this retry. The candidate itself is not
+# published until its release PR passes, so requiring Current to name it makes
+# a safe retry impossible.
+ensure_current_release_source_identity() {
+  local path main_commit current_commit
+  path="$(repo_path "${COMPOSE_REPO}")"
+  main_commit="$(git -C "${path}" rev-parse main)"
+  current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
+  if [[ "${current_commit}" == "${main_commit}" ]]; then
+    return 0
+  fi
+  if [[
+    -n "${RECOVERED_UNPUBLISHED_RELEASE_BASE}"
+    && "${current_commit}" == "${RECOVERED_UNPUBLISHED_RELEASE_BASE}"
+  ]]; then
+    printf 'current tag targets published parent %s of retained release candidate %s\n' \
+      "${current_commit}" "${main_commit}"
+    return 0
+  fi
+  printf 'current tag targets %s, not the validated container-compose main %s\n' \
+    "${current_commit}" "${main_commit}" >&2
+  exit 1
+}
+
 # Require the mutable Current build to identify the same source as local main.
 # Milestone releases additionally require a seven-day soak unless an explicit,
 # documented milestone-only override is supplied. Maintenance and security
 # releases retain the source-identity check but may bypass that waiting period.
 ensure_current_build_release_readiness() {
-  local path main_commit current_commit current_is_prerelease current_built_at
+  local path current_is_prerelease current_built_at
   path="$(repo_path "${COMPOSE_REPO}")"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -321,13 +347,7 @@ ensure_current_build_release_readiness() {
   fi
 
   need_command gh
-  main_commit="$(git -C "${path}" rev-parse main)"
-  current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
-  if [[ "${current_commit}" != "${main_commit}" ]]; then
-    printf 'current tag targets %s, not the validated container-compose main %s\n' \
-      "${current_commit}" "${main_commit}" >&2
-    exit 1
-  fi
+  ensure_current_release_source_identity
 
   current_is_prerelease="$(github_cli api \
     "repos/$(github_repo "${COMPOSE_REPO}")/releases/tags/current" \
@@ -365,6 +385,7 @@ PY
 # identity on every retry and makes evidence impossible to bind reliably.
 recover_unpublished_release_candidate() {
   local version="$1" path remote local_head remote_head subject subjects
+  RECOVERED_UNPUBLISHED_RELEASE_BASE=""
   path="$(repo_path "${COMPOSE_REPO}")"
   remote="$(push_remote "${COMPOSE_REPO}")"
   local_head="$(git -C "${path}" rev-parse main)"
@@ -402,6 +423,7 @@ recover_unpublished_release_candidate() {
     esac
   done <<<"${subjects}"
 
+  RECOVERED_UNPUBLISHED_RELEASE_BASE="${remote_head}"
   printf 'retaining unpublished release candidate %s after an earlier local gate failure\n' "${local_head}"
 }
 

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -454,6 +454,7 @@ cleanup() {
     trap - EXIT
     printf 'Stopping matched container runtime...\n'
     stop_runtime || true
+    release_container_runtime_lock
     exit "$status"
 }
 

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -31,6 +31,7 @@ container_binary=$1
 shift
 runtime_app_root=${CONTAINER_RUNTIME_APP_ROOT:-}
 runtime_service_namespace=${CONTAINER_RUNTIME_SERVICE_NAMESPACE:-}
+runtime_run_id=${CONTAINER_RUNTIME_RUN_ID:-}
 runtime_init_block_repo=${CONTAINER_RUNTIME_INIT_BLOCK_REPO:-}
 runtime_init_image_archive=${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}
 containerization_init_source_path=${CONTAINERIZATION_INIT_SOURCE_PATH:-}
@@ -57,8 +58,13 @@ configure_runtime_namespace() {
     local namespace_root_digest
     local socket_directory_digest
 
+    if [[ -z "$runtime_run_id" ]]; then
+        runtime_run_id="$(id -u)-$$-${RANDOM}-${SECONDS}"
+    fi
+    export CONTAINER_RUNTIME_RUN_ID="$runtime_run_id"
+
     if [[ -z "$runtime_service_namespace" ]]; then
-        namespace_root_digest=$(LC_ALL=C printf '%s' "${runtime_app_root}:$(id -u)" \
+        namespace_root_digest=$(LC_ALL=C printf '%s' "${runtime_app_root}:$(id -u):${runtime_run_id}" \
             | shasum -a 256 | awk '{print substr($1, 1, 24)}')
         runtime_service_namespace="io.github.stephenlclarke.container-compose.runtime.${namespace_root_digest}"
     fi
@@ -84,6 +90,60 @@ configure_runtime_namespace() {
     export CONTAINER_SERVICE_NAMESPACE="$runtime_service_namespace"
     export CONTAINER_RUNTIME_DOCKER_SOCKET="$runtime_docker_socket"
     export CONTAINER_RUNTIME_DOCKER_HOST="$runtime_docker_host"
+}
+
+# Fail before acquiring the host runtime lock or touching launchd when a
+# retained OCI archive cannot satisfy every image reference needed by this
+# validation run. The outer stable-release gate supplies both Compose's local
+# alias and Container's immutable Containerization reference.
+validate_runtime_init_image_archive() {
+    [[ -n "$runtime_init_image_archive" ]] || return 0
+
+    local required_references="$matched_init_image"
+    if [[ -n "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}" ]]; then
+        required_references+=" ${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES}"
+    fi
+
+    python3 - "$runtime_init_image_archive" "$required_references" <<'PY'
+import json
+from pathlib import Path
+import sys
+import tarfile
+
+archive = Path(sys.argv[1])
+required = set(sys.argv[2].split())
+try:
+    with tarfile.open(archive, "r:*") as bundle:
+        member = next(
+            (item for item in bundle.getmembers() if item.name.lstrip("./") == "index.json"),
+            None,
+        )
+        if member is None:
+            raise ValueError("index.json is missing")
+        stream = bundle.extractfile(member)
+        if stream is None:
+            raise ValueError("index.json is unreadable")
+        index = json.load(stream)
+except (OSError, tarfile.TarError, ValueError, json.JSONDecodeError) as error:
+    raise SystemExit(f"container runtime init-image archive is not a readable OCI archive: {archive} ({error})")
+
+available = {
+    manifest.get("annotations", {}).get("org.opencontainers.image.ref.name"): manifest.get("digest")
+    for manifest in index.get("manifests", [])
+}
+missing = sorted(reference for reference in required if reference not in available)
+if missing:
+    raise SystemExit(
+        "container runtime init-image archive is missing required reference(s): "
+        + ", ".join(missing)
+    )
+digests = {available[reference] for reference in required}
+if len(digests) != 1 or None in digests:
+    raise SystemExit(
+        "container runtime init-image archive required references do not resolve to one digest: "
+        + ", ".join(f"{reference}={available[reference]}" for reference in sorted(required))
+    )
+PY
 }
 
 validate_runtime_inputs() {
@@ -511,8 +571,16 @@ install_matched_init_image() {
 
 validate_runtime_inputs
 validate_containerization_init_source
+resolve_matched_init_image
+validate_runtime_init_image_archive
 configure_runtime_namespace
 verify_runtime_namespace_support
+
+if [[ "${CONTAINER_RUNTIME_MANAGED:-0}" == "1" ]]; then
+    "$@"
+    exit
+fi
+
 acquire_container_runtime_lock
 trap cleanup EXIT
 
@@ -521,7 +589,6 @@ stop_runtime
 sleep 3
 prepare_runtime_root
 stage_containerization_init_source
-resolve_matched_init_image
 resolve_initial_start_init_image_archive
 prepare_runtime_config_home
 configure_runtime_builder_image
@@ -565,4 +632,5 @@ if [[ -n "$runtime_config_home" ]]; then
     start_runtime
 fi
 
+export CONTAINER_RUNTIME_MANAGED=1
 "$@"


### PR DESCRIPTION
Prepares the exact 0.11.0 source candidate and makes failed release retries deterministic and safe.

This PR:
- integrates the signed stack-pin candidate at Container `59690f21f26a` and Containerization `7e4f5152e960`;
- moves runtime-lock ownership to a dedicated keeper so descendants cannot retain it;
- makes nested managed-runtime use explicit and gives each run a unique namespace;
- validates retained OCI archives and their required aliases before host mutation;
- binds recovery checkpoints to exact source, archive, environment, and toolchain inputs;
- permits retained unpublished recovery only against its verified published Current parent;
- redirects LLVM profiles to marker-protected disposable runtime storage;
- makes lock tests hermetic when executed inside the authoritative runtime owner.

Local evidence at exact head:
- release policy suite: 199/199 passed before the final test-only isolation patch;
- CI tool suite under inherited `CONTAINER_RUNTIME_LOCK_HELD`, keeper, and managed-runtime variables: 109/109 passed;
- focused lock suite under inherited outer-runtime state: 2/2 passed;
- `git diff --check`: passed;
- authoritative product proof immediately before this head: Containerization 719 tests / 91 suites, Linux integration 176/178 with 2 expected skips, Container live 301 concurrent + 96 serial, 68.71% combined line coverage.

The exact-head hosted checks and a fresh exact-head Codex review remain required before merge.
