### PR TITLE
fix(stack): adopt latest Container runtime

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "21cc4d9e38b335a590799d8f433f4bcb3ac2b56b16d3253acc6d6e57469dd8ed",
+  "originHash" : "e03fd4b97acddbd9299c5ca84b12b3d5d58829a3e0a09e18874f250564b9a819",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "788377c876469dc42f333e9a6003319640fb57d3"
+        "revision" : "3c7c48f64c6120c6f962b31f008b699c77232ff6"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "050cf2484a50fcc0931ee53f544e027bf4012e05"
+        "revision" : "c60ba717b990bd9086fd0dd6d073b57004a6dcf8"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "788377c876469dc42f333e9a6003319640fb57d3",
+        revision: "3c7c48f64c6120c6f962b31f008b699c77232ff6",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "050cf2484a50fcc0931ee53f544e027bf4012e05",
+        revision: "c60ba717b990bd9086fd0dd6d073b57004a6dcf8",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ in this stable baseline. Planned compatibility work is kept separately in
 > What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 27 August 2026 snapshot, the three support forks are **928 commits ahead of Apple upstream**:
 >
 > - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 203 ahead** at [`c60ba717b990`](https://github.com/stephenlclarke/containerization/commit/c60ba717b990bd9086fd0dd6d073b57004a6dcf8).
-> - [`container`](https://github.com/stephenlclarke/container): **1 behind, 682 ahead** at [`3c7c48f64c61`](https://github.com/stephenlclarke/container/commit/3c7c48f64c6120c6f962b31f008b699c77232ff6).
+> - [`container`](https://github.com/stephenlclarke/container): **2 behind, 682 ahead** at [`3c7c48f64c61`](https://github.com/stephenlclarke/container/commit/3c7c48f64c6120c6f962b31f008b699c77232ff6).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 43 ahead** at [`2df7b287e530`](https://github.com/stephenlclarke/container-builder-shim/commit/2df7b287e5306693567435383841fcc4b6012cbf).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ in this stable baseline. Planned compatibility work is kept separately in
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 26 August 2026 snapshot, the three support forks are **921 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 27 August 2026 snapshot, the three support forks are **928 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 202 ahead** at [`050cf2484a50`](https://github.com/stephenlclarke/containerization/commit/050cf2484a50fcc0931ee53f544e027bf4012e05).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 676 ahead** at [`788377c87646`](https://github.com/stephenlclarke/container/commit/788377c876469dc42f333e9a6003319640fb57d3).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 203 ahead** at [`c60ba717b990`](https://github.com/stephenlclarke/containerization/commit/c60ba717b990bd9086fd0dd6d073b57004a6dcf8).
+> - [`container`](https://github.com/stephenlclarke/container): **1 behind, 682 ahead** at [`3c7c48f64c61`](https://github.com/stephenlclarke/container/commit/3c7c48f64c6120c6f962b31f008b699c77232ff6).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 43 ahead** at [`2df7b287e530`](https://github.com/stephenlclarke/container-builder-shim/commit/2df7b287e5306693567435383841fcc4b6012cbf).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "788377c876469dc42f333e9a6003319640fb57d3",
+      "ref": "3c7c48f64c6120c6f962b31f008b699c77232ff6",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "050cf2484a50fcc0931ee53f544e027bf4012e05",
+      "ref": "c60ba717b990bd9086fd0dd6d073b57004a6dcf8",
       "repository": "stephenlclarke/containerization"
     }
   },


### PR DESCRIPTION
## Summary

- advance the Compose Container pin from `788377c8` to merged runtime head `3c7c48f6`
- advance the required Containerization pin to `c60ba717` so SwiftPM resolves one matched graph
- update the release stack manifest and resolved lockfile together

This brings the bootstrap limiting, explicit isolation modes, dedicated prewarming, and their subsequent runtime fixes into Compose’s normal pinned stack. The Container Engine API and builder-shim pins are unchanged.

## Validation

- `CONTAINER_STACK_REPO=/Users/sclarke/github/container python3 Tools/ci/check-stack-consistency.py`
- `python3 Tools/ci/test_check_stack_consistency.py` (10 tests passed)
- `make build-release` (production `compose` product built successfully)
- `git diff --check`

No full regression, documentation, or CodeQL cycle was run because this is a dependency-integration change rather than a release.