### PR TITLE
chore(parity): update Docker Compose reference to 5.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ CONTAINERIZATION_INIT_SOURCE_PATH ?= $(if $(wildcard $(CONTAINERIZATION_STACK_RE
 # their scripts verbatim, so selecting it here keeps every documented `make
 # docker-compose-…-parity` invocation runnable on either installation layout.
 DOCKER_COMPOSE_REFERENCE ?= $(shell if docker compose version >/dev/null 2>&1; then printf '%s' 'docker compose'; elif command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then printf '%s' docker-compose; else printf '%s' 'docker compose'; fi)
-DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.3.1
+DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.4.0
 DOCKER_COMPOSE_E2E_REF ?= f32009d4a2c687dd405398cc7975d12dccaf8dff
 DOCKER_TERMINAL_CANDIDATE_SOCKET ?= /tmp/container-engine-$(shell id -u)/docker.sock
 DOCKER_REST_LOGGING_CANDIDATE_SOCKET ?= $(DOCKER_TERMINAL_CANDIDATE_SOCKET)

--- a/Tools/parity/check-docker-compose-reference.sh
+++ b/Tools/parity/check-docker-compose-reference.sh
@@ -23,7 +23,7 @@
 #   DOCKER_COMPOSE                    Docker Compose command to validate.
 #                                     Defaults to "docker compose".
 #   DOCKER_COMPOSE_REFERENCE_VERSION  Required Docker Compose version.
-#                                     Defaults to 5.3.1.
+#                                     Defaults to 5.4.0.
 #
 # This preflight makes every parity target use the documented Docker Compose
 # oracle version rather than whichever version happens to be installed.
@@ -34,7 +34,7 @@ readonly SELF_PATH="${BASH_SOURCE[0]:-$0}"
 readonly SCRIPT_NAME="$(basename "$SELF_PATH")"
 
 DOCKER_COMPOSE_VALUE="${DOCKER_COMPOSE:-docker compose}"
-REQUIRED_VERSION="${DOCKER_COMPOSE_REFERENCE_VERSION:-5.3.1}"
+REQUIRED_VERSION="${DOCKER_COMPOSE_REFERENCE_VERSION:-5.4.0}"
 DOCKER_COMPOSE_COMMAND=()
 
 # Print an error message to stderr.

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1035,6 +1035,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def test_release_gate_includes_sibling_coverage_and_runtime_integration(self) -> None:
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
         validation = STACK_RELEASE_VALIDATION.read_text(encoding="utf-8")
+        reference_check = (
+            ROOT / "Tools" / "parity" / "check-docker-compose-reference.sh"
+        ).read_text(encoding="utf-8")
         self.assertIn("check-licenses vet lint coverage build", validation)
         self.assertIn("run-stack-release-validation.sh full", makefile)
         self.assertIn("run-stack-release-validation.sh hosted", makefile)
@@ -1117,7 +1120,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             makefile.count("env -u CONTAINER_BIN -u CONTAINER_COMPOSE_CONTAINER"),
             2,
         )
-        self.assertIn("DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.3.1", makefile)
+        self.assertIn("DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.4.0", makefile)
+        self.assertIn(
+            'REQUIRED_VERSION="${DOCKER_COMPOSE_REFERENCE_VERSION:-5.4.0}"',
+            reference_check,
+        )
         self.assertIn("DOCKER_COMPOSE_E2E_REF ?= f32009d4a2c687dd405398cc7975d12dccaf8dff", makefile)
         self.assertNotIn("repackage-release", makefile)
 


### PR DESCRIPTION
## Summary
- update the maintained Docker Compose oracle pin from 5.3.1 to 5.4.0
- keep the strict preflight default aligned with the release Makefile
- extend the release-policy test to prevent those two pins drifting apart

## Proof
- `./Tools/parity/check-docker-compose-reference.sh --strict`
- `python3 -m unittest Tools.release.test_container_stack_release` (86 tests)
- `git diff --check`

## Release context
The 0.11.0 stable gate stopped cleanly when the locally installed Docker Compose advanced to 5.4.0. All earlier six-stack checkpoints remain retained; this PR updates the explicit oracle contract before the parity gate resumes.