### PR TITLE
fix(config): include lifecycle helper images

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "95787ab5585d5af6b1768a98cb04fd2ffd29d1e6"
+        "revision" : "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "95787ab5585d5af6b1768a98cb04fd2ffd29d1e6",
+        revision: "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04",
     )
 }()
 

--- a/Sources/ComposeCore/ComposeOrchestratorConfigAndLinks.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorConfigAndLinks.swift
@@ -104,7 +104,7 @@ extension ComposeOrchestrator {
         try ComposeImageReference.normalized(reference)
     }
 
-    /// Returns images referenced by selected services, including generated build tags.
+    /// Returns service, build, and explicit lifecycle-helper images for selected services.
     func configImages(project: ComposeProject, services: [String]) throws -> [String] {
         let selected = try selectedServices(project: project, selected: services)
         let serviceImages = selected.compactMap { serviceImage(project: project, service: $0) }

--- a/Sources/ComposeCore/ComposeOrchestratorConfigAndLinks.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorConfigAndLinks.swift
@@ -107,7 +107,8 @@ extension ComposeOrchestrator {
     /// Returns images referenced by selected services, including generated build tags.
     func configImages(project: ComposeProject, services: [String]) throws -> [String] {
         let selected = try selectedServices(project: project, selected: services)
-        return Array(Set(selected.compactMap { serviceImage(project: project, service: $0) })).sorted()
+        let serviceImages = selected.compactMap { serviceImage(project: project, service: $0) }
+        return Array(Set(serviceImages + explicitPreStartImages(services: selected))).sorted()
     }
 
     /// Returns the interpolation environment loaded by compose-go.

--- a/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
@@ -2930,9 +2930,14 @@ extension ComposeOrchestratorTests {
                     $0.profiles = ["debug", "dev"]
                     $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
                     $0.networks = ["front"]
+                    $0.preStart = [
+                        ComposeServiceHook(command: ["prepare"], image: "example/api-init:1"),
+                        ComposeServiceHook(command: ["reuse"], image: "example/api-init:1"),
+                    ]
                 },
                 "worker": composeService(name: "worker") {
                     $0.build = ComposeBuild(context: "./worker")
+                    $0.preStart = [ComposeServiceHook(command: ["prepare"], image: "example/worker-init:1")]
                 },
             ]
         ) {
@@ -2951,7 +2956,11 @@ extension ComposeOrchestratorTests {
             $0.servicesOnly = true
             $0.services = ["missing"]
         }) == "api\nworker")
-        #expect(try orchestrator.config(project: project, options: ComposeConfigOptions { $0.images = true }) == "demo_worker:latest\nexample/api")
+        #expect(try orchestrator.config(project: project, options: ComposeConfigOptions { $0.images = true }) == "demo_worker:latest\nexample/api\nexample/api-init:1\nexample/worker-init:1")
+        #expect(try orchestrator.config(project: project, options: ComposeConfigOptions {
+            $0.images = true
+            $0.services = ["api"]
+        }) == "example/api\nexample/api-init:1")
         #expect(try orchestrator.config(project: project, options: ComposeConfigOptions { $0.networks = true }) == "back\nfront")
         #expect(try orchestrator.config(project: project, options: ComposeConfigOptions { $0.profiles = true }) == "debug\ndev")
         #expect(try orchestrator.config(project: project, options: ComposeConfigOptions {

--- a/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift
@@ -1732,8 +1732,8 @@ extension ComposeOrchestratorTests {
         ])
     }
 
-    @Test("pre start images stay out of service image projections and explicit pull")
-    func preStartImagesStayOutOfServiceImageProjectionsAndExplicitPull() async throws {
+    @Test("pre start images appear in config images but stay out of explicit pull")
+    func preStartImagesAppearInConfigImagesButStayOutOfExplicitPull() async throws {
         let imageManager = RecordingContainerImageManager()
         let project = ComposeProject(
             name: "demo",
@@ -1763,6 +1763,8 @@ extension ComposeOrchestratorTests {
             options: ComposeConfigOptions { $0.images = true }
         ) == """
         example/api:1
+        example/init:1
+        example/skip:1
         example/worker:1
         """)
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "95787ab5585d5af6b1768a98cb04fd2ffd29d1e6",
+      "ref": "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "d6de5694200468d99a61662bfb9bb3aba763e3e5",
-      "forkHead": "95787ab5585d5af6b1768a98cb04fd2ffd29d1e6",
+      "forkHead": "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -591,7 +591,9 @@
             "552ad8e951479b758f515054af2d63193c315412",
             "72bee394be10feb50e82a88c48ac4c804b06d4bd",
             "b636d3f9d07de7ef3b4721de17eb47351c2544c1",
-            "8683b9fde9caf3e4c341ddb0ec20fae9ec391b0e"
+            "8683b9fde9caf3e4c341ddb0ec20fae9ec391b0e",
+            "23cf93c4d74e862a37992afcfec2b306a7fb4f7a",
+            "f31dc1a14f8f76baac87509ec4c3f6c27262998c"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 22 August 2026
+Updated: 23 August 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `d6de5694200468d99a61662bfb9bb3aba763e3e5` | `95787ab5585d5af6b1768a98cb04fd2ffd29d1e6` | 0 | 668 | 580 |
+| `container` | `d6de5694200468d99a61662bfb9bb3aba763e3e5` | `d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04` | 0 | 671 | 582 |
 | `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `3e078480b85dceb843133392573cdd4d9efeec0d` | 0 | 195 | 159 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `88332c96705b024bbc5cd210642118ee82f8793d` | 0 | 40 | 34 |
-| **Total** | | | **0** | **901** | **772** |
+| **Total** | | | **0** | **906** | **775** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -33,7 +33,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
 | `support-maintenance` | 550 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
-| `generic-runtime-primitive` | 197 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
+| `generic-runtime-primitive` | 200 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
 

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -6983,6 +6983,52 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/304"
     },
     {
+      "id": "container-compose-309",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Include lifecycle helper images in config output",
+      "state": "submitted",
+      "lastVerified": "2026-08-23",
+      "commits": [
+        "23cf93c4d74e862a37992afcfec2b306a7fb4f7a",
+        "f31dc1a14f8f76baac87509ec4c3f6c27262998c",
+        "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-308.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-309.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/309"
+    },
+    {
+      "id": "container-compose-307",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Accept redacted create logging options",
+      "state": "closed",
+      "lastVerified": "2026-08-23",
+      "commits": [
+        "53d57ea17fc7fe93f15708db4176d37aacfdfc21",
+        "47712162fde811c0856bd96b1d972314be82af99",
+        "a956cbe7955ada0f35f12048676cf2cd4e3619df"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-306.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-307.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/307"
+    },
+    {
       "id": "container-compose-logging-syslog-tls-trust-fixture",
       "owner": "stephenlclarke/container-compose",
       "title": "Add the Syslog TLS trust-rejection parity fixture",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-08-22
 
-Entries: 379. Document snapshots: 660. Current supporting documents: 54.
+Entries: 381. Document snapshots: 664. Current supporting documents: 58.
 
-States: `active-draft` 2, `archived` 304, `closed` 16, `merged` 10, `submitted` 5, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 2, `archived` 304, `closed` 17, `merged` 10, `submitted` 6, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -209,6 +209,8 @@ States: `active-draft` 2, `archived` 304, `closed` 16, `merged` 10, `submitted` 
 | `stephenlclarke/container-compose` | Preserve complete scaled log identifiers | `closed` | `994de3172e1c` | [Issue details](container-compose/ISSUE-197.md); [PR details](container-compose/PR-197.md) |
 | `stephenlclarke/container-compose` | Honor local stack overlays in release builds | `closed` | `30d3017112a9` | [Issue details](container-compose/ISSUE-206.md); [PR details](container-compose/PR-206.md) |
 | `stephenlclarke/container-compose` | [Pin lifecycle identity inspection support](https://github.com/stephenlclarke/container-compose/pull/304) | `submitted` | `b636d3f9d07d`, `e76a28de2dcf`, `8683b9fde9ca`, `95787ab5585d` | [Issue details](container-compose/ISSUE-304.md); [PR details](container-compose/PR-304.md) |
+| `stephenlclarke/container-compose` | [Accept redacted create logging options](https://github.com/stephenlclarke/container-compose/pull/307) | `closed` | `53d57ea17fc7`, `47712162fde8`, `a956cbe7955a` | [Issue details](container-compose/ISSUE-306.md); [PR details](container-compose/PR-307.md) |
+| `stephenlclarke/container-compose` | [Include lifecycle helper images in config output](https://github.com/stephenlclarke/container-compose/pull/309) | `submitted` | `23cf93c4d74e`, `f31dc1a14f8f`, `d28f51eeb5a5` | [Issue details](container-compose/ISSUE-308.md); [PR details](container-compose/PR-309.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-308.md
+++ b/docs/upstream/container-compose/ISSUE-308.md
@@ -1,0 +1,28 @@
+# Issue 308: include lifecycle helper images in config image projection
+
+## Problem description
+
+Docker Compose includes explicit `pre_start.image` references in
+`config --images`. Container Compose projected only service images and generated
+build tags, so lifecycle projects omitted helper images even though the same
+images were used by pull and runtime preparation.
+
+## Resolution
+
+The image projection now combines selected services' normal runtime images with
+their distinct explicit pre-start helper images, then applies the existing
+deterministic sort. Selection remains scoped: helper images from unselected
+services are not reported.
+
+## Focused evidence
+
+- Focused `config renders supported projections` unit test, covering generated
+  build tags, helper-image deduplication, deterministic order, and selection.
+- Exact matched-stack lifecycle-hooks parity contract.
+
+## Scope
+
+This fixes the configuration projection only. Lifecycle execution and pull
+behavior already consumed explicit helper images.
+
+Refs [#308](https://github.com/stephenlclarke/container-compose/issues/308).

--- a/docs/upstream/container-compose/ISSUE-308.md
+++ b/docs/upstream/container-compose/ISSUE-308.md
@@ -4,8 +4,8 @@
 
 Docker Compose includes explicit `pre_start.image` references in
 `config --images`. Container Compose projected only service images and generated
-build tags, so lifecycle projects omitted helper images even though the same
-images were used by pull and runtime preparation.
+build tags, so lifecycle projects omitted helper images even though create and
+up preparation consumed them.
 
 ## Resolution
 
@@ -22,7 +22,8 @@ services are not reported.
 
 ## Scope
 
-This fixes the configuration projection only. Lifecycle execution and pull
-behavior already consumed explicit helper images.
+This fixes the configuration projection only. Lifecycle execution and create/up
+image-policy preparation already consumed explicit helper images. An explicit
+`compose pull` remains scoped to ordinary service images.
 
 Refs [#308](https://github.com/stephenlclarke/container-compose/issues/308).

--- a/docs/upstream/container-compose/PR-309.md
+++ b/docs/upstream/container-compose/PR-309.md
@@ -20,7 +20,7 @@ Closes [#308](https://github.com/stephenlclarke/container-compose/issues/308).
 - [x] Focused configuration and lifecycle image-projection tests
 - [x] Matched live helper execution, startup, and cleanup with Container pull
   request 138
-- [ ] Exact merged-stack lifecycle parity after the Container dependency pin
+- [x] Exact merged-stack lifecycle parity after the Container dependency pin
 
 ## Compatibility and risk
 

--- a/docs/upstream/container-compose/PR-309.md
+++ b/docs/upstream/container-compose/PR-309.md
@@ -1,0 +1,28 @@
+# Pull Request 309: include lifecycle helper images in config output
+
+## Summary
+
+- Include explicit `pre_start.image` references in `config --images`.
+- Preserve deterministic sorting, deduplication, generated build tags, and
+  selected-service scope.
+- Keep explicit helper images out of the ordinary pull projection.
+
+## Motivation and context
+
+Compose projects can use images solely for lifecycle helpers. Omitting those
+images from `config --images` made the resolved image inventory incomplete even
+though runtime preparation correctly consumed them.
+
+Closes [#308](https://github.com/stephenlclarke/container-compose/issues/308).
+
+## Testing
+
+- [x] Focused configuration and lifecycle image-projection tests
+- [x] Matched live helper execution, startup, and cleanup with Container pull
+  request 138
+- [ ] Exact merged-stack lifecycle parity after the Container dependency pin
+
+## Compatibility and risk
+
+This adds lifecycle-only images to an informational projection. It does not
+change ordinary service-image pulls or lifecycle execution semantics.


### PR DESCRIPTION
## Summary

- include explicit `pre_start.image` references in `config --images`
- preserve deterministic sorting, deduplication, generated build tags, and service selection
- keep explicit lifecycle helper pulls out of the ordinary `pull` projection

Closes #308.

## Verification

- `swift test --disable-automatic-resolution --filter 'preStartImagesAppearInConfigImagesButStayOutOfExplicitPull|configRendersSupportedProjections'`
- matched lifecycle-hooks live parity passes helper execution, startup, and cleanup with Container PR #138
