### PR TITLE
chore(deps): pin lifecycle identity fix

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f32783c5f908f05786e90602d5aac3de2eff8ed592a1f5614ded911940788cb5",
+  "originHash" : "25d2cbf6bac70671d619356a1e7944132f2782055f5c60063c80194df0ae4f51",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "50ab084a84461c8bae39b5012b6cb39c40c1ca76"
+        "revision" : "e76a28de2dcf2c3650871d8e5240d41d6a36cf12"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "50ab084a84461c8bae39b5012b6cb39c40c1ca76",
+        revision: "e76a28de2dcf2c3650871d8e5240d41d6a36cf12",
     )
 }()
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "50ab084a84461c8bae39b5012b6cb39c40c1ca76",
+      "ref": "e76a28de2dcf2c3650871d8e5240d41d6a36cf12",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-08-21",
+  "reviewedAt": "2026-08-22",
   "repositories": {
     "container": {
       "upstreamHead": "d6de5694200468d99a61662bfb9bb3aba763e3e5",
-      "forkHead": "50ab084a84461c8bae39b5012b6cb39c40c1ca76",
+      "forkHead": "e76a28de2dcf2c3650871d8e5240d41d6a36cf12",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -589,7 +589,8 @@
             "f5e25b12ed074e7e5fb09933d86a27652034f3e5",
             "b982f110d0d32e3b32722ef2528b19107a9661ec",
             "552ad8e951479b758f515054af2d63193c315412",
-            "72bee394be10feb50e82a88c48ac4c804b06d4bd"
+            "72bee394be10feb50e82a88c48ac4c804b06d4bd",
+            "b636d3f9d07de7ef3b4721de17eb47351c2544c1"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 21 August 2026
+Updated: 22 August 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `d6de5694200468d99a61662bfb9bb3aba763e3e5` | `a7ff132653e1a4f71de7ebb193beb9d651254b85` | 0 | 655 | 573 |
+| `container` | `d6de5694200468d99a61662bfb9bb3aba763e3e5` | `e76a28de2dcf2c3650871d8e5240d41d6a36cf12` | 0 | 666 | 579 |
 | `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `3e078480b85dceb843133392573cdd4d9efeec0d` | 0 | 195 | 159 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `88332c96705b024bbc5cd210642118ee82f8793d` | 0 | 40 | 34 |
-| **Total** | | | **0** | **890** | **766** |
+| **Total** | | | **0** | **901** | **772** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,8 +32,8 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 546 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
-| `generic-runtime-primitive` | 195 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
+| `support-maintenance` | 550 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `generic-runtime-primitive` | 197 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
 

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "archiveCommit": "3d77ec228c7f55a04f689d5e1453752fc0c27f72",
-  "generatedAt": "2026-08-06",
+  "generatedAt": "2026-08-22",
   "entries": [
     {
       "id": "apple-container-1459",
@@ -6957,6 +6957,28 @@
           "path": "docs/upstream/container-compose/PR-206.md"
         }
       ]
+    },
+    {
+      "id": "container-compose-304",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Pin lifecycle identity inspection support",
+      "state": "submitted",
+      "lastVerified": "2026-08-22",
+      "commits": [
+        "b636d3f9d07de7ef3b4721de17eb47351c2544c1",
+        "e76a28de2dcf2c3650871d8e5240d41d6a36cf12"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-304.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-304.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/304"
     },
     {
       "id": "container-compose-logging-syslog-tls-trust-fixture",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -6,11 +6,11 @@ This registry replaces the retired issue and pull-request handoff pairs.
 Current supporting records remain as ordinary Markdown files; every retired document
 links to an immutable Git snapshot.
 
-Last verified: 2026-08-06
+Last verified: 2026-08-22
 
-Entries: 378. Document snapshots: 658. Current supporting documents: 52.
+Entries: 379. Document snapshots: 660. Current supporting documents: 54.
 
-States: `active-draft` 2, `archived` 304, `closed` 16, `merged` 10, `submitted` 4, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 2, `archived` 304, `closed` 16, `merged` 10, `submitted` 5, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -208,6 +208,7 @@ States: `active-draft` 2, `archived` 304, `closed` 16, `merged` 10, `submitted` 
 | `stephenlclarke/container-compose` | Match Docker Compose static unreadable history | `closed` | `4f52a22b0432` | [Issue details](container-compose/ISSUE-196.md); [PR details](container-compose/PR-196.md) |
 | `stephenlclarke/container-compose` | Preserve complete scaled log identifiers | `closed` | `994de3172e1c` | [Issue details](container-compose/ISSUE-197.md); [PR details](container-compose/PR-197.md) |
 | `stephenlclarke/container-compose` | Honor local stack overlays in release builds | `closed` | `30d3017112a9` | [Issue details](container-compose/ISSUE-206.md); [PR details](container-compose/PR-206.md) |
+| `stephenlclarke/container-compose` | [Pin lifecycle identity inspection support](https://github.com/stephenlclarke/container-compose/pull/304) | `submitted` | `b636d3f9d07d`, `e76a28de2dcf` | [Issue details](container-compose/ISSUE-304.md); [PR details](container-compose/PR-304.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-304.md
+++ b/docs/upstream/container-compose/ISSUE-304.md
@@ -1,0 +1,19 @@
+# Pin native lifecycle identity inspection support
+
+## Problem
+
+Container Compose adopted atomic lifecycle discovery in [pull request 282](https://github.com/stephenlclarke/container-compose/pull/282), but its pinned Container revision could not inspect a native container by the immutable lifecycle ID returned from that discovery snapshot. Host-namespace lifecycle operations therefore discovered the correct container and then failed when the native `container inspect` command resolved only the legacy bundle-key namespace.
+
+## Required behavior
+
+The coordinated Compose stack must pin the merged Container correction from [Container pull request 135](https://github.com/stephenlclarke/container/pull/135). `Package.swift`, `Package.resolved`, the release stack manifest, and the reviewed fork classification must all name the same immutable Container revision. Native discovery must preserve the canonical Compose name and immutable ID, and native inspect/down must accept that discovered identity.
+
+## Resolution
+
+Container commit `b636d3f9d07de7ef3b4721de17eb47351c2544c1`, merged as `e76a28de2dcf2c3650871d8e5240d41d6a36cf12`, resolves inspect requests across the lifecycle ID, canonical name, and immutable bundle key. The focused live host-namespace certificate reached inspect and teardown successfully with that source commit. Compose pull request [304](https://github.com/stephenlclarke/container-compose/pull/304) moves every coordinated pin to the merged revision.
+
+## Tracking
+
+- Parent parity issue: [#274](https://github.com/stephenlclarke/container-compose/issues/274).
+- Compose pull request: [#304](https://github.com/stephenlclarke/container-compose/pull/304).
+- Container dependency: [stephenlclarke/container#135](https://github.com/stephenlclarke/container/pull/135).

--- a/docs/upstream/container-compose/PR-304.md
+++ b/docs/upstream/container-compose/PR-304.md
@@ -1,0 +1,27 @@
+# Pull Request 304: pin lifecycle identity inspection support
+
+## Summary
+
+- Pin Container to merged revision `e76a28de2dcf2c3650871d8e5240d41d6a36cf12`.
+- Keep the Swift manifest, resolved graph, release stack manifest, and fork classification on that exact revision.
+- Classify the reviewed Container lifecycle identity commit as a generic runtime primitive consumed by Compose.
+
+## Motivation and context
+
+Atomic lifecycle discovery returns an immutable container ID. Before Container pull request 135, the native inspect command resolved only the legacy bundle-key namespace, so a host-namespace lifecycle could discover a container successfully and then fail during inspection. This dependency update closes that exact cross-repository mismatch without changing Compose policy or manufacturing another identity.
+
+Refs [#274](https://github.com/stephenlclarke/container-compose/issues/274). Depends on [stephenlclarke/container#135](https://github.com/stephenlclarke/container/pull/135).
+
+## Testing
+
+- [x] `git diff --check` passes.
+- [x] Both changed JSON manifests parse successfully.
+- [x] The SwiftPM origin hash is regenerated for the new manifest while the reviewed transitive dependency versions remain pinned.
+- [x] `swift build --scratch-path .build --disable-automatic-resolution --target ComposeContainerRuntime` passes.
+- [x] `CONTAINER_STACK_REPO=/Users/sclarke/github/container python3 Tools/ci/check-stack-consistency.py` passes.
+- [x] Focused Container inspect unit tests pass for lifecycle ID, canonical name, immutable bundle key, duplicate aliases, and missing identities.
+- [x] The focused live host-namespace run reaches native inspect and teardown successfully with the exact Container source commit.
+
+## Compatibility and risk
+
+The change updates an exact dependency revision and does not alter the Compose API. Existing canonical names and bundle keys remain accepted while immutable lifecycle IDs become usable through the native CLI boundary. Release-build performance remains part of the single coherent 0.12.0 checkpoint gate rather than this pin-only review.


### PR DESCRIPTION
## Summary

- pin Container to the merged lifecycle identity inspection fix
- keep Package.swift, Package.resolved, the release stack manifest, and fork classification on one immutable revision
- regenerate the SwiftPM origin hash while preserving reviewed transitive dependency versions
- classify the reviewed Container commit that allows native inspect to resolve lifecycle IDs

## Verification

- `git diff --check`
- JSON parse validation for all changed manifests
- `swift build --scratch-path .build --disable-automatic-resolution --target ComposeContainerRuntime`
- `CONTAINER_STACK_REPO=/Users/sclarke/github/container python3 Tools/ci/check-stack-consistency.py`
- focused live host-namespace lifecycle proof using the exact Container source commit before merge

Refs #274
Depends on stephenlclarke/container#135