### PR TITLE
Fix up menu lifecycle parity assertions

### DIFF
--- a/Tools/parity/check-compose-up-menu.sh
+++ b/Tools/parity/check-compose-up-menu.sh
@@ -228,7 +228,8 @@ check_supported_menu_forms() {
 
 # Assert container-compose preserves the dry-run exit-control lifecycle plan.
 assert_container_menu_exit_control_plan() {
-    assert_file_contains "$LAST_STDOUT_FILE" "container run --name $PROJECT_NAME-api-1 --detach"
+    assert_file_contains "$LAST_STDOUT_FILE" "container create --name $PROJECT_NAME-api-1"
+    assert_file_contains "$LAST_STDOUT_FILE" "container start $PROJECT_NAME-api-1"
     assert_file_contains "$LAST_STDOUT_FILE" "compose-runtime wait $PROJECT_NAME-api-1"
     assert_file_contains "$LAST_STDOUT_FILE" "container delete $PROJECT_NAME-api-1"
 }
@@ -272,8 +273,9 @@ check_menu_watch() {
     expect_status 'container-compose accepts --menu with --watch dry-run' 0 \
         "$CONTAINER_COMPOSE" --ansi never -p "$PROJECT_NAME" -f "$FIXTURE_DIR/compose.yml" \
         --dry-run up --menu --watch api
-    assert_file_contains "$LAST_STDOUT_FILE" "container run --name $PROJECT_NAME-api-1 --detach"
-    assert_file_contains "$LAST_STDOUT_FILE" "compose-runtime logs --follow $PROJECT_NAME-api-1"
+    assert_file_contains "$LAST_STDOUT_FILE" "container create --name $PROJECT_NAME-api-1"
+    assert_file_contains "$LAST_STDOUT_FILE" "container start $PROJECT_NAME-api-1"
+    assert_file_contains "$LAST_STDOUT_FILE" "compose-runtime attach --no-stdin $PROJECT_NAME-api-1"
 }
 
 # Run the local-only Docker Compose V2 parity check.


### PR DESCRIPTION
Updates the late Docker Compose parity checkpoint to assert the atomic `container create` → `container start` lifecycle introduced by the 0.12.0 lifecycle work. It also verifies the current menu-watch attach plan instead of the obsolete log-follow plan.

Focused proof:
- `bash -n Tools/parity/check-compose-up-menu.sh`
- `Tools/parity/check-compose-up-menu.sh --strict`