### PR TITLE
fix(release): stabilize Current demo shell

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1092,7 +1092,12 @@ jobs:
           # in the published terminal session, including system startup, and
           # waits for that command's live output before proceeding.
           export CONTAINER_COMPOSE_DEMO_ROOT="${demo_source_root}"
-          sed "1s#^Output .*#Output \"${demo_output}\"#" docs/container-compose-demo.tape > "${tape}"
+          sed "1s#^Output .*#Output \"${demo_output}\"#" \
+            docs/container-compose-demo.tape \
+            | awk -v runtime_path="${demo_root}/bin:${PATH}" '
+                { print }
+                /^Set MarginFill / { printf "Env PATH \"%s\"\n", runtime_path }
+              ' > "${tape}"
           vhs validate "${tape}"
           RUNNER_TEMP="${demo_session_root}" bash Tools/release/record-vhs-live-demo.sh \
             "${tape}" "${demo_output}" "${container_binary}"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -586,6 +586,14 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             'sed "1s#^Output .*#Output \\\"${demo_output}\\\"#"',
             workflow,
         )
+        self.assertIn(
+            'awk -v runtime_path="${demo_root}/bin:${PATH}"',
+            workflow,
+        )
+        self.assertIn(
+            '/^Set MarginFill / { printf "Env PATH \\\"%s\\\"\\n", runtime_path }',
+            workflow,
+        )
         self.assertIn("docs/container-compose-demo.tape", workflow)
         self.assertIn("VHS itself is the fail-closed runtime gate", workflow)
         self.assertIn(
@@ -630,7 +638,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             tape.index('Type "container compose version"'),
         )
         self.assertEqual(tape.count("container system start"), 2)
-        self.assertEqual(tape.count('Wait+Screen@180s /status +running/'), 1)
+        self.assertIn("container-compose-system-ready", tape)
+        self.assertEqual(
+            tape.count(
+                "Wait+Screen@180s /container-compose-system-ready/"
+            ),
+            1,
+        )
         self.assertNotIn('Wait+Screen@900s /status +running/', tape)
         self.assertIn('Type "container compose version"', tape)
         live_up = (

--- a/docs/container-compose-demo.tape
+++ b/docs/container-compose-demo.tape
@@ -17,9 +17,9 @@ Type "cd $CONTAINER_COMPOSE_DEMO_ROOT || exit 1"
 Enter
 Sleep 2s
 
-Type "(container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60 || { sleep 5; container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60; }) && container system status"
+Type "(container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60 || { sleep 5; container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60; }) && container system status && printf '\ncontainer-compose-system-ready\n'"
 Enter
-Wait+Screen@180s /status +running/
+Wait+Screen@180s /container-compose-system-ready/
 Sleep 2s
 Ctrl+L
 Sleep 1s


### PR DESCRIPTION
## Summary
- pin the VHS terminal PATH to the staged signed runtime
- wait for an explicit end-of-startup marker before typing the next command
- preserve VHS display settings before applying the environment override

## Validation
- full signed-package live demo completed locally: startup, two Compose lifecycle passes, health checks, stats, volume reuse, teardown, clean stop
- 85 release policy tests passed
- workflow YAML parse and `git diff --check` passed
