### PR TITLE
fix(ci): route release gates to local runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
     name: Validate Runtime
     needs: changes
     if: needs.changes.outputs.heavy == 'true'
-    runs-on: macos-26
+    runs-on: [self-hosted, macOS, ARM64, container-compose-current]
     # Cover the 45-minute validation/coverage budget, 10-minute CLI smoke,
     # 25-minute Sonar retry budget, and dependency/setup overhead.
     timeout-minutes: 105

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -158,7 +158,7 @@ jobs:
   release-gate:
     name: Run Hosted Release Gate
     needs: resolve-candidate
-    runs-on: macos-26
+    runs-on: [self-hosted, macOS, ARM64, container-compose-release]
     timeout-minutes: 120
     steps:
       - name: Checkout the stable candidate

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1076,11 +1076,16 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_release_gate_includes_sibling_coverage_and_runtime_integration(self) -> None:
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
         validation = STACK_RELEASE_VALIDATION.read_text(encoding="utf-8")
         reference_check = (
             ROOT / "Tools" / "parity" / "check-docker-compose-reference.sh"
         ).read_text(encoding="utf-8")
         self.assertIn("check-licenses vet lint coverage build", validation)
+        self.assertIn(
+            "runs-on: [self-hosted, macOS, ARM64, container-compose-current]",
+            ci_workflow,
+        )
         self.assertIn("run-stack-release-validation.sh full", makefile)
         self.assertIn("run-stack-release-validation.sh hosted", makefile)
         direct_full_gate = subprocess.run(
@@ -1889,6 +1894,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self,
     ) -> None:
         workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            "runs-on: [self-hosted, macOS, ARM64, container-compose-release]",
+            workflow,
+        )
         self.assertIn("stable tag %s is not GitHub-verified", workflow)
         self.assertIn("stable tag %s is not the latest semantic source tag", workflow)
         self.assertIn("stable release %s already exists and is immutable", workflow)


### PR DESCRIPTION
## Summary

- route main Runtime Validation to the dedicated `container-compose-current` self-hosted Apple-silicon runner
- route the hosted stable release gate to the dedicated `container-compose-release` runner
- remove the unbounded generic `macos-26` hosted-runner queue from the 0.12.0 critical path

## Focused proof

- `actionlint .github/workflows/ci.yml .github/workflows/stable-release-gate.yml`
- two focused release-policy regression tests passed
- `git diff --check`