### PR TITLE
fix(release): accept dual-ref init image

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1075,40 +1075,10 @@ jobs:
               "${CONTAINERIZATION_REF:-<unset>}" >&2
             exit 1
           fi
-          expected_init_image_ref="ghcr.io/stephenlclarke/containerization/vminit:${CONTAINERIZATION_REF}"
-          actual_init_image_ref="$(
-            python3 - "${DEMO_INIT_IMAGE_ARCHIVE}" <<'PY'
-          import json
-          import sys
-          import tarfile
-
-          with tarfile.open(sys.argv[1], "r:*") as archive:
-              members = [
-                  member
-                  for member in archive.getmembers()
-                  if member.isfile() and member.name in {"index.json", "./index.json"}
-              ]
-              if len(members) != 1:
-                  raise SystemExit(
-                      f"expected exactly one root index.json member, found {len(members)}"
-                  )
-              stream = archive.extractfile(members[0])
-              if stream is None:
-                  raise SystemExit("root index.json member is unreadable")
-              index = json.load(stream)
-
-          print(
-              index["manifests"][0]["annotations"][
-                  "org.opencontainers.image.ref.name"
-              ]
-          )
-          PY
-          )"
-          if [[ "${actual_init_image_ref}" != "${expected_init_image_ref}" ]]; then
-            printf 'matched Current demo init-image ref mismatch (expected %s, got %s)\n' \
-              "${expected_init_image_ref}" "${actual_init_image_ref:-<missing>}" >&2
-            exit 1
-          fi
+          Tools/release/validate-oci-image-layout.py \
+            "${DEMO_INIT_IMAGE_ARCHIVE}" \
+            vminit:container-compose \
+            "ghcr.io/stephenlclarke/containerization/vminit:${CONTAINERIZATION_REF}"
 
           cp "${DEMO_INIT_IMAGE_ARCHIVE}" "${demo_init_image_archive}"
           staged_init_image_sha256="$(shasum -a 256 "${demo_init_image_archive}" | awk '{print $1}')"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -508,22 +508,16 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             '\"${DEMO_INIT_IMAGE_ARCHIVE}\" | awk \'{print $1}\')"',
             workflow,
         )
-        self.assertIn(
-            'expected_init_image_ref="ghcr.io/stephenlclarke/containerization/'
-            'vminit:${CONTAINERIZATION_REF}"',
-            workflow,
+        self.assertEqual(
+            package.count("Tools/release/validate-oci-image-layout.py"),
+            2,
         )
-        self.assertIn('with tarfile.open(sys.argv[1], "r:*") as archive:', workflow)
-        self.assertIn('{"index.json", "./index.json"}', workflow)
-        self.assertIn("expected exactly one root index.json member", workflow)
+        self.assertNotIn('index["manifests"][0]', workflow)
         self.assertNotIn(
             'tar -xOf "${DEMO_INIT_IMAGE_ARCHIVE}" index.json',
             workflow,
         )
-        self.assertIn(
-            'if [[ "${actual_init_image_ref}" != "${expected_init_image_ref}" ]]; then',
-            workflow,
-        )
+        self.assertNotIn("actual_init_image_ref", workflow)
         self.assertIn(
             'demo_session_root="/tmp/cc-current-'
             '${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',


### PR DESCRIPTION
## Summary
- replace the Current VHS step's order-dependent `manifests[0]` ref check with the authoritative OCI layout validator
- require both the portable alias and exact Containerization ref at point of use
- prevent a valid dual-ref archive from being rejected when the alias appears first

## Proof
- `python3 -m unittest Tools.release.test_container_stack_release` (88 tests, pass)
- focused Current workflow contract test (pass)
- validator against the exact f0bc99 archive with both refs (pass)
- `actionlint .github/workflows/prebuilt-binaries.yml` (pass)
- `git diff --check` (pass)

## Failure evidence
Current packaging run 31791759279 passed archive authority, runtime/package builds, and Developer ID verification, then failed because the duplicate VHS parser compared only `index.manifests[0]` (`vminit:container-compose`) with the exact ref. The archive is valid and contains both required refs.