### PR TITLE
fix(parity): accept redacted create logging options

### DIFF
--- a/Tools/parity/check-compose-create-options.sh
+++ b/Tools/parity/check-compose-create-options.sh
@@ -364,36 +364,54 @@ validate_container_compose_dry_run() {
 
     dry_run_output="$("$CONTAINER_COMPOSE" --dry-run -p "$CONTAINER_PROJECT_NAME" -f "$COMPOSE_FILE" create --build --force-recreate)"
 
-    [[ "$dry_run_output" == *"container build --tag $CONTAINER_PROJECT_NAME-built:latest"* ]]
-    [[ "$dry_run_output" == *"--file $FIXTURE_DIR/Dockerfile $FIXTURE_DIR"* ]]
-    [[ "$dry_run_output" == *"container create --name $CONTAINER_PROJECT_NAME-built-1"* ]]
-    [[ "$dry_run_output" == *"container create --name $CONTAINER_PROJECT_NAME-api-1"* ]]
-    [[ "$dry_run_output" == *"--log-opt max-file=3"* ]]
-    [[ "$dry_run_output" == *"--log-opt max-size=512b"* ]]
-    [[ "$dry_run_output" == *"--health-cmd 'test -f /tmp/ready || exit 1'"* ]]
-    [[ "$dry_run_output" == *"--health-interval 5s"* ]]
-    [[ "$dry_run_output" == *"--health-timeout 1s"* ]]
-    [[ "$dry_run_output" == *"--health-start-period 3s"* ]]
-    [[ "$dry_run_output" == *"--health-start-interval 1s"* ]]
-    [[ "$dry_run_output" == *"--health-retries 2"* ]]
-    [[ "$dry_run_output" == *"--restart unless-stopped"* ]]
-    [[ "$dry_run_output" == *"--publish 127.0.0.1:18080:8080"* ]]
-    [[ "$dry_run_output" == *"--volume $FIXTURE_DIR/api.conf:/etc/api.conf:ro"* ]]
-    [[ "$dry_run_output" == *"--volume $FIXTURE_DIR/api-token.txt:/run/secrets/api_token:ro"* ]]
-    [[ "$dry_run_output" == *"--workdir /srv/app"* ]]
-    [[ "$dry_run_output" == *"--user 1000:1000"* ]]
-    [[ "$dry_run_output" == *"--hostname api-host"* ]]
-    [[ "$dry_run_output" == *"--domainname compose.test"* ]]
-    [[ "$dry_run_output" == *"--dns-option use-vc"* ]]
-    [[ "$dry_run_output" == *"--add-host host.docker.internal:host-gateway"* ]]
-    [[ "$dry_run_output" == *"--add-host static.local:127.0.0.44"* ]]
-    [[ "$dry_run_output" == *"--sysctl net.ipv4.ip_unprivileged_port_start=1024"* ]]
-    [[ "$dry_run_output" == *"--blkio weight=300"* ]]
-    [[ "$dry_run_output" == *"container create --name $CONTAINER_PROJECT_NAME-worker-1"* ]]
-    [[ "$dry_run_output" == *"--log-driver none"* ]]
-    [[ "$dry_run_output" == *"--restart on-failure:4"* ]]
-    [[ "$dry_run_output" == *"--restart-delay 2s"* ]]
-    [[ "$dry_run_output" == *"--restart-window 6s"* ]]
+    require_dry_run_fragment() {
+        local expected="$1"
+        if [[ "$dry_run_output" != *"$expected"* ]]; then
+            error "container-compose dry run omitted expected fragment: $expected"
+            return 1
+        fi
+    }
+
+    reject_dry_run_fragment() {
+        local forbidden="$1"
+        if [[ "$dry_run_output" == *"$forbidden"* ]]; then
+            error "container-compose dry run exposed forbidden fragment: $forbidden"
+            return 1
+        fi
+    }
+
+    require_dry_run_fragment "container build --tag $CONTAINER_PROJECT_NAME-built:latest"
+    require_dry_run_fragment "--file $FIXTURE_DIR/Dockerfile $FIXTURE_DIR"
+    require_dry_run_fragment "container create --name $CONTAINER_PROJECT_NAME-built-1"
+    require_dry_run_fragment "container create --name $CONTAINER_PROJECT_NAME-api-1"
+    require_dry_run_fragment "--log-opt 'max-file=<redacted>'"
+    require_dry_run_fragment "--log-opt 'max-size=<redacted>'"
+    reject_dry_run_fragment "--log-opt max-file=3"
+    reject_dry_run_fragment "--log-opt max-size=512b"
+    require_dry_run_fragment "--health-cmd 'test -f /tmp/ready || exit 1'"
+    require_dry_run_fragment "--health-interval 5s"
+    require_dry_run_fragment "--health-timeout 1s"
+    require_dry_run_fragment "--health-start-period 3s"
+    require_dry_run_fragment "--health-start-interval 1s"
+    require_dry_run_fragment "--health-retries 2"
+    require_dry_run_fragment "--restart unless-stopped"
+    require_dry_run_fragment "--publish 127.0.0.1:18080:8080"
+    require_dry_run_fragment "--volume $FIXTURE_DIR/api.conf:/etc/api.conf:ro"
+    require_dry_run_fragment "--volume $FIXTURE_DIR/api-token.txt:/run/secrets/api_token:ro"
+    require_dry_run_fragment "--workdir /srv/app"
+    require_dry_run_fragment "--user 1000:1000"
+    require_dry_run_fragment "--hostname api-host"
+    require_dry_run_fragment "--domainname compose.test"
+    require_dry_run_fragment "--dns-option use-vc"
+    require_dry_run_fragment "--add-host host.docker.internal:host-gateway"
+    require_dry_run_fragment "--add-host static.local:127.0.0.44"
+    require_dry_run_fragment "--sysctl net.ipv4.ip_unprivileged_port_start=1024"
+    require_dry_run_fragment "--blkio weight=300"
+    require_dry_run_fragment "container create --name $CONTAINER_PROJECT_NAME-worker-1"
+    require_dry_run_fragment "--log-driver none"
+    require_dry_run_fragment "--restart on-failure:4"
+    require_dry_run_fragment "--restart-delay 2s"
+    require_dry_run_fragment "--restart-window 6s"
 }
 
 # Run container-compose create against the same fixture.

--- a/docs/upstream/container-compose/ISSUE-306.md
+++ b/docs/upstream/container-compose/ISSUE-306.md
@@ -1,0 +1,28 @@
+# Issue 306: update create-options parity for redacted dry-run logging values
+
+## Problem description
+
+The `docker-compose-create-options-parity` release check expected raw logging
+option values in `container-compose --dry-run` output. Dry-run rendering now
+deliberately redacts those values, so the product emitted the secure contract
+while the stale release assertion stopped the 0.12.0 gate without explaining
+which fragment was missing.
+
+## Resolution
+
+The parity check now requires the redacted logging-option form and rejects the
+former raw values. Every dry-run fragment assertion reports the exact missing
+or forbidden fragment instead of returning an unlabeled shell status.
+
+## Focused evidence
+
+- `bash -n Tools/parity/check-compose-create-options.sh`
+- `Tools/parity/check-compose-create-options.sh --strict` against the exact
+  matched Container release candidate
+
+## Scope
+
+This changes release evidence only. It does not alter Compose runtime behavior
+or weaken the live create exercise performed by the same parity check.
+
+Refs [#306](https://github.com/stephenlclarke/container-compose/issues/306).

--- a/docs/upstream/container-compose/PR-307.md
+++ b/docs/upstream/container-compose/PR-307.md
@@ -1,0 +1,30 @@
+# Pull Request 307: accept redacted create logging options
+
+## Summary
+
+- Align create-options parity with deliberate logging-option redaction in
+  `container-compose --dry-run` output.
+- Reject the former raw logging option values.
+- Report the exact missing or forbidden dry-run fragment when the contract
+  changes again.
+
+## Motivation and context
+
+The 0.12.0 release gate stopped because this parity script still expected raw
+`--log-opt` values. Runtime behavior was correct: dry-run output had begun
+redacting those values. The old unlabeled shell assertions also hid the exact
+reason for the failure.
+
+Closes [#306](https://github.com/stephenlclarke/container-compose/issues/306).
+
+## Testing
+
+- [x] `bash -n Tools/parity/check-compose-create-options.sh`
+- [x] `git diff --check`
+- [x] Exact matched-stack `docker-compose-create-options-parity`, including
+  the live create exercise
+
+## Compatibility and risk
+
+This changes release evidence only. It preserves dry-run secrecy and does not
+alter Compose runtime behavior.


### PR DESCRIPTION
## Summary

- align create-options parity with deliberate dry-run logging-option redaction
- reject the former raw values
- report the exact missing or forbidden dry-run fragment instead of an unlabeled shell failure

## Focused validation

- `bash -n Tools/parity/check-compose-create-options.sh`
- exact matched-stack `docker-compose-create-options-parity` passed, including live create

Closes #306.