### PR TITLE
fix(release): read canonical OCI root index

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1042,8 +1042,32 @@ jobs:
           fi
           expected_init_image_ref="ghcr.io/stephenlclarke/containerization/vminit:${CONTAINERIZATION_REF}"
           actual_init_image_ref="$(
-            tar -xOf "${DEMO_INIT_IMAGE_ARCHIVE}" index.json \
-              | python3 -c 'import json, sys; print(json.load(sys.stdin)["manifests"][0]["annotations"]["org.opencontainers.image.ref.name"])'
+            python3 - "${DEMO_INIT_IMAGE_ARCHIVE}" <<'PY'
+          import json
+          import sys
+          import tarfile
+
+          with tarfile.open(sys.argv[1], "r:*") as archive:
+              members = [
+                  member
+                  for member in archive.getmembers()
+                  if member.isfile() and member.name in {"index.json", "./index.json"}
+              ]
+              if len(members) != 1:
+                  raise SystemExit(
+                      f"expected exactly one root index.json member, found {len(members)}"
+                  )
+              stream = archive.extractfile(members[0])
+              if stream is None:
+                  raise SystemExit("root index.json member is unreadable")
+              index = json.load(stream)
+
+          print(
+              index["manifests"][0]["annotations"][
+                  "org.opencontainers.image.ref.name"
+              ]
+          )
+          PY
           )"
           if [[ "${actual_init_image_ref}" != "${expected_init_image_ref}" ]]; then
             printf 'matched Current demo init-image ref mismatch (expected %s, got %s)\n' \

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -489,7 +489,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             'vminit:${CONTAINERIZATION_REF}"',
             workflow,
         )
-        self.assertIn(
+        self.assertIn('with tarfile.open(sys.argv[1], "r:*") as archive:', workflow)
+        self.assertIn('{"index.json", "./index.json"}', workflow)
+        self.assertIn("expected exactly one root index.json member", workflow)
+        self.assertNotIn(
             'tar -xOf "${DEMO_INIT_IMAGE_ARCHIVE}" index.json',
             workflow,
         )


### PR DESCRIPTION
## Summary
- read the Current demo OCI index through Python tarfile instead of assuming one tar member spelling
- accept exactly one canonical root member (`index.json` or `./index.json`)
- reject missing, unreadable, or ambiguous root indexes before the live demo

## Validation
- focused release-policy regression test
- exact parser exercised against the pinned `5423cb7e` archive
- workflow YAML parse
- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `git diff --check`