### PR TITLE
fix(release): refresh current init image authority

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -639,7 +639,7 @@ jobs:
         env:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 61bd3bb4efa642e1be868deca6270f4a1309492b3bd0fc1de18ecb2c810aa73b
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 07ab89568d2805665ea82bd4556f683a0c28aa476805d584875a3feadca97991
         shell: bash
         working-directory: container-compose
         run: |
@@ -996,7 +996,7 @@ jobs:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           DEMO_ASSET: ${{ steps.lane.outputs.demo_asset }}
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 61bd3bb4efa642e1be868deca6270f4a1309492b3bd0fc1de18ecb2c810aa73b
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 07ab89568d2805665ea82bd4556f683a0c28aa476805d584875a3feadca97991
           PLUGIN_ARCHIVE: ${{ runner.temp }}/${{ steps.lane.outputs.asset }}
           RUNTIME_ARCHIVE: ${{ steps.runtime-package.outputs.local_asset }}
         shell: bash

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -486,7 +486,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertIn(
             "DEMO_INIT_IMAGE_ARCHIVE_SHA256: "
-            "61bd3bb4efa642e1be868deca6270f4a1309492b3bd0fc1de18ecb2c810aa73b",
+            "07ab89568d2805665ea82bd4556f683a0c28aa476805d584875a3feadca97991",
             workflow,
         )
         self.assertIn("Validate Current demo init-image authority", package)


### PR DESCRIPTION
## Summary
- pin the Current packaging lane to the exact source-built init image for Containerization `3e078480b85dceb843133392573cdd4d9efeec0d`
- update the release-policy regression expectation to the validated archive digest

## Validation
- `validate-oci-image-layout.py` accepts both required references
- targeted release-policy test passes (1/1)
- `git diff --check` passes

## Context
Unblocks Current packaging after lifecycle parity updated the matched Containerization ref.