### PR TITLE
chore(release): align Container kernel refresh

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "beac02ef6622d0240feb05f3eca2ad9022a04fb374f514a1cfbf67944a8bb5d7",
+  "originHash" : "f32783c5f908f05786e90602d5aac3de2eff8ed592a1f5614ded911940788cb5",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "21808d7760111ce4bab0a416d0e1398224fdf840"
+        "revision" : "a7ff132653e1a4f71de7ebb193beb9d651254b85"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "21808d7760111ce4bab0a416d0e1398224fdf840",
+        revision: "a7ff132653e1a4f71de7ebb193beb9d651254b85",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ in this stable baseline. Planned compatibility work is kept separately in
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 20 August 2026 snapshot, the three support forks are **888 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 21 August 2026 snapshot, the three support forks are **890 commits ahead of Apple upstream**:
 >
 > - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 195 ahead** at [`3e078480b85d`](https://github.com/stephenlclarke/containerization/commit/3e078480b85dceb843133392573cdd4d9efeec0d).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 653 ahead** at [`21808d776011`](https://github.com/stephenlclarke/container/commit/21808d7760111ce4bab0a416d0e1398224fdf840).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 655 ahead** at [`a7ff132653e1`](https://github.com/stephenlclarke/container/commit/a7ff132653e1a4f71de7ebb193beb9d651254b85).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 40 ahead** at [`88332c96705b`](https://github.com/stephenlclarke/container-builder-shim/commit/88332c96705b024bbc5cd210642118ee82f8793d).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "21808d7760111ce4bab0a416d0e1398224fdf840",
+      "ref": "a7ff132653e1a4f71de7ebb193beb9d651254b85",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-08-20",
+  "reviewedAt": "2026-08-21",
   "repositories": {
     "container": {
-      "upstreamHead": "04324afe634839ed9c3990c77ec25d1ae5c9e47e",
-      "forkHead": "21808d7760111ce4bab0a416d0e1398224fdf840",
+      "upstreamHead": "d6de5694200468d99a61662bfb9bb3aba763e3e5",
+      "forkHead": "a7ff132653e1a4f71de7ebb193beb9d651254b85",
       "slices": [
         {
           "id": "container-support-maintenance",

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 20 August 2026
+Updated: 21 August 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `04324afe634839ed9c3990c77ec25d1ae5c9e47e` | `21808d7760111ce4bab0a416d0e1398224fdf840` | 0 | 653 | 573 |
+| `container` | `d6de5694200468d99a61662bfb9bb3aba763e3e5` | `a7ff132653e1a4f71de7ebb193beb9d651254b85` | 0 | 655 | 573 |
 | `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `3e078480b85dceb843133392573cdd4d9efeec0d` | 0 | 195 | 159 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `88332c96705b024bbc5cd210642118ee82f8793d` | 0 | 40 | 34 |
-| **Total** | | | **0** | **888** | **766** |
+| **Total** | | | **0** | **890** | **766** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -182,11 +182,11 @@ Containerization dependency pin and Containerization's recursive
 signal-cancellation lock repair are independently reviewed release maintenance;
 they add no Compose-owned policy or temporary upstream port.
 
-The 20 August 2026 release refresh advances Apple Container through
-`04324afe6348`, Container through `21808d776011`, and Containerization through
+The 21 August 2026 release refresh advances Apple Container through
+`d6de56942004`, Container through `a7ff132653e1`, and Containerization through
 `3e078480b85d`. Apple's Kubernetes provisioner split, machine mount hardening,
-CLI conformance cleanup, and disk-usage identifier-validation tests are
-upstream history after the reviewed merges. Container's atomic lifecycle
-discovery commits and Containerization's lifecycle primitive are classified as
-generic runtime work. No temporary upstream port or rejected Compose-policy
-disposition changed in this refresh.
+CLI conformance cleanup, disk-usage identifier-validation tests, and Kata
+Containers 3.32.0 debug-kernel default are upstream history after the reviewed
+merges. Container's atomic lifecycle discovery commits and Containerization's
+lifecycle primitive are classified as generic runtime work. No temporary
+upstream port or rejected Compose-policy disposition changed in this refresh.


### PR DESCRIPTION
## Summary

- pin Container to signed merge a7ff132653e1 after Apple Kata 3.32.0 kernel refresh
- refresh exact fork classification heads and current README snapshot
- preserve the matched 0.12.0 release stack without changing Compose behavior

## Focused validation

- swift package resolve
- swift test --filter ContainerPackageCompatibilityTests (29 selected tests passed)
- make fork-classifications-check stack-consistency readme-upstream-metrics-check
- markdownlint on the two changed Markdown files
- JSON validation and git diff --check

The manifest has pre-existing strict swift-format findings outside this one-line revision change; this PR does not alter formatting.