### PR TITLE
fix(release): align Current demo init image

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -961,7 +961,7 @@ jobs:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           DEMO_ASSET: ${{ steps.lane.outputs.demo_asset }}
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 2248f64f62e1c4f8d7f1696ad462f42796d32a2a3bcf2843004be2e66b01645b
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 87c8e21ef404d91bd12eac4aeddb78fbfc3eda8f718d9dc0713e864d9164a9d0
           PLUGIN_ARCHIVE: ${{ runner.temp }}/${{ steps.lane.outputs.asset }}
           RUNTIME_ARCHIVE: ${{ steps.runtime-package.outputs.local_asset }}
         shell: bash

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -476,7 +476,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertIn(
             "DEMO_INIT_IMAGE_ARCHIVE_SHA256: "
-            "2248f64f62e1c4f8d7f1696ad462f42796d32a2a3bcf2843004be2e66b01645b",
+            "87c8e21ef404d91bd12eac4aeddb78fbfc3eda8f718d9dc0713e864d9164a9d0",
             workflow,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- align the Current VHS init-image digest with the pinned Containerization `5423cb7e` archive
- keep the fail-closed digest and OCI reference checks covered by the release-policy test

## Validation
- `python3 -m unittest Tools.release.test_container_stack_release` (85 tests)
- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `git diff --check`
- archive SHA-256 and OCI reference verified locally