### PR TITLE
fix(release): preload nested builder archive

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "a7ff132653e1a4f71de7ebb193beb9d651254b85"
+        "revision" : "df6c16958705c635a45d885e18d084f57e1cfcfd"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "a7ff132653e1a4f71de7ebb193beb9d651254b85",
+        revision: "df6c16958705c635a45d885e18d084f57e1cfcfd",
     )
 }()
 

--- a/Tools/ci/fingerprint-release-environment.py
+++ b/Tools/ci/fingerprint-release-environment.py
@@ -93,10 +93,15 @@ MAKE_ASSIGNMENT = re.compile(
 # than its random absolute location.
 CONTENT_ROOT_VARIABLES = frozenset({"XDG_CONFIG_HOME"})
 
-# The runtime wrapper copies the retained init image into a fresh staging
-# directory for every attempt. Its bytes and mode affect the proof, but the
-# random staging path does not.
-CONTENT_FILE_VARIABLES = frozenset({"CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"})
+# The runtime wrapper copies retained OCI archives into a fresh staging
+# directory for every attempt. Their bytes and modes affect the proof, but the
+# random staging paths do not.
+CONTENT_FILE_VARIABLES = frozenset(
+    {
+        "CONTAINER_RUNTIME_BUILDER_IMAGE_TAR",
+        "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE",
+    }
+)
 
 # The release helper extracts the same immutable Container candidate below a
 # fresh mktemp root on every retry. These selectors establish which PATH entry

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -461,6 +461,7 @@ for target in "${container_targets[@]}"; do
   run_checkpointed "container-${target//_/-}" \
     env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
       CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" \
+      CONTAINER_INIT_BUILDER_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_BUILDER_IMAGE_TAR:-}" \
       make -C "${container_repo}" "${runtime_make_args[@]}" \
         "${container_make_args[@]}" "${target}"
 done

--- a/Tools/ci/test_fingerprint_release_environment.py
+++ b/Tools/ci/test_fingerprint_release_environment.py
@@ -119,6 +119,42 @@ class FingerprintReleaseEnvironmentTest(unittest.TestCase):
             self.assertEqual(first_fingerprint, relocated_fingerprint)
             self.assertNotEqual(relocated_fingerprint, changed_fingerprint)
 
+    def test_staged_builder_archive_uses_content_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first" / "builder-image.oci.tar"
+            second = root / "second" / "builder-image.oci.tar"
+            first.parent.mkdir()
+            second.parent.mkdir()
+            first.write_bytes(b"same builder image")
+            second.write_bytes(b"same builder image")
+
+            first_fingerprint = self.module.fingerprint_environment(
+                {
+                    "CONTAINER_RUNTIME_BUILDER_IMAGE_TAR": str(first),
+                    "PATH": "/usr/bin",
+                },
+                root,
+            )
+            relocated_fingerprint = self.module.fingerprint_environment(
+                {
+                    "CONTAINER_RUNTIME_BUILDER_IMAGE_TAR": str(second),
+                    "PATH": "/usr/bin",
+                },
+                root,
+            )
+            second.write_bytes(b"changed builder image")
+            changed_fingerprint = self.module.fingerprint_environment(
+                {
+                    "CONTAINER_RUNTIME_BUILDER_IMAGE_TAR": str(second),
+                    "PATH": "/usr/bin",
+                },
+                root,
+            )
+
+            self.assertEqual(first_fingerprint, relocated_fingerprint)
+            self.assertNotEqual(relocated_fingerprint, changed_fingerprint)
+
     def test_staged_init_archive_preserves_literal_path_semantics(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "a7ff132653e1a4f71de7ebb193beb9d651254b85",
+      "ref": "df6c16958705c635a45d885e18d084f57e1cfcfd",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1121,6 +1121,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             'CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"',
             validation,
         )
+        self.assertIn(
+            'CONTAINER_INIT_BUILDER_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_BUILDER_IMAGE_TAR:-}"',
+            validation,
+        )
         self.assertIn("CONTAINER_COMPOSE_BUILD_CHECK_LIVE=1", makefile)
         self.assertIn("docker-compose-devices-parity", makefile)
         self.assertIn("docker-compose-named-volume-reuse-parity", makefile)
@@ -1344,6 +1348,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     "fi\n"
                     "printf '%s:%s\\n' \"$(basename \"$0\")\" \"$*\" >> \"${STACK_VALIDATION_LOG:?}\"\n"
                     "printf 'bootstrap:%s\\n' \"${CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE:-}\" >> \"${STACK_VALIDATION_LOG:?}\"\n"
+                    "printf 'builder:%s\\n' \"${CONTAINER_INIT_BUILDER_IMAGE_ARCHIVE:-}\" >> \"${STACK_VALIDATION_LOG:?}\"\n"
                     "if [[ \"$(basename \"$0\")\" == make && "
                     "-n \"${MUTATE_RUNTIME_CLI_AFTER_MATCH:-}\" && "
                     "\"$*\" == *\"${MUTATE_RUNTIME_CLI_AFTER_MATCH}\"* ]]; then\n"
@@ -1379,6 +1384,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             environment["STACK_VALIDATION_LOG"] = str(log)
             environment["FAKE_GO_VERSION"] = "go1.26.3"
             environment["CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"] = "/tmp/runtime-init.oci.tar"
+            environment["CONTAINER_RUNTIME_BUILDER_IMAGE_TAR"] = "/tmp/runtime-builder.oci.tar"
             environment["CONTAINER_RUNTIME_CLI"] = str(candidate_tools_resolved / "container")
             # This fixture substitutes its own candidate CLI. A full release
             # gate exports candidate identity and scratch locations for the
@@ -1467,6 +1473,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
             self.assertNotIn("CONCURRENT_TEST_SUITES=", full_commands)
             self.assertIn("bootstrap:/tmp/runtime-init.oci.tar", full_commands)
+            self.assertIn("builder:/tmp/runtime-builder.oci.tar", full_commands)
 
             repeated_runtime_directory = tempfile.TemporaryDirectory(
                 prefix="ccsv-retry-test.", dir="/tmp"


### PR DESCRIPTION
## Summary
- pass the staged builder OCI archive into nested Container release validation
- preload and content-fingerprint that archive so retry checkpoints remain valid
- pin Compose to the merged Container bootstrap support

## Release contract
This prevents the 0.12.0 local release gate from idling on a remote BuildKit fetch after the exact builder archive has already been staged locally.

## Focused validation
- three targeted release-helper regression tests
- shell syntax and shellcheck for the changed release script
- Python bytecode compilation for changed helpers
- focused Container install-init script tests
- Compose stack consistency against Container `df6c16958705c635a45d885e18d084f57e1cfcfd`

## Risk and rollback
The archive variable is optional outside release validation. Reverting these two commits restores the prior remote-fetch behavior; no runtime format or user-visible Compose behavior changes.