### PR TITLE
chore(release): align 0.12.0 container stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9786681b7b1b68edcbb14e6b628977a4fe0f224e845710a94a1d5f9cb77229fd",
+  "originHash" : "beac02ef6622d0240feb05f3eca2ad9022a04fb374f514a1cfbf67944a8bb5d7",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "99c0244f37c0bf4aabdfbff7b62d0d2d81541633"
+        "revision" : "21808d7760111ce4bab0a416d0e1398224fdf840"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "99c0244f37c0bf4aabdfbff7b62d0d2d81541633",
+        revision: "21808d7760111ce4bab0a416d0e1398224fdf840",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ in this stable baseline. Planned compatibility work is kept separately in
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 15 August 2026 snapshot, the three support forks are **879 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 20 August 2026 snapshot, the three support forks are **888 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 194 ahead** at [`f0bc99d26cd2`](https://github.com/stephenlclarke/containerization/commit/f0bc99d26cd27ed58b06236421a298d9e4acd5c1).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 645 ahead** at [`9aa1803223e8`](https://github.com/stephenlclarke/container/commit/9aa1803223e8573f169c2a2effa657392b4d6e30).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 195 ahead** at [`3e078480b85d`](https://github.com/stephenlclarke/containerization/commit/3e078480b85dceb843133392573cdd4d9efeec0d).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 653 ahead** at [`21808d776011`](https://github.com/stephenlclarke/container/commit/21808d7760111ce4bab0a416d0e1398224fdf840).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 40 ahead** at [`88332c96705b`](https://github.com/stephenlclarke/container-builder-shim/commit/88332c96705b024bbc5cd210642118ee82f8793d).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/Sources/ComposeContainerRuntime/ContainerFilesystemAdapter.swift
+++ b/Sources/ComposeContainerRuntime/ContainerFilesystemAdapter.swift
@@ -187,43 +187,27 @@ public struct ContainerClientCopier: ComposeRuntimeArchiveCopying {
         let (reader, writer) = try Self.archivePipe()
         let destinationOptions = ContainerCopyTransferOptions(preserveOwnership: options.preserveOwnership)
 
-        do {
-            try await withThrowingTaskGroup(of: Void.self) { group in
-                group.addTask {
-                    defer { try? writer.close() }
-                    try await copyFromContainerAsArchive(
-                        id: sourceID,
-                        source: archiveSource.path,
-                        archive: writer,
-                        copyContents: archiveSource.copyContents,
-                        options: options,
-                    )
-                }
-                group.addTask {
-                    defer { try? reader.close() }
-                    try await copyArchiveIntoContainer(
-                        id: destinationID,
-                        archive: reader,
-                        destination: destination,
-                        options: destinationOptions,
-                    )
-                }
-                do {
-                    for try await _ in group {
-                        // Drain both child completions so neither transfer outlives the pipe.
-                    }
-                } catch {
-                    try? writer.close()
-                    try? reader.close()
-                    group.cancelAll()
-                    throw error
-                }
-            }
-        } catch {
-            try? writer.close()
-            try? reader.close()
-            throw error
-        }
+        try await Self.transferArchive(
+            reader: reader,
+            writer: writer,
+            export: {
+                try await copyFromContainerAsArchive(
+                    id: sourceID,
+                    source: archiveSource.path,
+                    archive: writer,
+                    copyContents: archiveSource.copyContents,
+                    options: options,
+                )
+            },
+            import: {
+                try await copyArchiveIntoContainer(
+                    id: destinationID,
+                    archive: reader,
+                    destination: destination,
+                    options: destinationOptions,
+                )
+            },
+        )
     }
 
     private func copyBetweenContainersUsingStagedArchive(
@@ -293,6 +277,73 @@ public struct ContainerClientCopier: ComposeRuntimeArchiveCopying {
             FileHandle(fileDescriptor: descriptors[0], closeOnDealloc: true),
             FileHandle(fileDescriptor: descriptors[1], closeOnDealloc: true),
         )
+    }
+}
+
+private extension ContainerClientCopier {
+    static func transferArchive(
+        reader: FileHandle,
+        writer: FileHandle,
+        export: @escaping @Sendable () async throws -> Void,
+        import: @escaping @Sendable () async throws -> Void,
+    ) async throws {
+        let transferError = await withTaskGroup(of: Result<Void, any Error>.self) { group in
+            group.addTask {
+                defer { try? writer.close() }
+                return await transferResult(export)
+            }
+            group.addTask {
+                defer { try? reader.close() }
+                return await transferResult(`import`)
+            }
+
+            var failures = [any Error]()
+            while let result = await group.next() {
+                if case let .failure(error) = result {
+                    if failures.isEmpty {
+                        // Closing both endpoints unblocks synchronous reads and writes.
+                        try? writer.close()
+                        try? reader.close()
+                        group.cancelAll()
+                    }
+                    failures.append(error)
+                }
+            }
+
+            // Pipe closure can surface before the operation that caused it.
+            return failures.first(where: { !isBrokenPipe($0) }) ?? failures.first
+        }
+
+        if let transferError {
+            try? writer.close()
+            try? reader.close()
+            throw transferError
+        }
+    }
+
+    static func transferResult(
+        _ operation: @escaping @Sendable () async throws -> Void,
+    ) async -> Result<Void, any Error> {
+        do {
+            try await operation()
+            return .success(())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    static func isBrokenPipe(_ error: any Error) -> Bool {
+        var candidate: NSError? = error as NSError
+        while let current = candidate {
+            if current.domain == NSPOSIXErrorDomain, current.code == Int(EPIPE) {
+                return true
+            }
+            candidate = current.userInfo[NSUnderlyingErrorKey] as? NSError
+            if candidate === current {
+                break
+            }
+        }
+        return false
     }
 }
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "99c0244f37c0bf4aabdfbff7b62d0d2d81541633",
+      "ref": "21808d7760111ce4bab0a416d0e1398224fdf840",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-08-14",
+  "reviewedAt": "2026-08-20",
   "repositories": {
     "container": {
-      "upstreamHead": "7d4ffb6cb1aed2c4eba42d5787de09162c82b591",
-      "forkHead": "9aa1803223e8573f169c2a2effa657392b4d6e30",
+      "upstreamHead": "04324afe634839ed9c3990c77ec25d1ae5c9e47e",
+      "forkHead": "21808d7760111ce4bab0a416d0e1398224fdf840",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -582,7 +582,9 @@
             "77f6b1e795336c659536836bc909dcb906dd0f25",
             "bbe36565501f881800c0ef7e0060a3e19d6d9b29",
             "a12213b74509ddf618400b331aa5b778ef648b17",
-            "f5e25b12ed074e7e5fb09933d86a27652034f3e5"
+            "f5e25b12ed074e7e5fb09933d86a27652034f3e5",
+            "b982f110d0d32e3b32722ef2528b19107a9661ec",
+            "552ad8e951479b758f515054af2d63193c315412"
           ]
         },
         {
@@ -653,7 +655,7 @@
     },
     "containerization": {
       "upstreamHead": "5427fd21ded4b84034126caef5b3182900b4776d",
-      "forkHead": "f0bc99d26cd27ed58b06236421a298d9e4acd5c1",
+      "forkHead": "3e078480b85dceb843133392573cdd4d9efeec0d",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -818,7 +820,8 @@
             "1105266d0992c47d056a72a6d418cd13f11056af",
             "88fc904eda6223f061f17c3195c872f0232666d0",
             "7bf897186efb16e2def8aa48e5a99f803958df95",
-            "52386838456a431d24bed6c38a9e84fb0ad28997"
+            "52386838456a431d24bed6c38a9e84fb0ad28997",
+            "3e078480b85dceb843133392573cdd4d9efeec0d"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 14 August 2026
+Updated: 20 August 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `7d4ffb6cb1aed2c4eba42d5787de09162c82b591` | `9aa1803223e8573f169c2a2effa657392b4d6e30` | 0 | 645 | 571 |
-| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `f0bc99d26cd27ed58b06236421a298d9e4acd5c1` | 0 | 194 | 158 |
+| `container` | `04324afe634839ed9c3990c77ec25d1ae5c9e47e` | `21808d7760111ce4bab0a416d0e1398224fdf840` | 0 | 653 | 573 |
+| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `3e078480b85dceb843133392573cdd4d9efeec0d` | 0 | 195 | 159 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `88332c96705b024bbc5cd210642118ee82f8793d` | 0 | 40 | 34 |
-| **Total** | | | **0** | **879** | **763** |
+| **Total** | | | **0** | **888** | **766** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -33,7 +33,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
 | `support-maintenance` | 546 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
-| `generic-runtime-primitive` | 192 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
+| `generic-runtime-primitive` | 195 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
 
@@ -181,3 +181,12 @@ The final 14 August 2026 release refresh advances Container through
 Containerization dependency pin and Containerization's recursive
 signal-cancellation lock repair are independently reviewed release maintenance;
 they add no Compose-owned policy or temporary upstream port.
+
+The 20 August 2026 release refresh advances Apple Container through
+`04324afe6348`, Container through `21808d776011`, and Containerization through
+`3e078480b85d`. Apple's Kubernetes provisioner split, machine mount hardening,
+CLI conformance cleanup, and disk-usage identifier-validation tests are
+upstream history after the reviewed merges. Container's atomic lifecycle
+discovery commits and Containerization's lifecycle primitive are classified as
+generic runtime work. No temporary upstream port or rejected Compose-policy
+disposition changed in this refresh.


### PR DESCRIPTION
## Summary

- pin Compose to verified Container main `21808d776011`
- classify the lifecycle discovery/runtime commits and refresh all three fork baselines
- update the README snapshot to 888 commits ahead across the support forks

## Validation

- `swift package resolve`
- `swift test --filter ContainerPackageCompatibilityTests` (29 tests passed)
- `make fork-classifications-check stack-consistency readme-upstream-metrics-check`
- `markdownlint README.md docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md`
- `jq empty Tools/release/stack-refs.json docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json`
- `git diff --check`

## Release impact

This establishes the exact matched Container stack required before publishing the 0.12.0 Current proof and stable release.