### PR TITLE
fix(ci): launch isolated GPG agent for Sonar

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,8 @@ jobs:
           rm -rf "$scanner_root" "$gpg_home"
           mkdir -p "$scanner_root" "$gpg_home"
           chmod 700 "$gpg_home"
+          gpgconf --homedir "$gpg_home" --launch gpg-agent
+          trap 'gpgconf --homedir "$gpg_home" --kill gpg-agent 2>/dev/null || true' EXIT
 
           curl --fail --location --silent --show-error "$scanner_url" --output "$scanner_zip"
           curl --fail --location --silent --show-error "${scanner_url}.asc" --output "$scanner_signature"
@@ -436,6 +438,8 @@ jobs:
           fi
 
           gpg --homedir "$gpg_home" --batch --verify "$scanner_signature" "$scanner_zip"
+          gpgconf --homedir "$gpg_home" --kill gpg-agent
+          trap - EXIT
           unzip -q "$scanner_zip" -d "$scanner_root"
 
           scanner_bin="${scanner_root}/sonar-scanner-${SONAR_SCANNER_VERSION}-${scanner_flavor}/bin"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -982,11 +982,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "- name: Enforce SonarQube failures when the service is available"
             )
         ]
+        sonar_install = ci[
+            ci.index("- name: Install Sonar Scanner CLI") : ci.index(
+                "- name: SonarQube scan"
+            )
+        ]
         self.assertIn("timeout-minutes: 105", runtime_job)
         self.assertIn("continue-on-error: true", sonar)
         self.assertIn("timeout-minutes: 25", sonar)
         self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)
         self.assertIn("run: make sonar-scan", sonar)
+        self.assertIn('gpgconf --homedir "$gpg_home" --launch gpg-agent', sonar_install)
+        self.assertIn('gpgconf --homedir "$gpg_home" --kill gpg-agent', sonar_install)
 
     def test_stable_package_requires_candidate_bound_release_authority(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- launch the Sonar scanner verification agent inside its isolated GPG home on the self-hosted runner
- kill that exact agent after signature verification or on step exit
- preserve the pinned fingerprint and detached-signature verification

## Evidence

- reproduced the runner failure: key import succeeded, then GPG returned exit 2 because no homedir-specific agent socket existed
- verified `gpgconf --homedir ... --launch gpg-agent` imports and fingerprints the pinned SonarSource key successfully
- `actionlint .github/workflows/ci.yml`
- focused release-policy regression passed
- `git diff --check`