### PR TITLE
fix(parity): accept create commands in device dry runs

### DIFF
--- a/Tools/parity/check-compose-device-cgroup-rules.sh
+++ b/Tools/parity/check-compose-device-cgroup-rules.sh
@@ -228,7 +228,7 @@ PY
 dry_run_api_line() {
     local output="$1"
 
-    printf '%s\n' "$output" | grep -F "container run --name $PROJECT_NAME-api-" | head -n 1
+    printf '%s\n' "$output" | grep -E "container (run|create) --name ${PROJECT_NAME}-api-" | head -n 1 || true
 }
 
 # Return success when a dry-run command line includes a device cgroup rule.
@@ -258,7 +258,7 @@ validate_container_compose_behavior() {
     create_output="$("$CONTAINER_COMPOSE" --ansi never --dry-run -p "$PROJECT_NAME" -f "$COMPOSE_FILE" create api)"
     run_output="$("$CONTAINER_COMPOSE" --ansi never --dry-run -p "$PROJECT_NAME" -f "$COMPOSE_FILE" run api true)"
     up_line="$(dry_run_api_line "$up_output")"
-    create_line="$(printf '%s\n' "$create_output" | grep -F "container create --name $PROJECT_NAME-api-" | head -n 1)"
+    create_line="$(dry_run_api_line "$create_output")"
     run_line="$(dry_run_api_line "$run_output")"
 
     [[ -n "$up_line" ]] || { error 'missing dry-run command for device_cgroup_rules service up'; return 1; }

--- a/Tools/parity/check-compose-devices.sh
+++ b/Tools/parity/check-compose-devices.sh
@@ -245,7 +245,7 @@ PY
 dry_run_api_line() {
     local output="$1"
 
-    printf '%s\n' "$output" | grep -F "container run --name $PROJECT_NAME-api-" | head -n 1
+    printf '%s\n' "$output" | grep -E "container (run|create) --name ${PROJECT_NAME}-api-" | head -n 1 || true
 }
 
 # Validate container-compose config and dry-run command projection.
@@ -267,7 +267,7 @@ validate_container_compose_behavior() {
     create_output="$("$CONTAINER_COMPOSE" --ansi never --dry-run -p "$PROJECT_NAME" -f "$COMPOSE_FILE" create api)"
     run_output="$("$CONTAINER_COMPOSE" --ansi never --dry-run -p "$PROJECT_NAME" -f "$COMPOSE_FILE" run api true)"
     up_line="$(dry_run_api_line "$up_output")"
-    create_line="$(printf '%s\n' "$create_output" | grep -F "container create --name $PROJECT_NAME-api-" | head -n 1)"
+    create_line="$(dry_run_api_line "$create_output")"
     run_line="$(dry_run_api_line "$run_output")"
 
     [[ -n "$up_line" ]] || { error 'missing dry-run command for devices service up'; return 1; }


### PR DESCRIPTION
## Summary

- accept both `container create` and `container run` in device dry-run parity projections
- prevent `set -e` from hiding a missing command-line diagnostic
- use the shared matcher consistently for up, create, and run

## Validation

- `bash -n Tools/parity/check-compose-device-cgroup-rules.sh Tools/parity/check-compose-devices.sh`
- `shellcheck Tools/parity/check-compose-device-cgroup-rules.sh Tools/parity/check-compose-devices.sh`
- `./Tools/parity/check-compose-device-cgroup-rules.sh --strict`
- `./Tools/parity/check-compose-devices.sh --strict`

## Release impact

This repairs the exact stable 0.11.0 release-gate blocker at parity stage 42. The product projections were correct; the stale harness matcher rejected the current create/start implementation.