### PR TITLE
chore(release): advance 0.13.0 stack pins

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -639,7 +639,7 @@ jobs:
         env:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 07ab89568d2805665ea82bd4556f683a0c28aa476805d584875a3feadca97991
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 27761bf109808075f8ffec8c89e9137c6586a21caad40aabb49c3f6a384cad29
         shell: bash
         working-directory: container-compose
         run: |
@@ -996,7 +996,7 @@ jobs:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           DEMO_ASSET: ${{ steps.lane.outputs.demo_asset }}
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 07ab89568d2805665ea82bd4556f683a0c28aa476805d584875a3feadca97991
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 27761bf109808075f8ffec8c89e9137c6586a21caad40aabb49c3f6a384cad29
           PLUGIN_ARCHIVE: ${{ runner.temp }}/${{ steps.lane.outputs.asset }}
           RUNTIME_ARCHIVE: ${{ steps.runtime-package.outputs.local_asset }}
         shell: bash

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "215683c942ac980e60aca1f7a14884d30c829d903dbe7b10789736c409c910e9",
+  "originHash" : "6936225c45e4f857a4dfef22a5400fb8af2fdfb7be5b7f004bfa338af4e8dbdc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "1f830f601deb1ebfebab70a4b448b5156ce62a07"
+        "revision" : "94bb6c4bd1ad00deffb68fc40e931ee143c43c65"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "153492f49e4eef3af47401d1f2dee4f70ea4d975"
+        "revision" : "fefced145304666076d646609f21397f32909fcf"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "1f830f601deb1ebfebab70a4b448b5156ce62a07",
+        revision: "94bb6c4bd1ad00deffb68fc40e931ee143c43c65",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "153492f49e4eef3af47401d1f2dee4f70ea4d975",
+        revision: "fefced145304666076d646609f21397f32909fcf",
     )
 }()
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "1f830f601deb1ebfebab70a4b448b5156ce62a07",
+      "ref": "94bb6c4bd1ad00deffb68fc40e931ee143c43c65",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "153492f49e4eef3af47401d1f2dee4f70ea4d975",
+      "ref": "fefced145304666076d646609f21397f32909fcf",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -686,7 +686,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertIn(
             "DEMO_INIT_IMAGE_ARCHIVE_SHA256: "
-            "07ab89568d2805665ea82bd4556f683a0c28aa476805d584875a3feadca97991",
+            "27761bf109808075f8ffec8c89e9137c6586a21caad40aabb49c3f6a384cad29",
             workflow,
         )
         self.assertIn("Validate Current demo init-image authority", package)


### PR DESCRIPTION
## Docker contract

The 0.13.0 candidate must package one internally consistent Container-family stack: Compose, Container, Containerization, and the guest `vminit` image must all identify immutable matching authorities.

## Oracle and exact authorities

- Container: `94bb6c4bd1ad00deffb68fc40e931ee143c43c65` (container#141)
- Containerization: `fefced145304666076d646609f21397f32909fcf` (containerization#36)
- guest image manifest: `sha256:42469e85592c08a01d10bcee58d461b239367a888411ed07d49971505e2a46dc`
- guest OCI archive: `sha256:27761bf109808075f8ffec8c89e9137c6586a21caad40aabb49c3f6a384cad29`

## Changes

- advance exact Container and Containerization package revisions
- advance the checked-in stack-ref authorities consumed by CI/release workflows
- refresh the SwiftPM lock origin authority
- update both prebuilt-binary archive checksum gates
- update the focused release-policy regression

## Risk and rollback

The change is release metadata and dependency authority only. Rollback requires restoring the prior Container/Containerization pins, stack refs, and matching guest archive/digest together; individual rollback would create a mislabeled stack and is not supported.

No persistence schema, public API, or runtime topology changes are introduced by this PR itself.

## Focused proof

- `swift package resolve`
- `swift build --disable-automatic-resolution --product compose` — passed against the immutable merged stack
- `python3 -m unittest Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_current_build_records_and_publishes_the_matched_vhs_demo` — passed
- `CONTAINER_STACK_REPO=/Users/sclarke/github/container python3 Tools/ci/check-stack-consistency.py` — passed
- `python3 -m unittest Tools.ci.test_check_stack_consistency` — 10 passed
- both guest image references resolve to the same manifest digest
- archive SHA-256 verified locally

## Initial CI finding and correction

The first ASan run correctly rejected stale `Tools/release/stack-refs.json` authorities. Commit `47f8dfb035bd` aligns those recorded refs with the exact Package pins; focused consistency tests pass and the new exact-head CI run is authoritative.

## Performance

Not applicable: dependency and release-authority metadata only; no executable code changes.