### PR TITLE
fix(runtime): avoid optimized sleep crashes

### DIFF
--- a/Sources/ComposeContainerRuntime/ContainerLogAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerLogAdapter.swift
@@ -397,7 +397,7 @@ public struct ContainerClientLogManager: ComposeRuntimeLogManaging {
             let stopTask = Task {
                 while !Task.isCancelled {
                     do {
-                        try await Task.sleep(for: .milliseconds(250))
+                        try await ComposeTaskSleep.sleep(for: .milliseconds(250))
                         guard try await followStateProvider.isLiveForLogFollow(id: id) else {
                             fileHandle.readabilityHandler = nil
                             continuation.finish()

--- a/Sources/ComposeContainerRuntime/ContainerStatsAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerStatsAdapter.swift
@@ -84,7 +84,7 @@ public struct ContainerClientStatsManager: ComposeRuntimeStatsDataManaging {
         client: ContainerStatsAPIClienting = ContainerStatsAPIClient(),
         sampleInterval: Duration = .seconds(2),
         sampleIntervalMicroseconds: UInt64 = 2_000_000,
-        sleep: @escaping Sleeper = { try await Task.sleep(for: $0) },
+        sleep: @escaping Sleeper = ComposeTaskSleep.sleep,
     ) {
         self.client = client
         self.sampleInterval = sampleInterval

--- a/Sources/ComposeCore/ComposeExecutionOptions.swift
+++ b/Sources/ComposeCore/ComposeExecutionOptions.swift
@@ -30,7 +30,7 @@ public struct ComposeExecutionOptions {
         public var oneOffIdentifier: @Sendable () -> String = ComposeExecutionOptions.defaultOneOffIdentifier
         public var currentDate: @Sendable () -> Date = Date.init
         public var hostPortAllocator: @Sendable (_ hostAddress: String?, _ protocolName: String) throws -> UInt16 = ComposeExecutionOptions.defaultHostPortAllocator
-        public var sleep: @Sendable (Duration) async throws -> Void = { try await Task.sleep(for: $0) } {
+        public var sleep: @Sendable (Duration) async throws -> Void = ComposeTaskSleep.sleep {
             didSet {
                 usesDefaultSleep = false
             }
@@ -179,7 +179,7 @@ public struct ComposeExecutionOptions {
         materializedConfigSecretDirectory = ComposeExecutionOptions.defaultMaterializedConfigSecretDirectory()
         temporaryDirectory = FileManager.default.temporaryDirectory
         runtimeCapabilities = ComposeRuntimeCapabilities()
-        sleep = { try await Task.sleep(for: $0) }
+        sleep = ComposeTaskSleep.sleep
         usesDefaultSleep = true
         confirm = ComposeExecutionOptions.defaultConfirmation
         emitStatus = ComposeExecutionOptions.defaultStatusEmitter

--- a/Sources/ComposeCore/ComposeProgress.swift
+++ b/Sources/ComposeCore/ComposeProgress.swift
@@ -39,21 +39,7 @@ public struct ComposeProgressReporter: Sendable {
         emitData: @escaping @Sendable (Data) -> Void = { _ in
             // Silent until the CLI wires progress output to stderr.
         },
-        sleep: @escaping @Sendable (Duration) async throws -> Void = { duration in
-            let components = duration.components
-            let seconds = UInt64(clamping: components.seconds)
-            let attoseconds = UInt64(clamping: components.attoseconds)
-            let secondsAsNanoseconds = seconds.multipliedReportingOverflow(
-                by: 1_000_000_000,
-            )
-            let totalNanoseconds = secondsAsNanoseconds.partialValue.addingReportingOverflow(
-                attoseconds / 1_000_000_000,
-            )
-            let nanoseconds = secondsAsNanoseconds.overflow || totalNanoseconds.overflow
-                ? UInt64.max
-                : totalNanoseconds.partialValue
-            try await Task<Never, Never>.sleep(nanoseconds: nanoseconds)
-        },
+        sleep: @escaping @Sendable (Duration) async throws -> Void = ComposeTaskSleep.sleep,
     ) {
         self.style = style
         self.colorEnabled = colorEnabled

--- a/Sources/ComposeCore/ComposeTaskSleep.swift
+++ b/Sources/ComposeCore/ComposeTaskSleep.swift
@@ -5,7 +5,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// https://www.apache.org/licenses/LICENSE-2.0
+//   https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/Sources/ComposeCore/ComposeTaskSleep.swift
+++ b/Sources/ComposeCore/ComposeTaskSleep.swift
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 container-compose project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+/// Sleeps without specializing the generic clock-based `Task.sleep(for:)` API.
+///
+/// Swift 6.2 release builds on macOS 26 can abort while deallocating that
+/// specialization. The nanosecond API has equivalent cancellation semantics
+/// and avoids the affected optimizer/runtime path.
+public enum ComposeTaskSleep {
+    public static func sleep(for duration: Duration) async throws {
+        let components = duration.components
+        let seconds = UInt64(clamping: components.seconds)
+        let attoseconds = UInt64(clamping: components.attoseconds)
+        let secondsAsNanoseconds = seconds.multipliedReportingOverflow(
+            by: 1_000_000_000,
+        )
+        let totalNanoseconds = secondsAsNanoseconds.partialValue.addingReportingOverflow(
+            attoseconds / 1_000_000_000,
+        )
+        let nanoseconds = secondsAsNanoseconds.overflow || totalNanoseconds.overflow
+            ? UInt64.max
+            : totalNanoseconds.partialValue
+        try await Task<Never, Never>.sleep(nanoseconds: nanoseconds)
+    }
+}

--- a/Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift
@@ -953,6 +953,38 @@ extension ComposeOrchestratorTests {
         #expect(await client.statsRequests == ["demo-api-1", "demo-api-1"])
     }
 
+    @Test("stats manager default sleeper completes a static sample")
+    func statsManagerDefaultSleeperCompletesStaticSample() async throws {
+        let emitted = MessageRecorder()
+        let client = RecordingContainerStatsAPIClient(
+            targets: [ComposeStatsTarget(id: "demo-api-1", status: "running")],
+            statsResponses: [
+                "demo-api-1": [
+                    containerStats(id: "demo-api-1", cpuUsageUsec: 1_000_000),
+                    containerStats(id: "demo-api-1", cpuUsageUsec: 1_250_000),
+                ],
+            ]
+        )
+        let manager = ContainerClientStatsManager(
+            client: client,
+            sampleInterval: .milliseconds(1),
+            sampleIntervalMicroseconds: 1_000,
+        )
+
+        try await manager.stats(
+            ids: ["demo-api-1"],
+            format: "table",
+            noStream: true,
+            noTrunc: false,
+            includeStopped: false,
+            emit: { emitted.append($0) }
+        )
+
+        #expect(emitted.messages.count == 1)
+        #expect(emitted.messages[0].contains("demo-api-1"))
+        #expect(await client.statsRequests == ["demo-api-1", "demo-api-1"])
+    }
+
     @Test("stats manager renders template output from direct API stats")
     func statsManagerRendersTemplateOutputFromDirectAPIStats() async throws {
         let emitted = MessageRecorder()


### PR DESCRIPTION
## Summary

- centralize production sleeps on the non-generic nanosecond Task API
- cover progress, execution hooks, stats sampling, and log-follow polling
- add a regression for the stats manager's real default sleeper

## Release blocker

Current prebuilt run [32379231901](https://github.com/stephenlclarke/container-compose/actions/runs/32379231901) passed `up --wait` and `ps`, then the optimized packaged binary aborted in `stats --no-stream`.

The macOS crash report identifies `Task.sleep(for:)` in `ContainerStatsAdapter.swift:87` and `swift_task_dealloc`, the same Swift 6.2 release-runtime failure mode previously fixed for the TTY spinner in #286.

A production-source scan found four call sites. This patch moves all four to `ComposeTaskSleep.sleep(for:)`, which converts `Duration` safely and calls `Task<Never, Never>.sleep(nanoseconds:)`.

## Focused proof

- `swift test --filter statsManagerDefaultSleeperCompletesStaticSample`
- `swift test --filter 'default tty sleeper cancels cleanly'`
- `swift build -c release --product compose`
- production scan confirms no remaining generic `Task.sleep(for:)` call
- `git diff --check`
