### PR TITLE
fix(release): avoid nested virtualization in hosted gate

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -331,8 +331,11 @@ jobs:
           HAWKEYE_AUTO_INSTALL: "1"
 
       # GitHub-hosted macOS runners are VMs and cannot launch nested
-      # Virtualization.framework guests. The release helper runs the full live
-      # gate on a supported local Mac before it creates the signed source tag.
+      # Virtualization.framework guests. Hosted stack validation therefore uses
+      # Container's native build, dSYM, docs, and unit-coverage targets rather
+      # than the installer-staging target that builds Linux service workloads
+      # with Colima. The release helper runs the full packaging/live gate on a
+      # supported local Mac before it creates the signed source tag.
       - name: Run hosted release gate
         shell: bash
         run: |

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -40,7 +40,12 @@ case "${mode}" in
     ;;
   hosted)
     containerization_targets=(check containerization examples docs coverage)
-    container_targets=(check container dsym docs coverage-unit)
+    # The Container `container` target stages an installer and therefore builds
+    # Linux service workload images with Colima. GitHub-hosted macOS runners do
+    # not expose nested virtualization, so keep this lane on the native macOS
+    # application proofs. The full local gate remains responsible for installer
+    # staging and live runtime validation before the signed tag is created.
+    container_targets=(check build dsym docs coverage-unit)
     ;;
   *)
     printf 'unknown stack release validation mode: %s\n' "${mode}" >&2

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1100,7 +1100,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             validation,
         )
         self.assertIn(
-            "container_targets=(check container dsym docs coverage-unit)",
+            "container_targets=(check build dsym docs coverage-unit)",
             validation,
         )
         self.assertIn("container_runtime_parent_base=/private/tmp", validation)
@@ -1659,11 +1659,19 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             assert_make_targets(
                 hosted_commands,
                 container,
-                ("check", "container", "dsym", "docs", "coverage-unit"),
+                ("check", "build", "dsym", "docs", "coverage-unit"),
                 required_fragment=(
                     f"APP_ROOT={resolved_container}/.test-scratch/runtime/"
                     "stack-release-app-root"
                 ),
+            )
+            self.assertFalse(
+                any(
+                    line.startswith(f"make:-C {container} ")
+                    and line.endswith(" container")
+                    for line in hosted_commands.splitlines()
+                ),
+                hosted_commands,
             )
             self.assertNotIn(" integration", hosted_commands)
             self.assertNotIn(" fetch-default-kernel", hosted_commands)
@@ -1733,7 +1741,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             assert_make_targets(
                 external_commands,
                 container,
-                ("check", "container", "dsym", "docs", "coverage-unit"),
+                ("check", "build", "dsym", "docs", "coverage-unit"),
                 required_fragment=(
                     f"APP_ROOT={resolved_external_scratch}/runtime/"
                     "stack-release-app-root"
@@ -1761,7 +1769,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             assert_make_targets(
                 split_commands,
                 container,
-                ("check", "container", "dsym", "docs", "coverage-unit"),
+                ("check", "build", "dsym", "docs", "coverage-unit"),
                 required_fragment=(
                     f"APP_ROOT={internal_runtime.resolve()}/stack-release-app-root"
                 ),


### PR DESCRIPTION
## Summary
- replace Container installer staging in the hosted stable gate with its native macOS build proof
- retain dSYM, docs, and unit-coverage validation on the exact pinned runtime source
- assert the hosted path cannot select the virtualization-dependent `container` target

## Evidence
- failure isolated in stable gate run 31842435370: Colima could not start a nested VZ guest on GitHub-hosted macOS
- targeted hosted-stack regression test passes
- all 215 release policy tests pass
- `shellcheck Tools/ci/run-stack-release-validation.sh` passes
- `actionlint` passes

The full local release gate remains the installer-staging and live-runtime authority before tag creation.