### PR TITLE
fix(release): prevent repeated validation failures

### DIFF
--- a/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
+++ b/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
@@ -593,8 +593,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(topResult.stdout.contains("sleep"))
     }
 
-    @Test("runtime dry run up timestamps follows timestamped logs")
-    func runtimeDryRunUpTimestampsFollowsTimestampedLogs() throws {
+    @Test("runtime dry run up timestamps attaches foreground output")
+    func runtimeDryRunUpTimestampsAttachesForegroundOutput() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
             .appendingPathComponent("container-compose-runtime-\(UUID().uuidString)", isDirectory: true)
@@ -631,12 +631,13 @@ struct ComposeRuntimeSmokeTests {
             timeout: 30
         )
 
-        #expect(result.stdout.contains(containerDryRun("run --name \(project)-api-1 --detach")))
-        #expect(result.stdout.contains("+ compose-runtime logs --follow --timestamps \(project)-api-1"))
+        #expect(result.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
+        #expect(result.stdout.contains(containerDryRun("start \(project)-api-1")))
+        #expect(result.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
     }
 
-    @Test("runtime dry run up attach follows selected logs")
-    func runtimeDryRunUpAttachFollowsSelectedLogs() throws {
+    @Test("runtime dry run up attach selects foreground output")
+    func runtimeDryRunUpAttachSelectsForegroundOutput() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
             .appendingPathComponent("container-compose-runtime-\(UUID().uuidString)", isDirectory: true)
@@ -681,11 +682,11 @@ struct ComposeRuntimeSmokeTests {
         )
 
         #expect(selected.stdout.contains(containerDryRun("run --name \(project)-db-1 --detach")))
-        #expect(selected.stdout.contains(containerDryRun("run --name \(project)-api-1 --detach")))
-        #expect(selected.stdout.contains("+ compose-runtime logs --follow \(project)-api-1"))
-        #expect(!selected.stdout.contains("+ compose-runtime logs --follow \(project)-db-1"))
-        #expect(withDependencies.stdout.contains("+ compose-runtime logs --follow \(project)-db-1"))
-        #expect(withDependencies.stdout.contains("+ compose-runtime logs --follow \(project)-api-1"))
+        #expect(selected.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
+        #expect(selected.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
+        #expect(!selected.stdout.contains("+ compose-runtime attach --no-stdin \(project)-db-1"))
+        #expect(withDependencies.stdout.contains("+ compose-runtime attach --no-stdin \(project)-db-1"))
+        #expect(withDependencies.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
     }
 
     @Test("runtime dry run up accepts menu boolean values in no-start mode")
@@ -783,7 +784,9 @@ struct ComposeRuntimeSmokeTests {
             ],
             timeout: 30
         )
-        #expect(exitControl.stdout.contains(containerDryRun("run --name \(project)-api-1 --detach")))
+        #expect(exitControl.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
+        #expect(exitControl.stdout.contains(containerDryRun("start \(project)-api-1")))
+        #expect(exitControl.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(exitControl.stdout.contains("+ compose-runtime wait \(project)-api-1"))
         #expect(exitControl.stdout.contains(containerDryRun("delete \(project)-api-1")))
 
@@ -797,8 +800,9 @@ struct ComposeRuntimeSmokeTests {
             ],
             timeout: 30
         )
-        #expect(watch.stdout.contains(containerDryRun("run --name \(project)-api-1 --detach")))
-        #expect(watch.stdout.contains("+ compose-runtime logs --follow \(project)-api-1"))
+        #expect(watch.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
+        #expect(watch.stdout.contains(containerDryRun("start \(project)-api-1")))
+        #expect(watch.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(!watch.stderr.contains("unsupported compose feature"))
 
         let environmentMenu = try runProcess(
@@ -812,7 +816,9 @@ struct ComposeRuntimeSmokeTests {
             timeout: 30,
             environment: ["COMPOSE_MENU": "true"]
         )
-        #expect(environmentMenu.stdout.contains(containerDryRun("run --name \(project)-api-1 --detach")))
+        #expect(environmentMenu.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
+        #expect(environmentMenu.stdout.contains(containerDryRun("start \(project)-api-1")))
+        #expect(environmentMenu.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(environmentMenu.stdout.contains("+ compose-runtime wait \(project)-api-1"))
         #expect(environmentMenu.stdout.contains(containerDryRun("delete \(project)-api-1")))
     }
@@ -848,7 +854,7 @@ struct ComposeRuntimeSmokeTests {
             timeout: 30
         )
 
-        #expect(result.stdout.contains(containerDryRun("run --name \(project)-api-1 ")))
+        #expect(result.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
         #expect(result.stdout.contains("--privileged"))
     }
 
@@ -1116,8 +1122,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(result.stdout.split(whereSeparator: \.isWhitespace) == ["0", "0", "4294967295"])
     }
 
-    @Test("runtime dry run attach no-stdin follows logs with default signal proxy")
-    func runtimeDryRunAttachNoStdinFollowsLogsWithDefaultSignalProxy() throws {
+    @Test("runtime dry run attach no-stdin attaches output with default signal proxy")
+    func runtimeDryRunAttachNoStdinAttachesOutputWithDefaultSignalProxy() throws {
         let fileManager = FileManager.default
         let directory = fileManager.temporaryDirectory
             .appendingPathComponent("container-compose-runtime-\(UUID().uuidString)", isDirectory: true)
@@ -1146,7 +1152,7 @@ struct ComposeRuntimeSmokeTests {
             timeout: 30
         )
 
-        #expect(result.stdout.contains("+ compose-runtime logs --follow \(project)-api-1"))
+        #expect(result.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
 
         let withDetachKeys = try runProcess(
             composeBinary,
@@ -1159,7 +1165,7 @@ struct ComposeRuntimeSmokeTests {
             timeout: 30
         )
 
-        #expect(withDetachKeys.stdout.contains("+ compose-runtime logs --follow \(project)-api-1"))
+        #expect(withDetachKeys.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
     }
 
     @Test("runtime up exit-code-from returns selected service status")
@@ -1212,7 +1218,9 @@ struct ComposeRuntimeSmokeTests {
             timeout: 30
         )
         #expect(dryRun.stdout.contains(containerDryRun("run --name \(project)-db-1 --detach")))
-        #expect(dryRun.stdout.contains(containerDryRun("run --name \(project)-api-1 --detach")))
+        #expect(dryRun.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
+        #expect(dryRun.stdout.contains(containerDryRun("start \(project)-api-1")))
+        #expect(dryRun.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(dryRun.stdout.contains("+ compose-runtime wait \(project)-api-1"))
         #expect(dryRun.stdout.contains(containerDryRun("delete \(project)-api-1")))
 
@@ -1608,6 +1616,64 @@ struct ComposeRuntimeSmokeTests {
 
         let inspect = try runProcess(containerBinary, ["image", "inspect", imageName], timeout: 30)
         #expect(inspect.stdout.contains(imageTag))
+    }
+}
+
+@Suite("Compose dry-run runtime contract tests", .serialized)
+struct ComposeRuntimeDryRunContractTests {
+    @Test("foreground commands use direct attachment")
+    func foregroundCommandsUseDirectAttachment() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("container-compose-contract-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: directory)
+        }
+
+        let composeFile = directory.appendingPathComponent("compose.yml")
+        try """
+        services:
+          api:
+            image: alpine:3.20
+            depends_on:
+              db:
+                condition: service_started
+          db:
+            image: alpine:3.20
+        """.write(to: composeFile, atomically: true, encoding: .utf8)
+
+        let project = runtimeProjectName()
+        let composeBinary = ProcessInfo.processInfo.environment["COMPOSE_TEST_BINARY"] ?? ".build/debug/compose"
+        let upResult = try runProcess(
+            composeBinary,
+            [
+                "--ansi", "never",
+                "--project-name", project,
+                "--file", composeFile.path,
+                "--dry-run", "up", "--attach", "api", "--attach-dependencies", "api",
+            ],
+            timeout: 30
+        )
+        let attachResult = try runProcess(
+            composeBinary,
+            [
+                "--ansi", "never",
+                "--project-name", project,
+                "--file", composeFile.path,
+                "--dry-run", "attach", "--no-stdin", "api",
+            ],
+            timeout: 30
+        )
+
+        for service in ["db", "api"] {
+            #expect(upResult.stdout.contains(containerDryRun("create --name \(project)-\(service)-1 ")))
+            #expect(upResult.stdout.contains(containerDryRun("start \(project)-\(service)-1")))
+            #expect(upResult.stdout.contains("+ compose-runtime attach --no-stdin \(project)-\(service)-1"))
+        }
+        #expect(!upResult.stdout.contains("+ compose-runtime logs --follow"))
+        #expect(attachResult.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
+        #expect(!attachResult.stdout.contains("+ compose-runtime logs --follow"))
     }
 }
 

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -90,30 +90,15 @@ if [[ "${mode}" == "full" ]]; then
 fi
 
 checkpoint_directory=${CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR:-}
-validation_fingerprint=""
+builder_validation_fingerprint=""
+containerization_validation_fingerprint=""
+container_validation_fingerprint=""
+homebrew_validation_fingerprint=""
 if [[ -n "${checkpoint_directory}" ]]; then
-  validation_fingerprint=$(
+  common_validation_fingerprint=$(
     {
       printf 'mode=%s\n' "${mode}"
-      printf 'container_scratch_root=%s\n' "${container_scratch_root}"
-      printf 'containerization_targets=%s\n' "${containerization_targets[*]}"
-      printf 'container_targets=%s\n' "${container_targets[*]}"
-      printf 'required_init_references=%s\n' \
-        "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}"
       printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
-      for path in "${compose_repo}" "${builder_repo}" "${containerization_repo}" \
-        "${container_repo}" "${homebrew_tap_repo}"; do
-        tree=$(git -C "${path}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
-        printf 'tree=%s:%s\n' "${path}" "${tree}"
-      done
-      if [[ -n "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" ]]; then
-        if [[ -f "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" ]]; then
-          printf 'init_archive=%s\n' \
-            "$(shasum -a 256 "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')"
-        else
-          printf 'init_archive=missing:%s\n' "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}"
-        fi
-      fi
       printf 'environment=PATH=%s\n' "${PATH}"
       printf 'environment=DEVELOPER_DIR=%s\n' "${DEVELOPER_DIR:-}"
       printf 'environment=SDKROOT=%s\n' "${SDKROOT:-}"
@@ -148,8 +133,80 @@ if [[ -n "${checkpoint_directory}" ]]; then
       uname -a
     } | shasum -a 256 | awk '{print $1}'
   )
+  if [[ -n "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" ]]; then
+    if [[ -f "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" ]]; then
+      init_archive_fingerprint=$(shasum -a 256 \
+        "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')
+    else
+      init_archive_fingerprint="missing:${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}"
+    fi
+  else
+    init_archive_fingerprint="unset"
+  fi
+  builder_tree=$(git -C "${builder_repo}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
+  containerization_tree=$(git -C "${containerization_repo}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
+  container_tree=$(git -C "${container_repo}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
+  homebrew_tree=$(git -C "${homebrew_tap_repo}" rev-parse 'HEAD^{tree}' 2>/dev/null || printf 'fixture')
+  builder_validation_fingerprint=$(
+    {
+      printf 'common=%s\n' "${common_validation_fingerprint}"
+      printf 'stage=builder\n'
+      printf 'tree=%s:%s\n' "${builder_repo}" "${builder_tree}"
+    } | shasum -a 256 | awk '{print $1}'
+  )
+  containerization_validation_fingerprint=$(
+    {
+      printf 'common=%s\n' "${common_validation_fingerprint}"
+      printf 'stage=containerization\n'
+      printf 'targets=%s\n' "${containerization_targets[*]}"
+      printf 'tree=%s:%s\n' "${containerization_repo}" "${containerization_tree}"
+      printf 'required_init_references=%s\n' \
+        "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}"
+      printf 'init_archive=%s\n' "${init_archive_fingerprint}"
+    } | shasum -a 256 | awk '{print $1}'
+  )
+  container_validation_fingerprint=$(
+    {
+      printf 'common=%s\n' "${common_validation_fingerprint}"
+      printf 'stage=container\n'
+      printf 'targets=%s\n' "${container_targets[*]}"
+      printf 'tree=%s:%s\n' "${container_repo}" "${container_tree}"
+      printf 'scratch_root=%s\n' "${container_scratch_root}"
+      printf 'init_archive=%s\n' "${init_archive_fingerprint}"
+    } | shasum -a 256 | awk '{print $1}'
+  )
+  homebrew_validation_fingerprint=$(
+    {
+      printf 'common=%s\n' "${common_validation_fingerprint}"
+      printf 'stage=homebrew\n'
+      printf 'tree=%s:%s\n' "${homebrew_tap_repo}" "${homebrew_tree}"
+    } | shasum -a 256 | awk '{print $1}'
+  )
 fi
 
+# Returns the exact-input fingerprint for one independently validated stage.
+validation_fingerprint_for_stage() {
+  case "$1" in
+    builder)
+      printf '%s' "${builder_validation_fingerprint}"
+      ;;
+    containerization)
+      printf '%s' "${containerization_validation_fingerprint}"
+      ;;
+    container)
+      printf '%s' "${container_validation_fingerprint}"
+      ;;
+    homebrew)
+      printf '%s' "${homebrew_validation_fingerprint}"
+      ;;
+    *)
+      printf 'unknown stack validation checkpoint stage: %s\n' "$1" >&2
+      return 2
+      ;;
+  esac
+}
+
+# Runs one stage unless its own exact inputs already have a successful stamp.
 run_checkpointed() {
   local stage=$1
   shift
@@ -160,7 +217,8 @@ run_checkpointed() {
 
   mkdir -p "${checkpoint_directory}"
   local stamp="${checkpoint_directory}/${mode}-${stage}.sha256"
-  local expected="${validation_fingerprint}:${stage}"
+  local expected
+  expected="$(validation_fingerprint_for_stage "${stage}"):${stage}"
   local actual=""
   if [[ -f "${stamp}" ]]; then
     IFS= read -r actual <"${stamp}" || true
@@ -179,7 +237,14 @@ run_checkpointed() {
 
 printf 'running %s stack release validation\n' "${mode}"
 if [[ -n "${checkpoint_directory}" ]]; then
-  printf 'stack validation exact-input fingerprint: %s\n' "${validation_fingerprint}"
+  printf 'stack validation exact-input fingerprint: builder=%s\n' \
+    "${builder_validation_fingerprint}"
+  printf 'stack validation exact-input fingerprint: containerization=%s\n' \
+    "${containerization_validation_fingerprint}"
+  printf 'stack validation exact-input fingerprint: container=%s\n' \
+    "${container_validation_fingerprint}"
+  printf 'stack validation exact-input fingerprint: homebrew=%s\n' \
+    "${homebrew_validation_fingerprint}"
 fi
 run_checkpointed builder \
   make -C "${builder_repo}" check-licenses vet lint coverage build

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -961,7 +961,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             self.assertIn("do not resolve to one digest", result.stderr)
             self.assertFalse(container_log.exists())
 
-    def test_managed_runtime_does_not_restart_or_stop_its_owner(self) -> None:
+    def test_managed_runtime_ready_api_does_not_restart_or_stop_its_owner(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
             app_root = temporary_root / "app-root"
@@ -997,7 +997,69 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertEqual(command_log.read_text(encoding="utf-8"), "managed\n")
-            self.assertFalse(container_log.exists())
+            self.assertEqual(
+                container_log.read_text(encoding="utf-8"),
+                "list --all --format json\n",
+            )
+
+    def test_managed_runtime_recovers_owner_api_after_cli_reinstall(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            container_log = temporary_root / "container.log"
+            command_log = temporary_root / "command.log"
+            ready_marker = temporary_root / "ready"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(
+                fake_container,
+                body=(
+                    'if [[ "$*" == "list --all --format json" ]]; then\n'
+                    '  [[ -f "${READY_MARKER:?}" ]]\n'
+                    "  exit\n"
+                    "fi\n"
+                    'if [[ "$*" == *"system start"* ]]; then\n'
+                    '  : >"${READY_MARKER:?}"\n'
+                    "  exit 0\n"
+                    "fi\n"
+                ),
+            )
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_MANAGED": "1",
+                    "CONTAINER_RUNTIME_RUN_ID": "outer-owner",
+                    "CONTAINER_TEST_LOG": str(container_log),
+                    "COMMAND_LOG": str(command_log),
+                    "READY_MARKER": str(ready_marker),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT),
+                    str(fake_container),
+                    "/bin/sh",
+                    "-c",
+                    'printf "recovered\\n" >"$COMMAND_LOG"',
+                ],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(command_log.read_text(encoding="utf-8"), "recovered\n")
+            container_commands = container_log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(container_commands[0], "list --all --format json")
+            self.assertIn(
+                f"--debug system start --timeout 60 --enable-kernel-install --app-root {app_root}",
+                container_commands,
+            )
+            self.assertEqual(container_commands[-1], "list --all --format json")
+            self.assertFalse(any("system stop" in command for command in container_commands))
 
     def test_api_round_trip_failure_blocks_the_candidate_command(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -149,11 +149,14 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
 
     @staticmethod
     def find_staged_service_archive(invocations: str, name: str) -> Path:
-        prefix = "/private/tmp/container-compose-service-inputs."
+        prefixes = (
+            "/private/tmp/container-compose-service-inputs.",
+            "/tmp/container-compose-service-inputs.",
+        )
         paths = [
             Path(token)
             for token in invocations.split()
-            if token.startswith(prefix) and token.endswith(f"/{name}")
+            if token.startswith(prefixes) and token.endswith(f"/{name}")
         ]
         if len(paths) != 1:
             raise AssertionError(f"expected one staged {name}, got {paths}")

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -147,6 +147,18 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         ).stdout.strip()
         return source, source_head
 
+    @staticmethod
+    def find_staged_service_archive(invocations: str, name: str) -> Path:
+        prefix = "/private/tmp/container-compose-service-inputs."
+        paths = [
+            Path(token)
+            for token in invocations.split()
+            if token.startswith(prefix) and token.endswith(f"/{name}")
+        ]
+        if len(paths) != 1:
+            raise AssertionError(f"expected one staged {name}, got {paths}")
+        return paths[0]
+
     def test_rejects_invalid_runtime_inputs_before_service_side_effects(
         self,
     ) -> None:
@@ -654,7 +666,10 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             self.assertIn('[build]\nimage = "local/builder:test"', config)
             self.assertIn(f'[vminit]\nimage = "{DEFAULT_INIT_IMAGE}"', config)
             invocations = container_log.read_text(encoding="utf-8")
-            self.assertIn(f"image load -i {builder_archive}", invocations)
+            staged_builder_archive = self.find_staged_service_archive(
+                invocations, "builder-image.oci.tar"
+            )
+            self.assertIn(f"image load -i {staged_builder_archive}", invocations)
 
     def test_uses_bootstrap_archive_before_source_matched_init_build(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -726,7 +741,12 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 for invocation in invocations
                 if "system start" in invocation
             ]
-            self.assertIn(f"--init-image-archive {bootstrap_archive}", starts[0])
+            staged_bootstrap_archive = self.find_staged_service_archive(
+                "\n".join(invocations), "bootstrap-image.oci.tar"
+            )
+            self.assertIn(
+                f"--init-image-archive {staged_bootstrap_archive}", starts[0]
+            )
             self.assertIn("--enable-kernel-install", starts[0])
             self.assertNotIn(f"image load -i {bootstrap_archive}", invocations)
             self.assertLess(start_index, init_index)
@@ -787,7 +807,10 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 2,
             )
             self.assertIn("--disable-kernel-install", starts[0])
-            self.assertIn(f"--init-image-archive {init_archive}", starts[0])
+            staged_init_archive = self.find_staged_service_archive(
+                "\n".join(invocations), "matched-init-image.oci.tar"
+            )
+            self.assertIn(f"--init-image-archive {staged_init_archive}", starts[0])
             self.assertIn("--enable-kernel-install", starts[1])
             self.assertNotIn(f"image load -i {init_archive}", invocations)
             self.assertLess(invocations.index(starts[1]), command_index)
@@ -798,8 +821,25 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             init_archive = temporary_root / "vminit.tar"
             self.create_oci_archive(init_archive, DEFAULT_INIT_IMAGE)
             container_log = temporary_root / "container.log"
+            archive_digest_log = temporary_root / "archive-digest.log"
             fake_container = temporary_root / "container-cli"
-            self.write_fake_container(fake_container)
+            self.write_fake_container(
+                fake_container,
+                body=(
+                    "archive_path=\n"
+                    "while [[ $# -gt 0 ]]; do\n"
+                    '  if [[ "$1" == "--init-image-archive" ]]; then\n'
+                    "    archive_path=$2\n"
+                    "    break\n"
+                    "  fi\n"
+                    "  shift\n"
+                    "done\n"
+                    'if [[ -n "$archive_path" ]]; then\n'
+                    '  /usr/bin/shasum -a 256 "$archive_path" '
+                    '>>"${CONTAINER_ARCHIVE_DIGEST_LOG:?}"\n'
+                    "fi\n"
+                ),
+            )
             environment = self.runtime_environment()
             environment.update(
                 {
@@ -809,6 +849,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                         temporary_root / "runtime.lock"
                     ),
                     "CONTAINER_TEST_LOG": str(container_log),
+                    "CONTAINER_ARCHIVE_DIGEST_LOG": str(archive_digest_log),
                 }
             )
 
@@ -834,8 +875,17 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             ]
             self.assertEqual(len(starts), 2)
             self.assertIn("--disable-kernel-install", starts[0])
-            self.assertIn(f"--init-image-archive {init_archive}", starts[0])
+            staged_init_archive = self.find_staged_service_archive(
+                "\n".join(invocations), "retained-init-image.oci.tar"
+            )
+            self.assertIn(f"--init-image-archive {staged_init_archive}", starts[0])
             self.assertNotIn(f"image load --input {init_archive}", invocations)
+            expected_digest = hashlib.sha256(init_archive.read_bytes()).hexdigest()
+            self.assertEqual(
+                archive_digest_log.read_text(encoding="utf-8").split()[0],
+                expected_digest,
+            )
+            self.assertFalse(staged_init_archive.parent.exists())
 
     def test_rejects_retained_archive_missing_any_required_reference(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1043,6 +1043,26 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 (checkout / "Makefile").touch()
             (tap / "Formula").mkdir(parents=True)
             (tap / "Formula" / "container-compose.rb").touch()
+            subprocess.run(["git", "-C", str(compose), "init", "--quiet"], check=True)
+            subprocess.run(["git", "-C", str(compose), "add", "Makefile"], check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(compose),
+                    "-c",
+                    "user.name=Release Test",
+                    "-c",
+                    "user.email=release-test@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "fixture",
+                ],
+                check=True,
+            )
 
             tools = root / "tools"
             tools.mkdir()
@@ -1127,6 +1147,41 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "reusing exact-input validation checkpoint: containerization",
                 repeated_full.stdout,
+            )
+
+            (compose / "Makefile").write_text("compose-only-change:\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(compose), "add", "Makefile"], check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(compose),
+                    "-c",
+                    "user.name=Release Test",
+                    "-c",
+                    "user.email=release-test@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "compose-only change",
+                ],
+                check=True,
+            )
+            changed_compose = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+            )
+            self.assertEqual(changed_compose.returncode, 0, changed_compose.stderr)
+            self.assertEqual(log.read_text(encoding="utf-8"), full_commands)
+            self.assertEqual(
+                changed_compose.stdout.count("reusing exact-input validation checkpoint:"),
+                4,
+                changed_compose.stdout,
             )
 
             environment["FAKE_GO_VERSION"] = "go1.26.4"

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -388,6 +388,40 @@ start_runtime() {
     done
 }
 
+# A nested release target inherits the outer harness's lock and runtime
+# ownership. Recheck the API before trusting that ownership because a matched
+# CLI rebuild can replace the installed service binaries after the outer
+# runtime was started. Recover the same namespace/root once without taking a
+# second lock or stopping the owner.
+ensure_managed_runtime_ready() {
+    local start_log
+    local start_status
+
+    if "$container_binary" list --all --format json >/dev/null; then
+        return
+    fi
+
+    printf 'Managed Container API is not ready; re-establishing the owner runtime...\n' >&2
+    start_log=$(mktemp "${TMPDIR:-/tmp}/container-compose-runtime-managed-start.XXXXXX")
+    start_arguments=(--debug system start --timeout 60 --enable-kernel-install)
+    if [[ -n "$runtime_app_root" ]]; then
+        start_arguments+=(--app-root "$runtime_app_root")
+    fi
+    if "$container_binary" "${start_arguments[@]}" 2>&1 | tee "$start_log"; then
+        start_status=0
+    else
+        start_status=${PIPESTATUS[0]}
+        rm -f "$start_log"
+        return "$start_status"
+    fi
+    rm -f "$start_log"
+
+    if ! "$container_binary" list --all --format json >/dev/null; then
+        printf 'Managed Container API remained unavailable after owner-runtime recovery\n' >&2
+        return 1
+    fi
+}
+
 prepare_runtime_root() {
     mkdir -p "$runtime_app_root"
     local marker_path="$runtime_app_root/$runtime_root_marker"
@@ -630,6 +664,7 @@ configure_runtime_namespace
 verify_runtime_namespace_support
 
 if [[ "${CONTAINER_RUNTIME_MANAGED:-0}" == "1" ]]; then
+    ensure_managed_runtime_ready
     "$@"
     exit
 fi

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -52,6 +52,7 @@ initial_start_image_is_matched=false
 runtime_root_marker=.container-compose-runtime-root
 runtime_root_marker_value='container-compose isolated runtime state v1'
 provider_socket_path_limit=103
+runtime_service_inputs_root=
 
 # Derive and export the one non-default namespace used by this candidate.
 configure_runtime_namespace() {
@@ -411,6 +412,52 @@ prepare_runtime_root() {
         ! -name "$runtime_root_marker" ! -name kernels -exec rm -rf {} +
 }
 
+# launchd-managed Container services do not necessarily inherit the caller's
+# privacy access to removable volumes, Documents, or other user-controlled
+# locations. Copy every archive that a service may open into a private local
+# staging root before taking the host runtime lock. This turns a host-policy
+# mismatch into a bounded local copy instead of an opaque service-side open(2)
+# hang while the global lock is held.
+stage_runtime_service_inputs() {
+    runtime_service_inputs_root=$(mktemp -d /private/tmp/container-compose-service-inputs.XXXXXX)
+
+    stage_runtime_service_archive runtime_builder_image_tar builder-image.oci.tar
+    stage_runtime_service_archive runtime_bootstrap_image_tar bootstrap-image.oci.tar
+    stage_runtime_service_archive matched_init_image_tar matched-init-image.oci.tar
+    stage_runtime_service_archive runtime_init_image_archive retained-init-image.oci.tar
+}
+
+stage_runtime_service_archive() {
+    local variable_name="$1"
+    local destination_name="$2"
+    local source_path="${!variable_name}"
+    [[ -n "$source_path" ]] || return 0
+
+    local destination_path="$runtime_service_inputs_root/$destination_name"
+    local temporary_path="$destination_path.partial"
+    if ! /usr/bin/install -m 0600 "$source_path" "$temporary_path"; then
+        rm -f "$temporary_path"
+        printf 'failed to stage container runtime service archive: %s\n' "$source_path" >&2
+        exit 2
+    fi
+    mv -f "$temporary_path" "$destination_path"
+    printf -v "$variable_name" '%s' "$destination_path"
+}
+
+cleanup_runtime_service_inputs() {
+    [[ -n "$runtime_service_inputs_root" ]] || return 0
+    case "$runtime_service_inputs_root" in
+        /private/tmp/container-compose-service-inputs.*) ;;
+        *)
+            printf 'refusing to clear unexpected runtime service-input staging root: %s\n' \
+                "$runtime_service_inputs_root" >&2
+            return 1
+            ;;
+    esac
+    find "$runtime_service_inputs_root" -depth -delete 2>/dev/null || true
+    runtime_service_inputs_root=
+}
+
 resolve_matched_init_image() {
     has_matched_init_image_source || return 0
 
@@ -515,6 +562,7 @@ cleanup() {
     printf 'Stopping matched container runtime...\n'
     stop_runtime || true
     release_container_runtime_lock
+    cleanup_runtime_service_inputs || true
     exit "$status"
 }
 
@@ -581,6 +629,8 @@ if [[ "${CONTAINER_RUNTIME_MANAGED:-0}" == "1" ]]; then
     exit
 fi
 
+trap cleanup_runtime_service_inputs EXIT
+stage_runtime_service_inputs
 acquire_container_runtime_lock
 trap cleanup EXIT
 

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -419,7 +419,12 @@ prepare_runtime_root() {
 # mismatch into a bounded local copy instead of an opaque service-side open(2)
 # hang while the global lock is held.
 stage_runtime_service_inputs() {
-    runtime_service_inputs_root=$(mktemp -d /private/tmp/container-compose-service-inputs.XXXXXX)
+    local trusted_temporary_root=/private/tmp
+    if [[ ! -d "$trusted_temporary_root" ]]; then
+        trusted_temporary_root=/tmp
+    fi
+    runtime_service_inputs_root=$(mktemp -d \
+        "$trusted_temporary_root/container-compose-service-inputs.XXXXXX")
 
     stage_runtime_service_archive runtime_builder_image_tar builder-image.oci.tar
     stage_runtime_service_archive runtime_bootstrap_image_tar bootstrap-image.oci.tar
@@ -447,7 +452,7 @@ stage_runtime_service_archive() {
 cleanup_runtime_service_inputs() {
     [[ -n "$runtime_service_inputs_root" ]] || return 0
     case "$runtime_service_inputs_root" in
-        /private/tmp/container-compose-service-inputs.*) ;;
+        /private/tmp/container-compose-service-inputs.* | /tmp/container-compose-service-inputs.*) ;;
         *)
             printf 'refusing to clear unexpected runtime service-input staging root: %s\n' \
                 "$runtime_service_inputs_root" >&2


### PR DESCRIPTION
## Summary
- stage every archive a launchd-managed Container service may open into a private local temporary directory before acquiring the host runtime lock
- recover a managed nested validation step when the owner runtime API disappears after a Container CLI rebuild
- align live dry-run smoke assertions with the direct create/start/attach foreground contract and run that contract in ordinary CI
- fingerprint builder, Containerization, Container, and Homebrew checkpoints independently so Compose-only changes reuse unaffected sibling proof

## Why
The 0.11.0 stable gate exposed three release-harness gaps: launchd could not open an OCI archive from /Volumes/SSD, a post-build CLI transition could leave the owner runtime unavailable to a nested step, and the August direct-attach implementation had updated unit coverage without updating the gated live smoke assertions. The global checkpoint fingerprint then made each Compose-only correction invalidate hours of unrelated sibling proof.

These changes turn each failure into a deterministic transition or an ordinary CI contract and prevent unrelated source changes from invalidating unaffected stack stages.

## Validation
- python3 -m unittest Tools.ci.test_run_with_container_runtime (23/23)
- python3 Tools/release/test_container_stack_release.py (72/72)
- ComposeRuntimeDryRunContractTests (1/1)
- ComposeRuntimeSmokeTests.runtimeDryRun (7/7)
- shellcheck scripts/run-with-container-runtime.sh Tools/ci/run-stack-release-validation.sh
- bash -n scripts/run-with-container-runtime.sh Tools/ci/run-stack-release-validation.sh
- git diff --check