### PR TITLE
fix(release): wait for live VHS output

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -644,6 +644,22 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("Current build VHS recording is missing", workflow)
         self.assertIn('--current-asset "${{ steps.lane.outputs.demo_asset }}"', workflow)
         tape = (ROOT / "docs" / "container-compose-demo.tape").read_text(encoding="utf-8")
+        typed_command = None
+        for line in tape.splitlines():
+            if line.startswith('Type "'):
+                typed_command = shlex.split(line)[1]
+                continue
+            wait_match = re.fullmatch(r"Wait\+Screen@\S+ /(.*)/", line)
+            if wait_match is None:
+                continue
+            self.assertIsNotNone(typed_command)
+            wait_pattern = wait_match.group(1).replace(
+                "[[:space:]]", r"\s"
+            )
+            self.assertIsNone(
+                re.search(wait_pattern, typed_command or ""),
+                f"screen wait can match its typed command: {line}",
+            )
         self.assertIn('Set TypingSpeed 48ms', tape)
         self.assertIn('Set Width 1600', tape)
         self.assertIn('$CONTAINER_COMPOSE_DEMO_ROOT', tape)

--- a/docs/container-compose-demo.tape
+++ b/docs/container-compose-demo.tape
@@ -17,7 +17,7 @@ Type "cd $CONTAINER_COMPOSE_DEMO_ROOT || exit 1"
 Enter
 Sleep 2s
 
-Type "(container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60 || { sleep 5; container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60; }) && container system status && printf '\ncontainer-compose-system-ready\n'"
+Type "(container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60 || { sleep 5; container system start --app-root $CONTAINER_APP_ROOT --install-root $CONTAINER_INSTALL_ROOT --init-image-archive $CONTAINER_COMPOSE_DEMO_INIT_IMAGE_ARCHIVE --enable-kernel-install --timeout 60; }) && container system status && printf '\ncontainer-compose-system-%s\n' ready"
 Enter
 Wait+Screen@180s /container-compose-system-ready/
 Sleep 2s
@@ -26,7 +26,7 @@ Sleep 1s
 
 Type "container compose version"
 Enter
-Wait+Screen@30s /version/
+Wait+Screen@30s /container-compose [0-9]/
 Sleep 2s
 Ctrl+L
 Sleep 1s
@@ -57,7 +57,7 @@ Sleep 2s
 Ctrl+L
 Sleep 1s
 
-Type "container compose -f examples/monitoring-stack/docker-compose.yaml exec --no-tty nginx sh -c 'echo container-compose-volume-reuse-ok > /var/cache/nginx/.container-compose-volume-reuse && cat /var/cache/nginx/.container-compose-volume-reuse'"
+Type "container compose -f examples/monitoring-stack/docker-compose.yaml exec --no-tty nginx sh -c 'echo container-compose-volume-reuse-''ok > /var/cache/nginx/.container-compose-volume-reuse && cat /var/cache/nginx/.container-compose-volume-reuse'"
 Enter
 Wait+Screen@30s /container-compose-volume-reuse-ok/
 Sleep 3s


### PR DESCRIPTION
## Summary

- make the Current readiness marker appear only in command output, not in the typed command
- wait for the concrete `container-compose <version>` output instead of the typed word `version`
- split the volume-reuse marker in the typed command so its screen wait proves live container output
- regression-test every VHS screen wait against its preceding typed command

## Root cause

VHS screen matching includes the visible command line. The readiness wait therefore matched `container-compose-system-ready` while that text was still only part of the command, allowing the tape to continue during the kernel download. The same false-positive pattern also existed in the version and first volume-reuse waits.

## Validation

- regression demonstrated against the original tape
- `python3 -m unittest Tools.release.test_container_stack_release Tools.release.test_record_vhs_live_demo` — 94 tests passed
- real delayed VHS probe verified all three corrected waits match generated output
- `vhs validate docs/container-compose-demo.tape`
- `actionlint`
- `git diff --check`

## Impact

The Current release demo remains fail-closed and can no longer advance merely because a wait token is visible in the command that VHS typed.