### PR TITLE
fix(release): pin nested commands to candidate CLI

### DIFF
--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -582,7 +582,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                     "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
                     "CONTAINER_TEST_LOG": str(container_log),
                     "CONFIG_TEST_PATH": str(config_path),
-                    "EXPECTED_CONTAINER_CLI": str(fake_container),
+                    "EXPECTED_CONTAINER_CLI": str(fake_container.resolve()),
                     "INIT_TEST_LOG": str(init_log),
                 }
             )
@@ -1000,6 +1000,124 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             self.assertEqual(
                 container_log.read_text(encoding="utf-8"),
                 "list --all --format json\n",
+            )
+
+    def test_candidate_cli_leads_path_for_nested_commands(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            candidate_bin = temporary_root / "candidate-bin"
+            competing_bin = temporary_root / "competing-bin"
+            candidate_bin.mkdir()
+            competing_bin.mkdir()
+            candidate_container = candidate_bin / "container"
+            competing_container = competing_bin / "container"
+            candidate_log = temporary_root / "candidate.log"
+            competing_log = temporary_root / "competing.log"
+            self.write_fake_container(candidate_container)
+            competing_container.write_text(
+                "#!/usr/bin/env bash\n"
+                'printf "%s\\n" "$*" >>"${COMPETING_CONTAINER_LOG:?}"\n'
+                "exit 97\n",
+                encoding="utf-8",
+            )
+            competing_container.chmod(0o755)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_MANAGED": "1",
+                    "CONTAINER_RUNTIME_RUN_ID": "outer-owner",
+                    "CONTAINER_TEST_LOG": str(candidate_log),
+                    "COMPETING_CONTAINER_LOG": str(competing_log),
+                    "EXPECTED_CONTAINER_CLI": str(candidate_container.resolve()),
+                    "PATH": f"{competing_bin}:{environment['PATH']}",
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT),
+                    str(candidate_container),
+                    "/bin/sh",
+                    "-c",
+                    'test "$(command -v container)" = "$EXPECTED_CONTAINER_CLI" '
+                    "&& container nested-command-proof",
+                ],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn(
+                "nested-command-proof",
+                candidate_log.read_text(encoding="utf-8").splitlines(),
+            )
+            self.assertFalse(competing_log.exists())
+
+    def test_resolves_bare_candidate_command_before_pinning_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            candidate_bin = temporary_root / "candidate-bin"
+            candidate_bin.mkdir()
+            candidate_container = candidate_bin / "container"
+            candidate_log = temporary_root / "candidate.log"
+            self.write_fake_container(candidate_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_MANAGED": "1",
+                    "CONTAINER_RUNTIME_RUN_ID": "outer-owner",
+                    "CONTAINER_TEST_LOG": str(candidate_log),
+                    "BASH_ENV": "/dev/null",
+                    "ENV": "/dev/null",
+                    "EXPECTED_CONTAINER_CLI": str(candidate_container.resolve()),
+                    "PATH": f"{candidate_bin}:{environment['PATH']}",
+                }
+            )
+            resolved_candidate = subprocess.run(
+                ["/bin/bash", "-c", "command -v container"],
+                env=environment,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(resolved_candidate, str(candidate_container))
+
+            result = subprocess.run(
+                [
+                    str(SCRIPT),
+                    "container",
+                    "/bin/sh",
+                    "-c",
+                    'test "$(command -v container)" = "$EXPECTED_CONTAINER_CLI" '
+                    "&& container bare-command-proof",
+                ],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            candidate_invocations = (
+                candidate_log.read_text(encoding="utf-8")
+                if candidate_log.exists()
+                else "<candidate was not invoked>\n"
+            )
+            self.assertEqual(
+                result.returncode,
+                0,
+                result.stdout + result.stderr + candidate_invocations,
+            )
+            self.assertIn(
+                "bare-command-proof",
+                candidate_invocations.splitlines(),
             )
 
     def test_managed_runtime_recovers_owner_api_after_cli_reinstall(self) -> None:

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -27,8 +27,26 @@ readonly SCRIPT_DIRECTORY
 # shellcheck disable=SC1091
 source "$SCRIPT_DIRECTORY/../Tools/ci/container-runtime-lock.sh"
 
-container_binary=$1
+requested_container_binary=$1
+container_binary=$requested_container_binary
 shift
+if [[ "$container_binary" != */* ]]; then
+    if ! container_binary=$(command -v "$container_binary"); then
+        printf 'candidate container command was not found on PATH: %s\n' \
+            "$requested_container_binary" >&2
+        exit 2
+    fi
+fi
+if [[ ! -x "$container_binary" ]]; then
+    printf 'candidate container binary is not executable: %s\n' "$container_binary" >&2
+    exit 2
+fi
+container_binary_directory=$(cd "$(dirname "$container_binary")" && pwd -P)
+container_binary="$container_binary_directory/$(basename "$container_binary")"
+# Every nested Makefile and helper must resolve the same candidate CLI that
+# owns the isolated runtime. Otherwise a host-installed `container` earlier in
+# PATH can silently target the default service namespace mid-validation.
+export PATH="$container_binary_directory${PATH:+:$PATH}"
 runtime_app_root=${CONTAINER_RUNTIME_APP_ROOT:-}
 runtime_service_namespace=${CONTAINER_RUNTIME_SERVICE_NAMESPACE:-}
 runtime_run_id=${CONTAINER_RUNTIME_RUN_ID:-}


### PR DESCRIPTION
## What changed

- Resolve supported bare candidate command names through `PATH`, then canonicalize the resulting executable.
- Put the resolved candidate executable directory first on `PATH` for every nested command, Makefile, and helper launched by the isolated runtime wrapper.
- Reject a missing or non-executable candidate before touching runtime state.
- Add regressions for both invocation modes: an explicit candidate path with a deliberately competing `container` first on incoming `PATH`, and the Makefile's supported bare `container` fallback.

## Root cause

The 0.11.0 stable validation wrapper invoked the exact candidate CLI for its own start/status/stop operations, but did not constrain `PATH` for the validated sibling Makefiles. Containerization therefore completed its 719 tests and then resolved `/opt/homebrew/bin/container` for `make init`, targeting the default service namespace instead of the isolated candidate runtime. The resulting XPC connection failure looked like runtime instability even though the isolated runtime remained correctly scoped.

## Impact

Release validation can no longer cross executable or service-namespace boundaries when a different host-installed Container CLI is present. All nested release work uses the same reviewed candidate binary that owns the isolated runtime, while the existing bare-command fallback remains supported.

## Validation

- `uv run --with coverage coverage run --branch Tools/ci/test_run_with_container_runtime.py` — 25/25 passed
- branch coverage — 99% (551 statements, 3 missed; 18 branches)
- `python3 -m py_compile Tools/ci/test_run_with_container_runtime.py`
- `bash -n scripts/run-with-container-runtime.sh`
- `shellcheck scripts/run-with-container-runtime.sh`
- `git diff --check`

Review feedback about bare command names was implemented in exact head `953131cc6eab6747c2c5d93913af1474d228f3a8`. The commit is signed.