### PR TITLE
fix(release): stabilize signal cleanup supervision

### DIFF
--- a/Tools/ci/run-command-with-deadline.py
+++ b/Tools/ci/run-command-with-deadline.py
@@ -166,14 +166,21 @@ def run(arguments: Sequence[str]) -> int:
         signal.SIG_BLOCK, forwarded_signals
     )
 
-    def restore_child_signal_mask() -> None:
+    def restore_child_signal_state() -> None:
+        # This runner is often started as an asynchronous Bash child. Bash
+        # ignores SIGINT and SIGQUIT for such children, and an exec'd shell
+        # cannot later trap a signal that was ignored when it started. Reset
+        # every signal we supervise before exec so the detached command can
+        # install its own cleanup traps consistently.
+        for number in forwarded_signals:
+            signal.signal(number, signal.SIG_DFL)
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_signal_mask)
 
     try:
         process = subprocess.Popen(
             options.command,
             start_new_session=True,
-            preexec_fn=restore_child_signal_mask,
+            preexec_fn=restore_child_signal_state,
         )
     except FileNotFoundError:
         signal.pthread_sigmask(signal.SIG_SETMASK, previous_signal_mask)
@@ -186,9 +193,15 @@ def run(arguments: Sequence[str]) -> int:
 
     def forward_signal(number: int, _frame: object) -> None:
         nonlocal forwarded_signal
-        if forwarded_signal is None:
-            forwarded_signal = number
-        signal_process_group(process.pid, number)
+        if forwarded_signal is not None:
+            return
+        forwarded_signal = number
+        # Non-interactive shell trees can ignore inherited control signals
+        # while waiting for foreground children, even when their wrapper has
+        # cleanup traps. Preserve the caller-facing status for the original
+        # signal, but always give the detached command tree one portable,
+        # reliably trappable termination request for orderly cleanup.
+        signal_process_group(process.pid, signal.SIGTERM)
 
     for number in (
         signal.SIGHUP,

--- a/Tools/ci/test_run_command_with_deadline.py
+++ b/Tools/ci/test_run_command_with_deadline.py
@@ -316,6 +316,66 @@ raise SystemExit(module.run([
                         process.returncode, expected_status, stdout + stderr
                     )
 
+    def test_child_traps_work_when_the_runner_inherits_ignored_signals(self) -> None:
+        for delivered_signal, shell_signal, expected_status in (
+            (signal.SIGHUP, "HUP", 129),
+            (signal.SIGINT, "INT", 130),
+            (signal.SIGQUIT, "QUIT", 131),
+        ):
+            with self.subTest(signal=delivered_signal.name):
+                with tempfile.TemporaryDirectory() as directory:
+                    ready = Path(directory) / "ready"
+                    cleanup = Path(directory) / "cleanup"
+                    previous_handler = signal.signal(
+                        delivered_signal, signal.SIG_IGN
+                    )
+                    try:
+                        process = subprocess.Popen(
+                            [
+                                sys.executable,
+                                str(SCRIPT),
+                                "--no-deadline",
+                                "--grace-seconds",
+                                "0.2",
+                                "--",
+                                "/bin/sh",
+                                "-c",
+                                f"trap 'touch {cleanup}; exit 0' "
+                                f"{shell_signal} TERM; "
+                                f"touch {ready}; while :; do sleep 1; done",
+                            ],
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                        )
+                    finally:
+                        signal.signal(delivered_signal, previous_handler)
+
+                    ready_deadline = time.monotonic() + 2
+                    while not ready.exists():
+                        if time.monotonic() >= ready_deadline:
+                            process.terminate()
+                            process.communicate(timeout=2)
+                            self.fail("deadline child did not become ready")
+                        time.sleep(0.01)
+
+                    process.send_signal(delivered_signal)
+                    try:
+                        stdout, stderr = process.communicate(timeout=2)
+                    except subprocess.TimeoutExpired:
+                        process.terminate()
+                        stdout, stderr = process.communicate(timeout=2)
+                        self.fail(
+                            "ignored inherited signal prevented child cleanup\n"
+                            + stdout
+                            + stderr
+                        )
+
+                    self.assertEqual(
+                        process.returncode, expected_status, stdout + stderr
+                    )
+                    self.assertTrue(cleanup.exists(), stdout + stderr)
+
     def test_bounded_cleanup_can_ignore_repeated_parent_termination(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2084,6 +2084,22 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def test_local_release_gate_waits_for_signal_cleanup_before_candidate_deletion(
         self,
     ) -> None:
+        release_signals = (
+            signal.SIGHUP,
+            signal.SIGINT,
+            signal.SIGQUIT,
+            signal.SIGTERM,
+        )
+
+        def reset_release_signals() -> None:
+            # Long-running test supervisors can ignore SIGHUP before they
+            # launch this fixture. Bash cannot trap a signal that was ignored
+            # when the shell started, so normalise the child exactly as a
+            # directly launched release helper before exercising its traps.
+            for number in release_signals:
+                signal.signal(number, signal.SIG_DFL)
+            signal.pthread_sigmask(signal.SIG_UNBLOCK, release_signals)
+
         with tempfile.TemporaryDirectory() as directory:
             for delivered_signal, expected_status in (
                 (signal.SIGHUP, 129),
@@ -2153,6 +2169,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                         stderr=subprocess.PIPE,
                         text=True,
                         start_new_session=True,
+                        preexec_fn=reset_release_signals,
                     )
                     # This regression test deliberately coordinates three
                     # process layers. Give a busy release runner enough time
@@ -2162,8 +2179,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     while not ready.exists() and process.poll() is None:
                         if time.monotonic() >= deadline:
                             os.killpg(process.pid, signal.SIGKILL)
-                            process.wait(timeout=10)
-                            self.fail("outer release gate did not become ready")
+                            stdout, stderr = process.communicate(timeout=10)
+                            self.fail(
+                                "outer release gate did not become ready for "
+                                f"{delivered_signal.name}/{signal_scope}\n"
+                                + stdout
+                                + stderr
+                            )
                         time.sleep(0.05)
 
                     send_signal = os.kill if signal_scope == "process" else os.killpg
@@ -2172,8 +2194,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     while not cleanup_started.exists() and process.poll() is None:
                         if time.monotonic() >= deadline:
                             os.killpg(process.pid, signal.SIGKILL)
-                            process.wait(timeout=10)
-                            self.fail("candidate signal cleanup did not start")
+                            stdout, stderr = process.communicate(timeout=10)
+                            self.fail(
+                                "candidate signal cleanup did not start for "
+                                f"{delivered_signal.name}/{signal_scope}\n"
+                                + stdout
+                                + stderr
+                            )
                         time.sleep(0.01)
                     send_signal(process.pid, delivered_signal)
                     try:


### PR DESCRIPTION
## What changed

- reset supervised child signal dispositions and masks before exec
- collapse repeated cancellation into one orderly termination request while preserving the original caller-facing exit status
- harden the release signal-cleanup policy fixture against inherited ignored signals and improve timeout diagnostics
- add regression coverage for ignored inherited control signals

## Why

The stable 0.11.0 local gate passed its live runtime suites, then intermittently failed the release-policy signal cleanup test. Long-running/background shell supervisors could inherit ignored control-signal dispositions, and duplicate group delivery could prevent the detached candidate cleanup trap from running.

## Impact

Interrupted release gates now reliably run candidate cleanup before the staged runtime is removed. Normal successful and timeout behavior is unchanged.

## Validation

- `make lint`
- deadline runner unit suite: 10/10
- release policy suite: 215/215
- CI tools suite: 170/170
- formerly flaky signal cleanup regression: 30 consecutive clean-process passes
- `git diff --check`
