### PR TITLE
feat(lifecycle): adopt native restart and discovery

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0808c7d5b3de25adec9a265c893231fc529728acb27032fbd14399e1d0790b65",
+  "originHash" : "9786681b7b1b68edcbb14e6b628977a4fe0f224e845710a94a1d5f9cb77229fd",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "9aa1803223e8573f169c2a2effa657392b4d6e30"
+        "revision" : "4dee971a0bd66a5212cad63d064912e23136699e"
       }
     },
     {
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container-engine-api.git",
       "state" : {
-        "revision" : "5e6e24d017691596783515285e1ff56d29701235"
+        "revision" : "c66fac82d3b2368072959414c1c48c6c3711ae38"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "f0bc99d26cd27ed58b06236421a298d9e4acd5c1"
+        "revision" : "3e078480b85dceb843133392573cdd4d9efeec0d"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "4dee971a0bd66a5212cad63d064912e23136699e"
+        "revision" : "99c0244f37c0bf4aabdfbff7b62d0d2d81541633"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "4dee971a0bd66a5212cad63d064912e23136699e",
+        revision: "99c0244f37c0bf4aabdfbff7b62d0d2d81541633",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "9aa1803223e8573f169c2a2effa657392b4d6e30",
+        revision: "4dee971a0bd66a5212cad63d064912e23136699e",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "f0bc99d26cd27ed58b06236421a298d9e4acd5c1",
+        revision: "3e078480b85dceb843133392573cdd4d9efeec0d",
     )
 }()
 

--- a/Sources/ComposeContainerRuntime/ComposeContainerRuntime.swift
+++ b/Sources/ComposeContainerRuntime/ComposeContainerRuntime.swift
@@ -26,6 +26,7 @@ public enum ComposeContainerRuntime {
     public static func dependencies(
         runner: CommandRunning = ProcessRunner(),
         options: ComposeExecutionOptions = ComposeExecutionOptions(),
+        discoveryClient: ContainerDiscoveryAPIClienting = ContainerDiscoveryAPIClient(),
     ) -> ComposeOrchestratorDependencies {
         let commands = ComposeOrchestratorCommandDependencies(
             archiveManager: ContainerArchiveManager(),
@@ -45,11 +46,7 @@ public enum ComposeContainerRuntime {
                 resourceManager: ContainerClientResourceManager(),
                 secretReader: ComposeExternalSecretReader(),
             ),
-            discoveryManager: ContainerLiveDiscoveryManager(
-                runner: runner,
-                environmentLauncher: options.environmentLauncher,
-                containerBinary: options.containerBinary,
-            ),
+            discoveryManager: ContainerClientDiscoveryManager(client: discoveryClient),
             inspection: .init(
                 statsManager: ContainerClientStatsManager(),
                 topManager: ContainerClientTopManager(),

--- a/Sources/ComposeContainerRuntime/ContainerDiscoveryAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerDiscoveryAdapter.swift
@@ -29,6 +29,15 @@ public protocol ContainerDiscoveryAPIClienting: Sendable {
 
     /// Returns a container snapshot when `id` exists.
     func getContainer(id: String) async throws -> ContainerSnapshot?
+
+    /// Returns one coherent lifecycle-v2 snapshot for all containers.
+    func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2]
+}
+
+public extension ContainerDiscoveryAPIClienting {
+    func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2] {
+        []
+    }
 }
 
 /// Live Compose discovery through the stable container CLI JSON boundary.
@@ -127,16 +136,22 @@ public struct ContainerCLIJSONDiscoveryManager: ContainerDiscoveryManaging {
 public struct ContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
     public typealias List = @Sendable (ContainerListFilters) async throws -> [ContainerSnapshot]
     public typealias Get = @Sendable (String) async throws -> ContainerSnapshot
+    public typealias LifecycleList = @Sendable () async throws -> [ContainerLifecycleRecordV2]
 
     private let listOperation: List
     private let getOperation: Get
+    private let lifecycleListOperation: LifecycleList
 
     public init(
         list: @escaping List = { try await ContainerClient().list(filters: $0) },
         get: @escaping Get = { try await ContainerClient().get(id: $0) },
+        lifecycleList: @escaping LifecycleList = {
+            try await ContainerClient().lifecycleRecords()
+        },
     ) {
         listOperation = list
         getOperation = get
+        lifecycleListOperation = lifecycleList
     }
 
     /// Lists containers through `ContainerClient`.
@@ -152,6 +167,10 @@ public struct ContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
             return nil
         }
     }
+
+    public func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2] {
+        try await lifecycleListOperation()
+    }
 }
 
 /// `ContainerClient`-backed discovery manager for Compose project metadata.
@@ -164,25 +183,59 @@ public struct ContainerClientDiscoveryManager: ContainerDiscoveryManaging {
 
     /// Lists non-machine containers through `ContainerClient.list(filters:)`.
     public func listContainers(all: Bool) async throws -> [ComposeContainerSummary] {
-        let filters = ContainerListFilters(status: all ? nil : .running).withoutMachines()
-        let snapshots = try await client.listContainers(filters: filters)
-        return snapshots.map(ComposeContainerSummary.init(snapshot:))
+        // Lifecycle-v2 transient states do not all have a corresponding legacy
+        // RuntimeStatus. Fetch one coherent unfiltered snapshot and apply the
+        // Docker-visible active-state projection after joining lifecycle data.
+        let filters = ContainerListFilters().withoutMachines()
+        async let snapshots = client.listContainers(filters: filters)
+        async let lifecycleRecords = client.listLifecycleRecords()
+        let records = try await lifecycleRecords
+        let recordsByBundleKey = Dictionary(
+            uniqueKeysWithValues: records.map { ($0.immutableBundleKey, $0) },
+        )
+        let summaries = try await snapshots.map {
+            ComposeContainerSummary(
+                snapshot: $0,
+                lifecycle: recordsByBundleKey[$0.id],
+            )
+        }
+        guard !all else {
+            return summaries
+        }
+        return summaries.filter {
+            $0.status == "running" || $0.status == "paused"
+                || $0.status == "restarting"
+        }
     }
 
     /// Fetches one container through `ContainerClient.get(id:)`.
     public func getContainer(id: String) async throws -> ComposeContainerSummary? {
-        guard let snapshot = try await client.getContainer(id: id) else {
+        async let snapshotResult = client.getContainer(id: id)
+        async let lifecycleRecords = client.listLifecycleRecords()
+        guard let snapshot = try await snapshotResult else {
             return nil
         }
-        return ComposeContainerSummary(snapshot: snapshot)
+        let lifecycle = try await lifecycleRecords.first {
+            $0.immutableBundleKey == snapshot.id
+                || $0.containerID == id
+                || $0.canonicalName == id
+        }
+        return ComposeContainerSummary(snapshot: snapshot, lifecycle: lifecycle)
     }
 }
 
 private extension ComposeContainerSummary {
-    init(snapshot: ContainerSnapshot) {
+    init(
+        snapshot: ContainerSnapshot,
+        lifecycle: ContainerLifecycleRecordV2? = nil,
+    ) {
         self.init(
             id: snapshot.id,
-            status: Self.composeStatus(runtimeStatus: snapshot.status, startedDate: snapshot.startedDate),
+            status: lifecycle?.snapshot.state.rawValue
+                ?? Self.composeStatus(
+                    runtimeStatus: snapshot.status,
+                    startedDate: snapshot.startedDate,
+                ),
             labels: snapshot.configuration.labels,
             image: ComposeContainerSummary.Image(
                 reference: snapshot.configuration.image.reference,
@@ -194,7 +247,13 @@ private extension ComposeContainerSummary {
                 mounts: snapshot.configuration.mounts.map(Self.mount(from:)),
                 networks: snapshot.networks.map(Self.network(from:)),
             ),
-            state: ComposeContainerSummary.State(
+            state: lifecycle.map {
+                ComposeContainerSummary.State(
+                    exitCode: $0.snapshot.exitCode,
+                    exitedDate: $0.snapshot.finishedAt,
+                    health: $0.snapshot.health,
+                )
+            } ?? ComposeContainerSummary.State(
                 exitCode: snapshot.exitCode,
                 exitedDate: snapshot.exitedDate,
                 health: snapshot.health?.rawValue,

--- a/Sources/ComposeContainerRuntime/ContainerDiscoveryAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerDiscoveryAdapter.swift
@@ -30,13 +30,15 @@ public protocol ContainerDiscoveryAPIClienting: Sendable {
     /// Returns a container snapshot when `id` exists.
     func getContainer(id: String) async throws -> ContainerSnapshot?
 
-    /// Returns one coherent lifecycle-v2 snapshot for all containers.
-    func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2]
+    /// Returns atomically paired resource and lifecycle views.
+    func listLifecycleViews(filters: ContainerListFilters) async throws -> [ContainerLifecycleViewV2]
 }
 
 public extension ContainerDiscoveryAPIClienting {
-    func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2] {
-        []
+    func listLifecycleViews(filters _: ContainerListFilters) async throws -> [ContainerLifecycleViewV2] {
+        throw ComposeError.unsupported(
+            "the configured container discovery provider does not support atomic lifecycle views",
+        )
     }
 }
 
@@ -136,22 +138,22 @@ public struct ContainerCLIJSONDiscoveryManager: ContainerDiscoveryManaging {
 public struct ContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
     public typealias List = @Sendable (ContainerListFilters) async throws -> [ContainerSnapshot]
     public typealias Get = @Sendable (String) async throws -> ContainerSnapshot
-    public typealias LifecycleList = @Sendable () async throws -> [ContainerLifecycleRecordV2]
+    public typealias LifecycleViewList = @Sendable (ContainerListFilters) async throws -> [ContainerLifecycleViewV2]
 
     private let listOperation: List
     private let getOperation: Get
-    private let lifecycleListOperation: LifecycleList
+    private let lifecycleViewListOperation: LifecycleViewList
 
     public init(
         list: @escaping List = { try await ContainerClient().list(filters: $0) },
         get: @escaping Get = { try await ContainerClient().get(id: $0) },
-        lifecycleList: @escaping LifecycleList = {
-            try await ContainerClient().lifecycleRecords()
+        lifecycleViewList: @escaping LifecycleViewList = {
+            try await ContainerClient().lifecycleViews(filters: $0)
         },
     ) {
         listOperation = list
         getOperation = get
-        lifecycleListOperation = lifecycleList
+        lifecycleViewListOperation = lifecycleViewList
     }
 
     /// Lists containers through `ContainerClient`.
@@ -168,8 +170,8 @@ public struct ContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
         }
     }
 
-    public func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2] {
-        try await lifecycleListOperation()
+    public func listLifecycleViews(filters: ContainerListFilters) async throws -> [ContainerLifecycleViewV2] {
+        try await lifecycleViewListOperation(filters)
     }
 }
 
@@ -181,24 +183,14 @@ public struct ContainerClientDiscoveryManager: ContainerDiscoveryManaging {
         self.client = client
     }
 
-    /// Lists non-machine containers through `ContainerClient.list(filters:)`.
+    /// Lists non-machine containers through one atomic lifecycle-view read.
     public func listContainers(all: Bool) async throws -> [ComposeContainerSummary] {
         // Lifecycle-v2 transient states do not all have a corresponding legacy
-        // RuntimeStatus. Fetch one coherent unfiltered snapshot and apply the
-        // Docker-visible active-state projection after joining lifecycle data.
+        // RuntimeStatus. Fetch one coherent unfiltered view and apply the
+        // Docker-visible active-state projection from its lifecycle authority.
         let filters = ContainerListFilters().withoutMachines()
-        async let snapshots = client.listContainers(filters: filters)
-        async let lifecycleRecords = client.listLifecycleRecords()
-        let records = try await lifecycleRecords
-        let recordsByBundleKey = Dictionary(
-            uniqueKeysWithValues: records.map { ($0.immutableBundleKey, $0) },
-        )
-        let summaries = try await snapshots.map {
-            ComposeContainerSummary(
-                snapshot: $0,
-                lifecycle: recordsByBundleKey[$0.id],
-            )
-        }
+        let views = try await client.listLifecycleViews(filters: filters)
+        let summaries = views.map(ComposeContainerSummary.init(lifecycleView:))
         guard !all else {
             return summaries
         }
@@ -208,34 +200,29 @@ public struct ContainerClientDiscoveryManager: ContainerDiscoveryManaging {
         }
     }
 
-    /// Fetches one container through `ContainerClient.get(id:)`.
+    /// Fetches one container by immutable ID, canonical name, or bundle key.
     public func getContainer(id: String) async throws -> ComposeContainerSummary? {
-        async let snapshotResult = client.getContainer(id: id)
-        async let lifecycleRecords = client.listLifecycleRecords()
-        guard let snapshot = try await snapshotResult else {
+        let views = try await client.listLifecycleViews(filters: .all)
+        guard let view = views.first(where: {
+            $0.lifecycle.containerID == id
+                || $0.lifecycle.canonicalName == id
+                || $0.lifecycle.immutableBundleKey == id
+        }) else {
             return nil
         }
-        let lifecycle = try await lifecycleRecords.first {
-            $0.immutableBundleKey == snapshot.id
-                || $0.containerID == id
-                || $0.canonicalName == id
-        }
-        return ComposeContainerSummary(snapshot: snapshot, lifecycle: lifecycle)
+        return ComposeContainerSummary(lifecycleView: view)
     }
 }
 
 private extension ComposeContainerSummary {
-    init(
-        snapshot: ContainerSnapshot,
-        lifecycle: ContainerLifecycleRecordV2? = nil,
-    ) {
+    init(lifecycleView: ContainerLifecycleViewV2) {
+        let snapshot = lifecycleView.container
+        let lifecycle = lifecycleView.lifecycle
         self.init(
-            id: snapshot.id,
-            status: lifecycle?.snapshot.state.rawValue
-                ?? Self.composeStatus(
-                    runtimeStatus: snapshot.status,
-                    startedDate: snapshot.startedDate,
-                ),
+            id: lifecycle.containerID,
+            name: lifecycle.canonicalName,
+            bundleKey: lifecycle.immutableBundleKey,
+            status: lifecycle.snapshot.state.rawValue,
             labels: snapshot.configuration.labels,
             image: ComposeContainerSummary.Image(
                 reference: snapshot.configuration.image.reference,
@@ -247,16 +234,10 @@ private extension ComposeContainerSummary {
                 mounts: snapshot.configuration.mounts.map(Self.mount(from:)),
                 networks: snapshot.networks.map(Self.network(from:)),
             ),
-            state: lifecycle.map {
-                ComposeContainerSummary.State(
-                    exitCode: $0.snapshot.exitCode,
-                    exitedDate: $0.snapshot.finishedAt,
-                    health: $0.snapshot.health,
-                )
-            } ?? ComposeContainerSummary.State(
-                exitCode: snapshot.exitCode,
-                exitedDate: snapshot.exitedDate,
-                health: snapshot.health?.rawValue,
+            state: ComposeContainerSummary.State(
+                exitCode: lifecycle.snapshot.exitCode,
+                exitedDate: lifecycle.snapshot.finishedAt,
+                health: lifecycle.snapshot.health,
             ),
         )
     }
@@ -264,6 +245,8 @@ private extension ComposeContainerSummary {
     init(managedContainer: ManagedContainer) {
         self.init(
             id: managedContainer.id,
+            name: managedContainer.configuration.dockerName,
+            bundleKey: managedContainer.id,
             status: Self.composeStatus(
                 runtimeStatus: managedContainer.status.state,
                 startedDate: managedContainer.status.startedDate,

--- a/Sources/ComposeContainerRuntime/ContainerLifecycleAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerLifecycleAdapter.swift
@@ -31,6 +31,9 @@ public protocol ContainerLifecycleAPIClienting: Sendable {
     /// Stops container `id` with fully resolved stop options.
     func stopContainer(id: String, options: ContainerStopOptions) async throws
 
+    /// Atomically restarts container `id`.
+    func restartContainer(id: String, options: ContainerStopOptions) async throws
+
     /// Pauses container `id`.
     func pauseContainer(id: String) async throws
 
@@ -52,6 +55,7 @@ public struct ContainerLifecycleAPIClient: ContainerLifecycleAPIClienting {
     public typealias Start = @Sendable (String) async throws -> Void
     public typealias Kill = @Sendable (String, String) async throws -> Void
     public typealias Stop = @Sendable (String, ContainerStopOptions) async throws -> Void
+    public typealias Restart = @Sendable (String, ContainerStopOptions) async throws -> Void
     public typealias Pause = @Sendable (String) async throws -> Void
     public typealias Unpause = @Sendable (String) async throws -> Void
     public typealias Wait = @Sendable (String) async throws -> Int32
@@ -61,6 +65,7 @@ public struct ContainerLifecycleAPIClient: ContainerLifecycleAPIClienting {
     private let startOperation: Start
     private let killOperation: Kill
     private let stopOperation: Stop
+    private let restartOperation: Restart
     private let pauseOperation: Pause
     private let unpauseOperation: Unpause
     private let waitOperation: Wait
@@ -72,6 +77,7 @@ public struct ContainerLifecycleAPIClient: ContainerLifecycleAPIClienting {
         public var start: Start
         public var kill: Kill
         public var stop: Stop
+        public var restart: Restart
         public var pause: Pause
         public var unpause: Unpause
 
@@ -79,12 +85,14 @@ public struct ContainerLifecycleAPIClient: ContainerLifecycleAPIClienting {
             start: @escaping Start = ContainerLifecycleLiveAdapter.start,
             kill: @escaping Kill = { try await ContainerClient().kill(id: $0, signal: $1) },
             stop: @escaping Stop = { try await ContainerClient().stop(id: $0, opts: $1) },
+            restart: @escaping Restart = { try await ContainerClient().restart(id: $0, opts: $1) },
             pause: @escaping Pause = { try await ContainerClient().pause(id: $0) },
             unpause: @escaping Unpause = { try await ContainerClient().unpause(id: $0) },
         ) {
             self.start = start
             self.kill = kill
             self.stop = stop
+            self.restart = restart
             self.pause = pause
             self.unpause = unpause
         }
@@ -111,6 +119,7 @@ public struct ContainerLifecycleAPIClient: ContainerLifecycleAPIClienting {
         startOperation = control.start
         killOperation = control.kill
         stopOperation = control.stop
+        restartOperation = control.restart
         pauseOperation = control.pause
         unpauseOperation = control.unpause
         waitOperation = state.wait
@@ -131,6 +140,11 @@ public struct ContainerLifecycleAPIClient: ContainerLifecycleAPIClienting {
     /// Stops a container through `ContainerClient`.
     public func stopContainer(id: String, options: ContainerStopOptions) async throws {
         try await stopOperation(id, options)
+    }
+
+    /// Restarts a container through one authority operation.
+    public func restartContainer(id: String, options: ContainerStopOptions) async throws {
+        try await restartOperation(id, options)
     }
 
     /// Pauses a container through `ContainerClient`.
@@ -204,6 +218,14 @@ public struct ContainerClientLifecycleManager: ComposeRuntimeLifecycleManaging {
             signal: signal,
         )
         try await client.stopContainer(id: id, options: options)
+    }
+
+    public func restartContainer(id: String, signal: String?, timeoutInSeconds: Int?) async throws {
+        let options = try ContainerStopOptions(
+            timeoutInSeconds: stopTimeout(timeoutInSeconds),
+            signal: signal,
+        )
+        try await client.restartContainer(id: id, options: options)
     }
 
     /// Pauses a running container through `ContainerClient.pause(id:)`.

--- a/Sources/ComposeCore/ComposeCommandOptions.swift
+++ b/Sources/ComposeCore/ComposeCommandOptions.swift
@@ -915,6 +915,8 @@ struct ServiceContainerTarget {
     var service: ComposeService
     var index: Int
     var name: String
+    var displayName: String? = nil
+    var bundleKey: String? = nil
     var status: String?
 }
 

--- a/Sources/ComposeCore/ComposeOrchestratorContainerTargets.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorContainerTargets.swift
@@ -53,16 +53,19 @@ extension ComposeOrchestrator {
 
     /// Resolves the runtime ID for a service container index.
     func serviceContainerID(project: ComposeProject, service: ComposeService, index: Int) async throws -> String {
-        let id = try serviceContainerName(project: project, service: service, index: index)
-        guard index != 1, !options.dryRun else {
-            return id
+        let name = try serviceContainerName(project: project, service: service, index: index)
+        guard !options.dryRun else {
+            return name
         }
 
         let containers = try await projectContainers(projectName: project.name, all: true)
-        guard serviceContainerExists(containers, service: service, id: id) else {
-            throw ComposeError.invalidProject("service '\(service.name)' container '\(id)' does not exist")
+        guard let container = containers.first(where: {
+            ($0.displayName == name || $0.bundleKey == name)
+                && $0.serviceName == service.name && !$0.isOneOff
+        }) else {
+            throw ComposeError.invalidProject("service '\(service.name)' container '\(name)' does not exist")
         }
-        return id
+        return container.id
     }
 
     /// Returns the deterministic runtime name for a service container index.
@@ -121,12 +124,14 @@ extension ComposeOrchestrator {
                 let index = serviceContainerIndex(
                     project: project,
                     service: service,
-                    containerID: container.id,
+                    containerID: container.bundleKey ?? container.displayName,
                 ) ?? Int.max
                 return ServiceContainerTarget(
                     service: service,
                     index: index,
                     name: container.id,
+                    displayName: container.displayName,
+                    bundleKey: container.bundleKey,
                     status: container.status,
                 )
             }
@@ -176,7 +181,11 @@ extension ComposeOrchestrator {
             .filter { $0.serviceName == service.name && !$0.isOneOff }
             .sorted(by: serviceContainerSummaryOrder(project: project, service: service))
         for container in containers {
-            let index = serviceContainerIndex(project: project, service: service, containerID: container.id)
+            let index = serviceContainerIndex(
+                project: project,
+                service: service,
+                containerID: container.bundleKey ?? container.displayName,
+            )
             guard desiredCount == 0 || (index.map { $0 > desiredCount } ?? false) else {
                 continue
             }
@@ -188,12 +197,12 @@ extension ComposeOrchestrator {
     /// Returns a stable ordering for service container discovery.
     func serviceContainerSummaryOrder(project: ComposeProject, service: ComposeService) -> (ComposeContainerSummary, ComposeContainerSummary) -> Bool {
         { [self] lhs, rhs in
-            let lhsIndex = serviceContainerIndex(project: project, service: service, containerID: lhs.id) ?? Int.max
-            let rhsIndex = serviceContainerIndex(project: project, service: service, containerID: rhs.id) ?? Int.max
+            let lhsIndex = serviceContainerIndex(project: project, service: service, containerID: lhs.bundleKey ?? lhs.displayName) ?? Int.max
+            let rhsIndex = serviceContainerIndex(project: project, service: service, containerID: rhs.bundleKey ?? rhs.displayName) ?? Int.max
             if lhsIndex != rhsIndex {
                 return lhsIndex < rhsIndex
             }
-            return lhs.id < rhs.id
+            return lhs.displayName < rhs.displayName
         }
     }
 

--- a/Sources/ComposeCore/ComposeOrchestratorContainerTargets.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorContainerTargets.swift
@@ -60,7 +60,7 @@ extension ComposeOrchestrator {
 
         let containers = try await projectContainers(projectName: project.name, all: true)
         guard let container = containers.first(where: {
-            ($0.displayName == name || $0.bundleKey == name)
+            (($0.bundleKey.map { $0 == name }) ?? ($0.displayName == name))
                 && $0.serviceName == service.name && !$0.isOneOff
         }) else {
             throw ComposeError.invalidProject("service '\(service.name)' container '\(name)' does not exist")

--- a/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
@@ -884,23 +884,25 @@ public extension ComposeOrchestrator {
         })
     }
 
-    /// Restarts selected service containers, including dependencies unless disabled.
+    /// Restarts selected service containers and restart-propagating dependents.
     func restart(project: ComposeProject, options restart: ComposeRestartOptions) async throws {
         try validateTimeoutSeconds(restart.timeout, command: "restart")
-        let services = try restart.noDeps && !restart.services.isEmpty
-            ? selectedServices(project: project, selected: restart.services)
-            : orderedServices(project: project, selected: restart.services)
-        for service in services.reversed() where service.provider != nil {
-            _ = try await runProvider(project: project, service: service, action: .stop)
-        }
-        for service in services.reversed() {
-            for target in try await serviceContainerTargets(project: project, services: [service]) {
-                try await stopContainer(service: target.service, containerName: target.name, timeout: restart.timeout)
-            }
-        }
+        let services = try restartServices(
+            project: project,
+            selected: restart.services,
+            noDeps: restart.noDeps,
+        )
         for service in services {
+            if service.provider != nil {
+                _ = try await runProvider(project: project, service: service, action: .stop)
+                continue
+            }
             for target in try await serviceContainerTargets(project: project, services: [service]) {
-                try await startContainer(service: target.service, containerName: target.name)
+                try await restartContainer(
+                    service: target.service,
+                    containerName: target.name,
+                    timeout: restart.timeout,
+                )
             }
         }
     }

--- a/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
@@ -189,7 +189,7 @@ public extension ComposeOrchestrator {
             return containerName
         }
         guard target.index != Int.max else {
-            return target.name
+            return target.displayName ?? target.name
         }
         return "\(target.service.name)-\(target.index)"
     }

--- a/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
@@ -402,8 +402,27 @@ extension ComposeOrchestrator {
 
     /// Restarts a service container through the direct API.
     func restartContainer(service: ComposeService, containerName: String, timeout: Int? = nil) async throws {
-        try await stopContainer(service: service, containerName: containerName, timeout: timeout)
-        try await startContainer(service: service, containerName: containerName)
+        try validateLifecycleHookSupport(service: service)
+        try await runPreStopHooks(service: service, containerID: containerName)
+        let resolvedTimeout = timeout ?? service.stopGracePeriodSeconds
+        if options.dryRun {
+            var args = ["restart"]
+            if let signal = service.stopSignal, !signal.isEmpty {
+                args.append(contentsOf: ["--signal", signal])
+            }
+            if let resolvedTimeout {
+                args.append(contentsOf: ["--time", "\(resolvedTimeout)"])
+            }
+            args.append(containerName)
+            try await runContainer(args, check: false)
+        } else {
+            try await lifecycleManager.restartContainer(
+                id: containerName,
+                signal: service.stopSignal,
+                timeoutInSeconds: resolvedTimeout,
+            )
+        }
+        try await runPostStartHooks(service: service, containerID: containerName)
     }
 
     /// Stops a container that may not map to a declared service, such as an

--- a/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
@@ -312,7 +312,8 @@ extension ComposeOrchestrator {
             .filter {
                 $0.labels[projectLabel] == project.name
                     && $0.labels[imageVolumeAnonymousLabel] == "true"
-                    && $0.labels[imageVolumeContainerLabel] == target.name
+                    && $0.labels[imageVolumeContainerLabel]
+                    == (target.bundleKey ?? target.displayName ?? target.name)
             }
             .map(\.name)
         names.formUnion(imageVolumeNames)
@@ -567,7 +568,7 @@ extension ComposeOrchestrator {
             preservingServices: serviceNames,
         )
         if confirmBeforeRemoval, !remainingContainers.isEmpty {
-            let names = remainingContainers.map(\.id).joined(separator: ", ")
+            let names = remainingContainers.map(\.displayName).joined(separator: ", ")
             guard try await options.confirm("Going to remove orphan containers \(names)\nAre you sure? [yN] ") else {
                 return
             }
@@ -599,7 +600,7 @@ extension ComposeOrchestrator {
         guard !remainingContainers.isEmpty else {
             return
         }
-        let names = remainingContainers.map(\.id).joined(separator: ", ")
+        let names = remainingContainers.map(\.displayName).joined(separator: ", ")
         options.emitStatus(
             "warning: found orphan containers (\(names)) for this project; run with --remove-orphans to remove them",
         )
@@ -613,13 +614,13 @@ extension ComposeOrchestrator {
     ) async throws -> [ComposeContainerSummary] {
         try await projectContainers(projectName: project.name, all: true)
             .filter { container in
-                guard !declaredContainers.contains(container.id) else {
+                guard !declaredContainers.contains(container.bundleKey ?? container.displayName) else {
                     return false
                 }
                 let isPreservedService = container.serviceName.map { serviceNames.contains($0) } ?? false
                 return container.isOneOff || !isPreservedService
             }
-            .sorted { $0.id < $1.id }
+            .sorted { $0.displayName < $1.displayName }
     }
 
     /// Stops a project-scoped cleanup target with service hooks when its

--- a/Sources/ComposeCore/ComposeOrchestratorPlanning.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorPlanning.swift
@@ -82,6 +82,44 @@ public extension ComposeOrchestrator {
         return ordered
     }
 
+    /// Resolves Docker Compose restart propagation and dependency order.
+    internal func restartServices(
+        project: ComposeProject,
+        selected: [String],
+        noDeps: Bool,
+    ) throws -> [ComposeService] {
+        var included = selected.isEmpty ? Set(project.services.keys) : Set(selected)
+        for name in included where project.services[name] == nil {
+            throw ComposeError.invalidProject("unknown service '\(name)'")
+        }
+
+        if !noDeps, !selected.isEmpty {
+            var insertedDependent = true
+            while insertedDependent {
+                insertedDependent = false
+                for service in project.services.values where !included.contains(service.name) {
+                    let restartsAfterIncludedDependency = service.dependsOn?.contains { dependency in
+                        dependency.value.restart && included.contains(dependency.key)
+                    } ?? false
+                    if restartsAfterIncludedDependency {
+                        included.insert(service.name)
+                        insertedDependent = true
+                    }
+                }
+            }
+        }
+
+        let services = try selectedServices(project: project, selected: included.sorted())
+        let restartGraph = services.map { service in
+            var service = service
+            service.dependsOn = service.dependsOn?.filter { dependency in
+                dependency.value.restart && included.contains(dependency.key)
+            }
+            return service
+        }
+        return try Array(serviceDependencyLayers(services: restartGraph).joined())
+    }
+
     /// Groups selected services into dependency-safe runtime layers.
     func serviceDependencyLayers(
         services: [ComposeService],

--- a/Sources/ComposeCore/ComposeOrchestratorPreStart.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorPreStart.swift
@@ -63,12 +63,12 @@ extension ComposeOrchestrator {
         }
     }
 
-    /// Treats Apple `paused` as Docker's running state for start convergence.
+    /// Treats active lifecycle states as already started for convergence.
     func isStartedServiceTarget(_ target: ServiceContainerTarget) -> Bool {
         guard let status = target.status?.lowercased() else {
             return false
         }
-        return status == "running" || status == "paused"
+        return status == "running" || status == "paused" || status == "restarting"
     }
 
     /// Executes `pre_start` helpers sequentially against the lowest-numbered

--- a/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
@@ -387,7 +387,7 @@ extension ComposeOrchestrator {
             throw ComposeError.invalidProject("service '\(service.name)' container '\(indexedID)' does not exist")
         }
         return containers
-            .filter { $0.id == indexedID || $0.isOneOff }
+            .filter { $0.displayName == indexedID || $0.bundleKey == indexedID || $0.isOneOff }
             .map { ComposeCopyContainerTarget(id: $0.id, path: path) }
     }
 

--- a/Sources/ComposeCore/ComposeOrchestratorUpLogs.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUpLogs.swift
@@ -356,7 +356,9 @@ private final class ComposeUpAttachedOutputRenderer: @unchecked Sendable {
         if let containerName = target.service.containerName, !containerName.isEmpty {
             return containerName
         }
-        return target.index == Int.max ? target.name : "\(target.service.name)-\(target.index)"
+        return target.index == Int.max
+            ? target.displayName ?? target.name
+            : "\(target.service.name)-\(target.index)"
     }
 
     private static func colorCode(for target: ServiceContainerTarget) -> String {

--- a/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
@@ -38,11 +38,17 @@ public extension ComposeOrchestrator {
                 }
                 .sorted(by: serviceContainerSummaryOrder(project: project, service: service))
                 .map { container in
-                    let index = serviceContainerIndex(project: project, service: service, containerID: container.id)
+                    let index = serviceContainerIndex(
+                        project: project,
+                        service: service,
+                        containerID: container.bundleKey ?? container.displayName,
+                    )
                     return ServiceContainerTarget(
                         service: service,
                         index: index ?? Int.max,
                         name: container.id,
+                        displayName: container.displayName,
+                        bundleKey: container.bundleKey,
                         status: container.status,
                     )
                 }

--- a/Sources/ComposeCore/ComposeRenderHelpers.swift
+++ b/Sources/ComposeCore/ComposeRenderHelpers.swift
@@ -412,7 +412,7 @@ func startWaitState(_ container: ComposeContainerSummary) -> ComposeStartWaitSta
     switch container.status.lowercased() {
     case "running":
         return .ready
-    case "created", "creating", "starting", "stopping", "unknown":
+    case "created", "creating", "restarting", "starting", "stopping", "unknown":
         return .pending
     case "stopped":
         return .failed("is stopped")
@@ -813,13 +813,13 @@ func psStatusFilters(statuses: [String], filters: [String]) throws -> Set<String
 /// Validates Compose status values that the current runtime presentation can expose.
 func normalizedRuntimeStatus(_ status: String) throws -> String {
     switch status.lowercased() {
-    case "created", "exited", "paused", "running", "stopping", "unknown":
+    case "created", "dead", "exited", "paused", "removing", "restarting", "running", "stopping", "unknown":
         return status.lowercased()
     // Keep a legacy generic-runtime filter nonmatching. Docker Compose V2
     // accepts it but does not treat it as an alias for `exited`.
     case "stopped":
         return "stopped"
     default:
-        throw ComposeError.unsupported("ps status '\(status)'; current macOS Compose exposes created, exited, paused, running, stopping, and unknown")
+        throw ComposeError.unsupported("ps status '\(status)'; current macOS Compose exposes created, dead, exited, paused, removing, restarting, running, stopping, and unknown")
     }
 }

--- a/Sources/ComposeCore/ComposeRenderHelpers.swift
+++ b/Sources/ComposeCore/ComposeRenderHelpers.swift
@@ -117,7 +117,7 @@ func renderComposeContainerTable(
         ["NAME", "IMAGE", "SERVICE", "STATUS", "PORTS"],
     ] + containers.map { container in
         [
-            container.id,
+            container.displayName,
             container.imageReference,
             container.serviceName ?? "",
             container.status,
@@ -212,8 +212,8 @@ private func composeContainerStructuredTemplateValues(
             $0.type == "volume" || $0.type == "external-volume"
         }),
         "Mounts": .string(mounts),
-        "Name": .string(container.id),
-        "Names": .string(container.id),
+        "Name": .string(container.displayName),
+        "Names": .string(container.displayName),
         "Networks": .string(networks),
         "Ports": .string(ports),
         "Project": .string(container.projectName ?? ""),
@@ -280,7 +280,7 @@ func containerServiceNames(_ containers: [ComposeContainerSummary]) -> [String] 
         guard let service = container.serviceName, !service.isEmpty else {
             return nil
         }
-        return (container.id, service)
+        return (container.displayName, service)
     }
     var seen: Set<String> = []
     var services: [String] = []
@@ -352,7 +352,7 @@ func composeImageRecords(containers: [ComposeContainerSummary], selectedServices
         }
         let reference = splitImageReference(container.imageReference)
         return ComposeImageRecord(
-            container: container.id,
+            container: container.displayName,
             service: service,
             repository: reference.repository,
             tag: reference.tag,
@@ -430,7 +430,8 @@ enum ComposeStartWaitState {
 /// Returns true when a discovered normal service container matches an ID.
 func serviceContainerExists(_ containers: [ComposeContainerSummary], service: ComposeService, id: String) -> Bool {
     containers.contains { container in
-        container.id == id && container.serviceName == service.name && !container.isOneOff
+        (container.displayName == id || container.bundleKey == id)
+            && container.serviceName == service.name && !container.isOneOff
     }
 }
 
@@ -439,7 +440,7 @@ func compareCopyTargetContainers(_ lhs: ComposeContainerSummary, _ rhs: ComposeC
     if lhs.isOneOff != rhs.isOneOff {
         return !lhs.isOneOff
     }
-    return lhs.id < rhs.id
+    return lhs.displayName < rhs.displayName
 }
 
 /// Validates the `compose ls --format` value.

--- a/Sources/ComposeCore/ComposeUnconfiguredRuntime.swift
+++ b/Sources/ComposeCore/ComposeUnconfiguredRuntime.swift
@@ -117,6 +117,10 @@ struct ComposeUnconfiguredRuntime: ComposeRuntimeCopying, ComposeRuntimeExportin
         throw unavailable("container stop")
     }
 
+    func restartContainer(id _: String, signal _: String?, timeoutInSeconds _: Int?) async throws {
+        throw unavailable("container restart")
+    }
+
     func pauseContainer(id _: String) async throws {
         throw unavailable("container pause")
     }

--- a/Sources/ComposeRuntimeSPI/ComposeRuntimeCollaborators.swift
+++ b/Sources/ComposeRuntimeSPI/ComposeRuntimeCollaborators.swift
@@ -221,6 +221,9 @@ public protocol ComposeRuntimeLifecycleManaging: Sendable {
     /// Stops container `id` with the supplied signal and timeout.
     func stopContainer(id: String, signal: String?, timeoutInSeconds: Int?) async throws
 
+    /// Atomically restarts container `id` through the selected authority.
+    func restartContainer(id: String, signal: String?, timeoutInSeconds: Int?) async throws
+
     /// Pauses container `id`.
     func pauseContainer(id: String) async throws
 

--- a/Sources/ComposeRuntimeSPI/ComposeRuntimeDiscovery.swift
+++ b/Sources/ComposeRuntimeSPI/ComposeRuntimeDiscovery.swift
@@ -209,6 +209,10 @@ public struct ComposeContainerSummary: Sendable, Equatable, Codable {
     }
 
     public var id: String
+    /// Canonical runtime name used for presentation and name-based matching.
+    public var name: String?
+    /// Stable resource key used to retain Compose replica identity across renames.
+    public var bundleKey: String?
     public var status: String
     public var labels: [String: String]
     public var imageReference: String
@@ -223,6 +227,8 @@ public struct ComposeContainerSummary: Sendable, Equatable, Codable {
 
     public init(
         id: String,
+        name: String? = nil,
+        bundleKey: String? = nil,
         status: String,
         labels: [String: String] = [:],
         image: Image = Image(),
@@ -230,6 +236,8 @@ public struct ComposeContainerSummary: Sendable, Equatable, Codable {
         state: State = State(),
     ) {
         self.id = id
+        self.name = name
+        self.bundleKey = bundleKey
         self.status = status
         self.labels = labels
         imageReference = image.reference
@@ -241,6 +249,11 @@ public struct ComposeContainerSummary: Sendable, Equatable, Codable {
         exitCode = state.exitCode
         exitedDate = state.exitedDate
         health = state.health
+    }
+
+    /// Canonical runtime name, falling back to the operation identifier for legacy providers.
+    public var displayName: String {
+        name ?? id
     }
 
     public init(id: String, status: String, labels: [String: String] = [:], exitCode: Int32) {

--- a/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
@@ -1226,32 +1226,33 @@ extension ComposeOrchestratorTests {
         #expect(try listedContainerIDs(from: #require(emitted.messages.first)) == ["demo-api-1"])
     }
 
-    @Test("ps default discovery uses configured container binary and environment launcher")
-    func psDefaultDiscoveryUsesConfiguredContainerBinaryAndEnvironmentLauncher() async throws {
+    @Test("ps default discovery uses the native lifecycle API")
+    func psDefaultDiscoveryUsesNativeLifecycleAPI() async throws {
         let emitted = MessageRecorder()
-        let runner = RecordingRunner(responses: [
-            CommandResult(status: 0, stdout: "[]", stderr: ""),
-        ])
+        let runner = RecordingRunner()
         let options = ComposeExecutionOptions(
             containerBinary: "custom-container",
             environmentLauncher: "custom-env",
             runtimeHooks: .init(emit: { emitted.append($0) })
         )
+        let discoveryClient = ContainerDiscoveryAPIClient(
+            list: { _ in [] },
+            get: { _ in throw ComposeError.invalidProject("unexpected lookup") },
+            lifecycleList: { [] }
+        )
         let orchestrator = ComposeOrchestrator(
             runner: runner,
             options: options,
-            dependencies: ComposeContainerRuntime.dependencies(runner: runner, options: options)
+            dependencies: ComposeContainerRuntime.dependencies(
+                runner: runner,
+                options: options,
+                discoveryClient: discoveryClient
+            )
         )
 
         try await orchestrator.ps(project: ComposeProject(name: "demo", services: [:]))
 
-        let command = try #require(runner.commands.first)
-        #expect(runner.commands.count == 1)
-        #expect(command.executable == "custom-env")
-        #expect(command.arguments == ["custom-container", "list", "--format", "json"])
-        #expect(command.workingDirectory == nil)
-        #expect(command.environment == nil)
-        #expect(command.io == .captured(input: nil))
+        #expect(runner.commands.isEmpty)
         let output = try #require(emitted.messages.first)
         let rows = try JSONSerialization.jsonObject(with: Data(output.utf8)) as? [[String: Any]]
         #expect(rows?.isEmpty == true)
@@ -2030,6 +2031,14 @@ extension ComposeOrchestratorTests {
         #expect(try listedContainerIDs(from: #require(emitted.messages.first)) == ["demo-paused-1"])
     }
 
+    @Test("ps accepts lifecycle v2 status filters")
+    func psAcceptsLifecycleV2StatusFilters() throws {
+        #expect(try psStatusFilters(
+            statuses: ["restarting"],
+            filters: ["status=removing", "status=dead"]
+        ) == ["restarting", "removing", "dead"])
+    }
+
     @Test("ps status filters services projection")
     func psStatusFiltersServicesProjection() async throws {
         let emitted = MessageRecorder()
@@ -2102,11 +2111,11 @@ extension ComposeOrchestratorTests {
         do {
             try await orchestrator.ps(
                 project: ComposeProject(name: "demo", services: [:]),
-                options: ComposePsOptions { $0.statuses = ["restarting"] }
+                options: ComposePsOptions { $0.statuses = ["ghost"] }
             )
             Issue.record("Expected unsupported status error")
         } catch let error as ComposeError {
-            #expect(error == .unsupported("ps status 'restarting'; current macOS Compose exposes created, exited, paused, running, stopping, and unknown"))
+            #expect(error == .unsupported("ps status 'ghost'; current macOS Compose exposes created, dead, exited, paused, removing, restarting, running, stopping, and unknown"))
         } catch {
             Issue.record("Unexpected error: \(error)")
         }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
@@ -1238,7 +1238,7 @@ extension ComposeOrchestratorTests {
         let discoveryClient = ContainerDiscoveryAPIClient(
             list: { _ in [] },
             get: { _ in throw ComposeError.invalidProject("unexpected lookup") },
-            lifecycleList: { [] }
+            lifecycleViewList: { _ in [] }
         )
         let orchestrator = ComposeOrchestrator(
             runner: runner,

--- a/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
@@ -3224,8 +3224,19 @@ extension ComposeOrchestratorTests {
                 exitedDate: Date(timeIntervalSince1970: 1_700_000_000)
             ),
         ]
+        let apiLifecycle = ContainerLifecycleRecordV2(
+            containerID: "api-operation-id",
+            canonicalName: "demo-api-1",
+            immutableBundleKey: "demo-api-1",
+            selectedProviderFingerprint: "runtime",
+            snapshot: ContainerLifecycleSnapshotV2(
+                state: .running,
+                running: true,
+                health: "healthy"
+            )
+        )
         let workerLifecycle = ContainerLifecycleRecordV2(
-            containerID: String(repeating: "b", count: 64),
+            containerID: "worker-operation-id",
             canonicalName: "demo-worker-1",
             immutableBundleKey: "demo-worker-1",
             selectedProviderFingerprint: "runtime",
@@ -3238,9 +3249,10 @@ extension ComposeOrchestratorTests {
             )
         )
         let client = RecordingContainerDiscoveryAPIClient(
-            listResponse: snapshots,
-            getResponse: snapshots[1],
-            lifecycleResponse: [workerLifecycle]
+            lifecycleViewsResponse: [
+                ContainerLifecycleViewV2(container: snapshots[0], lifecycle: apiLifecycle),
+                ContainerLifecycleViewV2(container: snapshots[1], lifecycle: workerLifecycle),
+            ]
         )
         let manager = ContainerClientDiscoveryManager(client: client)
 
@@ -3263,15 +3275,27 @@ extension ComposeOrchestratorTests {
             platform: "linux/arm64"
         )
         let createdClient = RecordingContainerDiscoveryAPIClient(
-            listResponse: [createdSnapshot],
-            getResponse: createdSnapshot
+            lifecycleViewsResponse: [
+                ContainerLifecycleViewV2(
+                    container: createdSnapshot,
+                    lifecycle: ContainerLifecycleRecordV2(
+                        containerID: "created-operation-id",
+                        canonicalName: "demo-created-1",
+                        immutableBundleKey: "demo-created-1",
+                        selectedProviderFingerprint: "runtime",
+                        snapshot: ContainerLifecycleSnapshotV2(state: .created)
+                    )
+                ),
+            ]
         )
         let createdManager = ContainerClientDiscoveryManager(client: createdClient)
         let created = try await createdManager.getContainer(id: "demo-created-1")
 
-        #expect(running.map(\.id) == ["demo-api-1", "demo-worker-1"])
+        #expect(running.map(\.id) == ["api-operation-id", "worker-operation-id"])
         #expect(running.first == ComposeContainerSummary(
-            id: "demo-api-1",
+            id: "api-operation-id",
+            name: "demo-api-1",
+            bundleKey: "demo-api-1",
             status: "running",
             labels: [
                 composeProjectLabel: "demo",
@@ -3301,26 +3325,86 @@ extension ComposeOrchestratorTests {
                     ComposeContainerNetworkAttachment(network: "demo_backend", ipv4Address: "192.168.64.20"),
                 ]
             ),
-            state: ComposeContainerSummary.State(health: "healthy")
+            state: ComposeContainerSummary.State(exitCode: 0, health: "healthy")
         ))
         #expect(all.map(\.status) == ["running", "restarting"])
-        #expect(worker?.id == "demo-worker-1")
+        #expect(worker?.id == "worker-operation-id")
+        #expect(worker?.name == "demo-worker-1")
+        #expect(worker?.bundleKey == "demo-worker-1")
         #expect(worker?.status == "restarting")
         #expect(worker?.platform == "linux/amd64")
         #expect(worker?.exitCode == 17)
         #expect(worker?.exitedDate == Date(timeIntervalSince1970: 1_700_000_000))
         #expect(created?.status == "created")
-        #expect(created?.exitCode == nil)
+        #expect(created?.exitCode == 0)
         #expect(missing == nil)
 
-        let filters = await client.listFilters
-        #expect(filters.count == 2)
+        let filters = await client.lifecycleViewFilters
+        #expect(filters.count == 3)
         #expect(filters[0].status == nil)
         #expect(filters[0].labels[ResourceLabelKeys.plugin] == ContainerListFilters.exclude("machine"))
         #expect(filters[1].status == nil)
         #expect(filters[1].labels[ResourceLabelKeys.plugin] == ContainerListFilters.exclude("machine"))
-        #expect(await client.getRequests == ["demo-worker-1"])
-        #expect(await missingClient.getRequests == ["demo-missing-1"])
+        #expect(filters[2].ids.isEmpty)
+        #expect(filters[2].labels.isEmpty)
+        #expect(await client.getRequests.isEmpty)
+        #expect(await missingClient.getRequests.isEmpty)
+    }
+
+    @Test("atomic discovery preserves canonical presentation and immutable operation identity")
+    func atomicDiscoveryPreservesCanonicalAndImmutableIdentity() async throws {
+        var snapshot = try containerSnapshot(
+            id: "demo-api-1",
+            status: .running,
+            labels: [
+                composeProjectLabel: "demo",
+                composeServiceLabel: "api",
+            ],
+            imageReference: "example/api:latest",
+            imageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            platform: "linux/arm64"
+        )
+        snapshot.configuration.dockerName = "renamed-api"
+        let immutableID = String(repeating: "a", count: 64)
+        let lifecycle = ContainerLifecycleRecordV2(
+            containerID: immutableID,
+            canonicalName: "renamed-api",
+            immutableBundleKey: snapshot.id,
+            selectedProviderFingerprint: "runtime",
+            snapshot: ContainerLifecycleSnapshotV2(state: .running, running: true)
+        )
+        let manager = ContainerClientDiscoveryManager(
+            client: RecordingContainerDiscoveryAPIClient(
+                lifecycleViewsResponse: [
+                    ContainerLifecycleViewV2(container: snapshot, lifecycle: lifecycle),
+                ]
+            )
+        )
+
+        let summary = try #require(try await manager.getContainer(id: "renamed-api"))
+        let operationSummary = try #require(try await manager.getContainer(id: immutableID))
+        let service = composeService(name: "api", image: "example/api:latest")
+        let project = ComposeProject(name: "demo", services: ["api": service])
+        let orchestrator = ComposeOrchestrator(discoveryManager: manager)
+        let targets = try await orchestrator.serviceContainerTargets(
+            project: project,
+            services: [service]
+        )
+        let resolvedOperationID = try await orchestrator.serviceContainerID(
+            project: project,
+            service: service,
+            index: 1
+        )
+
+        #expect(summary.id == immutableID)
+        #expect(summary.displayName == "renamed-api")
+        #expect(summary.bundleKey == "demo-api-1")
+        #expect(operationSummary == summary)
+        #expect(containerIdentifiers([summary]) == [immutableID])
+        #expect(renderComposeContainerTable([summary], noTrunc: false).contains("renamed-api"))
+        #expect(targets.map(\.name) == [immutableID])
+        #expect(targets.compactMap(\.displayName) == ["renamed-api"])
+        #expect(resolvedOperationID == immutableID)
     }
 
     @Test("discovery manager does not revive legacy state cleared by lifecycle authority")
@@ -3348,8 +3432,9 @@ extension ComposeOrchestratorTests {
         )
         let manager = ContainerClientDiscoveryManager(
             client: RecordingContainerDiscoveryAPIClient(
-                getResponse: snapshot,
-                lifecycleResponse: [lifecycle]
+                lifecycleViewsResponse: [
+                    ContainerLifecycleViewV2(container: snapshot, lifecycle: lifecycle),
+                ]
             )
         )
 
@@ -3443,6 +3528,7 @@ extension ComposeOrchestratorTests {
         #expect(running == [
             ComposeContainerSummary(
                 id: "demo-api-1",
+                bundleKey: "demo-api-1",
                 status: "running",
                 labels: [
                     composeProjectLabel: "demo",
@@ -3592,7 +3678,20 @@ extension ComposeOrchestratorTests {
             imageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             platform: "linux/arm64"
         )
-        let recorder = RecordingContainerDiscoveryAPIClient(listResponse: [snapshot], getResponse: snapshot)
+        let lifecycleView = ContainerLifecycleViewV2(
+            container: snapshot,
+            lifecycle: ContainerLifecycleRecordV2.migrate(
+                bundleKey: snapshot.id,
+                canonicalName: snapshot.id,
+                selectedProviderFingerprint: "runtime",
+                legacy: nil
+            )
+        )
+        let recorder = RecordingContainerDiscoveryAPIClient(
+            listResponse: [snapshot],
+            getResponse: snapshot,
+            lifecycleViewsResponse: [lifecycleView]
+        )
         let client = ContainerDiscoveryAPIClient(
             list: { filters in
                 try await recorder.listContainers(filters: filters)
@@ -3602,17 +3701,23 @@ extension ComposeOrchestratorTests {
                     throw ComposeError.invalidProject("missing test snapshot")
                 }
                 return snapshot
+            },
+            lifecycleViewList: { filters in
+                try await recorder.listLifecycleViews(filters: filters)
             }
         )
         let filters = ContainerListFilters(ids: ["demo-api-1"], status: .running)
 
         let listed = try await client.listContainers(filters: filters)
         let fetched = try await client.getContainer(id: "demo-api-1")
+        let views = try await client.listLifecycleViews(filters: filters)
 
         #expect(listed.map(\.id) == ["demo-api-1"])
         #expect(fetched?.id == "demo-api-1")
+        #expect(views.map(\.lifecycle.containerID) == ["demo-api-1"])
         #expect(await recorder.listFilters.map(\.ids) == [["demo-api-1"]])
         #expect(await recorder.getRequests == ["demo-api-1"])
+        #expect(await recorder.lifecycleViewFilters.map(\.ids) == [["demo-api-1"]])
     }
 
     @Test("discovery API client maps not found and surfaces get failures")
@@ -3645,22 +3750,23 @@ extension ComposeOrchestratorTests {
         }
     }
 
-    @Test("discovery manager surfaces get failures")
-    func discoveryManagerSurfacesGetFailures() async throws {
-        let expected = ComposeError.invalidProject("get failed")
-        let client = RecordingContainerDiscoveryAPIClient(getError: expected)
+    @Test("discovery manager surfaces atomic lifecycle-view failures")
+    func discoveryManagerSurfacesLifecycleViewFailures() async throws {
+        let expected = ComposeError.invalidProject("lifecycle views failed")
+        let client = RecordingContainerDiscoveryAPIClient(lifecycleViewsError: expected)
         let manager = ContainerClientDiscoveryManager(client: client)
 
         do {
             _ = try await manager.getContainer(id: "demo-api-1")
-            Issue.record("Expected discovery get failure")
+            Issue.record("Expected lifecycle-view failure")
         } catch let error as ComposeError {
             #expect(error == expected)
         } catch {
             Issue.record("Unexpected error: \(error)")
         }
 
-        #expect(await client.getRequests == ["demo-api-1"])
+        #expect(await client.getRequests.isEmpty)
+        #expect(await client.lifecycleViewFilters.count == 1)
     }
 
 }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
@@ -839,8 +839,7 @@ extension ComposeOrchestratorTests {
         #expect(await lifecycleManager.requests == [
             .start(id: "demo-api-1"),
             .stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 9),
-            .stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 9),
-            .start(id: "demo-api-1"),
+            .restart(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 9),
             .stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 9),
             .delete(id: "demo-api-1", force: true),
             .kill(id: "demo-api-1", signal: "SIGTERM"),
@@ -1025,35 +1024,42 @@ extension ComposeOrchestratorTests {
             ),
         ])
         #expect(await lifecycleManager.requests == [
-            .stop(id: "demo-api-1", signal: nil, timeoutInSeconds: nil),
-            .start(id: "demo-api-1"),
+            .restart(id: "demo-api-1", signal: nil, timeoutInSeconds: nil),
         ])
         #expect(runner.commands.isEmpty)
     }
 
-    @Test("restart includes dependencies unless no-deps is set")
-    func restartIncludesDependenciesUnlessNoDepsIsSet() async throws {
+    @Test("restart follows restart dependencies unless no-deps is set")
+    func restartFollowsRestartDependenciesUnlessNoDepsIsSet() async throws {
         let lifecycleManager = RecordingContainerLifecycleManager()
         let project = ComposeProject(
             name: "demo",
             services: [
                 "api": composeService(name: "api", image: "example/api") {
-                    $0.dependsOn = ["db": ComposeDependency(condition: "service_started")]
+                    $0.dependsOn = [
+                        "cache": ComposeDependency(condition: "service_started"),
+                        "db": ComposeDependency(condition: "service_started", restart: true),
+                    ]
                 },
+                "cache": ComposeService(name: "cache", image: "redis"),
                 "db": ComposeService(name: "db", image: "postgres"),
+                "worker": composeService(name: "worker", image: "example/worker") {
+                    $0.dependsOn = [
+                        "api": ComposeDependency(condition: "service_started", restart: true),
+                    ]
+                },
             ]
         )
 
         try await ComposeOrchestrator(
             runner: RecordingRunner(),
             lifecycleManager: lifecycleManager
-        ).restart(project: project, services: ["api"])
+        ).restart(project: project, services: ["db"])
 
         #expect(await lifecycleManager.requests == [
-            .stop(id: "demo-api-1", signal: nil, timeoutInSeconds: nil),
-            .stop(id: "demo-db-1", signal: nil, timeoutInSeconds: nil),
-            .start(id: "demo-db-1"),
-            .start(id: "demo-api-1"),
+            .restart(id: "demo-db-1", signal: nil, timeoutInSeconds: nil),
+            .restart(id: "demo-api-1", signal: nil, timeoutInSeconds: nil),
+            .restart(id: "demo-worker-1", signal: nil, timeoutInSeconds: nil),
         ])
 
         let noDepsLifecycleManager = RecordingContainerLifecycleManager()
@@ -1061,14 +1067,61 @@ extension ComposeOrchestratorTests {
             runner: RecordingRunner(),
             lifecycleManager: noDepsLifecycleManager
         ).restart(project: project, options: ComposeRestartOptions {
-            $0.services = ["api"]
+            $0.services = ["db"]
             $0.noDeps = true
         })
 
         #expect(await noDepsLifecycleManager.requests == [
-            .stop(id: "demo-api-1", signal: nil, timeoutInSeconds: nil),
-            .start(id: "demo-api-1"),
+            .restart(id: "demo-db-1", signal: nil, timeoutInSeconds: nil),
         ])
+
+        let selectedNoDepsLifecycleManager = RecordingContainerLifecycleManager()
+        try await ComposeOrchestrator(
+            runner: RecordingRunner(),
+            lifecycleManager: selectedNoDepsLifecycleManager
+        ).restart(project: project, options: ComposeRestartOptions {
+            $0.services = ["api", "db"]
+            $0.noDeps = true
+        })
+
+        #expect(await selectedNoDepsLifecycleManager.requests == [
+            .restart(id: "demo-db-1", signal: nil, timeoutInSeconds: nil),
+            .restart(id: "demo-api-1", signal: nil, timeoutInSeconds: nil),
+        ])
+    }
+
+    @Test("restart dry run renders one native restart between lifecycle hooks")
+    func restartDryRunRendersOneNativeRestartBetweenLifecycleHooks() async throws {
+        let emitted = MessageRecorder()
+        let execManager = RecordingContainerExecManager()
+        let lifecycleManager = RecordingContainerLifecycleManager()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.preStop = [ComposeServiceHook(command: ["sh", "-c", "echo stopping"])]
+                    $0.postStart = [ComposeServiceHook(command: ["sh", "-c", "echo started"])]
+                    $0.stopSignal = "SIGUSR1"
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(
+            runner: RecordingRunner(),
+            options: ComposeExecutionOptions(dryRun: true, emit: { emitted.append($0) }),
+            dependencies: orchestratorDependencies {
+                $0.execManager = execManager
+                $0.lifecycleManager = lifecycleManager
+            }
+        ).restart(project: project, services: ["api"], timeout: 13)
+
+        #expect(emitted.messages == [
+            "+ container exec demo-api-1 sh -c 'echo stopping'",
+            "+ container restart --signal SIGUSR1 --time 13 demo-api-1",
+            "+ container exec demo-api-1 sh -c 'echo started'",
+        ])
+        #expect(await execManager.attachedRequests.isEmpty)
+        #expect(await lifecycleManager.requests.isEmpty)
     }
 
     @Test("lifecycle hooks render exec commands in dry run")
@@ -1546,8 +1599,8 @@ extension ComposeOrchestratorTests {
         ])
     }
 
-    @Test("pre start treats a paused replica as already running")
-    func preStartTreatsPausedReplicaAsAlreadyRunning() async throws {
+    @Test("pre start treats paused and restarting replicas as already running")
+    func preStartTreatsPausedAndRestartingReplicasAsAlreadyRunning() async throws {
         let runner = RecordingRunner()
         let lifecycleManager = RecordingContainerLifecycleManager()
         let service = composeService(name: "api", image: "example/api") {
@@ -1571,6 +1624,15 @@ extension ComposeOrchestratorTests {
                         ),
                         ComposeContainerSummary(
                             id: "demo-api-2",
+                            status: "restarting",
+                            labels: [
+                                composeProjectLabel: "demo",
+                                composeServiceLabel: "api",
+                                composeOneOffLabel: "false",
+                            ]
+                        ),
+                        ComposeContainerSummary(
+                            id: "demo-api-3",
                             status: "stopped",
                             labels: [
                                 composeProjectLabel: "demo",
@@ -1589,7 +1651,7 @@ extension ComposeOrchestratorTests {
 
         #expect(runner.commands.isEmpty)
         #expect(await lifecycleManager.requests == [
-            .start(id: "demo-api-2"),
+            .start(id: "demo-api-3"),
         ])
     }
 
@@ -2968,6 +3030,7 @@ extension ComposeOrchestratorTests {
         try await manager.killContainer(id: "demo-api-1", signal: "SIGTERM")
         try await manager.stopContainer(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 12)
         try await manager.stopContainer(id: "demo-worker-1", signal: nil, timeoutInSeconds: nil)
+        try await manager.restartContainer(id: "demo-api-1", signal: "SIGUSR2", timeoutInSeconds: 9)
         try await manager.pauseContainer(id: "demo-api-1")
         try await manager.unpauseContainer(id: "demo-api-1")
         let exitCode = try await manager.waitContainer(id: "demo-api-1")
@@ -2979,6 +3042,7 @@ extension ComposeOrchestratorTests {
             .kill(id: "demo-api-1", signal: "SIGTERM"),
             .stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 12),
             .stop(id: "demo-worker-1", signal: nil, timeoutInSeconds: nil),
+            .restart(id: "demo-api-1", signal: "SIGUSR2", timeoutInSeconds: 9),
             .pause(id: "demo-api-1"),
             .unpause(id: "demo-api-1"),
             .wait(id: "demo-api-1"),
@@ -3026,6 +3090,9 @@ extension ComposeOrchestratorTests {
                 stop: { id, options in
                     try await recorder.stopContainer(id: id, options: options)
                 },
+                restart: { id, options in
+                    try await recorder.restartContainer(id: id, options: options)
+                },
                 pause: { id in
                     try await recorder.pauseContainer(id: id)
                 },
@@ -3047,6 +3114,7 @@ extension ComposeOrchestratorTests {
         try await client.startContainer(id: "demo-api-1")
         try await client.killContainer(id: "demo-api-1", signal: "SIGTERM")
         try await client.stopContainer(id: "demo-api-1", options: stopOptions)
+        try await client.restartContainer(id: "demo-api-1", options: stopOptions)
         try await client.pauseContainer(id: "demo-api-1")
         try await client.unpauseContainer(id: "demo-api-1")
         _ = try await client.waitContainer(id: "demo-api-1")
@@ -3056,6 +3124,7 @@ extension ComposeOrchestratorTests {
             .start(id: "demo-api-1"),
             .kill(id: "demo-api-1", signal: "SIGTERM"),
             .stop(id: "demo-api-1", signal: "SIGQUIT", timeoutInSeconds: 15),
+            .restart(id: "demo-api-1", signal: "SIGQUIT", timeoutInSeconds: 15),
             .pause(id: "demo-api-1"),
             .unpause(id: "demo-api-1"),
             .wait(id: "demo-api-1"),
@@ -3155,7 +3224,24 @@ extension ComposeOrchestratorTests {
                 exitedDate: Date(timeIntervalSince1970: 1_700_000_000)
             ),
         ]
-        let client = RecordingContainerDiscoveryAPIClient(listResponse: snapshots, getResponse: snapshots[1])
+        let workerLifecycle = ContainerLifecycleRecordV2(
+            containerID: String(repeating: "b", count: 64),
+            canonicalName: "demo-worker-1",
+            immutableBundleKey: "demo-worker-1",
+            selectedProviderFingerprint: "runtime",
+            snapshot: ContainerLifecycleSnapshotV2(
+                state: .restarting,
+                running: true,
+                restarting: true,
+                exitCode: 17,
+                finishedAt: Date(timeIntervalSince1970: 1_700_000_000)
+            )
+        )
+        let client = RecordingContainerDiscoveryAPIClient(
+            listResponse: snapshots,
+            getResponse: snapshots[1],
+            lifecycleResponse: [workerLifecycle]
+        )
         let manager = ContainerClientDiscoveryManager(client: client)
 
         let running = try await manager.listContainers(all: false)
@@ -3217,8 +3303,9 @@ extension ComposeOrchestratorTests {
             ),
             state: ComposeContainerSummary.State(health: "healthy")
         ))
-        #expect(all.map(\.status) == ["running", "exited"])
+        #expect(all.map(\.status) == ["running", "restarting"])
         #expect(worker?.id == "demo-worker-1")
+        #expect(worker?.status == "restarting")
         #expect(worker?.platform == "linux/amd64")
         #expect(worker?.exitCode == 17)
         #expect(worker?.exitedDate == Date(timeIntervalSince1970: 1_700_000_000))
@@ -3228,12 +3315,50 @@ extension ComposeOrchestratorTests {
 
         let filters = await client.listFilters
         #expect(filters.count == 2)
-        #expect(filters[0].status == .running)
+        #expect(filters[0].status == nil)
         #expect(filters[0].labels[ResourceLabelKeys.plugin] == ContainerListFilters.exclude("machine"))
         #expect(filters[1].status == nil)
         #expect(filters[1].labels[ResourceLabelKeys.plugin] == ContainerListFilters.exclude("machine"))
         #expect(await client.getRequests == ["demo-worker-1"])
         #expect(await missingClient.getRequests == ["demo-missing-1"])
+    }
+
+    @Test("discovery manager does not revive legacy state cleared by lifecycle authority")
+    func discoveryManagerDoesNotReviveLegacyStateClearedByLifecycleAuthority() async throws {
+        let snapshot = try containerSnapshot(
+            id: "demo-api-1",
+            status: .stopped,
+            imageReference: "example/api:latest",
+            imageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            platform: "linux/arm64",
+            startedDate: Date(timeIntervalSince1970: 1_699_999_000),
+            exitCode: 23,
+            exitedDate: Date(timeIntervalSince1970: 1_700_000_000),
+            health: .unhealthy
+        )
+        let lifecycle = ContainerLifecycleRecordV2(
+            containerID: String(repeating: "a", count: 64),
+            canonicalName: "demo-api-1",
+            immutableBundleKey: "demo-api-1",
+            selectedProviderFingerprint: "runtime",
+            snapshot: ContainerLifecycleSnapshotV2(
+                state: .running,
+                running: true
+            )
+        )
+        let manager = ContainerClientDiscoveryManager(
+            client: RecordingContainerDiscoveryAPIClient(
+                getResponse: snapshot,
+                lifecycleResponse: [lifecycle]
+            )
+        )
+
+        let summary = try #require(try await manager.getContainer(id: "demo-api-1"))
+
+        #expect(summary.status == "running")
+        #expect(summary.exitCode == 0)
+        #expect(summary.exitedDate == nil)
+        #expect(summary.health == nil)
     }
 
     @Test("CLI JSON discovery manager maps container list output to compose summaries")

--- a/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
@@ -3407,6 +3407,72 @@ extension ComposeOrchestratorTests {
         #expect(resolvedOperationID == immutableID)
     }
 
+    @Test("replica index resolution prefers stable bundle identity over a reused canonical name")
+    func replicaIndexResolutionPrefersStableBundleIdentity() async throws {
+        var firstSnapshot = try containerSnapshot(
+            id: "demo-api-1",
+            status: .running,
+            labels: [
+                composeProjectLabel: "demo",
+                composeServiceLabel: "api",
+            ],
+            imageReference: "example/api:latest",
+            imageDigest: "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            platform: "linux/arm64"
+        )
+        firstSnapshot.configuration.dockerName = "demo-api-2"
+        var secondSnapshot = try containerSnapshot(
+            id: "demo-api-2",
+            status: .running,
+            labels: [
+                composeProjectLabel: "demo",
+                composeServiceLabel: "api",
+            ],
+            imageReference: "example/api:latest",
+            imageDigest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            platform: "linux/arm64"
+        )
+        secondSnapshot.configuration.dockerName = "renamed-api"
+        let firstID = String(repeating: "a", count: 64)
+        let secondID = String(repeating: "b", count: 64)
+        let manager = ContainerClientDiscoveryManager(
+            client: RecordingContainerDiscoveryAPIClient(
+                lifecycleViewsResponse: [
+                    ContainerLifecycleViewV2(
+                        container: firstSnapshot,
+                        lifecycle: ContainerLifecycleRecordV2(
+                            containerID: firstID,
+                            canonicalName: "demo-api-2",
+                            immutableBundleKey: firstSnapshot.id,
+                            selectedProviderFingerprint: "runtime",
+                            snapshot: ContainerLifecycleSnapshotV2(state: .running, running: true)
+                        )
+                    ),
+                    ContainerLifecycleViewV2(
+                        container: secondSnapshot,
+                        lifecycle: ContainerLifecycleRecordV2(
+                            containerID: secondID,
+                            canonicalName: "renamed-api",
+                            immutableBundleKey: secondSnapshot.id,
+                            selectedProviderFingerprint: "runtime",
+                            snapshot: ContainerLifecycleSnapshotV2(state: .running, running: true)
+                        )
+                    ),
+                ]
+            )
+        )
+        let service = composeService(name: "api", image: "example/api:latest")
+        let orchestrator = ComposeOrchestrator(discoveryManager: manager)
+
+        let resolvedID = try await orchestrator.serviceContainerID(
+            project: ComposeProject(name: "demo", services: ["api": service]),
+            service: service,
+            index: 2
+        )
+
+        #expect(resolvedID == secondID)
+    }
+
     @Test("discovery manager does not revive legacy state cleared by lifecycle authority")
     func discoveryManagerDoesNotReviveLegacyStateClearedByLifecycleAuthority() async throws {
         let snapshot = try containerSnapshot(

--- a/Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift
@@ -2623,8 +2623,7 @@ extension ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
         #expect(await lifecycleManager.requests == [
             .stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 12),
-            .stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 13),
-            .start(id: "demo-api-1"),
+            .restart(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 13),
             .stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 14),
             .delete(id: "demo-api-1", force: false),
         ])

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
@@ -1493,6 +1493,7 @@ enum ContainerLifecycleRequest: Equatable {
     case start(id: String)
     case kill(id: String, signal: String)
     case stop(id: String, signal: String?, timeoutInSeconds: Int?)
+    case restart(id: String, signal: String?, timeoutInSeconds: Int?)
     case pause(id: String)
     case unpause(id: String)
     case wait(id: String)
@@ -1505,7 +1506,7 @@ extension ContainerLifecycleRequest {
         switch self {
         case let .start(id), let .pause(id), let .unpause(id), let .wait(id), let .get(id):
             id
-        case let .kill(id, _), let .stop(id, _, _), let .delete(id, _):
+        case let .kill(id, _), let .stop(id, _, _), let .restart(id, _, _), let .delete(id, _):
             id
         }
     }
@@ -2125,6 +2126,10 @@ actor RecordingContainerLifecycleManager: ContainerLifecycleManaging {
         }
     }
 
+    func restartContainer(id: String, signal: String?, timeoutInSeconds: Int?) async throws {
+        storage.append(.restart(id: id, signal: signal, timeoutInSeconds: timeoutInSeconds))
+    }
+
     func pauseContainer(id: String) async throws {
         storage.append(.pause(id: id))
     }
@@ -2199,6 +2204,7 @@ actor RecordingContainerDiscoveryManager: ContainerDiscoveryManaging {
 actor RecordingContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
     private let listResponse: [ContainerSnapshot]
     private let getResponse: ContainerSnapshot?
+    private let lifecycleResponse: [ContainerLifecycleRecordV2]
     private let getError: (any Error)?
     private var filters: [ContainerListFilters] = []
     private var gets: [String] = []
@@ -2206,10 +2212,12 @@ actor RecordingContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
     init(
         listResponse: [ContainerSnapshot] = [],
         getResponse: ContainerSnapshot? = nil,
+        lifecycleResponse: [ContainerLifecycleRecordV2] = [],
         getError: (any Error)? = nil
     ) {
         self.listResponse = listResponse
         self.getResponse = getResponse
+        self.lifecycleResponse = lifecycleResponse
         self.getError = getError
     }
 
@@ -2232,6 +2240,10 @@ actor RecordingContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
             throw getError
         }
         return getResponse
+    }
+
+    func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2] {
+        lifecycleResponse
     }
 }
 
@@ -3545,6 +3557,14 @@ actor RecordingContainerLifecycleAPIClient: ContainerLifecycleAPIClienting {
 
     func stopContainer(id: String, options: ContainerStopOptions) async throws {
         storage.append(.stop(
+            id: id,
+            signal: options.signal,
+            timeoutInSeconds: options.timeoutInSeconds.map(Int.init)
+        ))
+    }
+
+    func restartContainer(id: String, options: ContainerStopOptions) async throws {
+        storage.append(.restart(
             id: id,
             signal: options.signal,
             timeoutInSeconds: options.timeoutInSeconds.map(Int.init)

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
@@ -2204,21 +2204,25 @@ actor RecordingContainerDiscoveryManager: ContainerDiscoveryManaging {
 actor RecordingContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
     private let listResponse: [ContainerSnapshot]
     private let getResponse: ContainerSnapshot?
-    private let lifecycleResponse: [ContainerLifecycleRecordV2]
+    private let lifecycleViewsResponse: [ContainerLifecycleViewV2]
     private let getError: (any Error)?
+    private let lifecycleViewsError: (any Error)?
     private var filters: [ContainerListFilters] = []
+    private var lifecycleFilters: [ContainerListFilters] = []
     private var gets: [String] = []
 
     init(
         listResponse: [ContainerSnapshot] = [],
         getResponse: ContainerSnapshot? = nil,
-        lifecycleResponse: [ContainerLifecycleRecordV2] = [],
-        getError: (any Error)? = nil
+        lifecycleViewsResponse: [ContainerLifecycleViewV2] = [],
+        getError: (any Error)? = nil,
+        lifecycleViewsError: (any Error)? = nil
     ) {
         self.listResponse = listResponse
         self.getResponse = getResponse
-        self.lifecycleResponse = lifecycleResponse
+        self.lifecycleViewsResponse = lifecycleViewsResponse
         self.getError = getError
+        self.lifecycleViewsError = lifecycleViewsError
     }
 
     var listFilters: [ContainerListFilters] {
@@ -2227,6 +2231,10 @@ actor RecordingContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
 
     var getRequests: [String] {
         gets
+    }
+
+    var lifecycleViewFilters: [ContainerListFilters] {
+        lifecycleFilters
     }
 
     func listContainers(filters: ContainerListFilters) async throws -> [ContainerSnapshot] {
@@ -2242,8 +2250,12 @@ actor RecordingContainerDiscoveryAPIClient: ContainerDiscoveryAPIClienting {
         return getResponse
     }
 
-    func listLifecycleRecords() async throws -> [ContainerLifecycleRecordV2] {
-        lifecycleResponse
+    func listLifecycleViews(filters: ContainerListFilters) async throws -> [ContainerLifecycleViewV2] {
+        lifecycleFilters.append(filters)
+        if let lifecycleViewsError {
+            throw lifecycleViewsError
+        }
+        return lifecycleViewsResponse
     }
 }
 

--- a/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
@@ -3171,14 +3171,15 @@ extension ComposeOrchestratorTests {
         #expect(await discoveryManager.listRequests == [true, true])
     }
 
-    @Test("up wait implies detached containers and polls until running")
-    func upWaitImpliesDetachedContainersAndPollsUntilRunning() async throws {
+    @Test("up wait implies detached containers and polls through restarting until running")
+    func upWaitImpliesDetachedContainersAndPollsThroughRestartingUntilRunning() async throws {
         let runner = RecordingRunner(responses: [.success])
         let discoveryManager = RecordingContainerDiscoveryManager(
             getResponses: [
                 "demo-api-1": [
                     nil,
                     ComposeContainerSummary(id: "demo-api-1", status: "starting"),
+                    ComposeContainerSummary(id: "demo-api-1", status: "restarting"),
                     ComposeContainerSummary(id: "demo-api-1", status: "running"),
                 ],
             ]
@@ -3200,7 +3201,7 @@ extension ComposeOrchestratorTests {
         let commands = runner.commands.map(\.arguments)
         #expect(commands.count == 1)
         #expect(commands[0].starts(with: ["container", "run", "--name", "demo-api-1", "--detach"]))
-        #expect(await discoveryManager.getRequests == ["demo-api-1", "demo-api-1", "demo-api-1"])
+        #expect(await discoveryManager.getRequests == ["demo-api-1", "demo-api-1", "demo-api-1", "demo-api-1"])
     }
 
     @Test("up wait treats deploy job modes as ordinary running services")

--- a/Tests/ComposeCoreTests/ComposeRuntimeProviderDefaultsTests.swift
+++ b/Tests/ComposeCoreTests/ComposeRuntimeProviderDefaultsTests.swift
@@ -159,6 +159,9 @@ struct ComposeRuntimeProviderDefaultsTests {
         await expectUnavailable("container stop") {
             try await lifecycle.stopContainer(id: "app", signal: nil, timeoutInSeconds: nil)
         }
+        await expectUnavailable("container restart") {
+            try await lifecycle.restartContainer(id: "app", signal: nil, timeoutInSeconds: nil)
+        }
         await expectUnavailable("container pause") {
             try await lifecycle.pauseContainer(id: "app")
         }

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -961,6 +961,12 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             )
             fake_bin = temporary_root / "fake-bin"
             fake_bin.mkdir()
+            fake_sleep = fake_bin / "sleep"
+            fake_sleep.write_text(
+                "#!/usr/bin/env bash\nexit 0\n",
+                encoding="utf-8",
+            )
+            fake_sleep.chmod(0o755)
             fake_git = fake_bin / "git"
             clone_started = temporary_root / "clone-started"
             real_git = shutil.which("git")
@@ -970,7 +976,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 "set -euo pipefail\n"
                 'if [[ "${1:-}" == "clone" ]]; then\n'
                 f"  touch {clone_started}\n"
-                "  sleep 30\n"
+                "  /bin/sleep 30\n"
                 "fi\n"
                 f'exec "{real_git}" "$@"\n',
                 encoding="utf-8",
@@ -987,7 +993,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                     "CONTAINER_RUNTIME_INIT_BLOCK_REPO": str(init_repo),
                     "CONTAINERIZATION_INIT_SOURCE_PATH": str(source),
                     "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
-                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "8",
+                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "10",
                     "CONTAINER_TEST_LOG": str(container_log),
                     "PATH": f"{fake_bin}:{environment['PATH']}",
                 }
@@ -1001,11 +1007,11 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 capture_output=True,
                 text=True,
                 check=False,
-                timeout=11,
+                timeout=13,
             )
 
             self.assertEqual(result.returncode, 124, result.stdout + result.stderr)
-            self.assertLess(time.monotonic() - started, 10)
+            self.assertLess(time.monotonic() - started, 12)
             self.assertTrue(clone_started.exists())
             self.assertFalse(command_marker.exists())
 
@@ -1078,22 +1084,43 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             app_root = temporary_root / "app-root"
             command_marker = temporary_root / "command-ran"
             container_log = temporary_root / "container.log"
-            fake_container = temporary_root / "container-cli"
+            fake_bin = temporary_root / "fake-bin"
+            fake_bin.mkdir()
+            fake_sleep = fake_bin / "sleep"
+            fake_sleep.write_text(
+                "#!/usr/bin/env bash\nexit 0\n",
+                encoding="utf-8",
+            )
+            fake_sleep.chmod(0o755)
+            first_start = temporary_root / "first-start"
+            fake_container = fake_bin / "container-cli"
             init_repo = temporary_root / "container"
             init_repo.mkdir()
             (init_repo / "Makefile").write_text(
                 "init-block:\n\t@true\n",
                 encoding="utf-8",
             )
-            self.write_fake_container(fake_container)
+            self.write_fake_container(
+                fake_container,
+                body=(
+                    'if [[ "$*" == *"system start"* ]]; then\n'
+                    '  if [[ -e "${FIRST_START:?}" ]]; then\n'
+                    "    /bin/sleep 30\n"
+                    "  fi\n"
+                    '  touch "${FIRST_START:?}"\n'
+                    "fi\n"
+                ),
+            )
             environment = self.runtime_environment()
             environment.update(
                 {
                     "CONTAINER_RUNTIME_APP_ROOT": str(app_root),
                     "CONTAINER_RUNTIME_INIT_BLOCK_REPO": str(init_repo),
                     "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
-                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "6",
+                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "8",
                     "CONTAINER_TEST_LOG": str(container_log),
+                    "FIRST_START": str(first_start),
+                    "PATH": f"{fake_bin}:{environment['PATH']}",
                 }
             )
 
@@ -1104,13 +1131,14 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 check=False,
                 capture_output=True,
                 text=True,
-                timeout=7,
+                timeout=11,
             )
 
             self.assertEqual(result.returncode, 124, result.stdout + result.stderr)
             self.assertFalse(command_marker.exists())
+            self.assertTrue(first_start.exists(), result.stdout + result.stderr)
             invocations = container_log.read_text(encoding="utf-8")
-            self.assertEqual(invocations.count("system start"), 1)
+            self.assertEqual(invocations.count("system start"), 2)
 
     def test_stale_runtime_stop_hang_consumes_the_shared_startup_deadline(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1162,12 +1190,20 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             container_log = temporary_root / "container.log"
             builder_archive = temporary_root / "builder.tar"
             builder_archive.touch()
+            fake_bin = temporary_root / "fake-bin"
+            fake_bin.mkdir()
+            fake_sleep = fake_bin / "sleep"
+            fake_sleep.write_text(
+                "#!/usr/bin/env bash\nexit 0\n",
+                encoding="utf-8",
+            )
+            fake_sleep.chmod(0o755)
             fake_container = temporary_root / "container-cli"
             self.write_fake_container(
                 fake_container,
                 body=(
                     'if [[ "$*" == "image load -i "* ]]; then\n'
-                    "  sleep 30\n"
+                    "  /bin/sleep 30\n"
                     "fi\n"
                 ),
             )
@@ -1178,8 +1214,9 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                     "CONTAINER_RUNTIME_BUILDER_IMAGE": "local/builder:test",
                     "CONTAINER_RUNTIME_BUILDER_IMAGE_TAR": str(builder_archive),
                     "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
-                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "6",
+                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "8",
                     "CONTAINER_TEST_LOG": str(container_log),
+                    "PATH": f"{fake_bin}:{environment['PATH']}",
                 }
             )
 
@@ -1191,11 +1228,11 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 check=False,
                 capture_output=True,
                 text=True,
-                timeout=9,
+                timeout=11,
             )
 
             self.assertEqual(result.returncode, 124, result.stdout + result.stderr)
-            self.assertLess(time.monotonic() - started, 8, result.stdout + result.stderr)
+            self.assertLess(time.monotonic() - started, 10, result.stdout + result.stderr)
             self.assertFalse(command_marker.exists())
             self.assertIn("image load -i", container_log.read_text(encoding="utf-8"))
 
@@ -2199,7 +2236,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                     "CONTAINER_RUNTIME_LOCK_FILE": str(
                         temporary_root / "runtime.lock"
                     ),
-                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "4",
+                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "8",
                     "CONTAINER_TEST_LOG": str(container_log),
                     "MKTEMP_STARTED": str(mktemp_started),
                     "MKTEMP_ARGUMENTS": str(mktemp_arguments),
@@ -2215,11 +2252,11 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
                 check=False,
                 capture_output=True,
                 text=True,
-                timeout=7,
+                timeout=11,
             )
 
             self.assertEqual(result.returncode, 124, result.stdout + result.stderr)
-            self.assertLess(time.monotonic() - started, 6)
+            self.assertLess(time.monotonic() - started, 10)
             self.assertTrue(
                 mktemp_started.exists(), result.stdout + result.stderr
             )

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "9aa1803223e8573f169c2a2effa657392b4d6e30",
+      "ref": "4dee971a0bd66a5212cad63d064912e23136699e",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "f0bc99d26cd27ed58b06236421a298d9e4acd5c1",
+      "ref": "3e078480b85dceb843133392573cdd4d9efeec0d",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "4dee971a0bd66a5212cad63d064912e23136699e",
+      "ref": "99c0244f37c0bf4aabdfbff7b62d0d2d81541633",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

- use one atomic native restart operation instead of stop/start orchestration
- require every lifecycle provider to implement atomic restart explicitly
- preserve Compose pre-stop and post-start hook ordering around that restart
- restart only `depends_on.restart: true` dependents and do so in dependency order
- discover created, running, paused, restarting, exited, removing, and dead state through lifecycle v2
- keep `ps` state filters and output on one coherent native snapshot
- align the checked-in coordinated stack with the merged lifecycle authority

## Verification

- `make check`: 400 tool and parity tests plus runtime-neutrality, stack consistency, handoff registry, licence, and secret checks
- `make test`: 1,376 Swift tests across 60 suites plus all Go packages
- runtime harness: 44 focused deadline and lifecycle tests
- strict SwiftFormat and SwiftLint on the changed restart and provider sources

Refs #274
Depends on stephenlclarke/container#126