### PR TITLE
test(lifecycle): align discovery fixtures

### DIFF
--- a/Tests/ComposeCoreTests/ComposeOrchestratorCopyExportCommitTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorCopyExportCommitTests.swift
@@ -1151,8 +1151,8 @@ extension ComposeOrchestratorTests {
         )
 
         #expect(await exporter.requests == [
-            ContainerExportRequest(id: "demo-api-1", output: nil, live: false),
-            ContainerExportRequest(id: "custom-db", output: "db.tar", live: false),
+            ContainerExportRequest(id: "demo-api-1", output: nil, live: true),
+            ContainerExportRequest(id: "custom-db", output: "db.tar", live: true),
         ])
         #expect(runner.commands.isEmpty)
     }
@@ -2033,6 +2033,10 @@ extension ComposeOrchestratorTests {
             ComposeContainerSummary(
                 id: "demo-api-1",
                 status: "running",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "api",
+                ],
                 publishedPorts: [
                     ComposeContainerPublishedPort(hostAddress: "0.0.0.0", hostPort: 8080, containerPort: 80, protocolName: "tcp"),
                     ComposeContainerPublishedPort(hostAddress: "127.0.0.1", hostPort: 8443, containerPort: 443, protocolName: "tcp"),
@@ -2100,6 +2104,10 @@ extension ComposeOrchestratorTests {
             ComposeContainerSummary(
                 id: "demo-api-1",
                 status: "running",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "api",
+                ],
                 publishedPorts: [
                     ComposeContainerPublishedPort(hostAddress: "0.0.0.0", hostPort: 8080, containerPort: 80, protocolName: "tcp", count: 3),
                 ]
@@ -2217,6 +2225,10 @@ extension ComposeOrchestratorTests {
             ComposeContainerSummary(
                 id: "demo-api-1",
                 status: "running",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "api",
+                ],
                 publishedPorts: [
                     ComposeContainerPublishedPort(hostAddress: "0.0.0.0", hostPort: 8080, containerPort: 80, protocolName: "tcp"),
                 ]

--- a/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
@@ -3780,7 +3780,7 @@ extension ComposeOrchestratorTests {
 
         #expect(listed.map(\.id) == ["demo-api-1"])
         #expect(fetched?.id == "demo-api-1")
-        #expect(views.map(\.lifecycle.containerID) == ["demo-api-1"])
+        #expect(views.map(\.lifecycle.containerID) == [lifecycleView.lifecycle.containerID])
         #expect(await recorder.listFilters.map(\.ids) == [["demo-api-1"]])
         #expect(await recorder.getRequests == ["demo-api-1"])
         #expect(await recorder.lifecycleViewFilters.map(\.ids) == [["demo-api-1"]])

--- a/Tests/ComposeCoreTests/ComposeOrchestratorLogsWatchAttachTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorLogsWatchAttachTests.swift
@@ -493,7 +493,7 @@ extension ComposeOrchestratorTests {
             }
         )
 
-        #expect(await discoveryManager.listRequests == [])
+        #expect(await discoveryManager.listRequests == [true])
         #expect(await logManager.requests == [
             ContainerLogRequest(id: "demo-api-1", tail: nil, follow: false),
         ])
@@ -1407,6 +1407,7 @@ extension ComposeOrchestratorTests {
             options: ComposeExecutionOptions { $0.emitAttachedData = { emitted.append(String(decoding: $0, as: UTF8.self)) } },
             dependencies: orchestratorDependencies {
                 $0.attachManager = attachManager
+                $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
                 $0.logManager = logManager
             }
         ).attach(
@@ -1444,6 +1445,7 @@ extension ComposeOrchestratorTests {
             options: ComposeExecutionOptions { $0.emitAttachedData = { emitted.append(String(decoding: $0, as: UTF8.self)) } },
             dependencies: orchestratorDependencies {
                 $0.attachManager = attachManager
+                $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
                 $0.logManager = logManager
             }
         ).attach(
@@ -1499,7 +1501,11 @@ extension ComposeOrchestratorTests {
             ]
         )
 
-        try await ComposeOrchestrator(runner: runner).attach(
+        try await ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(),
+            logManager: RecordingContainerLogManager()
+        ).attach(
             project: project,
             serviceName: "api",
             options: ComposeAttachOptions { $0.sigProxy = "false" }
@@ -1518,7 +1524,11 @@ extension ComposeOrchestratorTests {
             ]
         )
 
-        try await ComposeOrchestrator(runner: runner).attach(
+        try await ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(),
+            logManager: RecordingContainerLogManager()
+        ).attach(
             project: project,
             serviceName: "api",
             options: ComposeAttachOptions { $0.detachKeys = "ctrl-x,x" }
@@ -1548,6 +1558,7 @@ extension ComposeOrchestratorTests {
             options: ComposeExecutionOptions { $0.emitAttachedData = { emitted.append(String(decoding: $0, as: UTF8.self)) } },
             dependencies: orchestratorDependencies {
                 $0.attachManager = attachManager
+                $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
                 $0.lifecycleManager = lifecycleManager
                 $0.logManager = logManager
                 $0.signalProxy = signalProxy
@@ -1593,6 +1604,7 @@ extension ComposeOrchestratorTests {
             runner: RecordingRunner(),
             dependencies: orchestratorDependencies {
                 $0.attachManager = attachManager
+                $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
                 $0.lifecycleManager = lifecycleManager
                 $0.logManager = logManager
                 $0.signalProxy = signalProxy

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
@@ -624,7 +624,10 @@ extension ComposeOrchestrator {
     }
 
     convenience init(runner: CommandRunning, copier: ContainerCopying) {
-        self.init(runner: runner, dependencies: orchestratorDependencies { $0.copier = copier })
+        self.init(runner: runner, dependencies: orchestratorDependencies {
+            $0.copier = copier
+            $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
+        })
     }
 
     convenience init(runner: CommandRunning, discoveryManager: ContainerDiscoveryManaging) {
@@ -632,11 +635,17 @@ extension ComposeOrchestrator {
     }
 
     convenience init(runner: CommandRunning, execManager: ContainerExecManaging) {
-        self.init(runner: runner, dependencies: orchestratorDependencies { $0.execManager = execManager })
+        self.init(runner: runner, dependencies: orchestratorDependencies {
+            $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
+            $0.execManager = execManager
+        })
     }
 
     convenience init(runner: CommandRunning, exporter: ContainerExporting) {
-        self.init(runner: runner, dependencies: orchestratorDependencies { $0.exporter = exporter })
+        self.init(runner: runner, dependencies: orchestratorDependencies {
+            $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
+            $0.exporter = exporter
+        })
     }
 
     convenience init(runner: CommandRunning, imageManager: ContainerImageManaging) {
@@ -722,7 +731,10 @@ extension ComposeOrchestrator {
         options: ComposeExecutionOptions,
         copier: ContainerCopying
     ) {
-        self.init(runner: runner, options: options, dependencies: orchestratorDependencies { $0.copier = copier })
+        self.init(runner: runner, options: options, dependencies: orchestratorDependencies {
+            $0.copier = copier
+            $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
+        })
     }
 
     convenience init(
@@ -754,7 +766,10 @@ extension ComposeOrchestrator {
         options: ComposeExecutionOptions,
         execManager: ContainerExecManaging
     ) {
-        self.init(runner: runner, options: options, dependencies: orchestratorDependencies { $0.execManager = execManager })
+        self.init(runner: runner, options: options, dependencies: orchestratorDependencies {
+            $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
+            $0.execManager = execManager
+        })
     }
 
     convenience init(
@@ -798,7 +813,10 @@ extension ComposeOrchestrator {
         options: ComposeExecutionOptions,
         logManager: ContainerLogManaging
     ) {
-        self.init(runner: runner, options: options, dependencies: orchestratorDependencies { $0.logManager = logManager })
+        self.init(runner: runner, options: options, dependencies: orchestratorDependencies {
+            $0.discoveryManager = RecordingContainerDiscoveryManager(containers: runtimeServiceContainers())
+            $0.logManager = logManager
+        })
     }
 
     convenience init(
@@ -1252,6 +1270,33 @@ func discoveredContainers() -> [ComposeContainerSummary] {
                 digest: "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
                 platform: "linux/amd64"
             )
+        ),
+    ]
+}
+
+func runtimeServiceContainers() -> [ComposeContainerSummary] {
+    discoveredContainers() + [
+        ComposeContainerSummary(
+            id: "custom-db",
+            status: "running",
+            labels: [
+                composeProjectLabel: "demo",
+                composeServiceLabel: "db",
+                composeConfigHashLabel: "db-hash",
+                composeProjectConfigFilesLabel: "/tmp/demo/compose.yml",
+            ],
+            image: .init(reference: "postgres:latest", platform: "linux/arm64")
+        ),
+        ComposeContainerSummary(
+            id: "demo-db-1",
+            status: "running",
+            labels: [
+                composeProjectLabel: "demo",
+                composeServiceLabel: "db",
+                composeConfigHashLabel: "db-hash",
+                composeProjectConfigFilesLabel: "/tmp/demo/compose.yml",
+            ],
+            image: .init(reference: "postgres:latest", platform: "linux/arm64")
         ),
     ]
 }
@@ -2197,7 +2242,9 @@ actor RecordingContainerDiscoveryManager: ContainerDiscoveryManaging {
             getResponses[id] = responses
             return response
         }
-        return containers.first { $0.id == id }
+        return containers.first {
+            $0.id == id || $0.displayName == id || $0.bundleKey == id
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- align copy, export, attach, exec, logs, and port fixtures with atomic lifecycle discovery
- preserve canonical-name lookup while asserting immutable operation identity
- update runtime export expectations for discovered running containers

## Verification

- targeted regression selection: 28 tests passed
- git diff --check passed
- commit signature verified

This restores the main coverage gate after the lifecycle parity merge without changing production behavior.