### PR TITLE
fix(release): preserve lockfile during SwiftPM unedit

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -290,6 +290,119 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn("changed unrelated dependencies: transitive", result.stderr)
             self.assertEqual(json.loads(resolved.read_text(encoding="utf-8")), before)
 
+    def test_unedit_restores_lockfile_after_swiftpm_graph_refresh(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            package = root / "package"
+            package.mkdir()
+            before = {
+                "pins": [
+                    {"identity": "container", "state": {"revision": "expected"}},
+                    {"identity": "transitive", "state": {"version": "1.0.0"}},
+                ]
+            }
+            after = {
+                "pins": [
+                    {"identity": "container", "state": {"revision": "expected"}},
+                    {"identity": "transitive", "state": {"version": "1.1.0"}},
+                ]
+            }
+            resolved = package / "Package.resolved"
+            replacement = root / "after.json"
+            replacement.write_text(json.dumps(after), encoding="utf-8")
+            bin_directory = root / "bin"
+            bin_directory.mkdir()
+            fake_swift = bin_directory / "swift"
+            fake_swift.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    cp "$TEST_AFTER" "$TEST_PACKAGE/Package.resolved"
+                    if [ "${TEST_SWIFT_SIGNAL_PARENT:-0}" -eq 1 ]; then
+                        kill -TERM "$PPID"
+                        exit 0
+                    fi
+                    if [ "${TEST_SWIFT_SIGNAL_OUTER:-0}" -eq 1 ]; then
+                        outer_pid=$(ps -o ppid= -p "$PPID" | awk '{print $1}')
+                        kill -TERM "$outer_pid"
+                        exit 0
+                    fi
+                    if [ "$TEST_SWIFT_STATUS" -ne 0 ]; then
+                        printf 'not in edit mode\n' >&2
+                        exit "$TEST_SWIFT_STATUS"
+                    fi
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake_swift.chmod(0o755)
+
+            for status in (0, 1):
+                with self.subTest(swift_status=status):
+                    resolved.write_text(json.dumps(before), encoding="utf-8")
+                    result = self.run_release_function(
+                        root,
+                        f"unedit_release_dependency {shlex.quote(str(package))} container",
+                        shell_setup=(
+                            f"export PATH={shlex.quote(str(bin_directory))}:/usr/bin:/bin\n"
+                            f"export TEST_AFTER={shlex.quote(str(replacement))}\n"
+                            f"export TEST_PACKAGE={shlex.quote(str(package))}\n"
+                            f"export TEST_SWIFT_STATUS={status}"
+                        ),
+                    )
+
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(
+                        json.loads(resolved.read_text(encoding="utf-8")), before
+                    )
+
+            resolved.unlink()
+            result = self.run_release_function(
+                root,
+                f"unedit_release_dependency {shlex.quote(str(package))} container",
+                shell_setup=(
+                    f"export PATH={shlex.quote(str(bin_directory))}:/usr/bin:/bin\n"
+                    f"export TEST_AFTER={shlex.quote(str(replacement))}\n"
+                    f"export TEST_PACKAGE={shlex.quote(str(package))}\n"
+                    "export TEST_SWIFT_STATUS=0"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse(resolved.exists())
+
+            resolved.write_text(json.dumps(before), encoding="utf-8")
+            result = self.run_release_function(
+                root,
+                f"unedit_release_dependency {shlex.quote(str(package))} container",
+                shell_setup=(
+                    f"export PATH={shlex.quote(str(bin_directory))}:/usr/bin:/bin\n"
+                    f"export TEST_AFTER={shlex.quote(str(replacement))}\n"
+                    f"export TEST_PACKAGE={shlex.quote(str(package))}\n"
+                    "export TEST_SWIFT_STATUS=0\n"
+                    "export TEST_SWIFT_SIGNAL_PARENT=1"
+                ),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(json.loads(resolved.read_text(encoding="utf-8")), before)
+
+            resolved.write_text(json.dumps(before), encoding="utf-8")
+            result = self.run_release_function(
+                root,
+                f"unedit_release_dependency {shlex.quote(str(package))} container",
+                shell_setup=(
+                    f"export PATH={shlex.quote(str(bin_directory))}:/usr/bin:/bin\n"
+                    f"export TEST_AFTER={shlex.quote(str(replacement))}\n"
+                    f"export TEST_PACKAGE={shlex.quote(str(package))}\n"
+                    "export TEST_SWIFT_STATUS=0\n"
+                    "export TEST_SWIFT_SIGNAL_OUTER=1"
+                ),
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(json.loads(resolved.read_text(encoding="utf-8")), before)
+
     def test_containerization_pin_supports_literal_named_and_dynamic_revisions(self) -> None:
         revision = "a" * 40
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -1458,9 +1458,78 @@ print_component_refs() {
 
 # Remove a development edit so SwiftPM resolves the immutable release dependency.
 unedit_release_dependency() {
-  local path="$1" identity="$2" output
+  local path="$1" identity="$2" output backup="" status had_resolved=0
+  local previous_hup_trap previous_int_trap previous_quit_trap previous_term_trap
 
-  if output="$(swift package --package-path "${path}" unedit --force "${identity}" 2>&1)"; then
+  previous_hup_trap="$(trap -p HUP)"
+  previous_int_trap="$(trap -p INT)"
+  previous_quit_trap="$(trap -p QUIT)"
+  previous_term_trap="$(trap -p TERM)"
+
+  if [[ -f "${path}/Package.resolved" ]]; then
+    had_resolved=1
+    backup="$(mktemp "${TMPDIR:-/tmp}/container-compose-package-resolved.XXXXXX")"
+    cp "${path}/Package.resolved" "${backup}"
+  fi
+
+  restore_unedit_lockfile() {
+    if [[ -n "${backup}" && -f "${backup}" ]]; then
+      cp "${backup}" "${path}/Package.resolved"
+      rm -f "${backup}"
+    elif [[ "${had_resolved}" == "0" ]]; then
+      rm -f "${path}/Package.resolved"
+    fi
+  }
+
+  restore_unedit_signal_trap() {
+    local saved="$1" signal="$2"
+    if [[ -n "${saved}" ]]; then
+      eval "${saved}"
+    else
+      trap - "${signal}"
+    fi
+  }
+
+  restore_unedit_signal_traps() {
+    restore_unedit_signal_trap "${previous_hup_trap}" HUP
+    restore_unedit_signal_trap "${previous_int_trap}" INT
+    restore_unedit_signal_trap "${previous_quit_trap}" QUIT
+    restore_unedit_signal_trap "${previous_term_trap}" TERM
+  }
+
+  forward_unedit_signal_after_restore() {
+    local signal="$1"
+    restore_unedit_lockfile
+    restore_unedit_signal_traps
+    kill -s "${signal}" "$$"
+  }
+
+  # A trapped signal is deferred while Bash waits for the synchronous command
+  # substitution. Restore after that child finishes, then preserve the caller's
+  # original signal behaviour.
+  trap 'forward_unedit_signal_after_restore HUP' HUP
+  trap 'forward_unedit_signal_after_restore INT' INT
+  trap 'forward_unedit_signal_after_restore QUIT' QUIT
+  trap 'forward_unedit_signal_after_restore TERM' TERM
+
+  if output="$(
+    trap restore_unedit_lockfile EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 131' QUIT
+    trap 'exit 143' TERM
+    swift package --package-path "${path}" unedit --force "${identity}" 2>&1
+  )"; then
+    status=0
+  else
+    status=$?
+  fi
+  restore_unedit_signal_traps
+
+  # SwiftPM may refresh unrelated transitive pins before reporting that a
+  # package is not editable. Pin resolution below owns every intentional
+  # lockfile change, so unedit must only change workspace edit state.
+  if [[ "${status}" == "0" ]]; then
     printf 'removed editable SwiftPM dependency %s from %s\n' "${identity}" "${path}"
     return 0
   fi


### PR DESCRIPTION
## Summary

Prevent `swift package unedit --force` from silently rewriting unrelated transitive pins during stable release preparation. The helper now treats `unedit` as a workspace-state operation and restores `Package.resolved` byte-for-byte before the explicit, guarded pin-resolution phase.

## Failure reproduced

The guarded 0.12.0 release attempt at `d0974743` skipped graph refresh because the direct Container pins already matched, but `unedit` refreshed two unrelated dependencies before reporting edit state:

- `grpc-swift-nio-transport` 2.9.1 → 2.9.2
- `swift-service-lifecycle` 2.11.0 → 2.12.0

The attempt was stopped before any push or release tag.

## Validation

- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- Three focused release-policy tests, including success and not-in-edit-mode graph-refresh regressions
- Real local SwiftPM `unedit` calls for `containerization` and `container`, with the checked-in lockfile checksum unchanged
- `git diff --check`

No repository-wide or integration suite was rerun because this change is isolated to release preparation and the exact failure was reproduced directly.

## Compatibility and risk

No product/runtime code changes. Intentional direct pin updates remain owned by the existing guarded `resolve_release_dependency_pins` phase. The only behavioural change is that `unedit` cannot modify the checked-in lockfile.
