### PR TITLE
test(release): isolate validation scratch environment

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1336,11 +1336,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             environment["CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"] = "/tmp/runtime-init.oci.tar"
             environment["CONTAINER_RUNTIME_CLI"] = str(candidate_tools_resolved / "container")
             # This fixture substitutes its own candidate CLI. A full release
-            # gate exports both digests for the real candidate before running
-            # the policy tests, so inheriting either value would make the
-            # fixture validate the fake binary against unrelated live state.
+            # gate exports candidate identity and scratch locations for the
+            # real validation run before running the policy tests. Inheriting
+            # any of them would make the fixture validate its fake binary or
+            # expected default paths against unrelated live state.
             environment.pop("CONTAINER_RUNTIME_CLI_SHA256", None)
             environment.pop("CONTAINER_RUNTIME_CANDIDATE_SHA256", None)
+            environment.pop("CONTAINER_STACK_VALIDATION_SCRATCH_ROOT", None)
             environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
                 root / "checkpoints"
             )


### PR DESCRIPTION
## Summary

- prevent the stack-validation policy fixture from inheriting the live release gate scratch root
- keep hosted-path assertions deterministic under the exact production release environment

## Validation

- reproduced the original failure with the live release environment
- focused hosted stack validation policy test passes with live candidate digests and scratch variables
- full `python3 -m unittest discover Tools/release`: 213 tests pass in 123.038s

## Risk

Test-only environment isolation; product and release runtime behavior are unchanged.