### PR TITLE
fix(release): preserve runtime candidate signing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1087,7 +1087,8 @@ release:
 		printf 'VERSION_SELECTOR is required, for example: make release VERSION_SELECTOR=--+\n' >&2; \
 		exit 2; \
 	}
-	./scripts/CONTAINER_STACK_RELEASE.sh release "$(VERSION_SELECTOR)" --execute
+	CONTAINER_RUNTIME_CODESIGN_IDENTITY="$(CONTAINER_RUNTIME_CODESIGN_IDENTITY)" \
+		./scripts/CONTAINER_STACK_RELEASE.sh release "$(VERSION_SELECTOR)" --execute
 
 release-plan:
 	./scripts/CONTAINER_STACK_RELEASE.sh plan

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2822,6 +2822,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn("must not resolve to /", rejected.stderr)
 
     def test_local_release_gate_freezes_the_container_runtime_candidate(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
         staging = self.script[
             self.script.index("stage_container_runtime_candidate() {") : self.script.index(
                 "# Delete only the fresh marker-protected candidate extraction"
@@ -2834,7 +2835,20 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         ]
 
         self.assertIn("git -C \"${container_path}\" rev-parse", staging)
-        self.assertIn("homebrew-package \"HOMEBREW_ARCHIVE=${archive}\"", staging)
+        self.assertIn(
+            'CONTAINER_RUNTIME_CODESIGN_IDENTITY="$(CONTAINER_RUNTIME_CODESIGN_IDENTITY)"',
+            makefile,
+        )
+        self.assertIn("homebrew-package", staging)
+        self.assertIn('"HOMEBREW_ARCHIVE=${archive}"', staging)
+        self.assertIn(
+            '"CODESIGN_OPTS=--force --sign ${signing_identity} --timestamp=none"',
+            staging,
+        )
+        self.assertIn(
+            'artifact_root="${artifact_parent}/${container_head}-${signing_identity}"',
+            staging,
+        )
         self.assertIn("shasum -a 256 -c", staging)
         self.assertIn("tar -xzf \"${archive}\"", staging)
         self.assertIn("chmod -R a-w", staging)
@@ -2911,10 +2925,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
             bin_directory = root / "bin"
             bin_directory.mkdir()
+            make_arguments = root / "make-arguments"
+            signing_identity = "A" * 40
             fake_make = bin_directory / "make"
             fake_make.write_text(
                 "#!/usr/bin/env bash\n"
                 "set -euo pipefail\n"
+                "printf '%s\\n' \"$@\" >\"${MAKE_ARGUMENTS:?}\"\n"
                 "archive=\n"
                 "for argument in \"$@\"; do\n"
                 "  case \"$argument\" in\n"
@@ -2946,7 +2963,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "candidate_root=$CONTAINER_RUNTIME_CANDIDATE_ROOT; "
                 "test \"${#CONTAINER_RUNTIME_CANDIDATE_SHA256}\" -eq 64; "
                 "cleanup_container_runtime_candidate; test ! -e \"$candidate_root\"",
-                shell_setup=f"export PATH={shlex.quote(str(bin_directory))}:$PATH",
+                shell_setup=(
+                    f"export PATH={shlex.quote(str(bin_directory))}:$PATH\n"
+                    f"export MAKE_ARGUMENTS={shlex.quote(str(make_arguments))}\n"
+                    "export CONTAINER_RUNTIME_CODESIGN_IDENTITY="
+                    f"{signing_identity}"
+                ),
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
@@ -2955,6 +2977,29 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertTrue(
                 (artifacts[0] / ".container-compose-runtime-candidate-artifact").is_file()
             )
+            self.assertIn(
+                "CODESIGN_OPTS=--force --sign "
+                f"{signing_identity} --timestamp=none",
+                make_arguments.read_text(encoding="utf-8").splitlines(),
+            )
+
+    def test_runtime_candidate_staging_rejects_invalid_signing_identity(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            rejected = self.run_release_function(
+                root,
+                "stage_container_runtime_candidate /does/not/exist evidence",
+                shell_setup="export CONTAINER_RUNTIME_CODESIGN_IDENTITY=adhoc",
+            )
+
+            self.assertEqual(rejected.returncode, 2)
+            self.assertIn(
+                "set CONTAINER_RUNTIME_CODESIGN_IDENTITY to its 40-character fingerprint",
+                rejected.stderr,
+            )
+            self.assertFalse((root / "evidence").exists())
 
     def test_runtime_candidate_staging_cleans_interrupted_build_root(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -2994,6 +3039,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                     "EXECUTE=1",
                     f"export PATH={shlex.quote(str(bin_directory))}:$PATH",
                     f"export BUILD_READY={shlex.quote(str(ready))}",
+                    f"export CONTAINER_RUNTIME_CODESIGN_IDENTITY={'B' * 40}",
                     "stage_container_runtime_candidate "
                     f"{shlex.quote(str(container))} {shlex.quote(str(evidence))}",
                 ]

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -615,13 +615,20 @@ require_local_virtualization() {
 stage_container_runtime_candidate() {
   local container_path="$1" evidence_root="$2"
   local container_head artifact_parent artifact_root build_root archive archive_digest
-  local marker marker_value candidate_parent
+  local marker marker_value candidate_parent signing_identity expected_marker
+
+  signing_identity="${CONTAINER_RUNTIME_CODESIGN_IDENTITY:-}"
+  if [[ ! "${signing_identity}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
+    printf 'a Developer ID Application identity is required for the packaged Container runtime candidate; set CONTAINER_RUNTIME_CODESIGN_IDENTITY to its 40-character fingerprint\n' >&2
+    return 2
+  fi
 
   container_head="$(git -C "${container_path}" rev-parse --verify 'HEAD^{commit}')"
   artifact_parent="${evidence_root}/runtime-candidates"
-  artifact_root="${artifact_parent}/${container_head}"
+  artifact_root="${artifact_parent}/${container_head}-${signing_identity}"
   archive="${artifact_root}/container-homebrew-debug-arm64.tar.gz"
   marker="${artifact_root}/.container-compose-runtime-candidate-artifact"
+  expected_marker="container-compose runtime candidate artifact v2 ${container_head} ${signing_identity}"
 
   mkdir -p "${artifact_parent}"
   if [[ -e "${artifact_root}" ]]; then
@@ -629,7 +636,7 @@ stage_container_runtime_candidate() {
     if [[ -f "${marker}" ]]; then
       IFS= read -r marker_value <"${marker}" || true
     fi
-    if [[ "${marker_value}" != "container-compose runtime candidate artifact v1 ${container_head}" ]]; then
+    if [[ "${marker_value}" != "${expected_marker}" ]]; then
       printf 'refusing to reuse an unmarked Container runtime candidate artifact: %s\n' \
         "${artifact_root}" >&2
       return 1
@@ -671,7 +678,9 @@ stage_container_runtime_candidate() {
     trap 'exit 143' TERM
     trap 'cleanup_unpublished_runtime_candidate_build $?' EXIT
     archive="${build_root}/container-homebrew-debug-arm64.tar.gz"
-    if ! make -C "${container_path}" homebrew-package "HOMEBREW_ARCHIVE=${archive}"; then
+    if ! make -C "${container_path}" homebrew-package \
+      "HOMEBREW_ARCHIVE=${archive}" \
+      "CODESIGN_OPTS=--force --sign ${signing_identity} --timestamp=none"; then
       printf 'failed to build the packaged Container runtime candidate in: %s\n' \
         "${build_root}" >&2
       cleanup_unpublished_runtime_candidate_build 1 || true
@@ -683,8 +692,8 @@ stage_container_runtime_candidate() {
       cleanup_unpublished_runtime_candidate_build 1 || true
       return 1
     fi
-    printf 'container-compose runtime candidate artifact v1 %s\n' \
-      "${container_head}" >"${build_root}/.container-compose-runtime-candidate-artifact"
+    printf '%s\n' "${expected_marker}" \
+      >"${build_root}/.container-compose-runtime-candidate-artifact"
     mv "${build_root}" "${artifact_root}"
     build_root=""
     trap - EXIT HUP INT QUIT TERM


### PR DESCRIPTION
Fixes #319.

The stable release helper previously rebuilt its staged Container runtime with the Container repository default ad-hoc signature. The unattended runtime gate correctly rejected that candidate, stopping 0.13.0 before any push or tag.

This change forwards the resolved Developer ID Application fingerprint into the helper, passes it to the nested Container package build, and keys reusable candidate artifacts by both Container commit and signing identity.

Focused proof:
- 4 release-helper signing/staging tests pass
- shell syntax check passes
- Python bytecode compilation passes
- diff whitespace check passes