### PR TITLE
test(ci): remove scheduler-sensitive signal timing

### DIFF
--- a/Tools/ci/test_run_command_with_deadline.py
+++ b/Tools/ci/test_run_command_with_deadline.py
@@ -267,12 +267,13 @@ raise SystemExit(module.run([
                     self.fail("deadline child did not become ready")
                 time.sleep(0.01)
 
-            started = time.monotonic()
             process.send_signal(signal.SIGTERM)
+            # The timeout already proves the prompt child exits before the
+            # configured three-second grace period without asserting a
+            # scheduler-sensitive sub-second duration.
             stdout, stderr = process.communicate(timeout=2)
 
             self.assertEqual(process.returncode, 143, stdout + stderr)
-            self.assertLess(time.monotonic() - started, 1)
 
     def test_control_signals_are_forwarded_and_reap_the_detached_child_group(
         self,


### PR DESCRIPTION
## Summary

- keep the signal-forwarding test bounded by its existing two-second `communicate` timeout
- remove the redundant sub-second assertion that failed under normal hosted-runner scheduling
- preserve the invariant that prompt exit completes before the configured three-second cleanup grace period

## Validation

- focused signal-forwarding test: 10 consecutive passes
- full `python3 -m unittest discover Tools/ci`: 169 tests pass in 328.691s

## Risk

Test-only timing stabilization; command-deadline behavior is unchanged.