### PR TITLE
fix(release): quote Current demo output path

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1092,7 +1092,7 @@ jobs:
           # in the published terminal session, including system startup, and
           # waits for that command's live output before proceeding.
           export CONTAINER_COMPOSE_DEMO_ROOT="${demo_source_root}"
-          sed "1s#^Output .*#Output ${demo_output}#" docs/container-compose-demo.tape > "${tape}"
+          sed "1s#^Output .*#Output \"${demo_output}\"#" docs/container-compose-demo.tape > "${tape}"
           vhs validate "${tape}"
           RUNNER_TEMP="${demo_session_root}" bash Tools/release/record-vhs-live-demo.sh \
             "${tape}" "${demo_output}" "${container_binary}"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -582,6 +582,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             'export CONTAINER_COMPOSE_DEMO_ROOT="${demo_source_root}"',
             workflow,
         )
+        self.assertIn(
+            'sed "1s#^Output .*#Output \\\"${demo_output}\\\"#"',
+            workflow,
+        )
         self.assertIn("docs/container-compose-demo.tape", workflow)
         self.assertIn("VHS itself is the fail-closed runtime gate", workflow)
         self.assertIn(


### PR DESCRIPTION
## Summary

- quote the absolute Current demo GIF path in generated VHS tape syntax
- assert that the workflow preserves the quoted output contract

## Root cause

VHS parses an unquoted absolute path as commands after the leading slash. The internal-volume staging fix therefore failed during `vhs validate`, before any runtime process started.

## Validation

- generated the exact tape form with `Output "/tmp/.../output.gif"` and ran `vhs validate` — passed
- focused Current demo release-policy test — passed
- workflow YAML parse — passed
- Python byte-compilation and `git diff --check` — passed