### PR TITLE
fix(release): stage Current demo on internal volume

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -971,52 +971,52 @@ jobs:
           source Tools/ci/container-runtime-lock.sh
           acquire_container_runtime_lock
 
-          demo_root="${RUNNER_TEMP}/current-build-demo"
+          legacy_demo_root="${RUNNER_TEMP}/current-build-demo"
+          demo_session_root="/tmp/cc-current-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          demo_root="${demo_session_root}/install"
           # Darwin AF_UNIX paths are bounded. Keep the launchd-visible app root
           # short and real (not a symlink): launchd resolves service plists and
-          # the runtime rejects symlinked persisted-state roots. Package and
-          # install artifacts remain beneath the runner's managed temp path.
-          demo_app_root="/tmp/cc-current-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          demo_output=".build/current-demo/${DEMO_ASSET}"
-          tape="${RUNNER_TEMP}/container-compose-current-demo.tape"
+          # the runtime rejects symlinked persisted-state roots. Keep every
+          # launchd-visible executable and live-demo file on the internal APFS
+          # volume; self-hosted runner work and caches may live on an external
+          # volume that dyld cannot safely use for a launched service.
+          demo_app_root="${demo_session_root}/app"
+          demo_source_root="${demo_session_root}/source"
+          demo_output="${demo_session_root}/${DEMO_ASSET}"
+          tape="${demo_session_root}/container-compose-current-demo.tape"
+          demo_init_image_archive="${demo_session_root}/init-image.oci.tar"
 
-          remove_demo_app_root() {
-            case "${demo_app_root}" in
-              /tmp/cc-current-[0-9]*-[0-9]*) ;;
-              *)
-                printf 'refusing to remove unexpected Current demo app root: %s\n' "${demo_app_root}" >&2
-                return 1
-                ;;
-            esac
-            rm -rf -- "${demo_app_root}"
+          remove_demo_session_root() {
+            if [[ ! "${demo_session_root}" =~ ^/tmp/cc-current-[0-9]+-[0-9]+$ ]]; then
+              printf 'refusing to remove unexpected Current demo session root: %s\n' \
+                "${demo_session_root}" >&2
+              return 1
+            fi
+            rm -rf -- "${demo_session_root}"
           }
 
           cleanup() {
             if [[ -n "${container_binary:-}" ]]; then
               "${container_binary}" system stop || true
             fi
-            if [[ -n "${demo_init_image_archive:-}" ]]; then
-              rm -f -- "${demo_init_image_archive}"
-            fi
-            remove_demo_app_root
+            remove_demo_session_root
           }
           trap cleanup EXIT
 
-          # A self-hosted runner can retain the prior demo package and app
-          # root. Stop whichever CLI owns that root before replacing it so a
-          # stale launchd service cannot reject the newly typed app root.
-          if [[ -x "${demo_root}/bin/container" ]]; then
-            "${demo_root}/bin/container" system stop || true
-          elif command -v container >/dev/null 2>&1; then
+          # A self-hosted runner can retain a prior service. Use the installed
+          # CLI to stop it: an executable retained under an external runner
+          # temp directory may itself block in dyld before it can issue stop.
+          if command -v container >/dev/null 2>&1; then
             container system stop || true
           fi
           bash Tools/release/wait-for-container-system-stop.sh
-          remove_demo_app_root
-          rm -rf "${demo_root}"
+          remove_demo_session_root
+          rm -rf -- "${legacy_demo_root}"
 
           mkdir -p "${demo_root}/libexec/container-plugins"
           mkdir -p "${demo_app_root}"
-          mkdir -p "$(dirname "${demo_output}")"
+          mkdir -p "${demo_source_root}/examples"
+          cp -R examples/monitoring-stack "${demo_source_root}/examples/"
           tar -xzf "${RUNTIME_ARCHIVE}" -C "${demo_root}"
           tar -xzf "${PLUGIN_ARCHIVE}" -C "${demo_root}/libexec/container-plugins"
 
@@ -1075,8 +1075,6 @@ jobs:
             exit 1
           fi
 
-          demo_init_image_archive="/tmp/cc-current-init-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.oci.tar"
-          rm -f "${demo_init_image_archive}"
           cp "${DEMO_INIT_IMAGE_ARCHIVE}" "${demo_init_image_archive}"
           staged_init_image_sha256="$(shasum -a 256 "${demo_init_image_archive}" | awk '{print $1}')"
           if [[ "${staged_init_image_sha256}" != "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" ]]; then
@@ -1093,10 +1091,10 @@ jobs:
           # VHS itself is the fail-closed runtime gate. It types every command
           # in the published terminal session, including system startup, and
           # waits for that command's live output before proceeding.
-          export CONTAINER_COMPOSE_DEMO_ROOT="${PWD}"
+          export CONTAINER_COMPOSE_DEMO_ROOT="${demo_source_root}"
           sed "1s#^Output .*#Output ${demo_output}#" docs/container-compose-demo.tape > "${tape}"
           vhs validate "${tape}"
-          bash Tools/release/record-vhs-live-demo.sh \
+          RUNNER_TEMP="${demo_session_root}" bash Tools/release/record-vhs-live-demo.sh \
             "${tape}" "${demo_output}" "${container_binary}"
           cp "${demo_output}" "${RUNNER_TEMP}/${DEMO_ASSET}"
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -501,8 +501,22 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow,
         )
         self.assertIn(
-            'demo_init_image_archive="/tmp/cc-current-init-'
-            '${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.oci.tar"',
+            'demo_session_root="/tmp/cc-current-'
+            '${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+            workflow,
+        )
+        self.assertIn('demo_root="${demo_session_root}/install"', workflow)
+        self.assertIn('demo_app_root="${demo_session_root}/app"', workflow)
+        self.assertIn('demo_source_root="${demo_session_root}/source"', workflow)
+        self.assertIn(
+            'demo_output="${demo_session_root}/${DEMO_ASSET}"', workflow
+        )
+        self.assertIn(
+            'tape="${demo_session_root}/container-compose-current-demo.tape"',
+            workflow,
+        )
+        self.assertIn(
+            'demo_init_image_archive="${demo_session_root}/init-image.oci.tar"',
             workflow,
         )
         self.assertIn(
@@ -518,47 +532,63 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             'export CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE="${demo_init_image_archive}"',
             workflow,
         )
+        self.assertIn('mkdir -p "${demo_app_root}"', workflow)
+        self.assertIn('mkdir -p "${demo_source_root}/examples"', workflow)
         self.assertIn(
-            'demo_app_root="/tmp/cc-current-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+            'cp -R examples/monitoring-stack "${demo_source_root}/examples/"',
             workflow,
         )
-        self.assertIn('mkdir -p "${demo_app_root}"', workflow)
-        self.assertIn('remove_demo_app_root() {', workflow)
-        self.assertIn('/tmp/cc-current-[0-9]*-[0-9]*)', workflow)
-        self.assertIn('rm -rf -- "${demo_app_root}"', workflow)
+        self.assertIn('remove_demo_session_root() {', workflow)
+        self.assertIn(
+            '[[ ! "${demo_session_root}" =~ '
+            '^/tmp/cc-current-[0-9]+-[0-9]+$ ]]',
+            workflow,
+        )
+        self.assertIn('rm -rf -- "${demo_session_root}"', workflow)
         self.assertNotIn('ln -s "${demo_app_storage}"', workflow)
         longest_run_id = str(2**64 - 1)
         longest_attempt = str(2**32 - 1)
         provider_socket = (
             f"/tmp/cc-current-{longest_run_id}-{longest_attempt}"
-            "/engine-provider/provider.sock"
+            "/app/engine-provider/provider.sock"
         )
         self.assertLess(len(os.fsencode(provider_socket)), 104)
         self.assertIn('trap cleanup EXIT', workflow)
-        self.assertIn('rm -f -- "${demo_init_image_archive}"', workflow)
         self.assertNotIn("trap 'rm -f", workflow)
         self.assertIn('"${container_binary}" system stop || true', workflow)
-        self.assertIn('"${demo_root}/bin/container" system stop || true', workflow)
-        self.assertIn("elif command -v container >/dev/null 2>&1; then", workflow)
+        self.assertNotIn(
+            '"${demo_root}/bin/container" system stop || true', workflow
+        )
+        self.assertIn("if command -v container >/dev/null 2>&1; then", workflow)
         self.assertIn(
             "bash Tools/release/wait-for-container-system-stop.sh",
             workflow,
         )
         self.assertLess(
-            workflow.index('"${demo_root}/bin/container" system stop || true'),
+            workflow.index("if command -v container >/dev/null 2>&1; then"),
             workflow.index("bash Tools/release/wait-for-container-system-stop.sh"),
         )
-        self.assertLess(
-            workflow.index("bash Tools/release/wait-for-container-system-stop.sh"),
-            workflow.index('rm -rf "${demo_root}"'),
+        self.assertIn(
+            "bash Tools/release/wait-for-container-system-stop.sh\n"
+            "          remove_demo_session_root\n"
+            '          rm -rf -- "${legacy_demo_root}"',
+            workflow,
         )
         self.assertLess(
-            workflow.index('rm -rf "${demo_root}"'),
+            workflow.index('rm -rf -- "${legacy_demo_root}"'),
             workflow.index('tar -xzf "${RUNTIME_ARCHIVE}" -C "${demo_root}"'),
+        )
+        self.assertIn(
+            'export CONTAINER_COMPOSE_DEMO_ROOT="${demo_source_root}"',
+            workflow,
         )
         self.assertIn("docs/container-compose-demo.tape", workflow)
         self.assertIn("VHS itself is the fail-closed runtime gate", workflow)
-        self.assertIn("bash Tools/release/record-vhs-live-demo.sh", workflow)
+        self.assertIn(
+            'RUNNER_TEMP="${demo_session_root}" '
+            "bash Tools/release/record-vhs-live-demo.sh",
+            workflow,
+        )
         tape = (ROOT / "docs/container-compose-demo.tape").read_text(
             encoding="utf-8"
         )


### PR DESCRIPTION
## Summary

- keep self-hosted runner checkouts and build caches on the external SSD
- stage the launchd-visible Current demo runtime, plugin, app state, init image, source, recorder logs, and GIF output under a guarded internal `/tmp` session
- prevent startup cleanup from executing a retained runtime binary on the external volume
- add release-policy assertions for the internal staging and cleanup contract

## Root cause

The signed packaged `container-apiserver` blocked in dyld while launchd opened it directly from the external SSD. The same exact runtime and init-image fingerprint starts and stops normally from the internal APFS volume.

## Validation

- exact signed 0.11.0 runtime preflight: start, `system status`, `container compose version`, stop — passed
- `python3 Tools/release/test_container_stack_release.py` — 85 tests passed
- focused Current demo policy test — passed
- workflow YAML parse — passed
- Python byte-compilation and `git diff --check` — passed