### PR TITLE
perf: adopt optimized Container stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6936225c45e4f857a4dfef22a5400fb8af2fdfb7be5b7f004bfa338af4e8dbdc",
+  "originHash" : "21cc4d9e38b335a590799d8f433f4bcb3ac2b56b16d3253acc6d6e57469dd8ed",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "94bb6c4bd1ad00deffb68fc40e931ee143c43c65"
+        "revision" : "788377c876469dc42f333e9a6003319640fb57d3"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "fefced145304666076d646609f21397f32909fcf"
+        "revision" : "050cf2484a50fcc0931ee53f544e027bf4012e05"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "94bb6c4bd1ad00deffb68fc40e931ee143c43c65",
+        revision: "788377c876469dc42f333e9a6003319640fb57d3",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "fefced145304666076d646609f21397f32909fcf",
+        revision: "050cf2484a50fcc0931ee53f544e027bf4012e05",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ in this stable baseline. Planned compatibility work is kept separately in
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 25 August 2026 snapshot, the three support forks are **918 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 26 August 2026 snapshot, the three support forks are **921 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 201 ahead** at [`fefced145304`](https://github.com/stephenlclarke/containerization/commit/fefced145304666076d646609f21397f32909fcf).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 675 ahead** at [`94bb6c4bd1ad`](https://github.com/stephenlclarke/container/commit/94bb6c4bd1ad00deffb68fc40e931ee143c43c65).
-> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 42 ahead** at [`e4829be2203b`](https://github.com/stephenlclarke/container-builder-shim/commit/e4829be2203b7baa33cae75ca58be967e4b81280).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 202 ahead** at [`050cf2484a50`](https://github.com/stephenlclarke/containerization/commit/050cf2484a50fcc0931ee53f544e027bf4012e05).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 676 ahead** at [`788377c87646`](https://github.com/stephenlclarke/container/commit/788377c876469dc42f333e9a6003319640fb57d3).
+> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 43 ahead** at [`2df7b287e530`](https://github.com/stephenlclarke/container-builder-shim/commit/2df7b287e5306693567435383841fcc4b6012cbf).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >
 > What looks like a local Compose change can therefore require coordinated conflict resolution, pin updates, builds, tests, packaging, and release validation across the entire stack. The pinned revisions must move together.

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,20 +1,20 @@
 {
   "components": {
     "container": {
-      "ref": "94bb6c4bd1ad00deffb68fc40e931ee143c43c65",
+      "ref": "788377c876469dc42f333e9a6003319640fb57d3",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
       "image": {
-        "digest": "sha256:c29628471db683a53f4a75bcb759bb9147a65e097ede37c7dde05442afa7518c",
+        "digest": "sha256:d81d12e1dca1133ede535483a809803e6b256555a73d17f207003279539454a4",
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
-        "tag": "current-31545611348-88332c96705b"
+        "tag": "current-32967604909-2df7b287e530"
       },
-      "ref": "e4829be2203b7baa33cae75ca58be967e4b81280",
+      "ref": "2df7b287e5306693567435383841fcc4b6012cbf",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "fefced145304666076d646609f21397f32909fcf",
+      "ref": "050cf2484a50fcc0931ee53f544e027bf4012e05",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7097,6 +7097,28 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/322"
     },
     {
+      "id": "container-compose-325",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Adopt the optimized Container stack",
+      "state": "submitted",
+      "lastVerified": "2026-08-26",
+      "commits": [
+        "abf1a9759307d11ab0148043fba192f40bc6c1eb",
+        "94b6ea99e5c1dd448bc0599d04a392d68f8ac9bf"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-278.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-325.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/325"
+    },
+    {
       "id": "container-compose-307",
       "owner": "stephenlclarke/container-compose",
       "title": "Accept redacted create logging options",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-08-22
 
-Entries: 384. Document snapshots: 670. Current supporting documents: 64.
+Entries: 385. Document snapshots: 672. Current supporting documents: 66.
 
-States: `active-draft` 2, `archived` 304, `closed` 17, `merged` 10, `submitted` 9, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 2, `archived` 304, `closed` 17, `merged` 10, `submitted` 10, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -214,6 +214,7 @@ States: `active-draft` 2, `archived` 304, `closed` 17, `merged` 10, `submitted` 
 | `stephenlclarke/container-compose` | [Prevent repeated macOS privacy prompts during runtime validation](https://github.com/stephenlclarke/container-compose/pull/314) | `submitted` | `2763f1ccee9c`, `4cbde9789711`, `9115d096e75b`, `1db73de51a43`, `d48037e99109`, `a363f7f5fa10`, `42aa95502c89`, `722953ff5069`, `89572c904dab`, `5e574a15777b`, `60ff9c13d9fc`, `0e7dbc369349`, `e258cdec59b7`, `a316d628316b`, `18c7d0c071dd`, `75ce16dd5c43`, `5f63f64db9a5`, `15cfed9a7b17`, `f370ef982663`, `a9c0a794a67f` | [Issue details](container-compose/ISSUE-312.md); [PR details](container-compose/PR-314.md) |
 | `stephenlclarke/container-compose` | [Add a recoverable Nextflow build and test pipeline](https://github.com/stephenlclarke/container-compose/pull/315) | `submitted` | `3fd6d7214846`, `4587f306e32b`, `f44503be1caa` | [Issue details](container-compose/ISSUE-313.md); [PR details](container-compose/PR-315.md) |
 | `stephenlclarke/container-compose` | [Remove documentation and demo work from the release critical path](https://github.com/stephenlclarke/container-compose/pull/322) | `submitted` | `01b1f72e8d74`, `a0f83a1a637a`, `ba5c3c710add`, `8d90f6ca0b18`, `d16720755d60`, `9b3960c606df`, `04ed76315caa`, `3bb829f79f1f` | [Issue details](container-compose/ISSUE-321.md); [PR details](container-compose/PR-322.md) |
+| `stephenlclarke/container-compose` | [Adopt the optimized Container stack](https://github.com/stephenlclarke/container-compose/pull/325) | `submitted` | `abf1a9759307`, `94b6ea99e5c1` | [Issue details](container-compose/ISSUE-278.md); [PR details](container-compose/PR-325.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-278.md
+++ b/docs/upstream/container-compose/ISSUE-278.md
@@ -1,0 +1,30 @@
+# Issue 278: comparable-or-better same-host performance
+
+## Problem description
+
+Compose has functional parity evidence, but runtime lifecycle work still pays avoidable serialization and repeated preparation in the Container-family dependencies. The release stack must also pin exact mutually compatible source revisions so performance changes remain reproducible and recoverable.
+
+## Requested outcome
+
+- Retain Compose behavior while consuming the reviewed Containerization, builder-shim, and Container optimization stack.
+- Pin immutable merged dependency revisions in the Swift package graph and release stack manifest.
+- Keep generated builder protocol source paired with the immutable builder image used by Container.
+- Preserve the matched before/after evidence and its environment fingerprint without attributing aggregate gains to any isolated commit.
+- Continue tracking the separate Compose scaling gap where 10- and 50-service startup exceed the current Docker parity guard.
+
+## Acceptance evidence
+
+- Containerization, builder-shim, and Container dependency PRs are merged and green.
+- Compose package and release manifests resolve to the exact merged revisions.
+- Stack-consistency checks pass with no local override.
+- Focused Compose dependency, manifest, and lifecycle contract tests pass.
+- Exact-head review and required GitHub checks find no remaining issue.
+- The retained benchmark shows 84 of 84 operations passing in each lane with functional parity.
+
+## Remaining scope
+
+This dependency-integration slice is one measured contribution to issue 278, not its closure. The existing Compose startup scaling guard still exceeds Docker by more than 10x at 10 and 50 services, so issue 278 remains open for Compose-owned profiling and scaling work after this exact optimized runtime stack lands.
+
+## Related work
+
+This handoff records [issue 278](https://github.com/stephenlclarke/container-compose/issues/278). Its implementation dependencies are [Containerization pull request 37](https://github.com/stephenlclarke/containerization/pull/37), [builder-shim pull request 12](https://github.com/stephenlclarke/container-builder-shim/pull/12), and [Container pull request 142](https://github.com/stephenlclarke/container/pull/142).

--- a/docs/upstream/container-compose/PR-325.md
+++ b/docs/upstream/container-compose/PR-325.md
@@ -1,0 +1,54 @@
+# Pull request 325: adopt the optimized Container stack
+
+## Summary
+
+- Pin the merged Containerization, builder-shim, and Container optimization
+  revisions as one matched stack.
+- Pin the immutable builder image paired with the merged builder-shim source.
+- Refresh the README support-fork snapshot at the exact merged revisions.
+- Preserve issue 278 for the remaining Compose-owned Docker scaling gap.
+
+Pull request:
+[`#325`](https://github.com/stephenlclarke/container-compose/pull/325).
+Tracking issue:
+[`#278`](https://github.com/stephenlclarke/container-compose/issues/278).
+
+## Exact stack
+
+- Containerization: `050cf2484a50fcc0931ee53f544e027bf4012e05`
+- Container: `788377c876469dc42f333e9a6003319640fb57d3`
+- builder-shim: `2df7b287e5306693567435383841fcc4b6012cbf`
+- builder image: `current-32967604909-2df7b287e530`
+- builder digest:
+  `sha256:d81d12e1dca1133ede535483a809803e6b256555a73d17f207003279539454a4`
+
+## Validation
+
+- `swift build -c release --product compose` passed.
+- Stack consistency passed against the merged Container revision.
+- All 10 stack-consistency regression tests passed.
+- All 30 focused dependency, manifest, and compatibility seam tests passed.
+- `git diff --check` passed.
+- The retained matched benchmark completed 84 of 84 operations in both lanes
+  with functional parity.
+
+The matched medians improved by 28.6%, 18.1%, and 14.4% for 1-, 10-, and
+50-service starts. Stop medians improved by 16.5%, 9.8%, and 1.5% for the same
+service counts. The benchmark attributes those results only to the complete
+matched stack, not to an individual commit.
+
+## Scope boundary
+
+This pull request does not close issue 278. The existing 10- and 50-service
+startup comparison remains more than 10 times Docker Compose and requires
+separate Compose-owned profiling and scaling work.
+
+DocC, CodeQL, and VHS are not benchmark evidence and are not release blockers
+for this dependency-only integration. The production build, focused tests,
+retained benchmark, and exact-head review are the acceptance evidence.
+
+## Related work
+
+- [Containerization pull request 37](https://github.com/stephenlclarke/containerization/pull/37)
+- [builder-shim pull request 12](https://github.com/stephenlclarke/container-builder-shim/pull/12)
+- [Container pull request 142](https://github.com/stephenlclarke/container/pull/142)


### PR DESCRIPTION
## Summary

- pin the merged Containerization, builder-shim, and Container optimization revisions
- pin the immutable builder image used by the matched stack
- refresh the README support-fork snapshot
- record the relationship to performance parity issue #278 without closing it

## Evidence

- production build: `swift build -c release --product compose`
- stack consistency: passed against Container `788377c876469dc42f333e9a6003319640fb57d3`
- focused integration seams: 30 tests in 6 suites passed
- matched benchmark: 84/84 operations passed in both baseline and optimized lanes
- median improvements: start 1 service 28.6%, start 10 services 18.1%, start 50 services 14.4%; stop 1 service 16.5%, stop 10 services 9.8%, stop 50 services 1.5%

## Related work

- stephenlclarke/containerization#37
- stephenlclarke/container-builder-shim#12
- stephenlclarke/container#142
- contributes to #278; the remaining Compose-owned 10/50-service Docker scaling gap remains open
