### PR TITLE
test(runtime): align exit-code dry-run contract

### DIFF
--- a/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
+++ b/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
@@ -1217,7 +1217,8 @@ struct ComposeRuntimeSmokeTests {
             ],
             timeout: 30
         )
-        #expect(dryRun.stdout.contains(containerDryRun("run --name \(project)-db-1 --detach")))
+        #expect(dryRun.stdout.contains(containerDryRun("create --name \(project)-db-1 ")))
+        #expect(dryRun.stdout.contains(containerDryRun("start \(project)-db-1")))
         #expect(dryRun.stdout.contains(containerDryRun("create --name \(project)-api-1 ")))
         #expect(dryRun.stdout.contains(containerDryRun("start \(project)-api-1")))
         #expect(dryRun.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))


### PR DESCRIPTION
## Summary

- align the live `up --exit-code-from` dry-run expectation with the direct-attach create/start plan
- preserve the real packaged-runtime exit-status assertion

## Validation

- matched packaged Container runtime
- `ComposeRuntimeTests.ComposeRuntimeSmokeTests/runtimeUpExitCodeFromReturnsSelectedServiceStatus()` (1 test, passed; real exit status 7)
- `git diff --check`

## Risk

Test-only correction. Production behavior and release artifacts are unchanged.