### PR TITLE
fix(progress): avoid optimized spinner crash

### DIFF
--- a/Sources/ComposeCore/ComposeProgress.swift
+++ b/Sources/ComposeCore/ComposeProgress.swift
@@ -39,7 +39,21 @@ public struct ComposeProgressReporter: Sendable {
         emitData: @escaping @Sendable (Data) -> Void = { _ in
             // Silent until the CLI wires progress output to stderr.
         },
-        sleep: @escaping @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) },
+        sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
+            let components = duration.components
+            let seconds = UInt64(clamping: components.seconds)
+            let attoseconds = UInt64(clamping: components.attoseconds)
+            let secondsAsNanoseconds = seconds.multipliedReportingOverflow(
+                by: 1_000_000_000,
+            )
+            let totalNanoseconds = secondsAsNanoseconds.partialValue.addingReportingOverflow(
+                attoseconds / 1_000_000_000,
+            )
+            let nanoseconds = secondsAsNanoseconds.overflow || totalNanoseconds.overflow
+                ? UInt64.max
+                : totalNanoseconds.partialValue
+            try await Task<Never, Never>.sleep(nanoseconds: nanoseconds)
+        },
     ) {
         self.style = style
         self.colorEnabled = colorEnabled

--- a/Tests/ComposeCoreTests/ComposeProgressTests.swift
+++ b/Tests/ComposeCoreTests/ComposeProgressTests.swift
@@ -197,6 +197,19 @@ struct ComposeProgressTests {
     }
 
     @Test
+    func `default tty sleeper cancels cleanly`() async throws {
+        let emitted = LockedDataRecorder()
+        let reporter = ComposeProgressReporter(
+            style: .tty,
+            emitData: { emitted.append($0) },
+        )
+
+        try await reporter.activity("Loading Compose model") {}
+
+        #expect(emitted.string == "\r⠓ Loading Compose model\r\u{001B}[K✓ Loading Compose model\n")
+    }
+
+    @Test
     func `colored tty progress uses blue spinner and green done tick`() async throws {
         let emitted = LockedDataRecorder()
         let reporter = ComposeProgressReporter(


### PR DESCRIPTION
## Summary
- avoid the optimized Swift concurrency abort in the default TTY spinner sleeper
- preserve Duration-based injection while using the stable nanosecond sleep entry point
- cover clean cancellation of the default TTY sleeper

## Failure addressed
Current run 32369808516 reached runtime startup and Compose `up`, then the packaged `compose ps` aborted with `freed pointer was not the last allocation`. The macOS crash report points to cancellation of `Task.sleep(for:)` at `ComposeProgress.swift:42`.

## Targeted validation
- focused debug regression test passes (1/1)
- optimized `compose config` reproducer passes 10/10; the prior exact release binary aborts 1/1
- SwiftLint and SwiftFormat pass on both changed files
- `git diff --check` passes

## Known harness note
`swift test -c release --filter ...` built the optimized test bundle but SwiftPM then launched the `compose` product with its internal `--test-bundle-path` argument. The optimized product reproducer above directly exercises the crashing release path.