### PR TITLE
fix(release): validate current init image early

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -630,6 +630,41 @@ jobs:
             exit 1
           fi
 
+      # Validate the runner-local demo input before certificate import or any
+      # package build. The archive is intentionally external to the checkout,
+      # so a stale runner variable must fail in seconds rather than after the
+      # signed runtime and plugin archives have already been rebuilt.
+      - name: Validate Current demo init-image authority
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        env:
+          CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
+          DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: dd0d8d60c1b9dc055b74fdc9655bed2f644a5eb125833696ffd6575f05b3d8f9
+        shell: bash
+        working-directory: container-compose
+        run: |
+          set -euo pipefail
+          if [[ -z "${DEMO_INIT_IMAGE_ARCHIVE}" || ! -f "${DEMO_INIT_IMAGE_ARCHIVE}" ]]; then
+            printf 'matched Current demo init-image archive is unavailable: %s\n' \
+              "${DEMO_INIT_IMAGE_ARCHIVE:-<unset>}" >&2
+            exit 1
+          fi
+          if [[ ! "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+            printf 'matched Current demo init-image digest is invalid: %s\n' \
+              "${DEMO_INIT_IMAGE_ARCHIVE_SHA256:-<unset>}" >&2
+            exit 1
+          fi
+          actual_init_image_sha256="$(shasum -a 256 "${DEMO_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')"
+          if [[ "${actual_init_image_sha256}" != "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" ]]; then
+            printf 'matched Current demo init-image archive digest mismatch (expected %s, got %s)\n' \
+              "${DEMO_INIT_IMAGE_ARCHIVE_SHA256}" "${actual_init_image_sha256}" >&2
+            exit 1
+          fi
+          Tools/release/validate-oci-image-layout.py \
+            "${DEMO_INIT_IMAGE_ARCHIVE}" \
+            vminit:container-compose \
+            "ghcr.io/stephenlclarke/containerization/vminit:${CONTAINERIZATION_REF}"
+
       - name: Require the hosted release authority
         env:
           GH_TOKEN: ${{ github.token }}
@@ -961,7 +996,7 @@ jobs:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           DEMO_ASSET: ${{ steps.lane.outputs.demo_asset }}
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 87c8e21ef404d91bd12eac4aeddb78fbfc3eda8f718d9dc0713e864d9164a9d0
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: dd0d8d60c1b9dc055b74fdc9655bed2f644a5eb125833696ffd6575f05b3d8f9
           PLUGIN_ARCHIVE: ${{ runner.temp }}/${{ steps.lane.outputs.asset }}
           RUNTIME_ARCHIVE: ${{ steps.runtime-package.outputs.local_asset }}
         shell: bash

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -486,8 +486,22 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertIn(
             "DEMO_INIT_IMAGE_ARCHIVE_SHA256: "
-            "87c8e21ef404d91bd12eac4aeddb78fbfc3eda8f718d9dc0713e864d9164a9d0",
+            "dd0d8d60c1b9dc055b74fdc9655bed2f644a5eb125833696ffd6575f05b3d8f9",
             workflow,
+        )
+        self.assertIn("Validate Current demo init-image authority", package)
+        self.assertIn(
+            'Tools/release/validate-oci-image-layout.py \\\n'
+            '            "${DEMO_INIT_IMAGE_ARCHIVE}"',
+            package,
+        )
+        self.assertLess(
+            package.index("Validate Current demo init-image authority"),
+            package.index("Install Developer ID application certificate"),
+        )
+        self.assertLess(
+            package.index("Validate Current demo init-image authority"),
+            package.index("Build matched runtime package"),
         )
         self.assertIn(
             'actual_init_image_sha256="$(shasum -a 256 '


### PR DESCRIPTION
## Summary

- pin the Current demo to the exact dual-reference init archive for Containerization `f0bc99d26cd27ed58b06236421a298d9e4acd5c1`
- validate the runner-local archive's presence, SHA-256, and OCI references before certificate import or package compilation
- keep the later live-demo validation fail-closed

## Failure evidence

Current packaging run 31788956958 built and Developer-ID-verified both archives, then failed because the configured demo archive referenced the prior Containerization SHA `5423cb7e...` instead of `f0bc99d2...`.

## Proof

- `python3 -m unittest Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_current_build_records_and_publishes_the_matched_vhs_demo`
- `python3 -m unittest Tools.release.test_container_stack_release` — 88 tests passed
- `actionlint .github/workflows/prebuilt-binaries.yml`
- staged archive SHA-256: `dd0d8d60c1b9dc055b74fdc9655bed2f644a5eb125833696ffd6575f05b3d8f9`
- OCI refs: `vminit:container-compose` and `ghcr.io/stephenlclarke/containerization/vminit:f0bc99d26cd27ed58b06236421a298d9e4acd5c1`