### PR TITLE
fix(runtime): use bundle identity for container operations

### DIFF
--- a/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorCommitExport.swift
@@ -108,7 +108,7 @@ public extension ComposeOrchestrator {
         let rootfs = tempDirectory.appendingPathComponent("rootfs.tar")
         let archive = tempDirectory.appendingPathComponent("image.tar")
         try await exporter.exportContainer(
-            id: container.id,
+            id: container.runtimeIdentifier,
             output: rootfs.path,
             live: live,
             noFreeze: noFreeze,
@@ -149,7 +149,7 @@ public extension ComposeOrchestrator {
         guard let selected = matches.first else {
             throw ComposeError.invalidProject("service '\(service.name)' has no container to commit")
         }
-        return selected.id
+        return selected.runtimeIdentifier
     }
 
     /// Returns image config metadata used to seed Docker-compatible commit config when available.

--- a/Sources/ComposeCore/ComposeOrchestratorContainerTargets.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorContainerTargets.swift
@@ -65,7 +65,7 @@ extension ComposeOrchestrator {
         }) else {
             throw ComposeError.invalidProject("service '\(service.name)' container '\(name)' does not exist")
         }
-        return container.id
+        return container.runtimeIdentifier
     }
 
     /// Returns the deterministic runtime name for a service container index.
@@ -129,7 +129,7 @@ extension ComposeOrchestrator {
                 return ServiceContainerTarget(
                     service: service,
                     index: index,
-                    name: container.id,
+                    name: container.runtimeIdentifier,
                     displayName: container.displayName,
                     bundleKey: container.bundleKey,
                     status: container.status,
@@ -189,16 +189,24 @@ extension ComposeOrchestrator {
             guard desiredCount == 0 || (index.map { $0 > desiredCount } ?? false) else {
                 continue
             }
-            try await stopContainer(service: service, containerName: container.id, timeout: timeout)
-            try await deleteContainer(container.id)
+            try await stopContainer(service: service, containerName: container.runtimeIdentifier, timeout: timeout)
+            try await deleteContainer(container.runtimeIdentifier)
         }
     }
 
     /// Returns a stable ordering for service container discovery.
     func serviceContainerSummaryOrder(project: ComposeProject, service: ComposeService) -> (ComposeContainerSummary, ComposeContainerSummary) -> Bool {
         { [self] lhs, rhs in
-            let lhsIndex = serviceContainerIndex(project: project, service: service, containerID: lhs.bundleKey ?? lhs.displayName) ?? Int.max
-            let rhsIndex = serviceContainerIndex(project: project, service: service, containerID: rhs.bundleKey ?? rhs.displayName) ?? Int.max
+            let lhsIndex = serviceContainerIndex(
+                project: project,
+                service: service,
+                containerID: lhs.bundleKey ?? lhs.displayName,
+            ) ?? Int.max
+            let rhsIndex = serviceContainerIndex(
+                project: project,
+                service: service,
+                containerID: rhs.bundleKey ?? rhs.displayName,
+            ) ?? Int.max
             if lhsIndex != rhsIndex {
                 return lhsIndex < rhsIndex
             }

--- a/Sources/ComposeCore/ComposeOrchestratorHelpers.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorHelpers.swift
@@ -122,6 +122,15 @@ let networkMTUDriverOptionKeys = [
 let rfc1123LabelPattern = #"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$"#
 
 extension ComposeContainerSummary {
+    /// Stable identifier accepted by native Container operations.
+    ///
+    /// Atomic discovery exposes the Docker-compatible ID separately from the
+    /// bundle key used by ContainerClient lookups. Legacy providers may not
+    /// expose a bundle key, so retain their established operation ID.
+    var runtimeIdentifier: String {
+        bundleKey ?? id
+    }
+
     /// Compose project label attached to a runtime container.
     var projectName: String? {
         labels[projectLabel]

--- a/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift
@@ -578,7 +578,7 @@ extension ComposeOrchestrator {
                 try await stopRemainingProjectContainer(project: project, container: container, timeout: timeout)
             }
             try await ignoringMissingContainer {
-                try await deleteContainer(container.id)
+                try await deleteContainer(container.runtimeIdentifier)
             }
         }
     }
@@ -633,10 +633,10 @@ extension ComposeOrchestrator {
         guard let serviceName = container.serviceName,
               let service = project.services[serviceName]
         else {
-            try await stopContainer(id: container.id, timeout: timeout)
+            try await stopContainer(id: container.runtimeIdentifier, timeout: timeout)
             return
         }
-        try await stopContainer(service: service, containerName: container.id, timeout: timeout)
+        try await stopContainer(service: service, containerName: container.runtimeIdentifier, timeout: timeout)
     }
 
     /// Lists containers scoped to a Compose project through the direct API.

--- a/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
@@ -379,7 +379,7 @@ extension ComposeOrchestrator {
             .sorted(by: compareCopyTargetContainers)
 
         if index == 1 {
-            return containers.map { ComposeCopyContainerTarget(id: $0.id, path: path) }
+            return containers.map { ComposeCopyContainerTarget(id: $0.runtimeIdentifier, path: path) }
         }
 
         let indexedID = try serviceContainerName(project: project, service: service, index: index)
@@ -388,7 +388,7 @@ extension ComposeOrchestrator {
         }
         return containers
             .filter { $0.displayName == indexedID || $0.bundleKey == indexedID || $0.isOneOff }
-            .map { ComposeCopyContainerTarget(id: $0.id, path: path) }
+            .map { ComposeCopyContainerTarget(id: $0.runtimeIdentifier, path: path) }
     }
 
     /// Returns whether a copy operand prefix has Compose service-reference shape.

--- a/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUtilityCommands.swift
@@ -46,7 +46,7 @@ public extension ComposeOrchestrator {
                     return ServiceContainerTarget(
                         service: service,
                         index: index ?? Int.max,
-                        name: container.id,
+                        name: container.runtimeIdentifier,
                         displayName: container.displayName,
                         bundleKey: container.bundleKey,
                         status: container.status,

--- a/Tests/ComposeCoreTests/ComposeOrchestratorCopyExportCommitTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorCopyExportCommitTests.swift
@@ -637,7 +637,9 @@ extension ComposeOrchestratorTests {
         let copier = RecordingContainerCopier()
         let discoveryManager = RecordingContainerDiscoveryManager(containers: [
             ComposeContainerSummary(
-                id: "demo-api-run-first",
+                id: String(repeating: "e", count: 64),
+                name: "renamed-api-run-first",
+                bundleKey: "demo-api-run-first",
                 status: "stopped",
                 labels: [
                     composeProjectLabel: "demo",
@@ -647,7 +649,9 @@ extension ComposeOrchestratorTests {
                 ]
             ),
             ComposeContainerSummary(
-                id: "demo-api-1",
+                id: String(repeating: "f", count: 64),
+                name: "renamed-api",
+                bundleKey: "demo-api-1",
                 status: "running",
                 labels: [
                     composeProjectLabel: "demo",
@@ -1311,7 +1315,17 @@ extension ComposeOrchestratorTests {
         let discoveryManager = RecordingContainerDiscoveryManager(containers: [
             discoveredServiceContainer(id: "demo-api-2", serviceName: "api", status: "stopped"),
             discoveredServiceContainer(id: "demo-worker-1", serviceName: "worker", status: "stopped"),
-            discoveredServiceContainer(id: "demo-api-1", serviceName: "api", status: "stopped"),
+            ComposeContainerSummary(
+                id: String(repeating: "1", count: 64),
+                name: "renamed-api",
+                bundleKey: "demo-api-1",
+                status: "stopped",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "api",
+                    composeOneOffLabel: "false",
+                ]
+            ),
             ComposeContainerSummary(id: "demo-api-run-abc", status: "stopped", labels: [
                 composeProjectLabel: "demo",
                 composeServiceLabel: "api",

--- a/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
@@ -383,7 +383,30 @@ extension ComposeOrchestratorTests {
     func downRemovesRemainingProjectScopedContainers() async throws {
         let runner = RecordingRunner()
         let lifecycleManager = RecordingContainerLifecycleManager()
-        let discoveryManager = RecordingContainerDiscoveryManager(containers: discoveredContainers())
+        let discoveryManager = RecordingContainerDiscoveryManager(containers: [
+            ComposeContainerSummary(
+                id: String(repeating: "c", count: 64),
+                name: "renamed-api",
+                bundleKey: "demo-api-1",
+                status: "running",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "api",
+                    composeOneOffLabel: "false",
+                ]
+            ),
+            ComposeContainerSummary(
+                id: String(repeating: "d", count: 64),
+                name: "renamed-worker",
+                bundleKey: "demo-worker-1",
+                status: "running",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "worker",
+                    composeOneOffLabel: "false",
+                ]
+            ),
+        ])
         let orchestrator = ComposeOrchestrator(
             runner: runner,
             discoveryManager: discoveryManager,
@@ -3351,7 +3374,7 @@ extension ComposeOrchestratorTests {
         #expect(await missingClient.getRequests.isEmpty)
     }
 
-    @Test("atomic discovery preserves canonical presentation and immutable operation identity")
+    @Test("atomic discovery preserves canonical presentation and uses stable bundle operation identity")
     func atomicDiscoveryPreservesCanonicalAndImmutableIdentity() async throws {
         var snapshot = try containerSnapshot(
             id: "demo-api-1",
@@ -3402,9 +3425,9 @@ extension ComposeOrchestratorTests {
         #expect(operationSummary == summary)
         #expect(containerIdentifiers([summary]) == [immutableID])
         #expect(renderComposeContainerTable([summary], noTrunc: false).contains("renamed-api"))
-        #expect(targets.map(\.name) == [immutableID])
+        #expect(targets.map(\.name) == ["demo-api-1"])
         #expect(targets.compactMap(\.displayName) == ["renamed-api"])
-        #expect(resolvedOperationID == immutableID)
+        #expect(resolvedOperationID == "demo-api-1")
     }
 
     @Test("replica index resolution prefers stable bundle identity over a reused canonical name")
@@ -3470,7 +3493,7 @@ extension ComposeOrchestratorTests {
             index: 2
         )
 
-        #expect(resolvedID == secondID)
+        #expect(resolvedID == secondSnapshot.id)
     }
 
     @Test("discovery manager does not revive legacy state cleared by lifecycle authority")

--- a/Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift
@@ -2527,8 +2527,19 @@ extension ComposeOrchestratorTests {
     @Test("rm confirms before stopping containers")
     func rmConfirmsBeforeStoppingContainers() async throws {
         let runner = RecordingRunner()
+        let dockerID = String(repeating: "a", count: 64)
         let discoveryManager = RecordingContainerDiscoveryManager(containers: [
-            discoveredServiceContainer(id: "demo-api-1", serviceName: "api", status: "running"),
+            ComposeContainerSummary(
+                id: dockerID,
+                name: "renamed-api",
+                bundleKey: "demo-api-1",
+                status: "running",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "api",
+                    composeOneOffLabel: "false",
+                ]
+            ),
         ])
         let lifecycleManager = RecordingContainerLifecycleManager()
         let prompts = MessageRecorder()
@@ -2861,9 +2872,12 @@ extension ComposeOrchestratorTests {
     func execResolvesSelectedServiceContainerIndexes() async throws {
         let runner = RecordingRunner()
         let execManager = RecordingContainerExecManager()
+        let dockerID = String(repeating: "b", count: 64)
         let discoveryManager = RecordingContainerDiscoveryManager(containers: [
             ComposeContainerSummary(
-                id: "demo-api-2",
+                id: dockerID,
+                name: "renamed-api",
+                bundleKey: "demo-api-2",
                 status: "running",
                 labels: [
                     composeProjectLabel: "demo",
@@ -2898,6 +2912,45 @@ extension ComposeOrchestratorTests {
         #expect(await execManager.attachedRequests == [
             ContainerAttachedExecRequest(
                 id: "demo-api-2",
+                command: ["true"],
+                terminal: .init(interactive: true, tty: true)
+            ),
+        ])
+    }
+
+    @Test("exec preserves legacy discovery operation identifiers")
+    func execPreservesLegacyDiscoveryOperationIdentifiers() async throws {
+        let execManager = RecordingContainerExecManager()
+        let discoveryManager = RecordingContainerDiscoveryManager(containers: [
+            ComposeContainerSummary(
+                id: "legacy-operation-id",
+                name: "demo-api-1",
+                status: "running",
+                labels: [
+                    composeProjectLabel: "demo",
+                    composeServiceLabel: "api",
+                    composeOneOffLabel: "false",
+                ]
+            ),
+        ])
+        let orchestrator = ComposeOrchestrator(runner: RecordingRunner(), dependencies: orchestratorDependencies {
+            $0.discoveryManager = discoveryManager
+            $0.execManager = execManager
+        })
+        let project = ComposeProject(
+            name: "demo",
+            services: ["api": ComposeService(name: "api", image: "example/api")]
+        )
+
+        try await orchestrator.exec(
+            project: project,
+            serviceName: "api",
+            options: ComposeExecOptions { $0.command = ["true"] }
+        )
+
+        #expect(await execManager.attachedRequests == [
+            ContainerAttachedExecRequest(
+                id: "legacy-operation-id",
                 command: ["true"],
                 terminal: .init(interactive: true, tty: true)
             ),


### PR DESCRIPTION
## Summary

- keep Docker-compatible container IDs for presentation and Docker-facing output
- use immutable bundle keys for native Container lifecycle, exec, copy, export, and commit operations
- retain legacy provider operation IDs when no bundle key is available

## Validation

- 8 focused identity and operation regressions passed
- `git diff --check` passed
- exact-head static review: no actionable findings

## Release impact

Fixes the packaged Current workflow failure where `compose exec` passed a Docker-compatible 64-character ID to native `ContainerClient` lookup APIs.