### PR TITLE
docs(upstream): refresh Apple build baseline

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-08-13",
+  "reviewedAt": "2026-08-14",
   "repositories": {
     "container": {
-      "upstreamHead": "5fcbeab5701bc5aa739285e2d6d3e97c863188ee",
-      "forkHead": "d959c9998efc0ece41787bb866e6b25072813474",
+      "upstreamHead": "7d4ffb6cb1aed2c4eba42d5787de09162c82b591",
+      "forkHead": "7fa97f6e5636aaadc340f7cf95dc011c006033dc",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -427,7 +427,10 @@
             "925341c2d91d31a324ab3b518339d47fa4f08a8c",
             "55275d93a7f1fa2116524128043837f99551f767",
             "3cab6712ac077eda6d44267f3dc01b3dbd4b17b1",
-            "040f3370f0ee8f399909374baf240a6a05fd34cc"
+            "040f3370f0ee8f399909374baf240a6a05fd34cc",
+            "3121ac634ae5dca0feabfa17a2d5a960a1d0295a",
+            "7af8401f539d2e5fa315c339365e862b2d1a00be",
+            "db7d71bf5fc50d897af4391bf759975e85c683ec"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 13 August 2026
+Updated: 14 August 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `d2213f49e6f72fdacf5b895b4d23120c18a456df` | `4c527d221601935c614e8ab77c736692a91dd043` | 0 | 633 | 566 |
-| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `7e4f5152e9606a34a92c34186eb94f7cd37c134f` | 0 | 190 | 156 |
+| `container` | `7d4ffb6cb1aed2c4eba42d5787de09162c82b591` | `7fa97f6e5636aaadc340f7cf95dc011c006033dc` | 0 | 643 | 570 |
+| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `5423cb7e26b6f1fd78d7f005137efc7b5a776e0b` | 0 | 192 | 157 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `88332c96705b024bbc5cd210642118ee82f8793d` | 0 | 40 | 34 |
-| **Total** | | | **0** | **863** | **756** |
+| **Total** | | | **0** | **875** | **761** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 539 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 544 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -167,3 +167,11 @@ test's scoped-domain handling; it is upstream history after the merge. The
 fork's independently reviewed CoreDNS resolver-loop fix was already present in
 the support-maintenance slice, so this refresh changes no classifications and
 adds no unreviewed fork-only commit.
+
+The 14 August 2026 release refresh advances Apple Container through
+`7d4ffb6cb1ae` and the Container fork through `7fa97f6e5636`. Apple's build
+repair is upstream history after the signed merge; the fork retains its stronger
+owned and cancelled terminal-resize task while adopting the two missing
+`SystemPackage` imports. The three new patch-unique commits harden the semantic
+helper's environment snapshot and keep its integration fixture deterministic,
+so they are classified as support maintenance.


### PR DESCRIPTION
## Summary

- advance the reviewed Apple Container baseline through `7d4ffb6cb1aed2c4eba42d5787de09162c82b591`
- advance the Stephen fork baseline through `7fa97f6e5636aaadc340f7cf95dc011c006033dc`
- classify the three new semantic-helper commits as support maintenance and refresh the exact counts

## Validation

- `make fork-classifications-check`
- `make upstream-divergence-release-check`
- `markdownlint docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md`
- `jq empty docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json`
- `git diff --check`

## Compatibility

Documentation and release-control evidence only. No runtime or Compose behavior changes.