### PR TITLE
test(release): include inbound socket contract

### DIFF
--- a/Tools/release/test_write_build_info.py
+++ b/Tools/release/test_write_build_info.py
@@ -79,6 +79,7 @@ class BuildInfoWriterTests(unittest.TestCase):
                     "io.github.stephenlclarke.container.compose.lifecycle.v1",
                     "io.github.stephenlclarke.container.compose.network-scoped-aliases.v1",
                     "io.github.stephenlclarke.container.compose.observation.v1",
+                    "io.github.stephenlclarke.container.inbound-unix-socket.v1",
                     "io.github.stephenlclarke.container.logging-drivers.v1",
                 ],
             )


### PR DESCRIPTION
## Summary

Update the release metadata regression test to include the inbound Unix-socket runtime capability introduced on `main` by #310.

This restores the source-check lane currently blocking Dependabot PRs #288 and #289. The generated capability list was already correct; only the expected test fixture was stale.

## Validation

- `python3 -m unittest Tools.release.test_write_build_info`
- `git diff --check`