### PR TITLE
fix(release): authenticate Homebrew tap pushes

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1334,6 +1334,8 @@ jobs:
 
       - name: Commit atomic Homebrew stack update
         if: steps.current-freshness.outputs.publish == 'true' && steps.lane.outputs.update_tap == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
         shell: bash
         working-directory: homebrew-tap
         run: |
@@ -1346,6 +1348,7 @@ jobs:
             exit 0
           fi
 
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add "Formula/${compose_formula}" "Formula/${container_formula}"
@@ -1610,6 +1613,7 @@ jobs:
         shell: bash
         working-directory: homebrew-tap
         env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           RELEASE_VERSION: ${{ needs.resolve-publish-context.outputs.ref_name }}
         run: |
           set -euo pipefail
@@ -1618,6 +1622,7 @@ jobs:
             exit 0
           fi
 
+          gh auth setup-git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/container-compose.rb Formula/container.rb

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -397,6 +397,16 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertNotIn("${CONTAINER_SOURCE_DIR}/scripts/update-homebrew-formula.py", renderer)
         self.assertIn("compose/bin/compose", renderer)
 
+    def test_homebrew_tap_pushes_authenticate_with_the_tap_token(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertEqual(
+            workflow.count(
+                "GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}"
+            ),
+            2,
+        )
+        self.assertEqual(workflow.count("gh auth setup-git"), 2)
+
     def test_published_stable_tap_repair_does_not_repackage_or_replace_assets(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         repair = workflow[workflow.index("repair-stable-tap:") :]


### PR DESCRIPTION
## Summary
- authenticate Current and stable Homebrew tap pushes explicitly with the tap token
- avoid relying on actions/checkout includeIf credential path matching on self-hosted runners
- add release-policy coverage for both push paths

## Validation
- focused release policy regression passed
- workflow YAML parse and `git diff --check` passed
- failure reproduced in Current run 31740908182 after all build/demo gates passed
