### PR TITLE
test(release): allow loaded hosts to run cleanup traps

### DIFF
--- a/Tools/ci/test_run_command_with_deadline.py
+++ b/Tools/ci/test_run_command_with_deadline.py
@@ -336,7 +336,9 @@ raise SystemExit(module.run([
                                 str(SCRIPT),
                                 "--no-deadline",
                                 "--grace-seconds",
-                                "0.2",
+                                # Leave enough time for a loaded release host
+                                # to schedule the shell's cleanup trap.
+                                "2",
                                 "--",
                                 "/bin/sh",
                                 "-c",
@@ -361,7 +363,7 @@ raise SystemExit(module.run([
 
                     process.send_signal(delivered_signal)
                     try:
-                        stdout, stderr = process.communicate(timeout=2)
+                        stdout, stderr = process.communicate(timeout=5)
                     except subprocess.TimeoutExpired:
                         process.terminate()
                         stdout, stderr = process.communicate(timeout=2)


### PR DESCRIPTION
## Summary
- give the signal-cleanup regression enough test-only grace for a loaded release host
- keep production behavior unchanged

## Proof
- 20 consecutive signal-trap stress runs passed
- runner module: 10/10 passed
- CI tools: 170/170 passed