### PR TITLE
fix(ci): shorten Sonar GPG socket path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,13 +416,13 @@ jobs:
           scanner_zip="${RUNNER_TEMP}/${scanner_name}.zip"
           scanner_signature="${scanner_zip}.asc"
           scanner_root="${RUNNER_TEMP}/sonar-scanner-cli"
-          gpg_home="${RUNNER_TEMP}/sonar-scanner-gpg"
+          gpg_home="$(mktemp -d /private/tmp/container-compose-sonar-gpg.XXXXXX)"
 
-          rm -rf "$scanner_root" "$gpg_home"
-          mkdir -p "$scanner_root" "$gpg_home"
+          rm -rf "$scanner_root"
+          mkdir -p "$scanner_root"
           chmod 700 "$gpg_home"
           gpgconf --homedir "$gpg_home" --launch gpg-agent
-          trap 'gpgconf --homedir "$gpg_home" --kill gpg-agent 2>/dev/null || true' EXIT
+          trap 'gpgconf --homedir "$gpg_home" --kill gpg-agent 2>/dev/null || true; find "$gpg_home" -depth -delete' EXIT
 
           curl --fail --location --silent --show-error "$scanner_url" --output "$scanner_zip"
           curl --fail --location --silent --show-error "${scanner_url}.asc" --output "$scanner_signature"
@@ -439,6 +439,7 @@ jobs:
 
           gpg --homedir "$gpg_home" --batch --verify "$scanner_signature" "$scanner_zip"
           gpgconf --homedir "$gpg_home" --kill gpg-agent
+          find "$gpg_home" -depth -delete
           trap - EXIT
           unzip -q "$scanner_zip" -d "$scanner_root"
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -992,8 +992,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("timeout-minutes: 25", sonar)
         self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)
         self.assertIn("run: make sonar-scan", sonar)
+        self.assertIn(
+            'gpg_home="$(mktemp -d /private/tmp/container-compose-sonar-gpg.XXXXXX)"',
+            sonar_install,
+        )
         self.assertIn('gpgconf --homedir "$gpg_home" --launch gpg-agent', sonar_install)
         self.assertIn('gpgconf --homedir "$gpg_home" --kill gpg-agent', sonar_install)
+        self.assertIn('find "$gpg_home" -depth -delete', sonar_install)
 
     def test_stable_package_requires_candidate_bound_release_authority(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- create the isolated Sonar verification GPG home under a unique short `/private/tmp` path
- keep the pinned fingerprint and detached-signature verification
- kill the exact agent and delete only its mktemp-owned home on success or exit

## Root cause

The self-hosted runner path made `.../sonar-scanner-gpg/S.gpg-agent` exceed Darwin’s Unix-socket path limit. Key import completed, but GPG returned exit 2 because it could not connect to that socket. The same pinned import/fingerprint flow succeeds in the short path.

## Focused proof

- reproduced the long-path failure from exact workflow logs
- verified the pinned SonarSource key import and fingerprint in the short `/private/tmp` GPG home
- `actionlint .github/workflows/ci.yml`
- focused release-policy regression passed
- `git diff --check`