### PR TITLE
fix(release): finalize 0.11.0 archive ownership parity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,30 +390,30 @@ swift-coverage: swift-test-build
 		exit 1; \
 	fi
 	@rm -f .build/*/debug/codecov/*.profraw .build/*/debug/codecov/*.profdata .build/codecov/fallback.profdata coverage*.lcov coverage*.xml
-	@find .build -maxdepth 3 -path .build/index-build -prune -o -path '*/debug' -type d -exec mkdir -p '{}/codecov' \;
+	@find -L .build -maxdepth 3 -path .build/index-build -prune -o -path '*/debug' -type d -exec mkdir -p '{}/codecov' \;
 	@env -u CONTAINER_BIN -u CONTAINER_COMPOSE_CONTAINER \
 		PYTHON="$(PYTHON)" SWIFT_TEST_RESULT_LOG="$(SWIFT_TEST_RESULT_LOG)" SWIFT_TEST_ATTEMPTS="$(SWIFT_COVERAGE_TEST_ATTEMPTS)" SWIFT_TEST_ACCEPT_SIGNAL_13=0 \
 		Tools/ci/run-swift-test.sh $(SWIFT) test $(SWIFT_RESOLVED_FLAGS) --skip-build --enable-code-coverage $(SWIFT_TEST_RUN_FLAGS) $(SWIFT_TEST_FLAGS)
-	test_binary="$$(find .build -path '*.xctest/Contents/MacOS/container-composePackageTests' -type f | head -n 1)"; \
+	test_binary="$$(find -L .build -path '*.xctest/Contents/MacOS/container-composePackageTests' -type f | head -n 1)"; \
 	profile=".build/codecov/fallback.profdata"; \
 	if [[ -z "$$test_binary" ]]; then \
 		printf 'Swift test binary is missing; run make swift-test-build before make swift-coverage\n' >&2; \
 		exit 2; \
 	fi; \
-	raw_profile_count="$$(find .build -path .build/index-build -prune -o -name '*.profraw' -type f -print | wc -l | tr -d ' ')"; \
+	raw_profile_count="$$(find -L .build -path .build/index-build -prune -o -name '*.profraw' -type f -print | wc -l | tr -d ' ')"; \
 	for _ in 1 2 3 4 5 6 7 8 9 10; do \
 		if [[ "$$raw_profile_count" -gt 0 ]]; then \
 			break; \
 		fi; \
 		sleep 1; \
-		raw_profile_count="$$(find .build -path .build/index-build -prune -o -name '*.profraw' -type f -print | wc -l | tr -d ' ')"; \
+		raw_profile_count="$$(find -L .build -path .build/index-build -prune -o -name '*.profraw' -type f -print | wc -l | tr -d ' ')"; \
 	done; \
 	if [[ "$$raw_profile_count" -eq 0 ]]; then \
 		printf 'Swift coverage profile is missing and no raw .profraw files were found\n' >&2; \
 		exit 2; \
 	fi; \
 	mkdir -p .build/codecov; \
-	find .build -path .build/index-build -prune -o -name '*.profraw' -type f -print0 | xargs -0 "$(SWIFT_LLVM_PROFDATA)" merge -sparse -o "$$profile"; \
+	find -L .build -path .build/index-build -prune -o -name '*.profraw' -type f -print0 | xargs -0 "$(SWIFT_LLVM_PROFDATA)" merge -sparse -o "$$profile"; \
 	for coverage_target in \
 		core=Sources/ComposeCore \
 		runtime-spi=Sources/ComposeRuntimeSPI \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "3ef5b21521719d0bf18f823b822366785bca4fadd791862ceba48e178890af2b",
+  "originHash" : "7b496ac4a978f50f44b1d86390725679247d0b3c02ccec29d201dc71ce8b0864",
   "pins" : [
     {
       "identity" : "async-http-client",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "7744c2a035c68ec14726c709f031835e3e30bde1",
-        "version" : "1.34.0"
+        "revision" : "9544287b9416c0bc71e58b9f3aead8dd14b16103",
+        "version" : "1.36.0"
       }
     },
     {
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "d959c9998efc0ece41787bb866e6b25072813474"
+        "revision" : "7fa97f6e5636aaadc340f7cf95dc011c006033dc"
       }
     },
     {
@@ -39,8 +39,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift-2.git",
       "state" : {
-        "revision" : "21fe69ab7ce0e87ac089534733c52f037e74a3eb",
-        "version" : "2.4.1"
+        "revision" : "28cdd63ef88583ddc67d7bb179eab46fab465ce9",
+        "version" : "2.4.2"
       }
     },
     {
@@ -48,8 +48,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift-nio-transport.git",
       "state" : {
-        "revision" : "2ca31f06658ed288a2560e23ad649acbb3d6b3a3",
-        "version" : "2.9.0"
+        "revision" : "c46f77c07c3ae4fce4734e7af03fcb35ab544428",
+        "version" : "2.9.1"
       }
     },
     {
@@ -57,8 +57,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/grpc/grpc-swift-protobuf.git",
       "state" : {
-        "revision" : "b05885fa9bdd88f1eab2e7162f1ee81340b0da33",
-        "version" : "2.4.0"
+        "revision" : "176c5a434fd76f6f479848d1a8f7d44967534168",
+        "version" : "2.4.1"
       }
     },
     {
@@ -93,8 +93,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-async-algorithms.git",
       "state" : {
-        "revision" : "d0b4a06d0f173a2f3be27d3ea21b3c3aa18db440",
-        "version" : "1.1.4"
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
       }
     },
     {
@@ -111,8 +111,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "bde8ca32a096825dfce37467137c903418c1893d",
-        "version" : "1.19.1"
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
       }
     },
     {
@@ -147,8 +147,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
-        "version" : "3.15.1"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -228,8 +228,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "d2eeec0339074034f11a040a74aa2a341a2c4506",
-        "version" : "1.34.1"
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
       }
     },
     {
@@ -237,8 +237,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "61d1b44f6e4e118792be1cff88ee2bc0267c6f9a",
-        "version" : "1.44.0"
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
       }
     },
     {
@@ -272,8 +272,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
-        "version" : "1.38.0"
+        "revision" : "55d7a1cc5666b85c13464aea1c4b4a90feccb4c8",
+        "version" : "1.38.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "7fa97f6e5636aaadc340f7cf95dc011c006033dc"
+        "revision" : "9aa1803223e8573f169c2a2effa657392b4d6e30"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b"
+        "revision" : "f0bc99d26cd27ed58b06236421a298d9e4acd5c1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "d959c9998efc0ece41787bb866e6b25072813474",
+        revision: "7fa97f6e5636aaadc340f7cf95dc011c006033dc",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "7fa97f6e5636aaadc340f7cf95dc011c006033dc",
+        revision: "9aa1803223e8573f169c2a2effa657392b4d6e30",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b",
+        revision: "f0bc99d26cd27ed58b06236421a298d9e4acd5c1",
     )
 }()
 

--- a/Sources/ComposeContainerRuntime/ComposeRuntimeArchiveCopying.swift
+++ b/Sources/ComposeContainerRuntime/ComposeRuntimeArchiveCopying.swift
@@ -81,6 +81,12 @@ public extension ComposeRuntimeCopying {
         options: ContainerCopyTransferOptions,
         temporaryDirectory: URL,
     ) async throws {
+        guard !options.preserveOwnership else {
+            throw ComposeError.invalidProject(
+                "cp '-a -': runtime must provide native archive input to preserve numeric ownership",
+            )
+        }
+
         let tempDirectory = try Self.makeTemporaryDirectory(in: temporaryDirectory)
         defer { try? FileManager.default.removeItem(at: tempDirectory) }
 
@@ -88,7 +94,7 @@ public extension ComposeRuntimeCopying {
         try ComposeTemporaryFiles.createDirectory(at: extractedRoot)
 
         let reader = try ArchiveReader(file: archiveFile)
-        let rejectedPaths = try reader.extractContents(to: extractedRoot)
+        let rejectedPaths = try reader.extractContents(to: extractedRoot, preserveOwnership: false)
         try ComposeTemporaryFiles.secureDirectory(at: extractedRoot)
         if !rejectedPaths.isEmpty {
             throw ComposeError.invalidProject("cp '-': archive contains unsafe paths: \(rejectedPaths.sorted().joined(separator: ", "))")

--- a/Sources/ComposeContainerRuntime/ContainerFilesystemAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerFilesystemAdapter.swift
@@ -22,11 +22,11 @@ import Foundation
 
 /// `ContainerClient`-backed copier for real service container file copies.
 ///
-/// The documented main Container client supplies filesystem-path copy calls.
-/// Compose layers archive streaming over those calls when a runtime does not
-/// expose a native archive API, preserving the supported copy contract without
-/// binding this adapter to an optional Container revision.
-public struct ContainerClientCopier: ComposeRuntimeCopying {
+/// The pinned Container client supplies both filesystem-path and native archive
+/// copy calls. Native archive streaming is required for ownership preservation:
+/// extracting an archive on macOS cannot retain arbitrary numeric Linux owners
+/// before the staged files cross into the guest.
+public struct ContainerClientCopier: ComposeRuntimeArchiveCopying {
     public typealias CopyInto = @Sendable (String, String, String, ContainerCopyTransferOptions) async throws -> Void
     public typealias CopyFrom = @Sendable (String, String, String, ContainerCopyTransferOptions) async throws -> Void
     public typealias CopyArchiveInto =
@@ -59,8 +59,24 @@ public struct ContainerClientCopier: ComposeRuntimeCopying {
                 preserveOwnership: options.preserveOwnership,
             )
         },
-        copyArchiveInto: CopyArchiveInto? = nil,
-        copyArchiveFrom: CopyArchiveFrom? = nil,
+        copyArchiveInto: CopyArchiveInto? = { id, archive, destination, options in
+            try await ContainerClient().copyIn(
+                id: id,
+                archive: archive,
+                destination: destination,
+                createParents: true,
+                preserveOwnership: options.preserveOwnership,
+            )
+        },
+        copyArchiveFrom: CopyArchiveFrom? = { id, source, archive, copyContents, options in
+            try await ContainerClient().copyOut(
+                id: id,
+                source: source,
+                archive: archive,
+                followSymlink: options.followSymlink,
+                copyContents: copyContents,
+            )
+        },
     ) {
         copyIntoOperation = copyInto
         copyFromOperation = copyFrom

--- a/Tests/ComposeContainerRuntimeTests/ContainerFilesystemAdapterTests.swift
+++ b/Tests/ComposeContainerRuntimeTests/ContainerFilesystemAdapterTests.swift
@@ -15,12 +15,20 @@
 //===----------------------------------------------------------------------===//
 
 @testable import ComposeContainerRuntime
+import ComposeCore
 import ComposeRuntimeSPI
 import Foundation
 import Testing
 
 @Suite("Container filesystem adapter")
 struct ContainerFilesystemAdapterTests {
+    @Test
+    func `live copier exposes native archive streaming to the orchestrator`() {
+        let copier: any ComposeRuntimeCopying = ContainerClientCopier()
+
+        #expect(copier is any ComposeRuntimeArchiveCopying)
+    }
+
     @Test
     func `export staging is private and cleaned after provider failure`() async throws {
         let sharedRoot = FileManager.default.temporaryDirectory
@@ -97,6 +105,8 @@ struct ContainerFilesystemAdapterTests {
                     options: options,
                 )
             },
+            copyArchiveInto: nil,
+            copyArchiveFrom: nil,
         )
 
         try await copier.copyBetweenContainers(
@@ -129,10 +139,46 @@ struct ContainerFilesystemAdapterTests {
             ),
         ])
     }
+
+    @Test
+    func `archive fallback rejects ownership preservation instead of rewriting owners`() async throws {
+        let archive = FileManager.default.temporaryDirectory
+            .appendingPathComponent("compose-copy-archive-\(UUID().uuidString).tar")
+        try Data("not reached\n".utf8).write(to: archive)
+        defer { try? FileManager.default.removeItem(at: archive) }
+
+        let copier = ContainerClientCopier(
+            copyInto: { _, _, _, _ in
+                throw ArchiveFallbackFailure.pathCopyWasUsed
+            },
+            copyFrom: { _, _, _, _ in
+                throw ArchiveFallbackFailure.pathCopyWasUsed
+            },
+            copyArchiveInto: nil,
+            copyArchiveFrom: nil,
+        )
+        let input = try FileHandle(forReadingFrom: archive)
+        defer { try? input.close() }
+
+        await #expect(throws: ComposeError.invalidProject(
+            "cp '-a -': runtime must provide native archive input to preserve numeric ownership",
+        )) {
+            try await copier.copyArchiveIntoContainer(
+                id: "demo-api-1",
+                archive: input,
+                destination: "/tmp",
+                options: ContainerCopyTransferOptions(preserveOwnership: true),
+            )
+        }
+    }
 }
 
 private enum ExportFailure: Error {
     case expected
+}
+
+private enum ArchiveFallbackFailure: Error {
+    case pathCopyWasUsed
 }
 
 private final class ExportPermissionRecorder: @unchecked Sendable {

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "7fa97f6e5636aaadc340f7cf95dc011c006033dc",
+      "ref": "9aa1803223e8573f169c2a2effa657392b4d6e30",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b",
+      "ref": "f0bc99d26cd27ed58b06236421a298d9e4acd5c1",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "d959c9998efc0ece41787bb866e6b25072813474",
+      "ref": "7fa97f6e5636aaadc340f7cf95dc011c006033dc",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2898,6 +2898,29 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertNotEqual(candidate_head, remote_head)
             self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "")
 
+    def test_release_helper_retains_the_symlinked_coverage_gate_repair(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _remote, local = self.create_compose_checkout(root)
+            remote_head = self.git(local, "rev-parse", "origin/main")
+            self.commit_file(
+                local,
+                "Makefile",
+                "swift-coverage:\n\tfind -L .build\n",
+                "fix(coverage): follow symlinked build cache",
+            )
+            candidate_head = self.git(local, "rev-parse", "main")
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("retaining unpublished release candidate", result.stdout)
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
+            self.assertNotEqual(candidate_head, remote_head)
+
     def test_retained_candidate_rejects_current_from_any_commit_but_its_parent(
         self,
     ) -> None:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1128,6 +1128,16 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("DOCKER_COMPOSE_E2E_REF ?= f32009d4a2c687dd405398cc7975d12dccaf8dff", makefile)
         self.assertNotIn("repackage-release", makefile)
 
+    def test_swift_coverage_follows_ssd_backed_build_symlink(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        coverage_start = makefile.index("swift-coverage: swift-test-build")
+        coverage = makefile[
+            coverage_start : makefile.index("go-test:", coverage_start)
+        ]
+
+        self.assertEqual(coverage.count("find -L .build"), 5)
+        self.assertNotRegex(coverage, r"find \.build(?:\s|$)")
+
     def test_release_gate_fingerprint_tracks_archive_and_parity_inputs(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             archive = Path(directory) / "init.oci.tar"

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "7d4ffb6cb1aed2c4eba42d5787de09162c82b591",
-      "forkHead": "7fa97f6e5636aaadc340f7cf95dc011c006033dc",
+      "forkHead": "9aa1803223e8573f169c2a2effa657392b4d6e30",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -430,7 +430,8 @@
             "040f3370f0ee8f399909374baf240a6a05fd34cc",
             "3121ac634ae5dca0feabfa17a2d5a960a1d0295a",
             "7af8401f539d2e5fa315c339365e862b2d1a00be",
-            "db7d71bf5fc50d897af4391bf759975e85c683ec"
+            "db7d71bf5fc50d897af4391bf759975e85c683ec",
+            "b6549457f7458652010686da9c3182187fd649bb"
           ]
         },
         {
@@ -652,7 +653,7 @@
     },
     "containerization": {
       "upstreamHead": "5427fd21ded4b84034126caef5b3182900b4776d",
-      "forkHead": "5423cb7e26b6f1fd78d7f005137efc7b5a776e0b",
+      "forkHead": "f0bc99d26cd27ed58b06236421a298d9e4acd5c1",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -761,7 +762,8 @@
             "febf53bc4a961c2f51c0321708e1ba7f09c34866",
             "81522ed80496580d82a246a3810c6d37540c1748",
             "58d9a836b28cfbb055ce537a619a03aa662c9f6e",
-            "1461f16133d106c381e51eeaa98dca5ab9170890"
+            "1461f16133d106c381e51eeaa98dca5ab9170890",
+            "644a73cea4838222efafba7babc5c8a0eadf348f"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `7d4ffb6cb1aed2c4eba42d5787de09162c82b591` | `7fa97f6e5636aaadc340f7cf95dc011c006033dc` | 0 | 643 | 570 |
-| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `5423cb7e26b6f1fd78d7f005137efc7b5a776e0b` | 0 | 192 | 157 |
+| `container` | `7d4ffb6cb1aed2c4eba42d5787de09162c82b591` | `9aa1803223e8573f169c2a2effa657392b4d6e30` | 0 | 645 | 571 |
+| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `f0bc99d26cd27ed58b06236421a298d9e4acd5c1` | 0 | 194 | 158 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `88332c96705b024bbc5cd210642118ee82f8793d` | 0 | 40 | 34 |
-| **Total** | | | **0** | **875** | **761** |
+| **Total** | | | **0** | **879** | **763** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 544 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 546 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -175,3 +175,9 @@ owned and cancelled terminal-resize task while adopting the two missing
 `SystemPackage` imports. The three new patch-unique commits harden the semantic
 helper's environment snapshot and keep its integration fixture deterministic,
 so they are classified as support maintenance.
+
+The final 14 August 2026 release refresh advances Container through
+`9aa1803223e8` and Containerization through `f0bc99d26cd2`. Container's exact
+Containerization dependency pin and Containerization's recursive
+signal-cancellation lock repair are independently reviewed release maintenance;
+they add no Compose-owned policy or temporary upstream port.

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -426,7 +426,7 @@ recover_unpublished_release_candidate() {
   fi
   while IFS= read -r subject; do
     case "${subject}" in
-      "chore(release): prepare ${version}"|"chore(deps): pin containerization "[0-9a-f]*|"chore(deps): pin container "[0-9a-f]*|"chore(deps): pin container stack "[0-9a-f]*" "[0-9a-f]*)
+      "chore(release): prepare ${version}"|"chore(deps): pin containerization "[0-9a-f]*|"chore(deps): pin container "[0-9a-f]*|"chore(deps): pin container stack "[0-9a-f]*" "[0-9a-f]*|"fix(coverage): follow symlinked build cache")
         ;;
       *)
         printf 'container-compose main contains an unpublished non-release commit; refusing recovery: %s\n' "${subject}" >&2


### PR DESCRIPTION
## What changed

- pins the repaired Container `9aa1803223e8` and Containerization `f0bc99d26cd2` stack for 0.11.0
- makes Swift coverage follow the SSD-backed `.build` symlink and retains that recovery-safe release candidate
- routes stdin/stdout tar transfers through Container's native archive APIs
- rejects ownership-preserving archive input on the staged macOS fallback instead of silently rewriting Linux numeric owners
- adds regressions for native archive dispatch, fail-closed fallback behavior, coverage symlink traversal, and candidate recovery

## Root cause

Compose's fallback extracted stdin tar streams on macOS before copying files into the guest. An unprivileged macOS process cannot preserve arbitrary numeric Linux ownership such as `1234:2345`, so the staged path silently acquired the host owner `501:20`. The pinned Container client already exposes archive-stream APIs that preserve tar metadata inside the runtime boundary.

## Impact

`container compose cp -a -` now preserves numeric ownership, permissions, timestamps, sparse allocation, and hard-link identity in parity with Docker Compose. The release candidate also remains valid with its SSD-backed SwiftPM build cache.

## Validation

- `swift test --filter ContainerFilesystemAdapterTests`: 5 tests passed
- `swiftlint lint --strict` on the three changed Swift files: passed
- exact `docker-compose-cp-stdio-archive-streams-parity`: passed against Docker Compose 5.4.0
- preserved metadata: owner `1234:2345`, mode `0640`, mtime `1700000000`, sparse allocation `16777216:32768`, identical hard-link inode
- release policy suite for the coverage/recovery changes: 88 tests passed
- `git diff --check`: passed

## Release follow-up

After exact-head checks and merge, Current packaging must publish the merged SHA before the stable 0.11.0 release gate is dispatched. Stable tag, assets, attestations, and the paired Homebrew formula update remain part of the release transaction.