### PR TITLE
fix(release): normalize staged runtime inputs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "91d6ee9fa00d9cbe7f907ed72ce17e45696de410"
+        "revision" : "d959c9998efc0ece41787bb866e6b25072813474"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "7e4f5152e9606a34a92c34186eb94f7cd37c134f"
+        "revision" : "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "91d6ee9fa00d9cbe7f907ed72ce17e45696de410",
+        revision: "d959c9998efc0ece41787bb866e6b25072813474",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "7e4f5152e9606a34a92c34186eb94f7cd37c134f",
+        revision: "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b",
     )
 }()
 

--- a/Tools/ci/fingerprint-release-environment.py
+++ b/Tools/ci/fingerprint-release-environment.py
@@ -39,9 +39,13 @@ SCHEMA_VERSION = 2
 NON_RESULT_VARIABLES = frozenset(
     {
         "COMPOSE_CLI_SURFACE_REPORT",
+        "CONTAINER_APP_ROOT",
+        "CONTAINER_RUNTIME_DOCKER_HOST",
+        "CONTAINER_RUNTIME_DOCKER_SOCKET",
         "CONTAINER_RUNTIME_APP_ROOT",
         "CONTAINER_RUNTIME_RUN_ID",
         "CONTAINER_RUNTIME_SERVICE_NAMESPACE",
+        "CONTAINER_SERVICE_NAMESPACE",
         "CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR",
         "CONTAINER_STACK_VALIDATION_RUNTIME_ROOT",
         "CONTAINER_STACK_VALIDATION_SCRATCH_ROOT",
@@ -88,6 +92,11 @@ MAKE_ASSIGNMENT = re.compile(
 # contents can affect the result. Bind the proof to the directory tree rather
 # than its random absolute location.
 CONTENT_ROOT_VARIABLES = frozenset({"XDG_CONFIG_HOME"})
+
+# The runtime wrapper copies the retained init image into a fresh staging
+# directory for every attempt. Its bytes and mode affect the proof, but the
+# random staging path does not.
+CONTENT_FILE_VARIABLES = frozenset({"CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"})
 
 # The release helper extracts the same immutable Container candidate below a
 # fresh mktemp root on every retry. These selectors establish which PATH entry
@@ -326,6 +335,24 @@ def value_entry(
             "normalized_path_sha256": normalized_path_identity(
                 value, relocatable_directories
             )
+        }
+    if name in CONTENT_FILE_VARIABLES:
+        try:
+            artifact = Path(value)
+            if not artifact.is_absolute():
+                artifact = working_directory / artifact
+            if artifact.is_file():
+                return {
+                    "selected_file_mode": (
+                        f"{stat.S_IMODE(artifact.stat().st_mode):04o}"
+                    ),
+                    "selected_file_sha256": sha256_file(artifact),
+                }
+        except (OSError, RuntimeError):
+            pass
+        return {
+            "selected_file_state": "missing",
+            "value_sha256": sha256_bytes(value.encode("utf-8")),
         }
     if name in CONTENT_ROOT_VARIABLES:
         try:

--- a/Tools/ci/test_fingerprint_release_environment.py
+++ b/Tools/ci/test_fingerprint_release_environment.py
@@ -22,6 +22,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import ModuleType
+from unittest.mock import patch
 
 SCRIPT = Path(__file__).with_name("fingerprint-release-environment.py")
 
@@ -56,7 +57,11 @@ class FingerprintReleaseEnvironmentTest(unittest.TestCase):
         baseline = self.module.fingerprint_environment(
             {
                 "PATH": "/usr/bin",
+                "CONTAINER_APP_ROOT": "/tmp/first/app",
+                "CONTAINER_RUNTIME_DOCKER_HOST": "unix:///tmp/first/docker.sock",
+                "CONTAINER_RUNTIME_DOCKER_SOCKET": "/tmp/first/docker.sock",
                 "CONTAINER_RUNTIME_RUN_ID": "first",
+                "CONTAINER_SERVICE_NAMESPACE": "example.first",
                 "PARITY_EVIDENCE_DIR": "/tmp/first",
                 "CODEX_THREAD_ID": "first-task",
             },
@@ -65,7 +70,11 @@ class FingerprintReleaseEnvironmentTest(unittest.TestCase):
         changed = self.module.fingerprint_environment(
             {
                 "PATH": "/usr/bin",
+                "CONTAINER_APP_ROOT": "/tmp/second/app",
+                "CONTAINER_RUNTIME_DOCKER_HOST": "unix:///tmp/second/docker.sock",
+                "CONTAINER_RUNTIME_DOCKER_SOCKET": "/tmp/second/docker.sock",
                 "CONTAINER_RUNTIME_RUN_ID": "second",
+                "CONTAINER_SERVICE_NAMESPACE": "example.second",
                 "PARITY_EVIDENCE_DIR": "/tmp/second",
                 "CODEX_THREAD_ID": "second-task",
             },
@@ -73,6 +82,68 @@ class FingerprintReleaseEnvironmentTest(unittest.TestCase):
         )
 
         self.assertEqual(baseline, changed)
+
+    def test_staged_init_archive_uses_content_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first" / "retained-init-image.oci.tar"
+            second = root / "second" / "retained-init-image.oci.tar"
+            first.parent.mkdir()
+            second.parent.mkdir()
+            first.write_bytes(b"same init image")
+            second.write_bytes(b"same init image")
+
+            first_fingerprint = self.module.fingerprint_environment(
+                {
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(first),
+                    "PATH": "/usr/bin",
+                },
+                root,
+            )
+            relocated_fingerprint = self.module.fingerprint_environment(
+                {
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(second),
+                    "PATH": "/usr/bin",
+                },
+                root,
+            )
+            second.write_bytes(b"changed init image")
+            changed_fingerprint = self.module.fingerprint_environment(
+                {
+                    "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(second),
+                    "PATH": "/usr/bin",
+                },
+                root,
+            )
+
+            self.assertEqual(first_fingerprint, relocated_fingerprint)
+            self.assertNotEqual(relocated_fingerprint, changed_fingerprint)
+
+    def test_staged_init_archive_preserves_literal_path_semantics(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive = root / "retained-init-image.oci.tar"
+            archive.write_bytes(b"same init image")
+
+            with patch.dict(os.environ, {"HOME": str(root)}):
+                absolute_fingerprint = self.module.fingerprint_environment(
+                    {
+                        "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": str(archive),
+                        "PATH": "/usr/bin",
+                    },
+                    root,
+                )
+                unexpanded_fingerprint = self.module.fingerprint_environment(
+                    {
+                        "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE": (
+                            "~/retained-init-image.oci.tar"
+                        ),
+                        "PATH": "/usr/bin",
+                    },
+                    root,
+                )
+
+            self.assertNotEqual(absolute_fingerprint, unexpanded_fingerprint)
 
     def test_selected_executable_content_is_part_of_identity(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "91d6ee9fa00d9cbe7f907ed72ce17e45696de410",
+      "ref": "d959c9998efc0ece41787bb866e6b25072813474",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "7e4f5152e9606a34a92c34186eb94f7cd37c134f",
+      "ref": "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "5fcbeab5701bc5aa739285e2d6d3e97c863188ee",
-      "forkHead": "91d6ee9fa00d9cbe7f907ed72ce17e45696de410",
+      "forkHead": "d959c9998efc0ece41787bb866e6b25072813474",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -426,7 +426,8 @@
             "5b59927f999158e794c43e7734aaac2a6d7112f5",
             "925341c2d91d31a324ab3b518339d47fa4f08a8c",
             "55275d93a7f1fa2116524128043837f99551f767",
-            "3cab6712ac077eda6d44267f3dc01b3dbd4b17b1"
+            "3cab6712ac077eda6d44267f3dc01b3dbd4b17b1",
+            "040f3370f0ee8f399909374baf240a6a05fd34cc"
           ]
         },
         {
@@ -648,7 +649,7 @@
     },
     "containerization": {
       "upstreamHead": "5427fd21ded4b84034126caef5b3182900b4776d",
-      "forkHead": "7e4f5152e9606a34a92c34186eb94f7cd37c134f",
+      "forkHead": "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -756,7 +757,8 @@
             "1cec7943eacf89bc4d395954759dd8cf44f5fb11",
             "febf53bc4a961c2f51c0321708e1ba7f09c34866",
             "81522ed80496580d82a246a3810c6d37540c1748",
-            "58d9a836b28cfbb055ce537a619a03aa662c9f6e"
+            "58d9a836b28cfbb055ce537a619a03aa662c9f6e",
+            "1461f16133d106c381e51eeaa98dca5ab9170890"
           ]
         },
         {


### PR DESCRIPTION
## What changed

- pin the repaired Container and Containerization stack revisions
- normalize derived runtime roots, namespaces, and Docker socket locations out of release fingerprints
- bind the staged init archive by content and mode instead of its fresh pathname
- add regression coverage for relocated runtime inputs and changed init-image contents

## Root cause

The release wrapper allocates a fresh runtime root and stages the retained init archive under a new temporary path for every attempt. The environment fingerprint treated those derived paths as result inputs, so every retry invalidated completed exact-input checkpoints and repeated expensive stack validation.

## Validation

- `python3 -m unittest Tools.ci.test_fingerprint_release_environment`
- `python3 -m unittest Tools.ci.test_run_release_checkpoint`
- two isolated matched-runtime probes: `changed_entries=none`, `fingerprints_equal=true`
- `python3 -m py_compile Tools/ci/fingerprint-release-environment.py Tools/ci/test_fingerprint_release_environment.py`
- `git diff --check`

## Impact

Application behavior is unchanged. Release retries now reuse completed proof when only fresh runtime locations differ, while changed init-image bytes still invalidate the proof.