### PR TITLE
[Parity] Adopt the inbound Unix-socket transport stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "25d2cbf6bac70671d619356a1e7944132f2782055f5c60063c80194df0ae4f51",
+  "originHash" : "215683c942ac980e60aca1f7a14884d30c829d903dbe7b10789736c409c910e9",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04"
+        "revision" : "1f830f601deb1ebfebab70a4b448b5156ce62a07"
       }
     },
     {
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container-engine-api.git",
       "state" : {
-        "revision" : "c66fac82d3b2368072959414c1c48c6c3711ae38"
+        "revision" : "386a40c726ecd25d67a3e5933582aebbfbe4fa2f"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "3e078480b85dceb843133392573cdd4d9efeec0d"
+        "revision" : "153492f49e4eef3af47401d1f2dee4f70ea4d975"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04",
+        revision: "1f830f601deb1ebfebab70a4b448b5156ce62a07",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "3e078480b85dceb843133392573cdd4d9efeec0d",
+        revision: "153492f49e4eef3af47401d1f2dee4f70ea4d975",
     )
 }()
 

--- a/Sources/ComposePlugin/RuntimeCapabilityManifest.swift
+++ b/Sources/ComposePlugin/RuntimeCapabilityManifest.swift
@@ -23,6 +23,7 @@ enum ComposeRuntimeCapability: String, CaseIterable, Codable, Sendable {
     case lifecycle = "io.github.stephenlclarke.container.compose.lifecycle.v1"
     case networkScopedAliases = "io.github.stephenlclarke.container.compose.network-scoped-aliases.v1"
     case observation = "io.github.stephenlclarke.container.compose.observation.v1"
+    case inboundUnixSocket = "io.github.stephenlclarke.container.inbound-unix-socket.v1"
     case loggingDrivers = "io.github.stephenlclarke.container.logging-drivers.v1"
 }
 

--- a/Tests/ComposePluginTests/ContainerPackageCompatibilityTests.swift
+++ b/Tests/ComposePluginTests/ContainerPackageCompatibilityTests.swift
@@ -61,6 +61,7 @@ private let matchingSystemVersionJSON = """
         "io.github.stephenlclarke.container.compose.lifecycle.v1",
         "io.github.stephenlclarke.container.compose.network-scoped-aliases.v1",
         "io.github.stephenlclarke.container.compose.observation.v1",
+        "io.github.stephenlclarke.container.inbound-unix-socket.v1",
         "io.github.stephenlclarke.container.logging-drivers.v1"
       ],
       "source": "stephenlclarke/container",

--- a/Tools/release/runtime-capabilities.json
+++ b/Tools/release/runtime-capabilities.json
@@ -7,6 +7,7 @@
     "io.github.stephenlclarke.container.compose.lifecycle.v1",
     "io.github.stephenlclarke.container.compose.network-scoped-aliases.v1",
     "io.github.stephenlclarke.container.compose.observation.v1",
+    "io.github.stephenlclarke.container.inbound-unix-socket.v1",
     "io.github.stephenlclarke.container.logging-drivers.v1"
   ],
   "schemaVersion": 1

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04",
+      "ref": "1f830f601deb1ebfebab70a4b448b5156ce62a07",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "3e078480b85dceb843133392573cdd4d9efeec0d",
+      "ref": "153492f49e4eef3af47401d1f2dee4f70ea4d975",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/architecture/runtime-capabilities.md
+++ b/docs/architecture/runtime-capabilities.md
@@ -39,6 +39,7 @@ that it exactly matches the typed Compose and sibling Container definitions.
 | `create-configuration.v1` | Typed process, mount, network, resource, namespace, security, device, and GPU configuration used when creating service and one-off containers |
 | `image-filesystem.v1` | Image metadata and declared-volume discovery, image-volume copy-up, commit/export, and live snapshot behaviour |
 | `lifecycle.v1` | Create/start/stop/restart/exec/attach/kill/pause/wait controls, persisted exit state, and process metadata |
+| `inbound-unix-socket.v1` | Canonical guest socket intent, authority-selected host socket resolution, stable relay identity, and Docker-compatible guest ownership and mode; this transport primitive does not constitute a durable Engine API grant |
 | `logging-drivers.v1` | Typed logging requests, durable native histories, remote/provider lifecycle, cache/read policy, and exact-process foreground attachment |
 | `network-scoped-aliases.v1` | Source-scoped dynamic DNS aliases used to preserve Compose link isolation and target address changes |
 | `observation.v1` | Container discovery, health, logs, events, statistics, top, and network/port observation |

--- a/docs/project/BACKLOG.md
+++ b/docs/project/BACKLOG.md
@@ -119,9 +119,11 @@ WebSocket resize, selected image mutations, and volume creation.
 
 Remaining work includes the unimplemented generated routes, registry
 credentials, image push, search and history, build and session transports,
-large streams, typed guest socket grants, explicit authority handoff,
-Testcontainers and devcontainer adoption, root and non-root proof, and the
-exact `use_api_socket` transformation.
+large streams, durable generation-fenced guest socket grant records and
+recovery, explicit authority handoff, Testcontainers and devcontainer adoption,
+root and non-root end-to-end proof, and the exact `use_api_socket`
+transformation. The typed inbound Unix-socket transport primitive is complete;
+it does not by itself satisfy the grant or `use_api_socket` contract.
 
 `use_api_socket` remains disabled until the complete authority, credential,
 grant, security, recovery, and external-client contracts are proved.

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -249,10 +249,15 @@ discovery, logs, lifecycle, TTY attach and resize, unauthenticated image pull,
 tag and delete, and volume creation through the native authority. Focused
 unmodified Docker CLI certificates cover these paths.
 
+The matched runtime now also provides the typed inbound Unix-socket transport:
+canonical guest intent, authority-selected host socket resolution, stable relay
+identity, and Docker-oracled guest ownership and mode. This is a lower transport
+primitive, not the complete Engine API socket grant.
+
 Registry credentials, push, search, history, build and session transports,
-most remaining generated routes, typed guest socket grants, complete
-Testcontainers and devcontainer adoption, and `use_api_socket` are not current
-functionality.
+most remaining generated routes, durable generation-fenced socket grant
+records and recovery, complete Testcontainers and devcontainer adoption, and
+`use_api_socket` are not current functionality.
 
 ## CLI Commands
 


### PR DESCRIPTION
## Summary

- pin the merged Container and Containerization inbound Unix-socket transport heads
- publish and negotiate `io.github.stephenlclarke.container.inbound-unix-socket.v1`
- document the transport as current while keeping the durable Engine grant and `use_api_socket` transformation explicitly gated

This is a bounded progress PR for #270. It does **not** close #270 and does not enable Compose `use_api_socket`.

## Proof

- exact remote dependency graph compiled successfully
- the broad Swift pass executed 1,383 tests; its only 11 issues were the stale matching-capability fixture added by this PR
- after correcting that fixture, all 29 affected compatibility/readiness tests passed
- all Compose normalizer Go packages passed
- stack-consistency check passed, including its 10 focused tests
- changed Markdown passed markdownlint; `git diff --check` passed

## Remaining gates

- durable generation-fenced grant records and restart recovery
- sealed credentials and full authority/route coverage
- root and non-root guest end-to-end, restart, cleanup, and denial proof
- Compose `use_api_socket` transformation and external-client adoption

Refs #270