### PR TITLE
fix(release): pin candidate CLI through sibling gates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1388,7 +1388,8 @@ container-stack-build:
 
 .PHONY: container-stack-release-validation container-stack-hosted-release-validation
 container-stack-release-validation:
-	./Tools/ci/run-stack-release-validation.sh full "$(CURDIR)" \
+	CONTAINER_RUNTIME_CLI="$(CONTAINER_COMPOSE_CONTAINER)" \
+		./Tools/ci/run-stack-release-validation.sh full "$(CURDIR)" \
 		"$(CONTAINER_BUILDER_SHIM_STACK_REPO)" "$(CONTAINERIZATION_STACK_REPO)" \
 		"$(CONTAINER_STACK_REPO)" "$(HOMEBREW_TAP_REPO)"
 

--- a/Makefile
+++ b/Makefile
@@ -305,7 +305,9 @@ swift-test-build:
 
 swift-test: swift-test-build
 	@mkdir -p .build
-	@PYTHON="$(PYTHON)" SWIFT_TEST_RESULT_LOG="$(SWIFT_TEST_RESULT_LOG)" SWIFT_TEST_ATTEMPTS="$(SWIFT_TEST_ATTEMPTS)" Tools/ci/run-swift-test.sh $(SWIFT) test $(SWIFT_RESOLVED_FLAGS) --skip-build --enable-code-coverage $(SWIFT_TEST_RUN_FLAGS) $(SWIFT_TEST_FLAGS)
+	@env -u CONTAINER_BIN -u CONTAINER_COMPOSE_CONTAINER \
+		PYTHON="$(PYTHON)" SWIFT_TEST_RESULT_LOG="$(SWIFT_TEST_RESULT_LOG)" SWIFT_TEST_ATTEMPTS="$(SWIFT_TEST_ATTEMPTS)" \
+		Tools/ci/run-swift-test.sh $(SWIFT) test $(SWIFT_RESOLVED_FLAGS) --skip-build --enable-code-coverage $(SWIFT_TEST_RUN_FLAGS) $(SWIFT_TEST_FLAGS)
 	@if ! grep -Eq 'Test run with [1-9][0-9]* tests? .* passed|Executed [1-9][0-9]* tests?|swiftpm-testing-helper signal 13 toolchain failure' "$(SWIFT_TEST_RESULT_LOG)"; then \
 		printf 'swift test completed without running tests; check the active toolchain Testing.framework and rpath settings.\n' >&2; \
 		exit 1; \
@@ -343,7 +345,9 @@ swift-coverage: swift-test-build
 	fi
 	@rm -f .build/*/debug/codecov/*.profraw .build/*/debug/codecov/*.profdata .build/codecov/fallback.profdata coverage*.lcov coverage*.xml
 	@find .build -maxdepth 3 -path .build/index-build -prune -o -path '*/debug' -type d -exec mkdir -p '{}/codecov' \;
-	@PYTHON="$(PYTHON)" SWIFT_TEST_RESULT_LOG="$(SWIFT_TEST_RESULT_LOG)" SWIFT_TEST_ATTEMPTS="$(SWIFT_COVERAGE_TEST_ATTEMPTS)" SWIFT_TEST_ACCEPT_SIGNAL_13=0 Tools/ci/run-swift-test.sh $(SWIFT) test $(SWIFT_RESOLVED_FLAGS) --skip-build --enable-code-coverage $(SWIFT_TEST_RUN_FLAGS) $(SWIFT_TEST_FLAGS)
+	@env -u CONTAINER_BIN -u CONTAINER_COMPOSE_CONTAINER \
+		PYTHON="$(PYTHON)" SWIFT_TEST_RESULT_LOG="$(SWIFT_TEST_RESULT_LOG)" SWIFT_TEST_ATTEMPTS="$(SWIFT_COVERAGE_TEST_ATTEMPTS)" SWIFT_TEST_ACCEPT_SIGNAL_13=0 \
+		Tools/ci/run-swift-test.sh $(SWIFT) test $(SWIFT_RESOLVED_FLAGS) --skip-build --enable-code-coverage $(SWIFT_TEST_RUN_FLAGS) $(SWIFT_TEST_FLAGS)
 	test_binary="$$(find .build -path '*.xctest/Contents/MacOS/container-composePackageTests' -type f | head -n 1)"; \
 	profile=".build/codecov/fallback.profdata"; \
 	if [[ -z "$$test_binary" ]]; then \

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -64,7 +64,9 @@ fi
 # must never inherit stale machines, images, or networks from an earlier local
 # run, nor leave its own state behind for the next gate.  Keep the default under
 # Container's already-ignored test scratch directory, resolving relative hosted
-# checkout paths before passing the application root through make.
+# checkout paths before passing the application root through make.  Resolve
+# symlinks as well: Container's protected logging state deliberately rejects a
+# persistence root whose canonical path differs from the supplied path.
 if [[ -n "${CONTAINER_STACK_VALIDATION_SCRATCH_ROOT:-}" ]]; then
   container_scratch_root="${CONTAINER_STACK_VALIDATION_SCRATCH_ROOT}"
   if [[ "${container_scratch_root}" != /* || "${container_scratch_root}" == / ]]; then
@@ -73,7 +75,13 @@ if [[ -n "${CONTAINER_STACK_VALIDATION_SCRATCH_ROOT:-}" ]]; then
     exit 2
   fi
 else
-  container_scratch_root="$(cd "${container_repo}" && pwd -L)/.test-scratch"
+  container_scratch_root="$(cd "${container_repo}" && pwd -P)/.test-scratch"
+fi
+mkdir -p "${container_scratch_root}"
+container_scratch_root="$(cd "${container_scratch_root}" && pwd -P)"
+if [[ "${container_scratch_root}" == / ]]; then
+  printf 'CONTAINER_STACK_VALIDATION_SCRATCH_ROOT must not resolve to /\n' >&2
+  exit 2
 fi
 container_app_root="${container_scratch_root}/stack-release-app-root"
 container_log_root="${container_scratch_root}/stack-release-log-root"
@@ -94,12 +102,103 @@ builder_validation_fingerprint=""
 containerization_validation_fingerprint=""
 container_validation_fingerprint=""
 homebrew_validation_fingerprint=""
+runtime_cli=${CONTAINER_RUNTIME_CLI:-}
+runtime_cli_directory=""
+runtime_path=${PATH}
+runtime_cli_fingerprint="unset"
+runtime_cli_sha256="unset"
+runtime_candidate_sha256=${CONTAINER_RUNTIME_CANDIDATE_SHA256:-}
+validation_environment_path=${PATH}
+runtime_make_args=()
+if [[ "${mode}" == "full" ]]; then
+  if [[ "${runtime_cli}" != /* || ! -x "${runtime_cli}" ]]; then
+    printf 'full stack validation requires an absolute executable CONTAINER_RUNTIME_CLI: %s\n' \
+      "${runtime_cli:-unset}" >&2
+    exit 2
+  fi
+  runtime_cli_directory=$(cd "$(dirname "${runtime_cli}")" && pwd -P)
+  runtime_cli="${runtime_cli_directory}/$(basename "${runtime_cli}")"
+  runtime_path="${runtime_cli_directory}${PATH:+:${PATH}}"
+  runtime_cli_sha256="$(shasum -a 256 "${runtime_cli}" | awk '{print $1}')"
+  if [[ -n "${CONTAINER_RUNTIME_CLI_SHA256:-}" &&
+    "${CONTAINER_RUNTIME_CLI_SHA256}" != "${runtime_cli_sha256}" ]]; then
+    printf 'full stack validation Container CLI digest mismatch (expected %s, got %s): %s\n' \
+      "${CONTAINER_RUNTIME_CLI_SHA256}" "${runtime_cli_sha256}" "${runtime_cli}" >&2
+    exit 2
+  fi
+  if [[ -n "${runtime_candidate_sha256}" ]]; then
+    if ! [[ "${runtime_candidate_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+      printf 'CONTAINER_RUNTIME_CANDIDATE_SHA256 must be a lowercase SHA-256 digest: %s\n' \
+        "${runtime_candidate_sha256}" >&2
+      exit 2
+    fi
+    if [[ -w "${runtime_cli}" ]]; then
+      printf 'packaged Container runtime candidate CLI must be read-only during validation: %s\n' \
+        "${runtime_cli}" >&2
+      exit 2
+    fi
+  else
+    runtime_candidate_sha256="unpackaged"
+  fi
+  if [[ "${runtime_candidate_sha256}" == "unpackaged" ]]; then
+    runtime_cli_fingerprint="unpackaged:${runtime_cli}:${runtime_cli_sha256}"
+  else
+    runtime_cli_fingerprint="packaged:${runtime_candidate_sha256}:${runtime_cli_sha256}"
+    validation_path_first="${validation_environment_path%%:*}"
+    validation_path_first_resolved=""
+    if [[ -d "${validation_path_first}" ]]; then
+      validation_path_first_resolved=$(cd "${validation_path_first}" && pwd -P)
+    fi
+    if [[ "${validation_path_first_resolved}" == "${runtime_cli_directory}" ]]; then
+      if [[ "${validation_environment_path}" == *:* ]]; then
+        validation_environment_path="${validation_environment_path#*:}"
+      else
+        validation_environment_path=""
+      fi
+    fi
+  fi
+  runtime_make_args+=("PATH=${runtime_path}")
+fi
+
+# The full gate owns one namespace-scoped Container candidate. Pin PATH as a
+# make command-line variable so recursive sibling Makefiles cannot fall back
+# to a Homebrew/default-namespace CLI after their expensive unit suites.
+verify_runtime_cli_identity() {
+  [[ "${mode}" == "full" ]] || return 0
+
+  local resolved
+  if ! resolved=$(PATH="${runtime_path}" command -v container); then
+    printf 'full stack validation could not resolve container on its pinned PATH\n' >&2
+    return 2
+  fi
+  local resolved_directory
+  resolved_directory=$(cd "$(dirname "${resolved}")" && pwd -P)
+  resolved="${resolved_directory}/$(basename "${resolved}")"
+  if [[ "${resolved}" != "${runtime_cli}" ]]; then
+    printf 'full stack validation container path drifted (expected %s, got %s)\n' \
+      "${runtime_cli}" "${resolved}" >&2
+    return 2
+  fi
+
+  local current_sha256
+  current_sha256="$(shasum -a 256 "${runtime_cli}" | awk '{print $1}')"
+  if [[ "${current_sha256}" != "${runtime_cli_sha256}" ]]; then
+    printf 'full stack validation Container CLI content drifted (expected %s, got %s): %s\n' \
+      "${runtime_cli_sha256}" "${current_sha256}" "${runtime_cli}" >&2
+    return 2
+  fi
+}
+
+run_containerization_validation() {
+  make -C "${containerization_repo}" "${runtime_make_args[@]}" "${containerization_targets[@]}"
+}
+
 if [[ -n "${checkpoint_directory}" ]]; then
   common_validation_fingerprint=$(
     {
       printf 'mode=%s\n' "${mode}"
       printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
-      printf 'environment=PATH=%s\n' "${PATH}"
+      printf 'environment=PATH=%s\n' "${validation_environment_path}"
       printf 'environment=DEVELOPER_DIR=%s\n' "${DEVELOPER_DIR:-}"
       printf 'environment=SDKROOT=%s\n' "${SDKROOT:-}"
       printf 'environment=CC=%s\n' "${CC:-}"
@@ -163,6 +262,7 @@ if [[ -n "${checkpoint_directory}" ]]; then
       printf 'required_init_references=%s\n' \
         "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}"
       printf 'init_archive=%s\n' "${init_archive_fingerprint}"
+      printf 'runtime_cli=%s\n' "${runtime_cli_fingerprint}"
     } | shasum -a 256 | awk '{print $1}'
   )
   container_validation_fingerprint=$(
@@ -173,6 +273,7 @@ if [[ -n "${checkpoint_directory}" ]]; then
       printf 'tree=%s:%s\n' "${container_repo}" "${container_tree}"
       printf 'scratch_root=%s\n' "${container_scratch_root}"
       printf 'init_archive=%s\n' "${init_archive_fingerprint}"
+      printf 'runtime_cli=%s\n' "${runtime_cli_fingerprint}"
     } | shasum -a 256 | awk '{print $1}'
   )
   homebrew_validation_fingerprint=$(
@@ -210,8 +311,10 @@ validation_fingerprint_for_stage() {
 run_checkpointed() {
   local stage=$1
   shift
+  verify_runtime_cli_identity
   if [[ -z "${checkpoint_directory}" ]]; then
     "$@"
+    verify_runtime_cli_identity
     return
   fi
 
@@ -225,10 +328,12 @@ run_checkpointed() {
   fi
   if [[ "${actual}" == "${expected}" ]]; then
     printf 'reusing exact-input validation checkpoint: %s\n' "${stage}"
+    verify_runtime_cli_identity
     return
   fi
 
   "$@"
+  verify_runtime_cli_identity
   local temporary_stamp
   temporary_stamp=$(mktemp "${checkpoint_directory}/.${mode}-${stage}.XXXXXX")
   printf '%s\n' "${expected}" >"${temporary_stamp}"
@@ -249,7 +354,7 @@ fi
 run_checkpointed builder \
   make -C "${builder_repo}" check-licenses vet lint coverage build
 run_checkpointed containerization \
-  make -C "${containerization_repo}" "${containerization_targets[@]}"
+  run_containerization_validation
 # The outer stable gate may select an already-running isolated runtime for
 # Containerization's image build. Container's unit tests exercise their own
 # default namespace contract, so do not let that selector rewrite the expected
@@ -258,6 +363,7 @@ run_checkpointed containerization \
 run_checkpointed container \
   env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
     CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" \
-    make -C "${container_repo}" "${container_make_args[@]}" "${container_targets[@]}"
+    make -C "${container_repo}" "${runtime_make_args[@]}" \
+      "${container_make_args[@]}" "${container_targets[@]}"
 run_checkpointed homebrew \
   ruby -c "${homebrew_tap_repo}/Formula/container-compose.rb"

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -185,7 +185,16 @@ if [[ "${mode}" == "full" ]]; then
         "${runtime_candidate_sha256}" >&2
       exit 2
     fi
-    if [[ -w "${runtime_cli}" ]]; then
+    runtime_cli_mode=$(
+      /usr/bin/stat -f '%Lp' "${runtime_cli}" 2>/dev/null \
+        || /usr/bin/stat -c '%a' "${runtime_cli}" 2>/dev/null
+    )
+    if ! [[ "${runtime_cli_mode}" =~ ^[0-7]{3,4}$ ]]; then
+      printf 'could not determine packaged Container runtime candidate CLI mode: %s\n' \
+        "${runtime_cli}" >&2
+      exit 2
+    fi
+    if ((8#${runtime_cli_mode} & 8#222)); then
       printf 'packaged Container runtime candidate CLI must be read-only during validation: %s\n' \
         "${runtime_cli}" >&2
       exit 2

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -62,11 +62,12 @@ fi
 # Container integration is VM-backed and the CLI otherwise defaults to the
 # developer's persistent Application Support directory.  A stable-release gate
 # must never inherit stale machines, images, or networks from an earlier local
-# run, nor leave its own state behind for the next gate.  Keep the default under
-# Container's already-ignored test scratch directory, resolving relative hosted
-# checkout paths before passing the application root through make.  Resolve
-# symlinks as well: Container's protected logging state deliberately rejects a
-# persistence root whose canonical path differs from the supplied path.
+# run, nor leave its own state behind for the next gate. Build and log scratch
+# may live on an external volume, but launchd rejects service plists and
+# executables from those volumes. Keep runtime state independently configurable
+# so the stable-release helper can bind it to its marker-protected internal
+# lifecycle. Resolve symlinks: Container's protected state deliberately rejects
+# persistence roots whose canonical path differs from the supplied path.
 if [[ -n "${CONTAINER_STACK_VALIDATION_SCRATCH_ROOT:-}" ]]; then
   container_scratch_root="${CONTAINER_STACK_VALIDATION_SCRATCH_ROOT}"
   if [[ "${container_scratch_root}" != /* || "${container_scratch_root}" == / ]]; then
@@ -83,7 +84,23 @@ if [[ "${container_scratch_root}" == / ]]; then
   printf 'CONTAINER_STACK_VALIDATION_SCRATCH_ROOT must not resolve to /\n' >&2
   exit 2
 fi
-container_app_root="${container_scratch_root}/stack-release-app-root"
+if [[ -n "${CONTAINER_STACK_VALIDATION_RUNTIME_ROOT:-}" ]]; then
+  container_runtime_root="${CONTAINER_STACK_VALIDATION_RUNTIME_ROOT}"
+  if [[ "${container_runtime_root}" != /* || "${container_runtime_root}" == / ]]; then
+    printf 'CONTAINER_STACK_VALIDATION_RUNTIME_ROOT must be an absolute path other than /: %s\n' \
+      "${container_runtime_root}" >&2
+    exit 2
+  fi
+else
+  container_runtime_root="${container_scratch_root}/runtime"
+fi
+mkdir -p "${container_runtime_root}"
+container_runtime_root="$(cd "${container_runtime_root}" && pwd -P)"
+if [[ "${container_runtime_root}" == / ]]; then
+  printf 'CONTAINER_STACK_VALIDATION_RUNTIME_ROOT must not resolve to /\n' >&2
+  exit 2
+fi
+container_app_root="${container_runtime_root}/stack-release-app-root"
 container_log_root="${container_scratch_root}/stack-release-log-root"
 container_make_args=(
   "APP_ROOT=${container_app_root}"
@@ -272,6 +289,7 @@ if [[ -n "${checkpoint_directory}" ]]; then
       printf 'targets=%s\n' "${container_targets[*]}"
       printf 'tree=%s:%s\n' "${container_repo}" "${container_tree}"
       printf 'scratch_root=%s\n' "${container_scratch_root}"
+      printf 'runtime_root=%s\n' "${container_runtime_root}"
       printf 'init_archive=%s\n' "${init_archive_fingerprint}"
       printf 'runtime_cli=%s\n' "${runtime_cli_fingerprint}"
     } | shasum -a 256 | awk '{print $1}'

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -101,7 +101,11 @@ else
     # Full validation launches services. Keep its safe default short and on the
     # internal volume; hosted validation never launches them and may stay with
     # the checkout-backed scratch root.
-    container_runtime_root="/private/tmp/ccsv.${container_validation_suffix}"
+    container_runtime_parent_base=/private/tmp
+    if [[ ! -d "${container_runtime_parent_base}" || ! -w "${container_runtime_parent_base}" ]]; then
+      container_runtime_parent_base=/tmp
+    fi
+    container_runtime_root="${container_runtime_parent_base}/ccsv.${container_validation_suffix}"
   else
     container_runtime_root="${container_scratch_root}/runtime"
   fi

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -325,8 +325,6 @@ if [[ -n "${checkpoint_directory}" ]]; then
       printf 'targets=%s\n' "${container_targets[*]}"
       printf 'tree=%s:%s\n' "${container_repo}" "${container_tree}"
       printf 'scratch_root=%s\n' "${container_scratch_root}"
-      printf 'runtime_root=%s\n' "${container_runtime_root}"
-      printf 'provider_socket=%s\n' "${container_provider_socket}"
       printf 'init_archive=%s\n' "${init_archive_fingerprint}"
       printf 'runtime_cli=%s\n' "${runtime_cli_fingerprint}"
     } | shasum -a 256 | awk '{print $1}'

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -84,6 +84,11 @@ if [[ "${container_scratch_root}" == / ]]; then
   printf 'CONTAINER_STACK_VALIDATION_SCRATCH_ROOT must not resolve to /\n' >&2
   exit 2
 fi
+container_validation_suffix=""
+if [[ "${mode}" == "full" ]]; then
+  container_revision="$(git -C "${container_repo}" rev-parse --verify HEAD 2>/dev/null || printf 'fixture')"
+  container_validation_suffix="$(printf '%s' "${container_revision}" | tr -cd '[:alnum:]' | cut -c1-12)"
+fi
 if [[ -n "${CONTAINER_STACK_VALIDATION_RUNTIME_ROOT:-}" ]]; then
   container_runtime_root="${CONTAINER_STACK_VALIDATION_RUNTIME_ROOT}"
   if [[ "${container_runtime_root}" != /* || "${container_runtime_root}" == / ]]; then
@@ -92,7 +97,14 @@ if [[ -n "${CONTAINER_STACK_VALIDATION_RUNTIME_ROOT:-}" ]]; then
     exit 2
   fi
 else
-  container_runtime_root="${container_scratch_root}/runtime"
+  if [[ "${mode}" == "full" ]]; then
+    # Full validation launches services. Keep its safe default short and on the
+    # internal volume; hosted validation never launches them and may stay with
+    # the checkout-backed scratch root.
+    container_runtime_root="/private/tmp/ccsv.${container_validation_suffix}"
+  else
+    container_runtime_root="${container_scratch_root}/runtime"
+  fi
 fi
 mkdir -p "${container_runtime_root}"
 container_runtime_root="$(cd "${container_runtime_root}" && pwd -P)"
@@ -102,13 +114,19 @@ if [[ "${container_runtime_root}" == / ]]; then
 fi
 container_app_root="${container_runtime_root}/stack-release-app-root"
 container_log_root="${container_scratch_root}/stack-release-log-root"
+container_provider_socket="${container_app_root}/engine-provider/provider.sock"
+container_provider_socket_bytes=$(LC_ALL=C printf '%s' "${container_provider_socket}" \
+  | wc -c | tr -d '[:space:]')
+if [[ "${mode}" == "full" ]] && ((container_provider_socket_bytes > 103)); then
+  printf 'CONTAINER_STACK_VALIDATION_RUNTIME_ROOT exceeds the provider Unix socket path limit (%s > 103 bytes): %s\n' \
+    "${container_provider_socket_bytes}" "${container_provider_socket}" >&2
+  exit 2
+fi
 container_make_args=(
   "APP_ROOT=${container_app_root}"
   "LOG_ROOT=${container_log_root}"
 )
 if [[ "${mode}" == "full" ]]; then
-  container_revision="$(git -C "${container_repo}" rev-parse --verify HEAD 2>/dev/null || printf 'fixture')"
-  container_validation_suffix="$(printf '%s' "${container_revision}" | tr -cd '[:alnum:]' | cut -c1-12)"
   container_make_args+=(
     "INTEGRATION_SERVICE_NAMESPACE=io.github.container.stack-validation.${container_validation_suffix}"
   )
@@ -290,6 +308,7 @@ if [[ -n "${checkpoint_directory}" ]]; then
       printf 'tree=%s:%s\n' "${container_repo}" "${container_tree}"
       printf 'scratch_root=%s\n' "${container_scratch_root}"
       printf 'runtime_root=%s\n' "${container_runtime_root}"
+      printf 'provider_socket=%s\n' "${container_provider_socket}"
       printf 'init_archive=%s\n' "${init_archive_fingerprint}"
       printf 'runtime_cli=%s\n' "${runtime_cli_fingerprint}"
     } | shasum -a 256 | awk '{print $1}'

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -150,9 +150,23 @@ runtime_candidate_sha256=${CONTAINER_RUNTIME_CANDIDATE_SHA256:-}
 validation_environment_path=${PATH}
 runtime_make_args=()
 if [[ "${mode}" == "full" ]]; then
-  if [[ "${runtime_cli}" != /* || ! -x "${runtime_cli}" ]]; then
-    printf 'full stack validation requires an absolute executable CONTAINER_RUNTIME_CLI: %s\n' \
+  if [[ -z "${runtime_cli}" ]]; then
+    printf 'full stack validation requires an executable CONTAINER_RUNTIME_CLI: %s\n' \
       "${runtime_cli:-unset}" >&2
+    exit 2
+  fi
+  if [[ "${runtime_cli}" != */* ]]; then
+    if ! runtime_cli=$(command -v "${runtime_cli}"); then
+      printf 'full stack validation Container CLI was not found on PATH: %s\n' \
+        "${CONTAINER_RUNTIME_CLI}" >&2
+      exit 2
+    fi
+  elif [[ "${runtime_cli}" != /* ]]; then
+    runtime_cli="$(cd "$(dirname "${runtime_cli}")" && pwd -P)/$(basename "${runtime_cli}")"
+  fi
+  if [[ ! -x "${runtime_cli}" ]]; then
+    printf 'full stack validation requires an executable CONTAINER_RUNTIME_CLI: %s\n' \
+      "${runtime_cli}" >&2
     exit 2
   fi
   runtime_cli_directory=$(cd "$(dirname "${runtime_cli}")" && pwd -P)

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -185,11 +185,13 @@ if [[ "${mode}" == "full" ]]; then
         "${runtime_candidate_sha256}" >&2
       exit 2
     fi
-    runtime_cli_mode=$(
-      /usr/bin/stat -f '%Lp' "${runtime_cli}" 2>/dev/null \
-        || /usr/bin/stat -c '%a' "${runtime_cli}" 2>/dev/null
-    )
-    if ! [[ "${runtime_cli_mode}" =~ ^[0-7]{3,4}$ ]]; then
+    if ! runtime_cli_mode=$(python3 - "${runtime_cli}" <<'PY'
+import os
+import sys
+
+print(f"{os.stat(sys.argv[1]).st_mode & 0o777:o}")
+PY
+    ); then
       printf 'could not determine packaged Container runtime candidate CLI mode: %s\n' \
         "${runtime_cli}" >&2
       exit 2

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -435,14 +435,25 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
 
             self.assertNotEqual(namespaces[0], namespaces[1])
 
-    def test_group_termination_stops_the_isolated_runtime(self) -> None:
+    def test_repeated_group_termination_stops_the_isolated_runtime(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
             app_root = temporary_root / "app-root"
             container_log = temporary_root / "container.log"
             ready = temporary_root / "ready"
+            stop_started = temporary_root / "stop-started"
+            stop_complete = temporary_root / "stop-complete"
             fake_container = temporary_root / "container-cli"
-            self.write_fake_container(fake_container)
+            self.write_fake_container(
+                fake_container,
+                body=(
+                    'if [[ "$*" == "system stop" && -e "${READY_FILE:-}" ]]; then\n'
+                    '  touch "${STOP_STARTED:?}"\n'
+                    "  sleep 0.5\n"
+                    '  touch "${STOP_COMPLETE:?}"\n'
+                    "fi\n"
+                ),
+            )
             environment = self.runtime_environment()
             environment.update(
                 {
@@ -453,6 +464,8 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                     ),
                     "CONTAINER_TEST_LOG": str(container_log),
                     "READY_FILE": str(ready),
+                    "STOP_STARTED": str(stop_started),
+                    "STOP_COMPLETE": str(stop_complete),
                 }
             )
 
@@ -479,12 +492,20 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 time.sleep(0.05)
 
             os.killpg(process.pid, signal.SIGTERM)
+            deadline = time.monotonic() + 10
+            while not stop_started.exists() and process.poll() is None:
+                if time.monotonic() >= deadline:
+                    process.kill()
+                    self.fail("runtime stop did not begin")
+                time.sleep(0.01)
+            os.killpg(process.pid, signal.SIGTERM)
             stdout, stderr = process.communicate(timeout=10)
 
             self.assertEqual(process.returncode, 143, stdout + stderr)
             invocations = container_log.read_text(encoding="utf-8").splitlines()
             self.assertGreaterEqual(invocations.count("system stop"), 2)
             self.assertIn("Stopping matched container runtime...", stdout)
+            self.assertTrue(stop_complete.exists(), stdout + stderr)
 
     def test_rejects_legacy_global_stop_helper_before_service_side_effects(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -125,7 +125,9 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         *references: str,
         distinct_digests: bool = False,
         config_architecture: str = "arm64",
+        config_variant: str | None = None,
         indexed_architecture: str | None = None,
+        indexed_variant: str | None = None,
     ) -> None:
         def descriptor(payload: bytes, media_type: str) -> dict[str, object]:
             return {
@@ -134,9 +136,10 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 "size": len(payload),
             }
 
-        config = json.dumps(
-            {"architecture": config_architecture, "os": "linux"}, sort_keys=True
-        ).encode("utf-8")
+        config_payload = {"architecture": config_architecture, "os": "linux"}
+        if config_variant is not None:
+            config_payload["variant"] = config_variant
+        config = json.dumps(config_payload, sort_keys=True).encode("utf-8")
         layer = b"fixture-layer"
         config_descriptor = descriptor(
             config, "application/vnd.oci.image.config.v1+json"
@@ -175,6 +178,8 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 "architecture": indexed_architecture,
                 "os": "linux",
             }
+            if indexed_variant is not None:
+                child["platform"]["variant"] = indexed_variant
             nested = json.dumps(
                 {"schemaVersion": 2, "manifests": [child]}, sort_keys=True
             ).encode("utf-8")
@@ -1194,6 +1199,44 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 DEFAULT_INIT_IMAGE,
                 config_architecture="amd64",
                 indexed_architecture="arm64",
+            )
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app-root"),
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(init_archive),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(
+                "descriptor platform does not match image config", result.stderr
+            )
+            self.assertFalse(container_log.exists())
+
+    def test_rejects_required_index_with_mismatched_config_variant(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            init_archive = temporary_root / "vminit-variant-mismatch.tar"
+            self.create_oci_archive(
+                init_archive,
+                DEFAULT_INIT_IMAGE,
+                config_variant="v9",
+                indexed_architecture="arm64",
+                indexed_variant="v8",
             )
             container_log = temporary_root / "container.log"
             fake_container = temporary_root / "container-cli"

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -124,28 +124,57 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         *references: str,
         distinct_digests: bool = False,
     ) -> None:
+        def descriptor(payload: bytes, media_type: str) -> dict[str, object]:
+            return {
+                "mediaType": media_type,
+                "digest": "sha256:" + hashlib.sha256(payload).hexdigest(),
+                "size": len(payload),
+            }
+
+        config = b"{}"
+        layer = b"fixture-layer"
+        config_descriptor = descriptor(
+            config, "application/vnd.oci.image.config.v1+json"
+        )
+        layer_descriptor = descriptor(
+            layer, "application/vnd.oci.image.layer.v1.tar"
+        )
+        manifests: list[tuple[bytes, dict[str, object]]] = []
+        for position, reference in enumerate(references):
+            manifest = json.dumps(
+                {
+                    "schemaVersion": 2,
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "config": config_descriptor,
+                    "layers": [layer_descriptor],
+                    "fixture": position if distinct_digests else 0,
+                },
+                sort_keys=True,
+            ).encode("utf-8")
+            manifest_descriptor = descriptor(
+                manifest, "application/vnd.oci.image.manifest.v1+json"
+            )
+            manifest_descriptor["annotations"] = {
+                "org.opencontainers.image.ref.name": reference,
+            }
+            manifests.append((manifest, manifest_descriptor))
         index = {
             "schemaVersion": 2,
-            "manifests": [
-                {
-                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
-                    "digest": "sha256:"
-                    + (f"{index:x}" * 64)[:64]
-                    if distinct_digests
-                    else "sha256:" + "0" * 64,
-                    "size": 0,
-                    "annotations": {
-                        "org.opencontainers.image.ref.name": reference,
-                    },
-                }
-                for index, reference in enumerate(references, start=1)
-            ],
+            "manifests": [item[1] for item in manifests],
         }
-        payload = json.dumps(index).encode("utf-8")
+        payloads = [config, layer, *(item[0] for item in manifests)]
+        layout = json.dumps({"imageLayoutVersion": "1.0.0"}).encode("utf-8")
+        index_payload = json.dumps(index).encode("utf-8")
         with tarfile.open(path, "w") as archive:
-            member = tarfile.TarInfo("index.json")
-            member.size = len(payload)
-            archive.addfile(member, io.BytesIO(payload))
+            for name, payload in (("oci-layout", layout), ("index.json", index_payload)):
+                member = tarfile.TarInfo(name)
+                member.size = len(payload)
+                archive.addfile(member, io.BytesIO(payload))
+            for payload in payloads:
+                digest = hashlib.sha256(payload).hexdigest()
+                member = tarfile.TarInfo(f"blobs/sha256/{digest}")
+                member.size = len(payload)
+                archive.addfile(member, io.BytesIO(payload))
 
     @staticmethod
     def create_containerization_source(root: Path) -> tuple[Path, str]:
@@ -992,6 +1021,80 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertIn("do not resolve to one digest", result.stderr)
             self.assertFalse(container_log.exists())
+
+    def test_rejects_retained_archive_with_invalid_descriptor_closure(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            complete_archive = temporary_root / "complete.tar"
+            self.create_oci_archive(complete_archive, DEFAULT_INIT_IMAGE)
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+
+            with tarfile.open(complete_archive, "r") as source:
+                complete_payloads = {}
+                for member in source.getmembers():
+                    if not member.isfile():
+                        continue
+                    stream = source.extractfile(member)
+                    self.assertIsNotNone(stream)
+                    complete_payloads[member.name] = stream.read()
+
+            def missing_layer(payloads: dict[str, bytes]) -> None:
+                index = json.loads(payloads["index.json"])
+                manifest_digest = index["manifests"][0]["digest"].split(":", 1)[1]
+                manifest = json.loads(payloads[f"blobs/sha256/{manifest_digest}"])
+                layer_digest = manifest["layers"][0]["digest"].split(":", 1)[1]
+                del payloads[f"blobs/sha256/{layer_digest}"]
+
+            def wrong_size(payloads: dict[str, bytes]) -> None:
+                index = json.loads(payloads["index.json"])
+                index["manifests"][0]["size"] += 1
+                payloads["index.json"] = json.dumps(index).encode("utf-8")
+
+            def wrong_digest(payloads: dict[str, bytes]) -> None:
+                index = json.loads(payloads["index.json"])
+                manifest_digest = index["manifests"][0]["digest"].split(":", 1)[1]
+                member_name = f"blobs/sha256/{manifest_digest}"
+                payload = payloads[member_name]
+                payloads[member_name] = bytes([payload[0] ^ 1]) + payload[1:]
+
+            for name, mutation, expected_error in (
+                ("missing-layer", missing_layer, "missing required member: blobs/sha256/"),
+                ("wrong-size", wrong_size, "size mismatch"),
+                ("wrong-digest", wrong_digest, "digest mismatch"),
+            ):
+                with self.subTest(name=name):
+                    init_archive = temporary_root / f"{name}.tar"
+                    payloads = complete_payloads.copy()
+                    mutation(payloads)
+                    with tarfile.open(init_archive, "w") as destination:
+                        for member_name, payload in payloads.items():
+                            member = tarfile.TarInfo(member_name)
+                            member.size = len(payload)
+                            destination.addfile(member, io.BytesIO(payload))
+
+                    container_log = temporary_root / f"{name}.log"
+                    environment = self.runtime_environment()
+                    environment.update(
+                        {
+                            "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app"),
+                            "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(init_archive),
+                            "CONTAINER_TEST_LOG": str(container_log),
+                        }
+                    )
+
+                    result = subprocess.run(
+                        [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                        cwd=ROOT,
+                        env=environment,
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    )
+
+                    self.assertEqual(result.returncode, 1)
+                    self.assertIn(expected_error, result.stderr)
+                    self.assertFalse(container_log.exists())
 
     def test_managed_runtime_ready_api_does_not_restart_or_stop_its_owner(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -124,6 +124,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         path: Path,
         *references: str,
         distinct_digests: bool = False,
+        indexed_architecture: str | None = None,
     ) -> None:
         def descriptor(payload: bytes, media_type: str) -> dict[str, object]:
             return {
@@ -132,7 +133,9 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 "size": len(payload),
             }
 
-        config = b"{}"
+        config = json.dumps(
+            {"architecture": "arm64", "os": "linux"}, sort_keys=True
+        ).encode("utf-8")
         layer = b"fixture-layer"
         config_descriptor = descriptor(
             config, "application/vnd.oci.image.config.v1+json"
@@ -159,11 +162,30 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 "org.opencontainers.image.ref.name": reference,
             }
             manifests.append((manifest, manifest_descriptor))
-        index = {
-            "schemaVersion": 2,
-            "manifests": [item[1] for item in manifests],
-        }
         payloads = [config, layer, *(item[0] for item in manifests)]
+        if indexed_architecture is None:
+            index_manifests = [item[1] for item in manifests]
+        else:
+            if len(manifests) != 1:
+                raise ValueError("indexed fixture supports exactly one reference")
+            child = manifests[0][1].copy()
+            child.pop("annotations")
+            child["platform"] = {
+                "architecture": indexed_architecture,
+                "os": "linux",
+            }
+            nested = json.dumps(
+                {"schemaVersion": 2, "manifests": [child]}, sort_keys=True
+            ).encode("utf-8")
+            nested_descriptor = descriptor(
+                nested, "application/vnd.oci.image.index.v1+json"
+            )
+            nested_descriptor["annotations"] = {
+                "org.opencontainers.image.ref.name": references[0],
+            }
+            index_manifests = [nested_descriptor]
+            payloads.append(nested)
+        index = {"schemaVersion": 2, "manifests": index_manifests}
         layout = json.dumps({"imageLayoutVersion": "1.0.0"}).encode("utf-8")
         index_payload = json.dumps(index).encode("utf-8")
         with tarfile.open(path, "w") as archive:
@@ -1100,6 +1122,41 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             temporary_root = Path(temporary_directory)
             init_archive = temporary_root / "vminit-artifact.tar"
             self.create_oci_artifact_archive(init_archive, DEFAULT_INIT_IMAGE)
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app-root"),
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(init_archive),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("missing required reference(s)", result.stderr)
+            self.assertIn(DEFAULT_INIT_IMAGE, result.stderr)
+            self.assertFalse(container_log.exists())
+
+    def test_rejects_required_index_without_linux_arm64_image(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            init_archive = temporary_root / "vminit-amd64.tar"
+            self.create_oci_archive(
+                init_archive,
+                DEFAULT_INIT_IMAGE,
+                indexed_architecture="amd64",
+            )
             container_log = temporary_root / "container.log"
             fake_container = temporary_root / "container-cli"
             self.write_fake_container(fake_container)

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -178,6 +178,44 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 archive.addfile(member, io.BytesIO(payload))
 
     @staticmethod
+    def create_oci_artifact_archive(path: Path, reference: str) -> None:
+        artifact = json.dumps(
+            {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
+                "artifactType": "application/vnd.example.fixture",
+                "blobs": [],
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+        digest = hashlib.sha256(artifact).hexdigest()
+        index = json.dumps(
+            {
+                "schemaVersion": 2,
+                "manifests": [
+                    {
+                        "mediaType": "application/vnd.oci.artifact.manifest.v1+json",
+                        "digest": f"sha256:{digest}",
+                        "size": len(artifact),
+                        "annotations": {
+                            "org.opencontainers.image.ref.name": reference,
+                        },
+                    }
+                ],
+            }
+        ).encode("utf-8")
+        layout = json.dumps({"imageLayoutVersion": "1.0.0"}).encode("utf-8")
+        with tarfile.open(path, "w") as archive:
+            for name, payload in (
+                ("oci-layout", layout),
+                ("index.json", index),
+                (f"blobs/sha256/{digest}", artifact),
+            ):
+                member = tarfile.TarInfo(name)
+                member.size = len(payload)
+                archive.addfile(member, io.BytesIO(payload))
+
+    @staticmethod
     def create_containerization_source(root: Path) -> tuple[Path, str]:
         source = root / "containerization-source"
         (source / "vminitd").mkdir(parents=True)
@@ -1055,6 +1093,37 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
 
             self.assertEqual(result.returncode, 1)
             self.assertIn(immutable_reference, result.stderr)
+            self.assertFalse(container_log.exists())
+
+    def test_rejects_artifact_annotated_as_required_image(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            init_archive = temporary_root / "vminit-artifact.tar"
+            self.create_oci_artifact_archive(init_archive, DEFAULT_INIT_IMAGE)
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app-root"),
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(init_archive),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("missing required reference(s)", result.stderr)
+            self.assertIn(DEFAULT_INIT_IMAGE, result.stderr)
             self.assertFalse(container_log.exists())
 
     def test_rejects_required_archive_references_with_different_digests(self) -> None:

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -21,6 +21,7 @@ import hashlib
 import io
 import json
 import os
+import signal
 import subprocess
 import tarfile
 import tempfile
@@ -433,6 +434,57 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 namespaces.append(namespace_file.read_text(encoding="utf-8").strip())
 
             self.assertNotEqual(namespaces[0], namespaces[1])
+
+    def test_group_termination_stops_the_isolated_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            app_root = temporary_root / "app-root"
+            container_log = temporary_root / "container.log"
+            ready = temporary_root / "ready"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
+                    "CONTAINER_RUNTIME_RUN_ID": "termination-test-run",
+                    "CONTAINER_RUNTIME_LOCK_FILE": str(
+                        temporary_root / "runtime.lock"
+                    ),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                    "READY_FILE": str(ready),
+                }
+            )
+
+            process = subprocess.Popen(
+                [
+                    str(SCRIPT),
+                    str(fake_container),
+                    "/bin/sh",
+                    "-c",
+                    'touch "$READY_FILE"; while :; do sleep 1; done',
+                ],
+                cwd=ROOT,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+            deadline = time.monotonic() + 10
+            while not ready.exists() and process.poll() is None:
+                if time.monotonic() >= deadline:
+                    process.kill()
+                    self.fail("candidate command did not become ready")
+                time.sleep(0.05)
+
+            os.killpg(process.pid, signal.SIGTERM)
+            stdout, stderr = process.communicate(timeout=10)
+
+            self.assertEqual(process.returncode, 143, stdout + stderr)
+            invocations = container_log.read_text(encoding="utf-8").splitlines()
+            self.assertGreaterEqual(invocations.count("system stop"), 2)
+            self.assertIn("Stopping matched container runtime...", stdout)
 
     def test_rejects_legacy_global_stop_helper_before_service_side_effects(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -50,6 +50,9 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             "CONTAINER_RUNTIME_BOOTSTRAP_IMAGE_TAR",
             "CONTAINER_RUNTIME_BUILDER_IMAGE",
             "CONTAINER_RUNTIME_BUILDER_IMAGE_TAR",
+            "CONTAINER_RUNTIME_CANDIDATE_SHA256",
+            "CONTAINER_RUNTIME_CLI",
+            "CONTAINER_RUNTIME_CLI_SHA256",
             "CONTAINER_RUNTIME_SERVICE_NAMESPACE",
             "CONTAINER_RUNTIME_STOP_HELPER",
             "CONTAINER_SERVICE_NAMESPACE",
@@ -65,6 +68,35 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         ):
             environment.pop(variable, None)
         return environment
+
+    def test_rejects_a_candidate_cli_that_does_not_match_its_pinned_digest(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            fake_container = temporary_root / "container-cli"
+            container_log = temporary_root / "container.log"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app-root"),
+                    "CONTAINER_RUNTIME_CLI_SHA256": "0" * 64,
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("candidate container binary digest mismatch", result.stderr)
+            self.assertFalse(container_log.exists())
 
     @staticmethod
     def write_fake_container(
@@ -1042,6 +1074,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                     "/bin/sh",
                     "-c",
                     'test "$(command -v container)" = "$EXPECTED_CONTAINER_CLI" '
+                    '&& test "$CONTAINER_RUNTIME_CLI" = "$EXPECTED_CONTAINER_CLI" '
                     "&& container nested-command-proof",
                 ],
                 cwd=ROOT,
@@ -1096,6 +1129,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                     "/bin/sh",
                     "-c",
                     'test "$(command -v container)" = "$EXPECTED_CONTAINER_CLI" '
+                    '&& test "$CONTAINER_RUNTIME_CLI" = "$EXPECTED_CONTAINER_CLI" '
                     "&& container bare-command-proof",
                 ],
                 cwd=ROOT,

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -124,6 +124,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         path: Path,
         *references: str,
         distinct_digests: bool = False,
+        config_architecture: str = "arm64",
         indexed_architecture: str | None = None,
     ) -> None:
         def descriptor(payload: bytes, media_type: str) -> dict[str, object]:
@@ -134,7 +135,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             }
 
         config = json.dumps(
-            {"architecture": "arm64", "os": "linux"}, sort_keys=True
+            {"architecture": config_architecture, "os": "linux"}, sort_keys=True
         ).encode("utf-8")
         layer = b"fixture-layer"
         config_descriptor = descriptor(
@@ -1155,6 +1156,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             self.create_oci_archive(
                 init_archive,
                 DEFAULT_INIT_IMAGE,
+                config_architecture="amd64",
                 indexed_architecture="amd64",
             )
             container_log = temporary_root / "container.log"
@@ -1181,6 +1183,43 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             self.assertEqual(result.returncode, 1)
             self.assertIn("missing required reference(s)", result.stderr)
             self.assertIn(DEFAULT_INIT_IMAGE, result.stderr)
+            self.assertFalse(container_log.exists())
+
+    def test_rejects_required_index_with_mismatched_config_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            init_archive = temporary_root / "vminit-platform-mismatch.tar"
+            self.create_oci_archive(
+                init_archive,
+                DEFAULT_INIT_IMAGE,
+                config_architecture="amd64",
+                indexed_architecture="arm64",
+            )
+            container_log = temporary_root / "container.log"
+            fake_container = temporary_root / "container-cli"
+            self.write_fake_container(fake_container)
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app-root"),
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(init_archive),
+                    "CONTAINER_TEST_LOG": str(container_log),
+                }
+            )
+
+            result = subprocess.run(
+                [str(SCRIPT), str(fake_container), "/usr/bin/true"],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn(
+                "descriptor platform does not match image config", result.stderr
+            )
             self.assertFalse(container_log.exists())
 
     def test_rejects_required_archive_references_with_different_digests(self) -> None:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1197,6 +1197,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertNotIn("CONCURRENT_TEST_SUITES=", full_commands)
             self.assertIn("bootstrap:/tmp/runtime-init.oci.tar", full_commands)
 
+            repeated_runtime_directory = tempfile.TemporaryDirectory(
+                prefix="ccsv-retry-test.", dir="/tmp"
+            )
+            self.addCleanup(repeated_runtime_directory.cleanup)
+            environment["CONTAINER_STACK_VALIDATION_RUNTIME_ROOT"] = str(
+                Path(repeated_runtime_directory.name)
+            )
             repeated_full = subprocess.run(
                 [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
                 check=False,
@@ -1449,6 +1456,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             split_environment = external_environment.copy()
             split_environment["CONTAINER_STACK_VALIDATION_RUNTIME_ROOT"] = str(
                 internal_runtime
+            )
+            split_environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
+                root / "split-checkpoints"
             )
             split = subprocess.run(
                 [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1334,6 +1334,20 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 second_packaged.stdout,
             )
 
+            packaged_cli.chmod(0o755)
+            writable_packaged = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=packaged_environments[1],
+                text=True,
+            )
+            self.assertEqual(writable_packaged.returncode, 2)
+            self.assertIn(
+                "packaged Container runtime candidate CLI must be read-only",
+                writable_packaged.stderr,
+            )
+
             drift_environment = environment.copy()
             drift_environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
                 root / "drift-checkpoints"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1790,8 +1790,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 (signal.SIGINT, 130),
                 (signal.SIGTERM, 143),
             ):
-                with self.subTest(signal=delivered_signal.name):
-                    root = Path(directory) / delivered_signal.name
+                for signal_scope in ("process", "group"):
+                    root = Path(directory) / delivered_signal.name / signal_scope
                     candidate_root = root / "candidate"
                     candidate_bin = candidate_root / "bin"
                     candidate_bin.mkdir(parents=True)
@@ -1850,19 +1850,31 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     deadline = time.monotonic() + 10
                     while not ready.exists() and process.poll() is None:
                         if time.monotonic() >= deadline:
-                            process.kill()
+                            os.killpg(process.pid, signal.SIGKILL)
+                            process.wait(timeout=10)
                             self.fail("outer release gate did not become ready")
                         time.sleep(0.05)
 
-                    os.killpg(process.pid, delivered_signal)
+                    send_signal = os.kill if signal_scope == "process" else os.killpg
+                    send_signal(process.pid, delivered_signal)
                     deadline = time.monotonic() + 10
                     while not cleanup_started.exists() and process.poll() is None:
                         if time.monotonic() >= deadline:
-                            process.kill()
+                            os.killpg(process.pid, signal.SIGKILL)
+                            process.wait(timeout=10)
                             self.fail("candidate signal cleanup did not start")
                         time.sleep(0.01)
-                    os.killpg(process.pid, delivered_signal)
-                    stdout, stderr = process.communicate(timeout=10)
+                    send_signal(process.pid, delivered_signal)
+                    try:
+                        stdout, stderr = process.communicate(timeout=10)
+                    except subprocess.TimeoutExpired:
+                        os.killpg(process.pid, signal.SIGKILL)
+                        stdout, stderr = process.communicate(timeout=10)
+                        self.fail(
+                            "outer release gate did not finish after cleanup\n"
+                            + stdout
+                            + stderr
+                        )
 
                     self.assertEqual(
                         process.returncode, expected_status, stdout + stderr

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1737,6 +1737,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertNotIn('${TMPDIR:-/tmp}/cc-release.', local_gate)
         self.assertIn('${runtime_parent_base}/c.XXXXXX', local_gate)
+        self.assertIn(
+            '[[ ! -d "${candidate_parent}" || ! -w "${candidate_parent}" ]]',
+            self.script,
+        )
         self.assertIn("resolve_release_evidence_root", local_gate)
         self.assertLess(
             local_gate.index('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${init_image_archive}"'),

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1790,13 +1790,16 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     )
                     candidate_cli.chmod(0o755)
                     ready = root / "ready"
+                    cleanup_started = root / "cleanup-started"
                     stop_complete = root / "stop-complete"
                     removed = root / "removed"
                     fake_gate = root / "fake-gate"
                     fake_gate.write_text(
                         "#!/usr/bin/env bash\n"
                         "set -u\n"
-                        "cleanup() { test -x \"$CANDIDATE_ROOT/bin/container\"; "
+                        "cleanup() { trap '' INT TERM; "
+                        "test -x \"$CANDIDATE_ROOT/bin/container\"; "
+                        "touch \"$CLEANUP_STARTED\"; sleep 0.5; "
                         "touch \"$STOP_COMPLETE\"; }\n"
                         "trap 'cleanup; exit 130' INT\n"
                         "trap 'cleanup; exit 143' TERM\n"
@@ -1812,6 +1815,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                             f"source {shlex.quote(str(SCRIPT))}",
                             f"export CANDIDATE_ROOT={shlex.quote(str(candidate_root))}",
                             f"export READY={shlex.quote(str(ready))}",
+                            "export CLEANUP_STARTED="
+                            f"{shlex.quote(str(cleanup_started))}",
                             f"export STOP_COMPLETE={shlex.quote(str(stop_complete))}",
                             "status=0",
                             "run_local_release_gate_command "
@@ -1838,6 +1843,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                             self.fail("outer release gate did not become ready")
                         time.sleep(0.05)
 
+                    os.killpg(process.pid, delivered_signal)
+                    deadline = time.monotonic() + 10
+                    while not cleanup_started.exists() and process.poll() is None:
+                        if time.monotonic() >= deadline:
+                            process.kill()
+                            self.fail("candidate signal cleanup did not start")
+                        time.sleep(0.01)
                     os.killpg(process.pid, delivered_signal)
                     stdout, stderr = process.communicate(timeout=10)
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -995,6 +995,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             "container_targets=(check container dsym docs coverage-unit)",
             validation,
         )
+        self.assertIn("container_runtime_parent_base=/private/tmp", validation)
+        self.assertIn(
+            '[[ ! -d "${container_runtime_parent_base}" || ! -w "${container_runtime_parent_base}" ]]',
+            validation,
+        )
+        self.assertIn("container_runtime_parent_base=/tmp", validation)
         self.assertIn(
             "env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE",
             validation,
@@ -1123,6 +1129,14 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
                 root / "checkpoints"
             )
+            runtime_directory = tempfile.TemporaryDirectory(
+                prefix="ccsv-test.", dir="/tmp"
+            )
+            self.addCleanup(runtime_directory.cleanup)
+            explicit_runtime_root = Path(runtime_directory.name)
+            environment["CONTAINER_STACK_VALIDATION_RUNTIME_ROOT"] = str(
+                explicit_runtime_root
+            )
             validation_paths = [
                 str(compose),
                 str(builder),
@@ -1154,7 +1168,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 f"{container} "
                 f"PATH={candidate_tools_resolved}{os.pathsep}{tools}"
                 f"{os.pathsep}{environment['PATH'].split(os.pathsep, 1)[1]} "
-                "APP_ROOT=/private/tmp/ccsv.fixture/stack-release-app-root "
+                f"APP_ROOT={explicit_runtime_root.resolve()}/stack-release-app-root "
                 f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "INTEGRATION_SERVICE_NAMESPACE=io.github.container.stack-validation.fixture "
                 "check container dsym docs coverage",
@@ -1314,6 +1328,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
 
             log.unlink()
+            environment.pop("CONTAINER_STACK_VALIDATION_RUNTIME_ROOT")
             hosted = subprocess.run(
                 [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],
                 check=False,
@@ -1716,6 +1731,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             local_gate,
         )
         self.assertIn("runtime_parent_base=/private/tmp", local_gate)
+        self.assertIn(
+            '[[ ! -d "${runtime_parent_base}" || ! -w "${runtime_parent_base}" ]]',
+            local_gate,
+        )
         self.assertNotIn('${TMPDIR:-/tmp}/cc-release.', local_gate)
         self.assertIn('${runtime_parent_base}/c.XXXXXX', local_gate)
         self.assertIn("resolve_release_evidence_root", local_gate)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1010,6 +1010,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             "release-gate: container-stack-release-validation ci swift-runtime-test docker-compose-parity",
             makefile,
         )
+        self.assertEqual(
+            makefile.count("env -u CONTAINER_BIN -u CONTAINER_COMPOSE_CONTAINER"),
+            2,
+        )
         self.assertIn("DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.3.1", makefile)
         self.assertIn("DOCKER_COMPOSE_E2E_REF ?= f32009d4a2c687dd405398cc7975d12dccaf8dff", makefile)
         self.assertNotIn("repackage-release", makefile)
@@ -1066,6 +1070,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
             tools = root / "tools"
             tools.mkdir()
+            candidate_tools = root / "candidate-tools"
+            candidate_tools.mkdir()
+            candidate_tools_resolved = candidate_tools.resolve()
             log = root / "commands.log"
             for name in ("make", "ruby"):
                 tool = tools / name
@@ -1076,10 +1083,23 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     "  exit 0\n"
                     "fi\n"
                     "printf '%s:%s\\n' \"$(basename \"$0\")\" \"$*\" >> \"${STACK_VALIDATION_LOG:?}\"\n"
-                    "printf 'bootstrap:%s\\n' \"${CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE:-}\" >> \"${STACK_VALIDATION_LOG:?}\"\n",
+                    "printf 'bootstrap:%s\\n' \"${CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE:-}\" >> \"${STACK_VALIDATION_LOG:?}\"\n"
+                    "if [[ \"$(basename \"$0\")\" == make && "
+                    "-n \"${MUTATE_RUNTIME_CLI_AFTER_MATCH:-}\" && "
+                    "\"$*\" == *\"${MUTATE_RUNTIME_CLI_AFTER_MATCH}\"* ]]; then\n"
+                    "  printf '# drift\\n' >>\"${CONTAINER_RUNTIME_CLI:?}\"\n"
+                    "fi\n",
                     encoding="utf-8",
                 )
                 tool.chmod(0o755)
+            for directory, marker in ((tools, "competing"), (candidate_tools, "candidate")):
+                container_tool = directory / "container"
+                container_tool.write_text(
+                    "#!/usr/bin/env bash\n"
+                    f"printf '%s\\n' {shlex.quote(marker)}\n",
+                    encoding="utf-8",
+                )
+                container_tool.chmod(0o755)
             go_tool = tools / "go"
             go_tool.write_text(
                 "#!/usr/bin/env bash\n"
@@ -1099,6 +1119,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             environment["STACK_VALIDATION_LOG"] = str(log)
             environment["FAKE_GO_VERSION"] = "go1.26.3"
             environment["CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"] = "/tmp/runtime-init.oci.tar"
+            environment["CONTAINER_RUNTIME_CLI"] = str(candidate_tools_resolved / "container")
             environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
                 root / "checkpoints"
             )
@@ -1119,15 +1140,22 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
             self.assertEqual(full.returncode, 0, full.stderr)
             full_commands = log.read_text(encoding="utf-8")
+            resolved_container = container.resolve()
             self.assertIn(
-                f"make:-C {containerization} check containerization examples docs coverage fetch-default-kernel integration",
+                f"make:-C {containerization} PATH={candidate_tools_resolved}{os.pathsep}{tools}",
+                full_commands,
+            )
+            self.assertIn(
+                "check containerization examples docs coverage fetch-default-kernel integration",
                 full_commands,
             )
             self.assertIn(
                 "make:-C "
                 f"{container} "
-                f"APP_ROOT={container}/.test-scratch/stack-release-app-root "
-                f"LOG_ROOT={container}/.test-scratch/stack-release-log-root "
+                f"PATH={candidate_tools_resolved}{os.pathsep}{tools}"
+                f"{os.pathsep}{environment['PATH'].split(os.pathsep, 1)[1]} "
+                f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
+                f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "INTEGRATION_SERVICE_NAMESPACE=io.github.container.stack-validation.fixture "
                 "check container dsym docs coverage",
                 full_commands,
@@ -1208,6 +1236,83 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 changed_toolchain.stdout,
             )
 
+            packaged_log = root / "packaged-commands.log"
+            packaged_checkpoints = root / "packaged-checkpoints"
+            packaged_environments = []
+            for index in (1, 2):
+                packaged_tools = root / f"packaged-candidate-{index}"
+                packaged_tools.mkdir()
+                packaged_cli = packaged_tools / "container"
+                packaged_cli.write_text(
+                    "#!/usr/bin/env bash\nprintf 'packaged candidate\\n'\n",
+                    encoding="utf-8",
+                )
+                packaged_cli.chmod(0o555)
+                packaged_environment = environment.copy()
+                packaged_environment["PATH"] = (
+                    f"{packaged_tools}{os.pathsep}{environment['PATH']}"
+                )
+                packaged_environment["STACK_VALIDATION_LOG"] = str(packaged_log)
+                packaged_environment["CONTAINER_RUNTIME_CLI"] = str(packaged_cli)
+                packaged_environment["CONTAINER_RUNTIME_CANDIDATE_SHA256"] = "a" * 64
+                packaged_environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
+                    packaged_checkpoints
+                )
+                packaged_environments.append(packaged_environment)
+
+            first_packaged = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=packaged_environments[0],
+                text=True,
+            )
+            self.assertEqual(first_packaged.returncode, 0, first_packaged.stderr)
+            first_packaged_commands = packaged_log.read_text(encoding="utf-8")
+            second_packaged = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=packaged_environments[1],
+                text=True,
+            )
+            self.assertEqual(second_packaged.returncode, 0, second_packaged.stderr)
+            self.assertEqual(
+                packaged_log.read_text(encoding="utf-8"),
+                first_packaged_commands,
+                first_packaged.stdout
+                + first_packaged.stderr
+                + second_packaged.stdout
+                + second_packaged.stderr,
+            )
+            self.assertEqual(
+                second_packaged.stdout.count(
+                    "reusing exact-input validation checkpoint:"
+                ),
+                4,
+                second_packaged.stdout,
+            )
+
+            drift_environment = environment.copy()
+            drift_environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
+                root / "drift-checkpoints"
+            )
+            drift_environment["MUTATE_RUNTIME_CLI_AFTER_MATCH"] = str(
+                containerization
+            )
+            drift = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=drift_environment,
+                text=True,
+            )
+            self.assertEqual(drift.returncode, 2)
+            self.assertIn("Container CLI content drifted", drift.stderr)
+            self.assertFalse(
+                (root / "drift-checkpoints" / "full-containerization.sha256").exists()
+            )
+
             log.unlink()
             hosted = subprocess.run(
                 [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],
@@ -1225,8 +1330,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "make:-C "
                 f"{container} "
-                f"APP_ROOT={container}/.test-scratch/stack-release-app-root "
-                f"LOG_ROOT={container}/.test-scratch/stack-release-log-root "
+                f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
+                f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "check container dsym docs coverage-unit",
                 hosted_commands,
             )
@@ -1248,13 +1353,35 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
             self.assertEqual(relative.returncode, 0, relative.stderr)
             relative_commands = log.read_text(encoding="utf-8")
-            resolved_container = container.resolve()
             self.assertIn(
                 "make:-C container "
                 f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
                 f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "check container dsym docs coverage-unit",
                 relative_commands,
+            )
+
+            log.unlink()
+            container_link = root / "container-link"
+            container_link.symlink_to(container, target_is_directory=True)
+            symlink_paths = validation_paths.copy()
+            symlink_paths[3] = str(container_link)
+            symlinked = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "hosted", *symlink_paths],
+                check=False,
+                capture_output=True,
+                env=environment,
+                text=True,
+            )
+            self.assertEqual(symlinked.returncode, 0, symlinked.stderr)
+            symlinked_commands = log.read_text(encoding="utf-8")
+            self.assertIn(
+                "make:-C "
+                f"{container_link} "
+                f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
+                f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
+                "check container dsym docs coverage-unit",
+                symlinked_commands,
             )
 
             log.unlink()
@@ -1272,11 +1399,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
             self.assertEqual(external.returncode, 0, external.stderr)
             external_commands = log.read_text(encoding="utf-8")
+            resolved_external_scratch = external_scratch.resolve()
             self.assertIn(
                 "make:-C "
                 f"{container} "
-                f"APP_ROOT={external_scratch}/stack-release-app-root "
-                f"LOG_ROOT={external_scratch}/stack-release-log-root "
+                f"APP_ROOT={resolved_external_scratch}/stack-release-app-root "
+                f"LOG_ROOT={resolved_external_scratch}/stack-release-log-root "
                 "check container dsym docs coverage-unit",
                 external_commands,
             )
@@ -1294,6 +1422,25 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "CONTAINER_STACK_VALIDATION_SCRATCH_ROOT must be an absolute path",
                 invalid.stderr,
+            )
+
+            root_link = root / "root-link"
+            root_link.symlink_to(Path("/"), target_is_directory=True)
+            root_environment = environment.copy()
+            root_environment["CONTAINER_STACK_VALIDATION_SCRATCH_ROOT"] = str(
+                root_link
+            )
+            root_scratch = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=root_environment,
+                text=True,
+            )
+            self.assertEqual(root_scratch.returncode, 2)
+            self.assertIn(
+                "CONTAINER_STACK_VALIDATION_SCRATCH_ROOT must not resolve to /",
+                root_scratch.stderr,
             )
 
     def test_hosted_release_gate_uses_an_unpublished_verified_tag_and_immutable_tap_snapshot(
@@ -1473,10 +1620,139 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('profile_root="${runtime_parent}/profiles"', local_gate)
         self.assertIn('mkdir -p "${profile_root}"', local_gate)
         self.assertIn('LLVM_PROFILE_FILE="${profile_root}/%p-%m.profraw"', local_gate)
+        self.assertIn(
+            'init_image_archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"',
+            local_gate,
+        )
+        self.assertIn(
+            "local release gate requires an absolute retained OCI init-image archive",
+            local_gate,
+        )
+        self.assertIn(
+            'CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="${init_image_archive}"',
+            local_gate,
+        )
+        self.assertIn(
+            'CONTAINER_STACK_VALIDATION_SCRATCH_ROOT="${evidence_root}/container-scratch"',
+            local_gate,
+        )
         self.assertLess(
             local_gate.index('profile_root="${runtime_parent}/profiles"'),
             local_gate.index('"${path}/scripts/run-with-container-runtime.sh"'),
         )
+
+    def test_local_release_gate_freezes_the_container_runtime_candidate(self) -> None:
+        staging = self.script[
+            self.script.index("stage_container_runtime_candidate() {") : self.script.index(
+                "# Delete only the fresh marker-protected candidate extraction"
+            )
+        ]
+        local_gate = self.script[
+            self.script.index("run_local_release_gate() {") : self.script.index(
+                "# Verify that Apple remotes cannot be pushed"
+            )
+        ]
+
+        self.assertIn("git -C \"${container_path}\" rev-parse", staging)
+        self.assertIn("homebrew-package \"HOMEBREW_ARCHIVE=${archive}\"", staging)
+        self.assertIn("shasum -a 256 -c", staging)
+        self.assertIn("tar -xzf \"${archive}\"", staging)
+        self.assertIn("chmod -R a-w", staging)
+        self.assertIn("candidate_parent=/private/tmp", staging)
+        self.assertNotIn('candidate_parent="${artifact_root}/runs"', staging)
+        self.assertIn(".container-compose-runtime-candidate-artifact", staging)
+        self.assertIn(".container-compose-runtime-candidate-run", staging)
+        self.assertNotIn('make -C "${container_path}" container', local_gate)
+        self.assertIn(
+            'container_binary="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container"',
+            local_gate,
+        )
+        self.assertIn(
+            'CONTAINER_RUNTIME_CANDIDATE_SHA256="${CONTAINER_RUNTIME_CANDIDATE_SHA256}"',
+            local_gate,
+        )
+        self.assertIn(
+            '"CONTAINER_BUILDER_SHIM_STACK_REPO=$(repo_path "container-builder-shim")"',
+            local_gate,
+        )
+        self.assertIn(
+            '"CONTAINERIZATION_STACK_REPO=${containerization_path}"',
+            local_gate,
+        )
+        self.assertIn('"CONTAINER_STACK_REPO=${container_path}"', local_gate)
+        self.assertIn(
+            '"CONTAINER_COMPOSE_CONTAINER=${container_binary}"',
+            local_gate,
+        )
+        self.assertIn("trap cleanup_container_runtime_candidate EXIT", local_gate)
+        self.assertIn(
+            "/private/tmp/container-compose-runtime-candidate.*",
+            self.script,
+        )
+
+    def test_runtime_candidate_staging_is_read_only_reusable_and_marker_cleaned(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            container = root / "container"
+            container.mkdir()
+            (container / "fixture").write_text("source\n", encoding="utf-8")
+            for command in (
+                ["git", "init", "--quiet", str(container)],
+                ["git", "-C", str(container), "config", "user.email", "test@example.com"],
+                ["git", "-C", str(container), "config", "user.name", "Container Test"],
+                ["git", "-C", str(container), "add", "."],
+                ["git", "-C", str(container), "commit", "--quiet", "-m", "fixture"],
+            ):
+                subprocess.run(command, check=True, capture_output=True, text=True)
+
+            bin_directory = root / "bin"
+            bin_directory.mkdir()
+            fake_make = bin_directory / "make"
+            fake_make.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                "archive=\n"
+                "for argument in \"$@\"; do\n"
+                "  case \"$argument\" in\n"
+                "    HOMEBREW_ARCHIVE=*) archive=${argument#*=} ;;\n"
+                "  esac\n"
+                "done\n"
+                "test -n \"$archive\"\n"
+                "payload=$(mktemp -d)\n"
+                "mkdir -p \"$payload/bin\" \"$payload/libexec/container\"\n"
+                "printf '#!/usr/bin/env bash\\nexit 0\\n' >\"$payload/bin/container\"\n"
+                "chmod +x \"$payload/bin/container\"\n"
+                "tar -czf \"$archive\" -C \"$payload\" .\n"
+                "(cd \"$(dirname \"$archive\")\" && "
+                "shasum -a 256 \"$(basename \"$archive\")\" >\"$(basename \"$archive\").sha256\")\n"
+                "find \"$payload\" -depth -delete\n",
+                encoding="utf-8",
+            )
+            fake_make.chmod(0o755)
+            evidence = root / "evidence"
+            result = self.run_release_function(
+                root,
+                f"evidence={shlex.quote(str(evidence))}; "
+                "stage_container_runtime_candidate "
+                f"{shlex.quote(str(container))} {shlex.quote(str(evidence))}; "
+                "test -x \"$CONTAINER_RUNTIME_CANDIDATE_ROOT/bin/container\"; "
+                "test ! -w \"$CONTAINER_RUNTIME_CANDIDATE_ROOT/bin/container\"; "
+                "test \"${CONTAINER_RUNTIME_CANDIDATE_ROOT#\"$evidence\"/}\" = "
+                '"$CONTAINER_RUNTIME_CANDIDATE_ROOT"; '
+                "candidate_root=$CONTAINER_RUNTIME_CANDIDATE_ROOT; "
+                "test \"${#CONTAINER_RUNTIME_CANDIDATE_SHA256}\" -eq 64; "
+                "cleanup_container_runtime_candidate; test ! -e \"$candidate_root\"",
+                shell_setup=f"export PATH={shlex.quote(str(bin_directory))}:$PATH",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            artifacts = list((evidence / "runtime-candidates").glob("*"))
+            self.assertEqual(len(artifacts), 1)
+            self.assertTrue(
+                (artifacts[0] / ".container-compose-runtime-candidate-artifact").is_file()
+            )
 
     def test_local_virtualization_preflight_requires_hardware_support(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1154,7 +1154,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 f"{container} "
                 f"PATH={candidate_tools_resolved}{os.pathsep}{tools}"
                 f"{os.pathsep}{environment['PATH'].split(os.pathsep, 1)[1]} "
-                f"APP_ROOT={resolved_container}/.test-scratch/runtime/stack-release-app-root "
+                "APP_ROOT=/private/tmp/ccsv.fixture/stack-release-app-root "
                 f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "INTEGRATION_SERVICE_NAMESPACE=io.github.container.stack-validation.fixture "
                 "check container dsym docs coverage",
@@ -1501,6 +1501,23 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 root_runtime.stderr,
             )
 
+            long_runtime_environment = environment.copy()
+            long_runtime_environment["CONTAINER_STACK_VALIDATION_RUNTIME_ROOT"] = str(
+                root / ("long-runtime-" + "x" * 80)
+            )
+            long_runtime = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "full", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=long_runtime_environment,
+                text=True,
+            )
+            self.assertEqual(long_runtime.returncode, 2)
+            self.assertIn(
+                "exceeds the provider Unix socket path limit",
+                long_runtime.stderr,
+            )
+
     def test_hosted_release_gate_uses_an_unpublished_verified_tag_and_immutable_tap_snapshot(
         self,
     ) -> None:
@@ -1695,11 +1712,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             local_gate,
         )
         self.assertIn(
-            'CONTAINER_STACK_VALIDATION_RUNTIME_ROOT="${runtime_parent}/container-integration"',
+            'CONTAINER_STACK_VALIDATION_RUNTIME_ROOT="${runtime_parent}/i"',
             local_gate,
         )
         self.assertIn("runtime_parent_base=/private/tmp", local_gate)
         self.assertNotIn('${TMPDIR:-/tmp}/cc-release.', local_gate)
+        self.assertIn('${runtime_parent_base}/c.XXXXXX', local_gate)
         self.assertIn("resolve_release_evidence_root", local_gate)
         self.assertLess(
             local_gate.index('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${init_image_archive}"'),

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2114,6 +2114,76 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 (artifacts[0] / ".container-compose-runtime-candidate-artifact").is_file()
             )
 
+    def test_runtime_candidate_staging_cleans_interrupted_build_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            container = root / "container"
+            container.mkdir()
+            (container / "fixture").write_text("source\n", encoding="utf-8")
+            for command in (
+                ["git", "init", "--quiet", str(container)],
+                ["git", "-C", str(container), "config", "user.email", "test@example.com"],
+                ["git", "-C", str(container), "config", "user.name", "Container Test"],
+                ["git", "-C", str(container), "add", "."],
+                ["git", "-C", str(container), "commit", "--quiet", "-m", "fixture"],
+            ):
+                subprocess.run(command, check=True, capture_output=True, text=True)
+
+            bin_directory = root / "bin"
+            bin_directory.mkdir()
+            ready = root / "ready"
+            fake_make = bin_directory / "make"
+            fake_make.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -u\n"
+                "trap 'exit 143' TERM\n"
+                'touch "${BUILD_READY:?}"\n'
+                "while :; do sleep 1; done\n",
+                encoding="utf-8",
+            )
+            fake_make.chmod(0o755)
+            evidence = root / "evidence"
+            shell = "\n".join(
+                [
+                    "set -euo pipefail",
+                    "export CONTAINER_STACK_RELEASE_LIBRARY=1",
+                    f"source {shlex.quote(str(SCRIPT))}",
+                    f"ROOT={shlex.quote(str(root))}",
+                    "EXECUTE=1",
+                    f"export PATH={shlex.quote(str(bin_directory))}:$PATH",
+                    f"export BUILD_READY={shlex.quote(str(ready))}",
+                    "stage_container_runtime_candidate "
+                    f"{shlex.quote(str(container))} {shlex.quote(str(evidence))}",
+                ]
+            )
+            process = subprocess.Popen(
+                ["bash", "-c", shell],
+                cwd=ROOT,
+                env=self.non_interactive_environment(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+            deadline = time.monotonic() + 10
+            while not ready.exists() and process.poll() is None:
+                if time.monotonic() >= deadline:
+                    os.killpg(process.pid, signal.SIGKILL)
+                    process.wait(timeout=10)
+                    self.fail("runtime candidate package build did not start")
+                time.sleep(0.05)
+
+            os.killpg(process.pid, signal.SIGTERM)
+            stdout, stderr = process.communicate(timeout=10)
+
+            self.assertEqual(process.returncode, 143, stdout + stderr)
+            artifact_parent = evidence / "runtime-candidates"
+            self.assertEqual(list(artifact_parent.glob(".build-*")), [])
+            self.assertEqual(
+                [path for path in artifact_parent.iterdir() if not path.name.startswith(".")],
+                [],
+            )
+
     def test_local_virtualization_preflight_requires_hardware_support(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1952,6 +1952,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertEqual(interrupted.returncode, 143, interrupted.stderr)
         self.assertFalse(runtime_parent.exists(), interrupted.stderr)
 
+    def test_creator_disarms_exit_cleanup_after_successful_publication(self) -> None:
+        published = self.run_release_function(
+            Path("/tmp"),
+            'published="$(create_release_runtime_parent /tmp)"; '
+            'test -d "$published"; '
+            'cleanup_release_runtime_parent "$published"; '
+            'test ! -e "$published"',
+        )
+
+        self.assertEqual(published.returncode, 0, published.stderr)
+        self.assertEqual(published.stderr, "")
+
     def test_release_evidence_root_is_absolute_canonical_and_not_root(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1154,7 +1154,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 f"{container} "
                 f"PATH={candidate_tools_resolved}{os.pathsep}{tools}"
                 f"{os.pathsep}{environment['PATH'].split(os.pathsep, 1)[1]} "
-                f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
+                f"APP_ROOT={resolved_container}/.test-scratch/runtime/stack-release-app-root "
                 f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "INTEGRATION_SERVICE_NAMESPACE=io.github.container.stack-validation.fixture "
                 "check container dsym docs coverage",
@@ -1330,7 +1330,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "make:-C "
                 f"{container} "
-                f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
+                f"APP_ROOT={resolved_container}/.test-scratch/runtime/stack-release-app-root "
                 f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "check container dsym docs coverage-unit",
                 hosted_commands,
@@ -1355,7 +1355,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             relative_commands = log.read_text(encoding="utf-8")
             self.assertIn(
                 "make:-C container "
-                f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
+                f"APP_ROOT={resolved_container}/.test-scratch/runtime/stack-release-app-root "
                 f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "check container dsym docs coverage-unit",
                 relative_commands,
@@ -1378,7 +1378,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "make:-C "
                 f"{container_link} "
-                f"APP_ROOT={resolved_container}/.test-scratch/stack-release-app-root "
+                f"APP_ROOT={resolved_container}/.test-scratch/runtime/stack-release-app-root "
                 f"LOG_ROOT={resolved_container}/.test-scratch/stack-release-log-root "
                 "check container dsym docs coverage-unit",
                 symlinked_commands,
@@ -1403,10 +1403,34 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "make:-C "
                 f"{container} "
-                f"APP_ROOT={resolved_external_scratch}/stack-release-app-root "
+                f"APP_ROOT={resolved_external_scratch}/runtime/stack-release-app-root "
                 f"LOG_ROOT={resolved_external_scratch}/stack-release-log-root "
                 "check container dsym docs coverage-unit",
                 external_commands,
+            )
+
+            log.unlink()
+            internal_runtime = root / "internal-launchd-runtime"
+            split_environment = external_environment.copy()
+            split_environment["CONTAINER_STACK_VALIDATION_RUNTIME_ROOT"] = str(
+                internal_runtime
+            )
+            split = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=split_environment,
+                text=True,
+            )
+            self.assertEqual(split.returncode, 0, split.stderr)
+            split_commands = log.read_text(encoding="utf-8")
+            self.assertIn(
+                "make:-C "
+                f"{container} "
+                f"APP_ROOT={internal_runtime.resolve()}/stack-release-app-root "
+                f"LOG_ROOT={resolved_external_scratch}/stack-release-log-root "
+                "check container dsym docs coverage-unit",
+                split_commands,
             )
 
             invalid_environment = environment.copy()
@@ -1441,6 +1465,40 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(
                 "CONTAINER_STACK_VALIDATION_SCRATCH_ROOT must not resolve to /",
                 root_scratch.stderr,
+            )
+
+            relative_runtime_environment = environment.copy()
+            relative_runtime_environment[
+                "CONTAINER_STACK_VALIDATION_RUNTIME_ROOT"
+            ] = ".runtime"
+            relative_runtime = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=relative_runtime_environment,
+                text=True,
+            )
+            self.assertEqual(relative_runtime.returncode, 2)
+            self.assertIn(
+                "CONTAINER_STACK_VALIDATION_RUNTIME_ROOT must be an absolute path",
+                relative_runtime.stderr,
+            )
+
+            root_runtime_environment = environment.copy()
+            root_runtime_environment["CONTAINER_STACK_VALIDATION_RUNTIME_ROOT"] = str(
+                root_link
+            )
+            root_runtime = subprocess.run(
+                [str(STACK_RELEASE_VALIDATION), "hosted", *validation_paths],
+                check=False,
+                capture_output=True,
+                env=root_runtime_environment,
+                text=True,
+            )
+            self.assertEqual(root_runtime.returncode, 2)
+            self.assertIn(
+                "CONTAINER_STACK_VALIDATION_RUNTIME_ROOT must not resolve to /",
+                root_runtime.stderr,
             )
 
     def test_hosted_release_gate_uses_an_unpublished_verified_tag_and_immutable_tap_snapshot(
@@ -1636,10 +1694,47 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             'CONTAINER_STACK_VALIDATION_SCRATCH_ROOT="${evidence_root}/container-scratch"',
             local_gate,
         )
+        self.assertIn(
+            'CONTAINER_STACK_VALIDATION_RUNTIME_ROOT="${runtime_parent}/container-integration"',
+            local_gate,
+        )
+        self.assertIn("runtime_parent_base=/private/tmp", local_gate)
+        self.assertNotIn('${TMPDIR:-/tmp}/cc-release.', local_gate)
+        self.assertIn("resolve_release_evidence_root", local_gate)
+        self.assertLess(
+            local_gate.index('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${init_image_archive}"'),
+            local_gate.index('stage_container_runtime_candidate "${container_path}"'),
+        )
         self.assertLess(
             local_gate.index('profile_root="${runtime_parent}/profiles"'),
             local_gate.index('"${path}/scripts/run-with-container-runtime.sh"'),
         )
+
+    def test_release_evidence_root_is_absolute_canonical_and_not_root(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "compose"
+            compose.mkdir()
+            relative = self.run_release_function(
+                root,
+                "resolve_release_evidence_root "
+                f"{shlex.quote(str(compose))} .build/release-evidence",
+            )
+            self.assertEqual(relative.returncode, 0, relative.stderr)
+            self.assertEqual(
+                relative.stdout.strip(),
+                str((compose / ".build" / "release-evidence").resolve()),
+            )
+
+            root_link = root / "root-link"
+            root_link.symlink_to(Path("/"), target_is_directory=True)
+            rejected = self.run_release_function(
+                root,
+                "resolve_release_evidence_root "
+                f"{shlex.quote(str(compose))} {shlex.quote(str(root_link))}",
+            )
+            self.assertEqual(rejected.returncode, 2)
+            self.assertIn("must not resolve to /", rejected.stderr)
 
     def test_local_release_gate_freezes_the_container_runtime_candidate(self) -> None:
         staging = self.script[

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1901,6 +1901,45 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
             self.assertEqual(cleaned.returncode, 0, cleaned.stderr)
 
+    def test_creator_cleanup_stays_armed_through_path_publication(self) -> None:
+        runtime_parent = Path("/tmp") / (
+            f"c.publication-test.{os.getpid()}.{time.time_ns()}"
+        )
+        self.addCleanup(
+            lambda: subprocess.run(
+                ["find", str(runtime_parent), "-depth", "-delete"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if runtime_parent.exists()
+            else None
+        )
+        shell_setup = textwrap.dedent(
+            f"""\
+            runtime_parent_fixture={shlex.quote(str(runtime_parent))}
+            mktemp() {{
+              mkdir "${{runtime_parent_fixture}}"
+              builtin printf '%s\\n' "${{runtime_parent_fixture}}"
+            }}
+            printf() {{
+              if [[ "$#" -eq 2 && "$1" == '%s\\n' && "$2" == "${{runtime_parent_fixture}}" ]]; then
+                kill -TERM "${{BASHPID}}"
+              fi
+              builtin printf "$@"
+            }}
+            """
+        )
+
+        interrupted = self.run_release_function(
+            Path("/tmp"),
+            'published="$(create_release_runtime_parent /tmp)"',
+            shell_setup=shell_setup,
+        )
+
+        self.assertEqual(interrupted.returncode, 143, interrupted.stderr)
+        self.assertFalse(runtime_parent.exists(), interrupted.stderr)
+
     def test_release_evidence_root_is_absolute_canonical_and_not_root(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -20,10 +20,12 @@
 import json
 import os
 import re
+import signal
 import shlex
 import subprocess
 import tempfile
 import textwrap
+import time
 import unittest
 from pathlib import Path
 
@@ -975,6 +977,24 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("check-licenses vet lint coverage build", validation)
         self.assertIn("run-stack-release-validation.sh full", makefile)
         self.assertIn("run-stack-release-validation.sh hosted", makefile)
+        direct_full_gate = subprocess.run(
+            [
+                "make",
+                "-n",
+                "container-stack-release-validation",
+                "CONTAINER_COMPOSE_CONTAINER=container",
+            ],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=self.non_interactive_environment(),
+        )
+        self.assertEqual(direct_full_gate.returncode, 0, direct_full_gate.stderr)
+        self.assertIn(
+            'CONTAINER_RUNTIME_CLI="container"',
+            direct_full_gate.stdout,
+        )
         self.assertIn(
             "containerization_targets=(check containerization examples docs coverage fetch-default-kernel integration)",
             validation,
@@ -1750,6 +1770,72 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             local_gate.index('profile_root="${runtime_parent}/profiles"'),
             local_gate.index('"${path}/scripts/run-with-container-runtime.sh"'),
         )
+
+    def test_local_release_gate_waits_for_signal_cleanup_before_candidate_deletion(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            candidate_root = root / "candidate"
+            candidate_bin = candidate_root / "bin"
+            candidate_bin.mkdir(parents=True)
+            candidate_cli = candidate_bin / "container"
+            candidate_cli.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            candidate_cli.chmod(0o755)
+            ready = root / "ready"
+            stop_complete = root / "stop-complete"
+            removed = root / "removed"
+            fake_gate = root / "fake-gate"
+            fake_gate.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -u\n"
+                "trap 'test -x \"$CANDIDATE_ROOT/bin/container\"; "
+                "touch \"$STOP_COMPLETE\"; exit 143' TERM\n"
+                "touch \"$READY\"\n"
+                "while :; do sleep 1; done\n",
+                encoding="utf-8",
+            )
+            fake_gate.chmod(0o755)
+            shell = "\n".join(
+                [
+                    "set -u",
+                    "export CONTAINER_STACK_RELEASE_LIBRARY=1",
+                    f"source {shlex.quote(str(SCRIPT))}",
+                    f"export CANDIDATE_ROOT={shlex.quote(str(candidate_root))}",
+                    f"export READY={shlex.quote(str(ready))}",
+                    f"export STOP_COMPLETE={shlex.quote(str(stop_complete))}",
+                    "status=0",
+                    f"run_local_release_gate_command {shlex.quote(str(fake_gate))} "
+                    "|| status=$?",
+                    'test -f "$STOP_COMPLETE"',
+                    'find "$CANDIDATE_ROOT" -depth -delete',
+                    f"touch {shlex.quote(str(removed))}",
+                    'exit "$status"',
+                ]
+            )
+            process = subprocess.Popen(
+                ["bash", "-c", shell],
+                cwd=ROOT,
+                env=self.non_interactive_environment(),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+            deadline = time.monotonic() + 10
+            while not ready.exists() and process.poll() is None:
+                if time.monotonic() >= deadline:
+                    process.kill()
+                    self.fail("outer release gate did not become ready")
+                time.sleep(0.05)
+
+            os.killpg(process.pid, signal.SIGTERM)
+            stdout, stderr = process.communicate(timeout=10)
+
+            self.assertEqual(process.returncode, 143, stdout + stderr)
+            self.assertTrue(stop_complete.exists(), stdout + stderr)
+            self.assertTrue(removed.exists(), stdout + stderr)
+            self.assertFalse(candidate_root.exists(), stdout + stderr)
 
     def test_release_evidence_root_is_absolute_canonical_and_not_root(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1756,7 +1756,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             local_gate,
         )
         self.assertNotIn('${TMPDIR:-/tmp}/cc-release.', local_gate)
-        self.assertIn('${runtime_parent_base}/c.XXXXXX', local_gate)
+        self.assertIn(
+            'runtime_parent="$(create_release_runtime_parent "${runtime_parent_base}")"',
+            local_gate,
+        )
+        self.assertIn(
+            '.container-compose-release-runtime-parent',
+            self.script,
+        )
+        self.assertLess(
+            local_gate.index('create_release_runtime_parent "${runtime_parent_base}"'),
+            local_gate.index('run_local_release_gate_command env'),
+        )
         self.assertIn(
             '[[ ! -d "${candidate_parent}" || ! -w "${candidate_parent}" ]]',
             self.script,
@@ -1860,6 +1871,36 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     self.assertTrue(removed.exists(), stdout + stderr)
                     self.assertFalse(candidate_root.exists(), stdout + stderr)
 
+    def test_outer_marker_cleans_a_pre_runtime_interrupt_root(self) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="cc-parent-test.") as directory:
+            fixture_root = Path(directory)
+            runtime_parent = Path(
+                tempfile.mkdtemp(prefix="c.pre-marker-test.", dir="/tmp")
+            )
+            self.addCleanup(
+                lambda: subprocess.run(
+                    ["find", str(runtime_parent), "-depth", "-delete"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if runtime_parent.exists()
+                else None
+            )
+            (runtime_parent / ".container-compose-release-runtime-parent").write_text(
+                "container-compose release runtime parent v1\n", encoding="utf-8"
+            )
+            (runtime_parent / "profiles").mkdir()
+
+            cleaned = self.run_release_function(
+                fixture_root,
+                "cleanup_release_runtime_parent "
+                f"{shlex.quote(str(runtime_parent))}; "
+                f"test ! -e {shlex.quote(str(runtime_parent))}",
+            )
+
+            self.assertEqual(cleaned.returncode, 0, cleaned.stderr)
+
     def test_release_evidence_root_is_absolute_canonical_and_not_root(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -1929,7 +1970,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             '"CONTAINER_COMPOSE_CONTAINER=${container_binary}"',
             local_gate,
         )
-        self.assertIn("trap cleanup_container_runtime_candidate EXIT", local_gate)
+        self.assertIn("trap cleanup_local_release_gate_roots EXIT", local_gate)
+        self.assertIn("cleanup_container_runtime_candidate || cleanup_failed=1", local_gate)
         self.assertIn(
             "/private/tmp/container-compose-runtime-candidate.*",
             self.script,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1775,67 +1775,78 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            candidate_root = root / "candidate"
-            candidate_bin = candidate_root / "bin"
-            candidate_bin.mkdir(parents=True)
-            candidate_cli = candidate_bin / "container"
-            candidate_cli.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
-            candidate_cli.chmod(0o755)
-            ready = root / "ready"
-            stop_complete = root / "stop-complete"
-            removed = root / "removed"
-            fake_gate = root / "fake-gate"
-            fake_gate.write_text(
-                "#!/usr/bin/env bash\n"
-                "set -u\n"
-                "trap 'test -x \"$CANDIDATE_ROOT/bin/container\"; "
-                "touch \"$STOP_COMPLETE\"; exit 143' TERM\n"
-                "touch \"$READY\"\n"
-                "while :; do sleep 1; done\n",
-                encoding="utf-8",
-            )
-            fake_gate.chmod(0o755)
-            shell = "\n".join(
-                [
-                    "set -u",
-                    "export CONTAINER_STACK_RELEASE_LIBRARY=1",
-                    f"source {shlex.quote(str(SCRIPT))}",
-                    f"export CANDIDATE_ROOT={shlex.quote(str(candidate_root))}",
-                    f"export READY={shlex.quote(str(ready))}",
-                    f"export STOP_COMPLETE={shlex.quote(str(stop_complete))}",
-                    "status=0",
-                    f"run_local_release_gate_command {shlex.quote(str(fake_gate))} "
-                    "|| status=$?",
-                    'test -f "$STOP_COMPLETE"',
-                    'find "$CANDIDATE_ROOT" -depth -delete',
-                    f"touch {shlex.quote(str(removed))}",
-                    'exit "$status"',
-                ]
-            )
-            process = subprocess.Popen(
-                ["bash", "-c", shell],
-                cwd=ROOT,
-                env=self.non_interactive_environment(),
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                text=True,
-                start_new_session=True,
-            )
-            deadline = time.monotonic() + 10
-            while not ready.exists() and process.poll() is None:
-                if time.monotonic() >= deadline:
-                    process.kill()
-                    self.fail("outer release gate did not become ready")
-                time.sleep(0.05)
+            for delivered_signal, expected_status in (
+                (signal.SIGINT, 130),
+                (signal.SIGTERM, 143),
+            ):
+                with self.subTest(signal=delivered_signal.name):
+                    root = Path(directory) / delivered_signal.name
+                    candidate_root = root / "candidate"
+                    candidate_bin = candidate_root / "bin"
+                    candidate_bin.mkdir(parents=True)
+                    candidate_cli = candidate_bin / "container"
+                    candidate_cli.write_text(
+                        "#!/usr/bin/env bash\nexit 0\n", encoding="utf-8"
+                    )
+                    candidate_cli.chmod(0o755)
+                    ready = root / "ready"
+                    stop_complete = root / "stop-complete"
+                    removed = root / "removed"
+                    fake_gate = root / "fake-gate"
+                    fake_gate.write_text(
+                        "#!/usr/bin/env bash\n"
+                        "set -u\n"
+                        "cleanup() { test -x \"$CANDIDATE_ROOT/bin/container\"; "
+                        "touch \"$STOP_COMPLETE\"; }\n"
+                        "trap 'cleanup; exit 130' INT\n"
+                        "trap 'cleanup; exit 143' TERM\n"
+                        "touch \"$READY\"\n"
+                        "while :; do sleep 1; done\n",
+                        encoding="utf-8",
+                    )
+                    fake_gate.chmod(0o755)
+                    shell = "\n".join(
+                        [
+                            "set -u",
+                            "export CONTAINER_STACK_RELEASE_LIBRARY=1",
+                            f"source {shlex.quote(str(SCRIPT))}",
+                            f"export CANDIDATE_ROOT={shlex.quote(str(candidate_root))}",
+                            f"export READY={shlex.quote(str(ready))}",
+                            f"export STOP_COMPLETE={shlex.quote(str(stop_complete))}",
+                            "status=0",
+                            "run_local_release_gate_command "
+                            f"{shlex.quote(str(fake_gate))} || status=$?",
+                            'test -f "$STOP_COMPLETE"',
+                            'find "$CANDIDATE_ROOT" -depth -delete',
+                            f"touch {shlex.quote(str(removed))}",
+                            'exit "$status"',
+                        ]
+                    )
+                    process = subprocess.Popen(
+                        ["bash", "-c", shell],
+                        cwd=ROOT,
+                        env=self.non_interactive_environment(),
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        text=True,
+                        start_new_session=True,
+                    )
+                    deadline = time.monotonic() + 10
+                    while not ready.exists() and process.poll() is None:
+                        if time.monotonic() >= deadline:
+                            process.kill()
+                            self.fail("outer release gate did not become ready")
+                        time.sleep(0.05)
 
-            os.killpg(process.pid, signal.SIGTERM)
-            stdout, stderr = process.communicate(timeout=10)
+                    os.killpg(process.pid, delivered_signal)
+                    stdout, stderr = process.communicate(timeout=10)
 
-            self.assertEqual(process.returncode, 143, stdout + stderr)
-            self.assertTrue(stop_complete.exists(), stdout + stderr)
-            self.assertTrue(removed.exists(), stdout + stderr)
-            self.assertFalse(candidate_root.exists(), stdout + stderr)
+                    self.assertEqual(
+                        process.returncode, expected_status, stdout + stderr
+                    )
+                    self.assertTrue(stop_complete.exists(), stdout + stderr)
+                    self.assertTrue(removed.exists(), stdout + stderr)
+                    self.assertFalse(candidate_root.exists(), stdout + stderr)
 
     def test_release_evidence_root_is_absolute_canonical_and_not_root(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/validate-oci-image-layout.py
+++ b/Tools/release/validate-oci-image-layout.py
@@ -197,6 +197,13 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                 config = load_json(config_payload, f"{context}.config")
                 if platform is not None and not isinstance(platform, dict):
                     raise ValidationError(f"{context} platform must be an object")
+                if platform is not None and (
+                    platform.get("os") != config.get("os")
+                    or platform.get("architecture") != config.get("architecture")
+                ):
+                    raise ValidationError(
+                        f"{context} descriptor platform does not match image config"
+                    )
                 platform_source = platform if platform is not None else config
                 compatible = (
                     platform_source.get("os") == "linux"

--- a/Tools/release/validate-oci-image-layout.py
+++ b/Tools/release/validate-oci-image-layout.py
@@ -102,7 +102,7 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
         if not isinstance(root_manifests, list):
             raise ValidationError("index.json manifests must be an array")
 
-        validated: set[str] = set()
+        validated: dict[tuple[str, str], bool] = {}
 
         def descriptor_payload(descriptor: Any, context: str) -> tuple[bytes, str, str]:
             if not isinstance(descriptor, dict):
@@ -150,11 +150,11 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                 raise ValidationError(f"{context} digest mismatch for {digest}")
             return b"".join(chunks), media_type, digest
 
-        def validate_descriptor(descriptor: Any, context: str) -> None:
+        def validate_descriptor(descriptor: Any, context: str) -> bool:
             payload, media_type, digest = descriptor_payload(descriptor, context)
-            if digest in validated:
-                return
-            validated.add(digest)
+            cache_key = (digest, media_type)
+            if cache_key in validated:
+                return validated[cache_key]
 
             if media_type in INDEX_MEDIA_TYPES:
                 nested = load_json(payload, f"{context} {digest}")
@@ -163,8 +163,12 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                 manifests = nested.get("manifests")
                 if not isinstance(manifests, list):
                     raise ValidationError(f"{context} {digest} manifests must be an array")
+                contains_image = False
                 for position, child in enumerate(manifests):
-                    validate_descriptor(child, f"{context}.manifests[{position}]")
+                    contains_image = (
+                        validate_descriptor(child, f"{context}.manifests[{position}]")
+                        or contains_image
+                    )
                 subject = nested.get("subject")
                 if subject is not None:
                     subject_media_type = (
@@ -176,7 +180,8 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                         validate_descriptor(subject, f"{context}.subject")
                     else:
                         descriptor_payload(subject, f"{context}.subject")
-                return
+                validated[cache_key] = contains_image
+                return contains_image
 
             if media_type in MANIFEST_MEDIA_TYPES:
                 manifest = load_json(payload, f"{context} {digest}")
@@ -199,7 +204,8 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                         validate_descriptor(subject, f"{context}.subject")
                     else:
                         descriptor_payload(subject, f"{context}.subject")
-                return
+                validated[cache_key] = True
+                return True
 
             if media_type == ARTIFACT_MEDIA_TYPE:
                 manifest = load_json(payload, f"{context} {digest}")
@@ -219,7 +225,8 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                         validate_descriptor(subject, f"{context}.subject")
                     else:
                         descriptor_payload(subject, f"{context}.subject")
-                return
+                validated[cache_key] = False
+                return False
 
             raise ValidationError(
                 f"{context} uses unsupported manifest mediaType: {media_type}"
@@ -227,7 +234,9 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
 
         available: dict[str, str] = {}
         for position, manifest in enumerate(root_manifests):
-            validate_descriptor(manifest, f"index.json.manifests[{position}]")
+            contains_image = validate_descriptor(
+                manifest, f"index.json.manifests[{position}]"
+            )
             if not isinstance(manifest, dict):
                 continue
             annotations = manifest.get("annotations", {})
@@ -237,7 +246,7 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                 )
             reference = annotations.get("org.opencontainers.image.ref.name")
             digest = manifest.get("digest")
-            if isinstance(reference, str):
+            if isinstance(reference, str) and contains_image:
                 if reference in available and available[reference] != digest:
                     raise ValidationError(
                         f"required reference is ambiguous: {reference}"

--- a/Tools/release/validate-oci-image-layout.py
+++ b/Tools/release/validate-oci-image-layout.py
@@ -200,6 +200,11 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                 if platform is not None and (
                     platform.get("os") != config.get("os")
                     or platform.get("architecture") != config.get("architecture")
+                    or (
+                        platform.get("variant") is not None
+                        and config.get("variant") is not None
+                        and platform.get("variant") != config.get("variant")
+                    )
                 ):
                     raise ValidationError(
                         f"{context} descriptor platform does not match image config"

--- a/Tools/release/validate-oci-image-layout.py
+++ b/Tools/release/validate-oci-image-layout.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Validate a retained OCI image-layout archive and its descriptor closure."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import re
+import sys
+import tarfile
+from typing import Any
+
+
+INDEX_MEDIA_TYPES = {
+    "application/vnd.oci.image.index.v1+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+}
+MANIFEST_MEDIA_TYPES = {
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.docker.distribution.manifest.v2+json",
+}
+ARTIFACT_MEDIA_TYPE = "application/vnd.oci.artifact.manifest.v1+json"
+DIGEST_PATTERN = re.compile(r"^[a-z0-9]+(?:[+._-][a-z0-9]+)*:[0-9a-f]+$")
+
+
+class ValidationError(ValueError):
+    """An OCI layout invariant was not satisfied."""
+
+
+def normalized_member_name(name: str) -> str:
+    path = PurePosixPath(name)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValidationError(f"archive contains unsafe member path: {name}")
+    parts = list(path.parts)
+    while parts and parts[0] == ".":
+        parts.pop(0)
+    return str(PurePosixPath(*parts))
+
+
+def load_json(payload: bytes, context: str) -> dict[str, Any]:
+    try:
+        value = json.loads(payload)
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValidationError(f"{context} is not valid JSON ({error})") from error
+    if not isinstance(value, dict):
+        raise ValidationError(f"{context} must contain a JSON object")
+    return value
+
+
+def validate_archive(archive_path: Path, required_references: set[str]) -> None:
+    try:
+        archive = tarfile.open(archive_path, "r:*")
+    except (OSError, tarfile.TarError) as error:
+        raise ValidationError(f"archive is unreadable ({error})") from error
+
+    with archive:
+        members: dict[str, tarfile.TarInfo] = {}
+        for member in archive.getmembers():
+            name = normalized_member_name(member.name)
+            if name in {".", ""} or member.isdir():
+                continue
+            if name in members:
+                raise ValidationError(f"archive contains duplicate member: {name}")
+            if not member.isfile():
+                raise ValidationError(f"archive member is not a regular file: {name}")
+            members[name] = member
+
+        def read_member(name: str) -> bytes:
+            member = members.get(name)
+            if member is None:
+                raise ValidationError(f"archive is missing required member: {name}")
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise ValidationError(f"archive member is unreadable: {name}")
+            return stream.read()
+
+        layout = load_json(read_member("oci-layout"), "oci-layout")
+        if layout.get("imageLayoutVersion") != "1.0.0":
+            raise ValidationError("oci-layout imageLayoutVersion must be 1.0.0")
+
+        index = load_json(read_member("index.json"), "index.json")
+        if index.get("schemaVersion") != 2:
+            raise ValidationError("index.json schemaVersion must be 2")
+        root_manifests = index.get("manifests")
+        if not isinstance(root_manifests, list):
+            raise ValidationError("index.json manifests must be an array")
+
+        validated: set[str] = set()
+
+        def descriptor_payload(descriptor: Any, context: str) -> tuple[bytes, str, str]:
+            if not isinstance(descriptor, dict):
+                raise ValidationError(f"{context} descriptor must be an object")
+            digest = descriptor.get("digest")
+            size = descriptor.get("size")
+            media_type = descriptor.get("mediaType")
+            if not isinstance(digest, str) or DIGEST_PATTERN.fullmatch(digest) is None:
+                raise ValidationError(f"{context} has an invalid digest: {digest!r}")
+            if not isinstance(size, int) or isinstance(size, bool) or size < 0:
+                raise ValidationError(f"{context} has an invalid size: {size!r}")
+            if not isinstance(media_type, str) or not media_type:
+                raise ValidationError(f"{context} has no mediaType")
+            algorithm, encoded = digest.split(":", 1)
+            try:
+                hasher = hashlib.new(algorithm)
+            except ValueError as error:
+                raise ValidationError(
+                    f"{context} uses unsupported digest algorithm: {algorithm}"
+                ) from error
+            member_name = f"blobs/{algorithm}/{encoded}"
+            member = members.get(member_name)
+            if member is None:
+                raise ValidationError(
+                    f"archive is missing required member: {member_name}"
+                )
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise ValidationError(f"archive member is unreadable: {member_name}")
+            retain_payload = media_type in (
+                INDEX_MEDIA_TYPES | MANIFEST_MEDIA_TYPES | {ARTIFACT_MEDIA_TYPE}
+            )
+            chunks: list[bytes] = []
+            actual_size = 0
+            while chunk := stream.read(1024 * 1024):
+                actual_size += len(chunk)
+                hasher.update(chunk)
+                if retain_payload:
+                    chunks.append(chunk)
+            if actual_size != size:
+                raise ValidationError(
+                    f"{context} size mismatch for {digest}: expected {size}, got {actual_size}"
+                )
+            if hasher.hexdigest() != encoded:
+                raise ValidationError(f"{context} digest mismatch for {digest}")
+            return b"".join(chunks), media_type, digest
+
+        def validate_descriptor(descriptor: Any, context: str) -> None:
+            payload, media_type, digest = descriptor_payload(descriptor, context)
+            if digest in validated:
+                return
+            validated.add(digest)
+
+            if media_type in INDEX_MEDIA_TYPES:
+                nested = load_json(payload, f"{context} {digest}")
+                if nested.get("schemaVersion") != 2:
+                    raise ValidationError(f"{context} {digest} schemaVersion must be 2")
+                manifests = nested.get("manifests")
+                if not isinstance(manifests, list):
+                    raise ValidationError(f"{context} {digest} manifests must be an array")
+                for position, child in enumerate(manifests):
+                    validate_descriptor(child, f"{context}.manifests[{position}]")
+                subject = nested.get("subject")
+                if subject is not None:
+                    subject_media_type = (
+                        subject.get("mediaType") if isinstance(subject, dict) else None
+                    )
+                    if subject_media_type in (
+                        INDEX_MEDIA_TYPES | MANIFEST_MEDIA_TYPES | {ARTIFACT_MEDIA_TYPE}
+                    ):
+                        validate_descriptor(subject, f"{context}.subject")
+                    else:
+                        descriptor_payload(subject, f"{context}.subject")
+                return
+
+            if media_type in MANIFEST_MEDIA_TYPES:
+                manifest = load_json(payload, f"{context} {digest}")
+                if manifest.get("schemaVersion") != 2:
+                    raise ValidationError(f"{context} {digest} schemaVersion must be 2")
+                descriptor_payload(manifest.get("config"), f"{context}.config")
+                layers = manifest.get("layers")
+                if not isinstance(layers, list):
+                    raise ValidationError(f"{context} {digest} layers must be an array")
+                for position, layer in enumerate(layers):
+                    descriptor_payload(layer, f"{context}.layers[{position}]")
+                subject = manifest.get("subject")
+                if subject is not None:
+                    subject_media_type = (
+                        subject.get("mediaType") if isinstance(subject, dict) else None
+                    )
+                    if subject_media_type in (
+                        INDEX_MEDIA_TYPES | MANIFEST_MEDIA_TYPES | {ARTIFACT_MEDIA_TYPE}
+                    ):
+                        validate_descriptor(subject, f"{context}.subject")
+                    else:
+                        descriptor_payload(subject, f"{context}.subject")
+                return
+
+            if media_type == ARTIFACT_MEDIA_TYPE:
+                manifest = load_json(payload, f"{context} {digest}")
+                blobs = manifest.get("blobs")
+                if not isinstance(blobs, list):
+                    raise ValidationError(f"{context} {digest} blobs must be an array")
+                for position, blob in enumerate(blobs):
+                    descriptor_payload(blob, f"{context}.blobs[{position}]")
+                subject = manifest.get("subject")
+                if subject is not None:
+                    subject_media_type = (
+                        subject.get("mediaType") if isinstance(subject, dict) else None
+                    )
+                    if subject_media_type in (
+                        INDEX_MEDIA_TYPES | MANIFEST_MEDIA_TYPES | {ARTIFACT_MEDIA_TYPE}
+                    ):
+                        validate_descriptor(subject, f"{context}.subject")
+                    else:
+                        descriptor_payload(subject, f"{context}.subject")
+                return
+
+            raise ValidationError(
+                f"{context} uses unsupported manifest mediaType: {media_type}"
+            )
+
+        available: dict[str, str] = {}
+        for position, manifest in enumerate(root_manifests):
+            validate_descriptor(manifest, f"index.json.manifests[{position}]")
+            if not isinstance(manifest, dict):
+                continue
+            annotations = manifest.get("annotations", {})
+            if not isinstance(annotations, dict):
+                raise ValidationError(
+                    f"index.json.manifests[{position}] annotations must be an object"
+                )
+            reference = annotations.get("org.opencontainers.image.ref.name")
+            digest = manifest.get("digest")
+            if isinstance(reference, str):
+                if reference in available and available[reference] != digest:
+                    raise ValidationError(
+                        f"required reference is ambiguous: {reference}"
+                    )
+                available[reference] = digest
+
+        missing = sorted(required_references - available.keys())
+        if missing:
+            raise ValidationError(
+                "archive is missing required reference(s): " + ", ".join(missing)
+            )
+        required_digests = {available[reference] for reference in required_references}
+        if len(required_digests) > 1:
+            raise ValidationError(
+                "archive required references do not resolve to one digest: "
+                + ", ".join(
+                    f"{reference}={available[reference]}"
+                    for reference in sorted(required_references)
+                )
+            )
+
+
+def main(arguments: list[str]) -> int:
+    if len(arguments) < 2:
+        print(
+            f"usage: {Path(arguments[0]).name} OCI_ARCHIVE [REQUIRED_REFERENCE ...]",
+            file=sys.stderr,
+        )
+        return 2
+    archive = Path(arguments[1])
+    try:
+        validate_archive(archive, set(arguments[2:]))
+    except ValidationError as error:
+        print(
+            f"container runtime init-image archive is not a complete OCI archive: "
+            f"{archive} ({error})",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/Tools/release/validate-oci-image-layout.py
+++ b/Tools/release/validate-oci-image-layout.py
@@ -102,9 +102,11 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
         if not isinstance(root_manifests, list):
             raise ValidationError("index.json manifests must be an array")
 
-        validated: dict[tuple[str, str], bool] = {}
+        validated: dict[tuple[str, str, str], bool] = {}
 
-        def descriptor_payload(descriptor: Any, context: str) -> tuple[bytes, str, str]:
+        def descriptor_payload(
+            descriptor: Any, context: str, *, retain: bool = False
+        ) -> tuple[bytes, str, str]:
             if not isinstance(descriptor, dict):
                 raise ValidationError(f"{context} descriptor must be an object")
             digest = descriptor.get("digest")
@@ -132,7 +134,7 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
             stream = archive.extractfile(member)
             if stream is None:
                 raise ValidationError(f"archive member is unreadable: {member_name}")
-            retain_payload = media_type in (
+            retain_payload = retain or media_type in (
                 INDEX_MEDIA_TYPES | MANIFEST_MEDIA_TYPES | {ARTIFACT_MEDIA_TYPE}
             )
             chunks: list[bytes] = []
@@ -152,7 +154,9 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
 
         def validate_descriptor(descriptor: Any, context: str) -> bool:
             payload, media_type, digest = descriptor_payload(descriptor, context)
-            cache_key = (digest, media_type)
+            platform = descriptor.get("platform") if isinstance(descriptor, dict) else None
+            platform_key = json.dumps(platform, sort_keys=True)
+            cache_key = (digest, media_type, platform_key)
             if cache_key in validated:
                 return validated[cache_key]
 
@@ -187,7 +191,17 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                 manifest = load_json(payload, f"{context} {digest}")
                 if manifest.get("schemaVersion") != 2:
                     raise ValidationError(f"{context} {digest} schemaVersion must be 2")
-                descriptor_payload(manifest.get("config"), f"{context}.config")
+                config_payload, _, _ = descriptor_payload(
+                    manifest.get("config"), f"{context}.config", retain=True
+                )
+                config = load_json(config_payload, f"{context}.config")
+                if platform is not None and not isinstance(platform, dict):
+                    raise ValidationError(f"{context} platform must be an object")
+                platform_source = platform if platform is not None else config
+                compatible = (
+                    platform_source.get("os") == "linux"
+                    and platform_source.get("architecture") == "arm64"
+                )
                 layers = manifest.get("layers")
                 if not isinstance(layers, list):
                     raise ValidationError(f"{context} {digest} layers must be an array")
@@ -204,8 +218,8 @@ def validate_archive(archive_path: Path, required_references: set[str]) -> None:
                         validate_descriptor(subject, f"{context}.subject")
                     else:
                         descriptor_payload(subject, f"{context}.subject")
-                validated[cache_key] = True
-                return True
+                validated[cache_key] = compatible
+                return compatible
 
             if media_type == ARTIFACT_MEDIA_TYPE:
                 manifest = load_json(payload, f"{context} {digest}")

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -747,7 +747,14 @@ run_local_release_gate_command() {
   trap 'wait_for_candidate_cleanup_on_signal INT 130' INT
   trap 'wait_for_candidate_cleanup_on_signal TERM 143' TERM
 
-  "$@" &
+  # Bash gives asynchronous commands ignored SIGINT/SIGQUIT dispositions and
+  # otherwise keeps an intermediate subshell whose death would make this wait
+  # finish before the exec'd wrapper cleans up. Reset the dispositions inside
+  # that child and exec the wrapper so child_pid remains the runtime owner.
+  (
+    trap - INT TERM
+    exec "$@"
+  ) &
   child_pid=$!
   # Cover a signal delivered after the launch decision but before Bash stored
   # $!: re-deliver it to the child now that its PID is known.

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -808,6 +808,10 @@ run_local_release_gate_command() {
     # candidate executable used by the child's cleanup trap.
     trap '' INT TERM
     if [[ -n "${child_pid}" ]]; then
+      # A direct signal to this helper does not reach the background cleanup
+      # owner. Forward it before waiting; a process-group signal is harmlessly
+      # redelivered because the wrapper ignores repeats while cleaning up.
+      kill -s "${signal_name}" "${child_pid}" 2>/dev/null || true
       if wait "${child_pid}"; then
         child_status=0
       else

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -717,6 +717,59 @@ cleanup_container_runtime_candidate() {
   find "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" -depth -delete
 }
 
+# Run the candidate-owned gate in the background so this shell can explicitly
+# wait for its namespace cleanup when the process group receives INT or TERM.
+# The candidate extraction must remain present until the wrapper's signal trap
+# has completed its namespace-scoped `system stop`.
+run_local_release_gate_command() {
+  local child_pid=""
+  local child_status=0
+  local signal_name=""
+  local signal_status=0
+
+  # shellcheck disable=SC2329
+  wait_for_candidate_cleanup_on_signal() {
+    signal_name="$1"
+    signal_status="$2"
+    # A second signal must not interrupt the one wait that protects the
+    # candidate executable used by the child's cleanup trap.
+    trap - INT TERM
+    if [[ -n "${child_pid}" ]]; then
+      if wait "${child_pid}"; then
+        child_status=0
+      else
+        child_status=$?
+      fi
+      child_pid=""
+    fi
+  }
+
+  trap 'wait_for_candidate_cleanup_on_signal INT 130' INT
+  trap 'wait_for_candidate_cleanup_on_signal TERM 143' TERM
+
+  "$@" &
+  child_pid=$!
+  # Cover a signal delivered after the launch decision but before Bash stored
+  # $!: re-deliver it to the child now that its PID is known.
+  if [[ -n "${signal_name}" ]]; then
+    kill -s "${signal_name}" "${child_pid}" 2>/dev/null || true
+  fi
+  if [[ -n "${child_pid}" ]]; then
+    if wait "${child_pid}"; then
+      child_status=0
+    else
+      child_status=$?
+    fi
+    child_pid=""
+  fi
+
+  trap - INT TERM
+  if ((signal_status != 0)); then
+    return "${signal_status}"
+  fi
+  return "${child_status}"
+}
+
 # Resolve retained evidence before it is also used as an absolute build/log
 # scratch root. Relative values are Compose-checkout-relative, matching the
 # documented .build/... form, and symlinks cannot smuggle the root directory
@@ -813,7 +866,7 @@ PY
   profile_root="${runtime_parent}/profiles"
   mkdir -p "${profile_root}"
   status=0
-  env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
+  run_local_release_gate_command env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
     -u CONTAINER_RUNTIME_SERVICE_NAMESPACE -u CONTAINER_RUNTIME_RUN_ID \
     HAWKEYE_AUTO_INSTALL=1 \
     CONTAINER_RUNTIME_APP_ROOT="${runtime_app_root}" \

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -733,7 +733,7 @@ run_local_release_gate_command() {
     signal_status="$2"
     # A second signal must not interrupt the one wait that protects the
     # candidate executable used by the child's cleanup trap.
-    trap - INT TERM
+    trap '' INT TERM
     if [[ -n "${child_pid}" ]]; then
       if wait "${child_pid}"; then
         child_status=0

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -138,6 +138,11 @@ Environment:
   CONTAINER_STACK_COMPOSE_PACKAGE_POLL_SECONDS
       Override the default one-hour package workflow wait and 30-second poll.
 
+  CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE
+      Absolute path to the retained OCI init-image archive used by the local
+      release gate. Execute mode requires this hermetic bootstrap input so
+      runtime startup cannot fall back to a mutable registry or host login.
+
   CONTAINER_STACK_RELEASE_ROOT
       Override the parent directory containing the four source checkouts and
       the Homebrew tap. Defaults to ~/github. Use an isolated stack root for
@@ -591,9 +596,130 @@ require_local_virtualization() {
   fi
 }
 
+# Build one packaged Container runtime for the exact source head, then unpack
+# it into a fresh read-only root for this gate. Keep the reusable archive and
+# its evidence on the configured artifact volume, but stage launchd-managed
+# executables on the local system volume. macOS launchd can register an
+# executable from a removable volume with ownership disabled while leaving its
+# process stuck in xpcproxy, which otherwise surfaces only as an opaque XPC
+# timeout. Later sibling validation may rebuild the source checkout, but it
+# cannot replace the candidate already running or change the identity bound
+# into reusable checkpoint evidence.
+stage_container_runtime_candidate() {
+  local container_path="$1" evidence_root="$2"
+  local container_head artifact_parent artifact_root build_root archive archive_digest
+  local marker marker_value candidate_parent
+
+  container_head="$(git -C "${container_path}" rev-parse --verify 'HEAD^{commit}')"
+  artifact_parent="${evidence_root}/runtime-candidates"
+  artifact_root="${artifact_parent}/${container_head}"
+  archive="${artifact_root}/container-homebrew-debug-arm64.tar.gz"
+  marker="${artifact_root}/.container-compose-runtime-candidate-artifact"
+
+  mkdir -p "${artifact_parent}"
+  if [[ -e "${artifact_root}" ]]; then
+    marker_value=""
+    if [[ -f "${marker}" ]]; then
+      IFS= read -r marker_value <"${marker}" || true
+    fi
+    if [[ "${marker_value}" != "container-compose runtime candidate artifact v1 ${container_head}" ]]; then
+      printf 'refusing to reuse an unmarked Container runtime candidate artifact: %s\n' \
+        "${artifact_root}" >&2
+      return 1
+    fi
+    if [[ ! -f "${archive}" || ! -f "${archive}.sha256" ]]; then
+      printf 'Container runtime candidate artifact is incomplete: %s\n' \
+        "${artifact_root}" >&2
+      return 1
+    fi
+    if ! (cd "${artifact_root}" && shasum -a 256 -c "$(basename "${archive}.sha256")"); then
+      printf 'Container runtime candidate artifact checksum is invalid: %s\n' \
+        "${archive}" >&2
+      return 1
+    fi
+  else
+    build_root="$(mktemp -d "${artifact_parent}/.build-${container_head}.XXXXXX")"
+    archive="${build_root}/container-homebrew-debug-arm64.tar.gz"
+    if ! make -C "${container_path}" homebrew-package "HOMEBREW_ARCHIVE=${archive}"; then
+      printf 'failed to build the packaged Container runtime candidate in: %s\n' \
+        "${build_root}" >&2
+      find "${build_root}" -depth -delete
+      return 1
+    fi
+    if ! (cd "${build_root}" && shasum -a 256 -c "$(basename "${archive}.sha256")"); then
+      printf 'new Container runtime candidate artifact checksum is invalid: %s\n' \
+        "${archive}" >&2
+      find "${build_root}" -depth -delete
+      return 1
+    fi
+    printf 'container-compose runtime candidate artifact v1 %s\n' \
+      "${container_head}" >"${build_root}/.container-compose-runtime-candidate-artifact"
+    mv "${build_root}" "${artifact_root}"
+    archive="${artifact_root}/container-homebrew-debug-arm64.tar.gz"
+  fi
+
+  archive_digest="$(shasum -a 256 "${archive}" | awk '{print $1}')"
+  candidate_parent=/private/tmp
+  if [[ ! -d "${candidate_parent}" ]]; then
+    candidate_parent=/tmp
+  fi
+  CONTAINER_RUNTIME_CANDIDATE_ROOT="$(mktemp -d \
+    "${candidate_parent}/container-compose-runtime-candidate.${container_head}.XXXXXX")"
+  if ! tar -xzf "${archive}" -C "${CONTAINER_RUNTIME_CANDIDATE_ROOT}"; then
+    printf 'failed to extract the Container runtime candidate archive: %s\n' \
+      "${archive}" >&2
+    find "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" -depth -delete
+    CONTAINER_RUNTIME_CANDIDATE_ROOT=""
+    return 1
+  fi
+  if [[ ! -x "${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container" ]]; then
+    printf 'packaged Container runtime candidate has no executable CLI: %s\n' \
+      "${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container" >&2
+    find "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" -depth -delete
+    CONTAINER_RUNTIME_CANDIDATE_ROOT=""
+    return 1
+  fi
+  printf 'container-compose runtime candidate run v1 %s %s\n' \
+    "${container_head}" "${archive_digest}" \
+    >"${CONTAINER_RUNTIME_CANDIDATE_ROOT}/.container-compose-runtime-candidate-run"
+  chmod -R a-w "${CONTAINER_RUNTIME_CANDIDATE_ROOT}"
+
+  CONTAINER_RUNTIME_CANDIDATE_SHA256="${archive_digest}"
+}
+
+# Delete only the fresh marker-protected candidate extraction owned by this gate.
+cleanup_container_runtime_candidate() {
+  [[ -n "${CONTAINER_RUNTIME_CANDIDATE_ROOT:-}" ]] || return 0
+
+  case "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" in
+    /private/tmp/container-compose-runtime-candidate.* | /tmp/container-compose-runtime-candidate.*)
+      ;;
+    *)
+      printf 'refusing to remove a runtime candidate outside local temporary storage: %s\n' \
+        "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" >&2
+      return 1
+      ;;
+  esac
+
+  local marker="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/.container-compose-runtime-candidate-run"
+  local marker_value=""
+  if [[ -f "${marker}" ]]; then
+    IFS= read -r marker_value <"${marker}" || true
+  fi
+  if [[ "${marker_value}" != container-compose\ runtime\ candidate\ run\ v1\ * ]]; then
+    printf 'refusing to remove an unmarked Container runtime candidate root: %s\n' \
+      "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" >&2
+    return 1
+  fi
+
+  chmod -R u+w "${CONTAINER_RUNTIME_CANDIDATE_ROOT}"
+  find "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" -depth -delete
+}
+
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
-  local path repository container_path containerization_path container_binary runtime_parent runtime_app_root profile_root
+  (
+  local path repository container_path containerization_path container_binary runtime_parent runtime_app_root profile_root evidence_root init_image_archive
   local containerization_reference required_init_references status marker_value
   path="$(repo_path "${COMPOSE_REPO}")"
   container_path="$(repo_path "${CONTAINER_REPO}")"
@@ -623,18 +749,23 @@ run_local_release_gate() {
     )
   done
   run make -C "${containerization_path}" fetch-default-kernel
-  run make -C "${container_path}" container
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run the complete local gate inside one fresh marker-protected runtime lifecycle\n'
+    printf 'would package an immutable Container runtime candidate and run the complete local gate inside one fresh marker-protected runtime lifecycle\n'
     return 0
   fi
 
-  container_binary="${container_path}/bin/container"
-  if [[ ! -x "${container_binary}" ]]; then
-    printf 'local release gate did not produce an executable Container CLI: %s\n' \
-      "${container_binary}" >&2
-    exit 1
+  init_image_archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
+  if [[ "${init_image_archive}" != /* || ! -f "${init_image_archive}" ]]; then
+    printf 'local release gate requires an absolute retained OCI init-image archive via CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE: %s\n' \
+      "${init_image_archive:-unset}" >&2
+    return 2
   fi
+  init_image_archive="$(cd "$(dirname "${init_image_archive}")" && pwd -P)/$(basename "${init_image_archive}")"
+
+  evidence_root="${PARITY_EVIDENCE_DIR:-${path}/.build/release-evidence}"
+  stage_container_runtime_candidate "${container_path}" "${evidence_root}"
+  trap cleanup_container_runtime_candidate EXIT
+  container_binary="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container"
   containerization_reference="$(python3 - "${path}/Tools/release/stack-refs.json" <<'PY'
 import json
 from pathlib import Path
@@ -655,12 +786,20 @@ PY
     HAWKEYE_AUTO_INSTALL=1 \
     CONTAINER_RUNTIME_APP_ROOT="${runtime_app_root}" \
     CONTAINER_RUNTIME_INIT_BLOCK_REPO="${container_path}" \
+    CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="${init_image_archive}" \
     CONTAINERIZATION_INIT_SOURCE_PATH="${containerization_path}" \
     CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES="${required_init_references}" \
-    CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR="${PARITY_EVIDENCE_DIR:-${path}/.build/release-evidence}/stack-validation" \
+    CONTAINER_RUNTIME_CANDIDATE_SHA256="${CONTAINER_RUNTIME_CANDIDATE_SHA256}" \
+    CONTAINER_STACK_VALIDATION_SCRATCH_ROOT="${evidence_root}/container-scratch" \
+    CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR="${evidence_root}/stack-validation" \
     LLVM_PROFILE_FILE="${profile_root}/%p-%m.profraw" \
     "${path}/scripts/run-with-container-runtime.sh" "${container_binary}" \
-    make -C "${path}" release-gate "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}" || status=$?
+    make -C "${path}" release-gate \
+    "CONTAINER_BUILDER_SHIM_STACK_REPO=$(repo_path "container-builder-shim")" \
+    "CONTAINERIZATION_STACK_REPO=${containerization_path}" \
+    "CONTAINER_STACK_REPO=${container_path}" \
+    "CONTAINER_COMPOSE_CONTAINER=${container_binary}" \
+    "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}" || status=$?
 
   marker_value=""
   if [[ -f "${runtime_app_root}/.container-compose-runtime-root" ]]; then
@@ -671,8 +810,15 @@ PY
   else
     printf 'refusing to remove release runtime root without its valid marker: %s\n' \
       "${runtime_parent}" >&2
+    status=1
   fi
+  if ! cleanup_container_runtime_candidate; then
+    status=1
+  fi
+  CONTAINER_RUNTIME_CANDIDATE_ROOT=""
+  trap - EXIT
   return "${status}"
+  )
 }
 
 # Verify that Apple remotes cannot be pushed and stephenlclarke remotes are the target.

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -788,6 +788,10 @@ create_release_runtime_parent() {
     >"${runtime_parent}/.container-compose-release-runtime-parent"
   runtime_parent_published=1
   printf '%s\n' "${runtime_parent}"
+  # Publication is complete. Ignore a late signal before disarming EXIT so it
+  # cannot outlive this function and expand locals that have left scope.
+  trap '' INT TERM
+  trap - EXIT
 }
 
 # Run the candidate-owned gate in the background so this shell can explicitly

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -806,7 +806,9 @@ PY
   if [[ ! -d "${runtime_parent_base}" ]]; then
     runtime_parent_base=/tmp
   fi
-  runtime_parent="$(mktemp -d "${runtime_parent_base}/cc-release.XXXXXX")"
+  # Keep both this candidate's provider socket and Container integration's
+  # nested provider socket below Darwin's 103-byte sockaddr_un limit.
+  runtime_parent="$(mktemp -d "${runtime_parent_base}/c.XXXXXX")"
   runtime_app_root="${runtime_parent}/app"
   profile_root="${runtime_parent}/profiles"
   mkdir -p "${profile_root}"
@@ -821,7 +823,7 @@ PY
     CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES="${required_init_references}" \
     CONTAINER_RUNTIME_CANDIDATE_SHA256="${CONTAINER_RUNTIME_CANDIDATE_SHA256}" \
     CONTAINER_STACK_VALIDATION_SCRATCH_ROOT="${evidence_root}/container-scratch" \
-    CONTAINER_STACK_VALIDATION_RUNTIME_ROOT="${runtime_parent}/container-integration" \
+    CONTAINER_STACK_VALIDATION_RUNTIME_ROOT="${runtime_parent}/i" \
     CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR="${evidence_root}/stack-validation" \
     LLVM_PROFILE_FILE="${profile_root}/%p-%m.profraw" \
     "${path}/scripts/run-with-container-runtime.sh" "${container_binary}" \

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -661,7 +661,7 @@ stage_container_runtime_candidate() {
 
   archive_digest="$(shasum -a 256 "${archive}" | awk '{print $1}')"
   candidate_parent=/private/tmp
-  if [[ ! -d "${candidate_parent}" ]]; then
+  if [[ ! -d "${candidate_parent}" || ! -w "${candidate_parent}" ]]; then
     candidate_parent=/tmp
   fi
   CONTAINER_RUNTIME_CANDIDATE_ROOT="$(mktemp -d \

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -755,11 +755,16 @@ cleanup_release_runtime_parent() {
 create_release_runtime_parent() {
   local runtime_parent_base="$1"
   local runtime_parent=""
+  local runtime_parent_published=0
 
   # shellcheck disable=SC2329
   cleanup_incomplete_release_runtime_parent() {
     local trapped_status=$?
     trap - EXIT
+    trap '' INT TERM
+    if ((trapped_status == 0 && runtime_parent_published != 0)); then
+      return 0
+    fi
     if [[ -n "${runtime_parent}" && -d "${runtime_parent}" ]]; then
       case "${runtime_parent}" in
         /private/tmp/c.* | /tmp/c.*)
@@ -775,11 +780,13 @@ create_release_runtime_parent() {
     return "${trapped_status}"
   }
 
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
   trap cleanup_incomplete_release_runtime_parent EXIT
   runtime_parent="$(mktemp -d "${runtime_parent_base}/c.XXXXXX")"
   printf 'container-compose release runtime parent v1\n' \
     >"${runtime_parent}/.container-compose-release-runtime-parent"
-  trap - EXIT
+  runtime_parent_published=1
   printf '%s\n' "${runtime_parent}"
 }
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -21,6 +21,7 @@ readonly SELF_PATH="${BASH_SOURCE[0]:-$0}"
 SELF_DIRECTORY="$(cd "$(dirname "${SELF_PATH}")" && pwd -P)"
 readonly SELF_DIRECTORY
 readonly COMPOSE_PROMOTION_REVIEW_TOOL="${SELF_DIRECTORY}/../Tools/release/compose_promotion_review.py"
+readonly OCI_IMAGE_LAYOUT_VALIDATOR="${SELF_DIRECTORY}/../Tools/release/validate-oci-image-layout.py"
 SCRIPT_NAME="$(basename "${SELF_PATH}")"
 readonly SCRIPT_NAME
 readonly SCRIPT_USAGE="scripts/${SCRIPT_NAME}"
@@ -716,10 +717,30 @@ cleanup_container_runtime_candidate() {
   find "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" -depth -delete
 }
 
+# Resolve retained evidence before it is also used as an absolute build/log
+# scratch root. Relative values are Compose-checkout-relative, matching the
+# documented .build/... form, and symlinks cannot smuggle the root directory
+# through later destructive cleanup guards.
+resolve_release_evidence_root() {
+  local compose_path="$1"
+  local configured_root="$2"
+  local evidence_root="${configured_root}"
+  if [[ "${evidence_root}" != /* ]]; then
+    evidence_root="${compose_path}/${evidence_root}"
+  fi
+  mkdir -p "${evidence_root}"
+  evidence_root="$(cd "${evidence_root}" && pwd -P)"
+  if [[ "${evidence_root}" == / ]]; then
+    printf 'release evidence root must not resolve to /\n' >&2
+    return 2
+  fi
+  printf '%s\n' "${evidence_root}"
+}
+
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
   (
-  local path repository container_path containerization_path container_binary runtime_parent runtime_app_root profile_root evidence_root init_image_archive
+  local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive
   local containerization_reference required_init_references status marker_value
   path="$(repo_path "${COMPOSE_REPO}")"
   container_path="$(repo_path "${CONTAINER_REPO}")"
@@ -762,10 +783,6 @@ run_local_release_gate() {
   fi
   init_image_archive="$(cd "$(dirname "${init_image_archive}")" && pwd -P)/$(basename "${init_image_archive}")"
 
-  evidence_root="${PARITY_EVIDENCE_DIR:-${path}/.build/release-evidence}"
-  stage_container_runtime_candidate "${container_path}" "${evidence_root}"
-  trap cleanup_container_runtime_candidate EXIT
-  container_binary="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container"
   containerization_reference="$(python3 - "${path}/Tools/release/stack-refs.json" <<'PY'
 import json
 from pathlib import Path
@@ -776,7 +793,20 @@ print(manifest["components"]["containerization"]["ref"])
 PY
 )"
   required_init_references="vminit:container-compose ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
-  runtime_parent="$(mktemp -d "${TMPDIR:-/tmp}/cc-release.XXXXXX")"
+  "${OCI_IMAGE_LAYOUT_VALIDATOR}" "${init_image_archive}" \
+    vminit:container-compose \
+    "ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
+
+  evidence_root="$(resolve_release_evidence_root "${path}" \
+    "${PARITY_EVIDENCE_DIR:-.build/release-evidence}")"
+  stage_container_runtime_candidate "${container_path}" "${evidence_root}"
+  trap cleanup_container_runtime_candidate EXIT
+  container_binary="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container"
+  runtime_parent_base=/private/tmp
+  if [[ ! -d "${runtime_parent_base}" ]]; then
+    runtime_parent_base=/tmp
+  fi
+  runtime_parent="$(mktemp -d "${runtime_parent_base}/cc-release.XXXXXX")"
   runtime_app_root="${runtime_parent}/app"
   profile_root="${runtime_parent}/profiles"
   mkdir -p "${profile_root}"
@@ -791,6 +821,7 @@ PY
     CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES="${required_init_references}" \
     CONTAINER_RUNTIME_CANDIDATE_SHA256="${CONTAINER_RUNTIME_CANDIDATE_SHA256}" \
     CONTAINER_STACK_VALIDATION_SCRATCH_ROOT="${evidence_root}/container-scratch" \
+    CONTAINER_STACK_VALIDATION_RUNTIME_ROOT="${runtime_parent}/container-integration" \
     CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR="${evidence_root}/stack-validation" \
     LLVM_PROFILE_FILE="${profile_root}/%p-%m.profraw" \
     "${path}/scripts/run-with-container-runtime.sh" "${container_binary}" \

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -717,6 +717,72 @@ cleanup_container_runtime_candidate() {
   find "${CONTAINER_RUNTIME_CANDIDATE_ROOT}" -depth -delete
 }
 
+# Delete only the fresh short runtime parent created and marked by this gate.
+# This outer marker exists before the wrapper starts, so an interrupt during
+# input staging, lock acquisition, or the initial stop can still clean up.
+cleanup_release_runtime_parent() {
+  local runtime_parent="$1"
+  [[ -n "${runtime_parent}" ]] || return 0
+
+  case "${runtime_parent}" in
+    /private/tmp/c.* | /tmp/c.*)
+      ;;
+    *)
+      printf 'refusing to remove a release runtime root outside local temporary storage: %s\n' \
+        "${runtime_parent}" >&2
+      return 1
+      ;;
+  esac
+
+  local marker="${runtime_parent}/.container-compose-release-runtime-parent"
+  local marker_value=""
+  if [[ -f "${marker}" ]]; then
+    IFS= read -r marker_value <"${marker}" || true
+  fi
+  if [[ "${marker_value}" != "container-compose release runtime parent v1" ]]; then
+    printf 'refusing to remove a release runtime root without its valid outer marker: %s\n' \
+      "${runtime_parent}" >&2
+    return 1
+  fi
+
+  find "${runtime_parent}" -depth -delete
+}
+
+# Publish a runtime parent path to the caller only after its ownership marker
+# is durable. The command substitution runs this function in a subshell; its
+# EXIT trap can therefore remove the exact mktemp result even if interruption
+# occurs in the otherwise unavoidable directory-before-marker interval.
+create_release_runtime_parent() {
+  local runtime_parent_base="$1"
+  local runtime_parent=""
+
+  # shellcheck disable=SC2329
+  cleanup_incomplete_release_runtime_parent() {
+    local trapped_status=$?
+    trap - EXIT
+    if [[ -n "${runtime_parent}" && -d "${runtime_parent}" ]]; then
+      case "${runtime_parent}" in
+        /private/tmp/c.* | /tmp/c.*)
+          find "${runtime_parent}" -depth -delete
+          ;;
+        *)
+          printf 'refusing to remove an incomplete release runtime root outside local temporary storage: %s\n' \
+            "${runtime_parent}" >&2
+          return 1
+          ;;
+      esac
+    fi
+    return "${trapped_status}"
+  }
+
+  trap cleanup_incomplete_release_runtime_parent EXIT
+  runtime_parent="$(mktemp -d "${runtime_parent_base}/c.XXXXXX")"
+  printf 'container-compose release runtime parent v1\n' \
+    >"${runtime_parent}/.container-compose-release-runtime-parent"
+  trap - EXIT
+  printf '%s\n' "${runtime_parent}"
+}
+
 # Run the candidate-owned gate in the background so this shell can explicitly
 # wait for its namespace cleanup when the process group receives INT or TERM.
 # The candidate extraction must remain present until the wrapper's signal trap
@@ -801,7 +867,7 @@ resolve_release_evidence_root() {
 run_local_release_gate() {
   (
   local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive
-  local containerization_reference required_init_references status marker_value
+  local containerization_reference required_init_references status
   path="$(repo_path "${COMPOSE_REPO}")"
   container_path="$(repo_path "${CONTAINER_REPO}")"
   containerization_path="$(repo_path "containerization")"
@@ -860,7 +926,19 @@ PY
   evidence_root="$(resolve_release_evidence_root "${path}" \
     "${PARITY_EVIDENCE_DIR:-.build/release-evidence}")"
   stage_container_runtime_candidate "${container_path}" "${evidence_root}"
-  trap cleanup_container_runtime_candidate EXIT
+  runtime_parent=""
+  # shellcheck disable=SC2329
+  cleanup_local_release_gate_roots() {
+    local trapped_status=$?
+    local cleanup_failed=0
+    cleanup_release_runtime_parent "${runtime_parent}" || cleanup_failed=1
+    cleanup_container_runtime_candidate || cleanup_failed=1
+    if ((cleanup_failed != 0)); then
+      return 1
+    fi
+    return "${trapped_status}"
+  }
+  trap cleanup_local_release_gate_roots EXIT
   container_binary="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container"
   runtime_parent_base=/private/tmp
   if [[ ! -d "${runtime_parent_base}" || ! -w "${runtime_parent_base}" ]]; then
@@ -868,7 +946,7 @@ PY
   fi
   # Keep both this candidate's provider socket and Container integration's
   # nested provider socket below Darwin's 103-byte sockaddr_un limit.
-  runtime_parent="$(mktemp -d "${runtime_parent_base}/c.XXXXXX")"
+  runtime_parent="$(create_release_runtime_parent "${runtime_parent_base}")"
   runtime_app_root="${runtime_parent}/app"
   profile_root="${runtime_parent}/profiles"
   mkdir -p "${profile_root}"
@@ -894,17 +972,10 @@ PY
     "CONTAINER_COMPOSE_CONTAINER=${container_binary}" \
     "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}" || status=$?
 
-  marker_value=""
-  if [[ -f "${runtime_app_root}/.container-compose-runtime-root" ]]; then
-    IFS= read -r marker_value <"${runtime_app_root}/.container-compose-runtime-root" || true
-  fi
-  if [[ "${marker_value}" == "container-compose isolated runtime state v1" ]]; then
-    find "${runtime_parent}" -depth -delete
-  else
-    printf 'refusing to remove release runtime root without its valid marker: %s\n' \
-      "${runtime_parent}" >&2
+  if ! cleanup_release_runtime_parent "${runtime_parent}"; then
     status=1
   fi
+  runtime_parent=""
   if ! cleanup_container_runtime_candidate; then
     status=1
   fi

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -640,22 +640,46 @@ stage_container_runtime_candidate() {
     fi
   else
     build_root="$(mktemp -d "${artifact_parent}/.build-${container_head}.XXXXXX")"
+    # shellcheck disable=SC2329
+    cleanup_unpublished_runtime_candidate_build() {
+      local trapped_status="${1:-$?}"
+      trap - EXIT
+      trap '' INT TERM
+      if [[ -n "${build_root:-}" && -d "${build_root}" ]]; then
+        case "${build_root}" in
+          "${artifact_parent}/.build-${container_head}."*)
+            find "${build_root}" -depth -delete
+            ;;
+          *)
+            printf 'refusing to remove a runtime candidate build outside its evidence root: %s\n' \
+              "${build_root}" >&2
+            return 1
+            ;;
+        esac
+      fi
+      return "${trapped_status}"
+    }
+    trap 'exit 130' INT
+    trap 'exit 143' TERM
+    trap 'cleanup_unpublished_runtime_candidate_build $?' EXIT
     archive="${build_root}/container-homebrew-debug-arm64.tar.gz"
     if ! make -C "${container_path}" homebrew-package "HOMEBREW_ARCHIVE=${archive}"; then
       printf 'failed to build the packaged Container runtime candidate in: %s\n' \
         "${build_root}" >&2
-      find "${build_root}" -depth -delete
+      cleanup_unpublished_runtime_candidate_build 1 || true
       return 1
     fi
     if ! (cd "${build_root}" && shasum -a 256 -c "$(basename "${archive}.sha256")"); then
       printf 'new Container runtime candidate artifact checksum is invalid: %s\n' \
         "${archive}" >&2
-      find "${build_root}" -depth -delete
+      cleanup_unpublished_runtime_candidate_build 1 || true
       return 1
     fi
     printf 'container-compose runtime candidate artifact v1 %s\n' \
       "${container_head}" >"${build_root}/.container-compose-runtime-candidate-artifact"
     mv "${build_root}" "${artifact_root}"
+    build_root=""
+    trap - EXIT INT TERM
     archive="${artifact_root}/container-homebrew-debug-arm64.tar.gz"
   fi
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -803,7 +803,7 @@ PY
   trap cleanup_container_runtime_candidate EXIT
   container_binary="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container"
   runtime_parent_base=/private/tmp
-  if [[ ! -d "${runtime_parent_base}" ]]; then
+  if [[ ! -d "${runtime_parent_base}" || ! -w "${runtime_parent_base}" ]]; then
     runtime_parent_base=/tmp
   fi
   # Keep both this candidate's provider socket and Container integration's

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -131,47 +131,10 @@ validate_runtime_init_image_archive() {
     if [[ -n "${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES:-}" ]]; then
         required_references+=" ${CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES}"
     fi
-
-    python3 - "$runtime_init_image_archive" "$required_references" <<'PY'
-import json
-from pathlib import Path
-import sys
-import tarfile
-
-archive = Path(sys.argv[1])
-required = set(sys.argv[2].split())
-try:
-    with tarfile.open(archive, "r:*") as bundle:
-        member = next(
-            (item for item in bundle.getmembers() if item.name.lstrip("./") == "index.json"),
-            None,
-        )
-        if member is None:
-            raise ValueError("index.json is missing")
-        stream = bundle.extractfile(member)
-        if stream is None:
-            raise ValueError("index.json is unreadable")
-        index = json.load(stream)
-except (OSError, tarfile.TarError, ValueError, json.JSONDecodeError) as error:
-    raise SystemExit(f"container runtime init-image archive is not a readable OCI archive: {archive} ({error})")
-
-available = {
-    manifest.get("annotations", {}).get("org.opencontainers.image.ref.name"): manifest.get("digest")
-    for manifest in index.get("manifests", [])
-}
-missing = sorted(reference for reference in required if reference not in available)
-if missing:
-    raise SystemExit(
-        "container runtime init-image archive is missing required reference(s): "
-        + ", ".join(missing)
-    )
-digests = {available[reference] for reference in required}
-if len(digests) != 1 or None in digests:
-    raise SystemExit(
-        "container runtime init-image archive required references do not resolve to one digest: "
-        + ", ".join(f"{reference}={available[reference]}" for reference in sorted(required))
-    )
-PY
+    local references=()
+    read -r -a references <<<"$required_references"
+    "$SCRIPT_DIRECTORY/../Tools/release/validate-oci-image-layout.py" \
+        "$runtime_init_image_archive" "${references[@]}"
 }
 
 validate_runtime_inputs() {

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -587,7 +587,7 @@ install_runtime_bootstrap_image() {
 
 cleanup() {
     local status=$?
-    trap - EXIT
+    trap - EXIT INT TERM
     printf 'Stopping matched container runtime...\n'
     stop_runtime || true
     release_container_runtime_lock
@@ -662,6 +662,8 @@ fi
 trap cleanup_runtime_service_inputs EXIT
 stage_runtime_service_inputs
 acquire_container_runtime_lock
+trap 'exit 130' INT
+trap 'exit 143' TERM
 trap cleanup EXIT
 
 printf 'Stopping stale container services...\n'

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -43,10 +43,19 @@ if [[ ! -x "$container_binary" ]]; then
 fi
 container_binary_directory=$(cd "$(dirname "$container_binary")" && pwd -P)
 container_binary="$container_binary_directory/$(basename "$container_binary")"
+container_binary_sha256=$(shasum -a 256 "$container_binary" | awk '{print $1}')
+if [[ -n "${CONTAINER_RUNTIME_CLI_SHA256:-}" &&
+    "${CONTAINER_RUNTIME_CLI_SHA256}" != "$container_binary_sha256" ]]; then
+    printf 'candidate container binary digest mismatch (expected %s, got %s): %s\n' \
+        "${CONTAINER_RUNTIME_CLI_SHA256}" "$container_binary_sha256" "$container_binary" >&2
+    exit 2
+fi
 # Every nested Makefile and helper must resolve the same candidate CLI that
 # owns the isolated runtime. Otherwise a host-installed `container` earlier in
 # PATH can silently target the default service namespace mid-validation.
 export PATH="$container_binary_directory${PATH:+:$PATH}"
+export CONTAINER_RUNTIME_CLI="$container_binary"
+export CONTAINER_RUNTIME_CLI_SHA256="$container_binary_sha256"
 runtime_app_root=${CONTAINER_RUNTIME_APP_ROOT:-}
 runtime_service_namespace=${CONTAINER_RUNTIME_SERVICE_NAMESPACE:-}
 runtime_run_id=${CONTAINER_RUNTIME_RUN_ID:-}

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -587,7 +587,8 @@ install_runtime_bootstrap_image() {
 
 cleanup() {
     local status=$?
-    trap - EXIT INT TERM
+    trap - EXIT
+    trap '' INT TERM
     printf 'Stopping matched container runtime...\n'
     stop_runtime || true
     release_container_runtime_lock


### PR DESCRIPTION
## Summary
- export the exact isolated runtime CLI as an explicit release contract
- pin recursive sibling Makefiles to that CLI with a command-line `PATH` override
- include the CLI binary digest in reusable release checkpoints
- add a competing-Homebrew regression fixture

## Root cause evidence
The stable gate passed all 719 Containerization tests, then its Linux image build invoked two `/opt/homebrew/Cellar/container/0.10.1/bin/container` processes before the candidate CLI. Recursive Makefiles had escaped the earlier environment-only PATH boundary.

## Verification
- `python3 -m unittest Tools.ci.test_run_with_container_runtime` (25 tests)
- `python3 -m unittest Tools.release.test_container_stack_release` (72 tests)
- `shellcheck scripts/run-with-container-runtime.sh Tools/ci/run-stack-release-validation.sh`
- `bash -n` and `git diff --check`