### PR TITLE
chore(release): prepare 0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ DOCS_OUTPUT_DIR ?= _site
 DOCS_SERVER_DIR ?= _serve
 DOCS_HOSTING_BASE_PATH ?= container-compose
 DOCS_SCRATCH_PATH ?= .build/docc
-COMPOSE_VERSION ?= 0.11.0
+COMPOSE_VERSION ?= 0.12.0
 CONTAINER_COMPOSE_SOURCE ?= $(shell $(PYTHON) -c 'import subprocess; result = subprocess.run(["git", "remote", "get-url", "origin"], capture_output=True, text=True); url = result.stdout.strip() if result.returncode == 0 else ""; url = url[len("git@github.com:"):] if url.startswith("git@github.com:") else url; url = url[len("https://github.com/"):] if url.startswith("https://github.com/") else url; url = url[:-4] if url.endswith(".git") else url; print(url)')
 CONTAINER_COMPOSE_BRANCH ?= $(shell git branch --show-current 2>/dev/null || git rev-parse --short HEAD)
 CONTAINER_COMPOSE_LANE ?= $(shell $(PYTHON) -c 'branch = "$(CONTAINER_COMPOSE_BRANCH)"; print("main" if branch == "main" else "release" if branch == "release" or branch.startswith("release-") else "detached" if branch in ("", "HEAD") else "development")')
@@ -509,16 +509,16 @@ cli-smoke-built:
 	.build/debug/compose --ansi never version >/dev/null
 	.build/debug/compose version --dry-run >/dev/null
 	version_short_output="$$(".build/debug/compose" version --short)"; \
-	[[ "$$version_short_output" == "0.11.0" ]]; \
+	[[ "$$version_short_output" == "0.12.0" ]]; \
 	version_pretty_output="$$(".build/debug/compose" version)"; \
-	[[ "$$version_pretty_output" == *"container-compose 0.11.0"* ]]; \
+	[[ "$$version_pretty_output" == *"container-compose 0.12.0"* ]]; \
 	[[ "$$version_pretty_output" == *"container:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"containerization:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"compose-go: $(COMPOSE_GO_VERSION)"* ]]; \
 	[[ "$$version_pretty_output" == *"runtime-capability-schema: 1"* ]]; \
 	[[ "$$version_pretty_output" == *"runtime-capability: io.github.stephenlclarke.container.compose.archive-copy.v1"* ]]; \
 	version_json_output="$$(".build/debug/compose" version --format json)"; \
-	[[ "$$version_json_output" == *'"version":"0.11.0"'* ]]; \
+	[[ "$$version_json_output" == *'"version":"0.12.0"'* ]]; \
 	[[ "$$version_json_output" == *'"containerSource":"stephenlclarke/container"'* ]]; \
 	[[ "$$version_json_output" == *'"containerRef":"$(CONTAINER_REF)"'* ]]; \
 	[[ "$$version_json_output" == *'"containerDistribution":"custom"'* ]]; \
@@ -528,16 +528,16 @@ cli-smoke-built:
 	[[ "$$version_json_output" == *'"runtimeCapabilitySchemaVersion":1'* ]]; \
 	[[ "$$version_json_output" == *'"runtimeCapabilities":["io.github.stephenlclarke.container.compose.archive-copy.v1"'* ]]; \
 	version_short_format_output="$$(".build/debug/compose" version -f json)"; \
-	[[ "$$version_short_format_output" == *'"version":"0.11.0"'* ]]; \
+	[[ "$$version_short_format_output" == *'"version":"0.12.0"'* ]]; \
 	version_compact_format_output="$$(".build/debug/compose" version -fjson)"; \
-	[[ "$$version_compact_format_output" == *'"version":"0.11.0"'* ]]; \
+	[[ "$$version_compact_format_output" == *'"version":"0.12.0"'* ]]; \
 	package_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$package_tmp"' EXIT; \
 	mkdir -p "$$package_tmp/compose/bin" "$$package_tmp/compose/resources" "$$package_tmp/bin"; \
 	cp .build/debug/compose "$$package_tmp/compose/bin/compose"; \
 	cp "$(PLUGIN_ICON)" "$$package_tmp/compose/resources/container-compose-icon.png"; \
 	test -f "$$package_tmp/compose/resources/container-compose-icon.png"; \
-	printf '%s\n' '{"version":"0.11.0","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
+	printf '%s\n' '{"version":"0.12.0","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
 	ln -s ../compose/bin/compose "$$package_tmp/bin/container-compose"; \
 	packaged_version_output="$$(cd /tmp && "$$package_tmp/bin/container-compose" version --format json)"; \
 	[[ "$$packaged_version_output" == *'"branch":"symlink-smoke"'* ]]; \
@@ -561,7 +561,7 @@ cli-smoke-built:
 	[[ "$$compat_output" == *"https://github.com/stephenlclarke/container-compose/blob/main/docs/guides/INSTALL.md"* ]]; \
 	service_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$service_tmp"' EXIT; \
-	printf '%s\n' '{"version":"0.11.0","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
+	printf '%s\n' '{"version":"0.12.0","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
 	printf '%s\n' '#!/usr/bin/env bash' 'if [[ "$$*" == "system version --format json" ]]; then' '  printf '\''[{"appName":"container","buildType":"release","commit":"matched-container","containerization":"stephenlclarke/containerization@matched-containerization","distribution":"custom","runtimeCapabilitySchemaVersion":1,"runtimeCapabilities":["io.github.stephenlclarke.container.compose.archive-copy.v1","io.github.stephenlclarke.container.compose.build-extensions.v1","io.github.stephenlclarke.container.compose.create-configuration.v1","io.github.stephenlclarke.container.compose.image-filesystem.v1","io.github.stephenlclarke.container.compose.lifecycle.v1","io.github.stephenlclarke.container.compose.observation.v1"],"source":"stephenlclarke/container","version":"homebrew-main"}]\n'\''' '  exit 0' 'fi' 'if [[ "$$*" == "system status" ]]; then' '  printf '\''apiserver is not running and not registered with launchd\n'\'' >&2' '  exit 1' 'fi' 'exit 2' > "$$service_tmp/container"; \
 	chmod +x "$$service_tmp/container"; \
 	set +e; \
@@ -796,7 +796,7 @@ cli-smoke-built:
 	printf 'services:\n  api:\n    image: alpine\n    build:\n      context: ./api\n    volumes:\n      - ./src:/src\n' > "$$tmpdir/relative-paths.yml"; \
 	printf 'services:\n  api:\n    image: alpine\n    depends_on:\n      - missing\n' > "$$tmpdir/missing-dependency.yml"; \
 	version_compact_global_output="$$(".build/debug/compose" -pcompact -f"$$tmpdir/compose.yml" version --short)"; \
-	[[ "$$version_compact_global_output" == "0.11.0" ]]; \
+	[[ "$$version_compact_global_output" == "0.12.0" ]]; \
 	config_output="$$(".build/debug/compose" -f "$$tmpdir/compose.yml" config)"; \
 	[[ "$$config_output" == *"name: \"demo\""* ]]; \
 	[[ "$$config_output" == *"services:"* ]]; \

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "df6c16958705c635a45d885e18d084f57e1cfcfd"
+        "revision" : "baed0ecf48a08ad84b596bd6fa4a913937674498"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "baed0ecf48a08ad84b596bd6fa4a913937674498"
+        "revision" : "50ab084a84461c8bae39b5012b6cb39c40c1ca76"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "baed0ecf48a08ad84b596bd6fa4a913937674498",
+        revision: "50ab084a84461c8bae39b5012b6cb39c40c1ca76",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "df6c16958705c635a45d885e18d084f57e1cfcfd",
+        revision: "baed0ecf48a08ad84b596bd6fa4a913937674498",
     )
 }()
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -29,7 +29,7 @@ private let composePluginVersionNumber = composeBuildInfo.version
 private let composePluginVersionString = "container-compose \(composePluginVersionNumber)"
 
 struct ComposeBuildInfo: Codable {
-    var version: String = "0.11.0"
+    var version: String = "0.12.0"
     var source: String = "unspecified"
     var branch: String = "unspecified"
     var lane: String = "unspecified"
@@ -120,7 +120,7 @@ struct ComposeBuildInfo: Codable {
             declaredSource: environment["CONTAINERIZATION_SOURCE"]
         )
         return ComposeBuildInfo(
-            version: "0.11.0",
+            version: "0.12.0",
             source: remoteSource(root: root),
             branch: branch,
             lane: lane(for: branch),

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "df6c16958705c635a45d885e18d084f57e1cfcfd",
+      "ref": "50ab084a84461c8bae39b5012b6cb39c40c1ca76",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "d6de5694200468d99a61662bfb9bb3aba763e3e5",
-      "forkHead": "baed0ecf48a08ad84b596bd6fa4a913937674498",
+      "forkHead": "50ab084a84461c8bae39b5012b6cb39c40c1ca76",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -433,7 +433,8 @@
             "db7d71bf5fc50d897af4391bf759975e85c683ec",
             "b6549457f7458652010686da9c3182187fd649bb",
             "5acc34e1f3da70f94e7d9e223259d9c98c94565e",
-            "7a8a6c824e90e3f8ec2789d07bfcf1ef1ea1988e"
+            "7a8a6c824e90e3f8ec2789d07bfcf1ef1ea1988e",
+            "60ffeab66af4429c566c42e290e96fa7e84d057c"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "d6de5694200468d99a61662bfb9bb3aba763e3e5",
-      "forkHead": "a7ff132653e1a4f71de7ebb193beb9d651254b85",
+      "forkHead": "baed0ecf48a08ad84b596bd6fa4a913937674498",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -431,7 +431,9 @@
             "3121ac634ae5dca0feabfa17a2d5a960a1d0295a",
             "7af8401f539d2e5fa315c339365e862b2d1a00be",
             "db7d71bf5fc50d897af4391bf759975e85c683ec",
-            "b6549457f7458652010686da9c3182187fd649bb"
+            "b6549457f7458652010686da9c3182187fd649bb",
+            "5acc34e1f3da70f94e7d9e223259d9c98c94565e",
+            "7a8a6c824e90e3f8ec2789d07bfcf1ef1ea1988e"
           ]
         },
         {


### PR DESCRIPTION
## Summary

- declare container-compose 0.12.0
- pin the matched Container stack to reviewed Container `50ab084a84461c8bae39b5012b6cb39c40c1ca76` and Containerization `3e078480b85dceb843133392573cdd4d9efeec0d`
- update the release stack manifest and upstream classification snapshot

## Proof already completed

- Compose lifecycle suite: 1,378 tests passed before final dependency pin
- Container lifecycle and machine release blockers: focused unit and runtime integration proof passed
- package manifest parse, JSON validation, stack-consistency check, and `git diff --check` passed at the exact pinned heads

This PR establishes the reviewed main/current-package provenance required before stable 0.12.0 promotion.