### PR TITLE
chore(upstream): refresh release fork classifications

### DIFF
--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "d6de5694200468d99a61662bfb9bb3aba763e3e5",
-      "forkHead": "d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04",
+      "forkHead": "94bb6c4bd1ad00deffb68fc40e931ee143c43c65",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -435,7 +435,9 @@
             "5acc34e1f3da70f94e7d9e223259d9c98c94565e",
             "7a8a6c824e90e3f8ec2789d07bfcf1ef1ea1988e",
             "60ffeab66af4429c566c42e290e96fa7e84d057c",
-            "4e2791dcd8e3a1c69752af8cb703e3fe5d740ac0"
+            "4e2791dcd8e3a1c69752af8cb703e3fe5d740ac0",
+            "e33814906fdb2d5e55ee4cb9a93151b4f1c721bb",
+            "39d68474c86cbda67c991232e89ca42d64581681"
           ]
         },
         {
@@ -593,7 +595,8 @@
             "b636d3f9d07de7ef3b4721de17eb47351c2544c1",
             "8683b9fde9caf3e4c341ddb0ec20fae9ec391b0e",
             "23cf93c4d74e862a37992afcfec2b306a7fb4f7a",
-            "f31dc1a14f8f76baac87509ec4c3f6c27262998c"
+            "f31dc1a14f8f76baac87509ec4c3f6c27262998c",
+            "1f830f601deb1ebfebab70a4b448b5156ce62a07"
           ]
         },
         {
@@ -664,7 +667,7 @@
     },
     "containerization": {
       "upstreamHead": "5427fd21ded4b84034126caef5b3182900b4776d",
-      "forkHead": "3e078480b85dceb843133392573cdd4d9efeec0d",
+      "forkHead": "fefced145304666076d646609f21397f32909fcf",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -774,7 +777,10 @@
             "81522ed80496580d82a246a3810c6d37540c1748",
             "58d9a836b28cfbb055ce537a619a03aa662c9f6e",
             "1461f16133d106c381e51eeaa98dca5ab9170890",
-            "644a73cea4838222efafba7babc5c8a0eadf348f"
+            "644a73cea4838222efafba7babc5c8a0eadf348f",
+            "09cf958bfa4b79d0384dacfbb31eaee86837f58b",
+            "f2474b6338d367434a273d495f664c3e1138c5e3",
+            "662c4c02aa793040f2d624634f507fc7c97f1a7d"
           ]
         },
         {
@@ -830,7 +836,9 @@
             "88fc904eda6223f061f17c3195c872f0232666d0",
             "7bf897186efb16e2def8aa48e5a99f803958df95",
             "52386838456a431d24bed6c38a9e84fb0ad28997",
-            "3e078480b85dceb843133392573cdd4d9efeec0d"
+            "3e078480b85dceb843133392573cdd4d9efeec0d",
+            "153492f49e4eef3af47401d1f2dee4f70ea4d975",
+            "73a5e108afb7956c15f8894b454d221d3f300bee"
           ]
         },
         {
@@ -937,7 +945,7 @@
     },
     "container-builder-shim": {
       "upstreamHead": "e18d2182fd060dbf1c68113a74e7564d563dde27",
-      "forkHead": "88332c96705b024bbc5cd210642118ee82f8793d",
+      "forkHead": "e4829be2203b7baa33cae75ca58be967e4b81280",
       "slices": [
         {
           "id": "container-builder-shim-support-maintenance",
@@ -970,7 +978,9 @@
             "8c6f4c3aaa767b179ff3b3548010bb2622e4324c",
             "15b224bb9d87124f0799236ffbb9583af8b82ba0",
             "bc26468b7a6a06e677484100a4fb59a16a89aaca",
-            "88332c96705b024bbc5cd210642118ee82f8793d"
+            "88332c96705b024bbc5cd210642118ee82f8793d",
+            "4c037e46248b5b215d35a417b31af915f8c25be5",
+            "e4829be2203b7baa33cae75ca58be967e4b81280"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 23 August 2026
+Updated: 24 August 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `d6de5694200468d99a61662bfb9bb3aba763e3e5` | `d28f51eeb5a5cc0189b4c29e5dd7e40ac322ee04` | 0 | 671 | 582 |
-| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `3e078480b85dceb843133392573cdd4d9efeec0d` | 0 | 195 | 159 |
-| `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `88332c96705b024bbc5cd210642118ee82f8793d` | 0 | 40 | 34 |
-| **Total** | | | **0** | **906** | **775** |
+| `container` | `d6de5694200468d99a61662bfb9bb3aba763e3e5` | `94bb6c4bd1ad00deffb68fc40e931ee143c43c65` | 0 | 675 | 585 |
+| `containerization` | `5427fd21ded4b84034126caef5b3182900b4776d` | `fefced145304666076d646609f21397f32909fcf` | 0 | 201 | 164 |
+| `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `e4829be2203b7baa33cae75ca58be967e4b81280` | 0 | 42 | 36 |
+| **Total** | | | **0** | **918** | **785** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,8 +32,8 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 550 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
-| `generic-runtime-primitive` | 200 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
+| `support-maintenance` | 557 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `generic-runtime-primitive` | 203 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
 
@@ -190,3 +190,11 @@ Containers 3.32.0 debug-kernel default are upstream history after the reviewed
 merges. Container's atomic lifecycle discovery commits and Containerization's
 lifecycle primitive are classified as generic runtime work. No temporary
 upstream port or rejected Compose-policy disposition changed in this refresh.
+
+The 24 August 2026 release refresh advances Container through
+`94bb6c4bd1ad`, Containerization through `fefced145304`, and the builder shim
+through `e4829be2203b`. The Engine socket guest projection, inbound relay
+identity, and socket-relay errno correction are generic runtime primitives.
+Dependency repairs and pins, generated-protobuf normalization, and their
+review documentation are support maintenance. No temporary upstream port or
+rejected Compose-policy disposition changed in this refresh.


### PR DESCRIPTION
## Summary

- classify the ten newly merged fork-only commits by owning-layer semantics
- advance all three reviewed fork heads to the exact 0.13.0 stack inputs
- refresh the human-readable baseline and disposition totals

Closes #317

## Testing

- `make fork-classifications-check`
- `make upstream-divergence-release-check`
- `python3 -m unittest Tools.ci.test_upstream_divergence_report` (11 passed)
- Markdownlint and `git diff --check`

## Release review

This corrects a preflight omission: the registry should have been refreshed in the stack-pin pull request before Current publication. The first full release-process review will record and address that ordering defect.

Release-Note: none