### PR TITLE
feat(runtime): project Compose isolation modes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e03fd4b97acddbd9299c5ca84b12b3d5d58829a3e0a09e18874f250564b9a819",
+  "originHash" : "883b0512a19427ccb79d7b911e7f3ac5ca61f85d7eb1062577af50ee7ecbb7c3",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "3c7c48f64c6120c6f962b31f008b699c77232ff6"
+        "revision" : "85ef54862953c11849bad674931070efa18a3c3a"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "c60ba717b990bd9086fd0dd6d073b57004a6dcf8"
+        "revision" : "56912c03bc70f8d9559877485bee9dc6ad28dae0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "3c7c48f64c6120c6f962b31f008b699c77232ff6",
+        revision: "85ef54862953c11849bad674931070efa18a3c3a",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "c60ba717b990bd9086fd0dd6d073b57004a6dcf8",
+        revision: "56912c03bc70f8d9559877485bee9dc6ad28dae0",
     )
 }()
 

--- a/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
@@ -181,6 +181,9 @@ extension ComposeOrchestrator {
                 args.append(contentsOf: ["--network", networkArgument])
             }
         }
+        if let isolation = try runtimeIsolationArgument(service: service) {
+            args.append(contentsOf: ["--isolation", isolation])
+        }
         if let pid = try runtimePIDArgument(service: service) {
             args.append(contentsOf: ["--pid", pid])
         }

--- a/Sources/ComposeCore/ComposeOrchestratorRuntimeSupport.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorRuntimeSupport.swift
@@ -27,12 +27,6 @@ struct ComposeRuntimeUnsupportedField {
     let reason: String
 }
 
-private struct ComposeRuntimeUnsupportedOptionalValue {
-    let composeName: String
-    let value: String?
-    let reason: String
-}
-
 extension ComposeOrchestrator {
     /// Validates all selected services before any runtime side effects occur.
     func validateRuntimeSupport(
@@ -45,22 +39,33 @@ extension ComposeOrchestrator {
         }
     }
 
-    /// Returns unsupported string-valued fields that need missing runtime primitives.
-    func unsupportedRuntimeStringFields(service: ComposeService) -> [ComposeRuntimeUnsupportedValue] {
-        [
-            ComposeRuntimeUnsupportedOptionalValue(
-                composeName: "isolation",
-                value: service.isolation,
-                reason: "isolation support needs an apple/container runtime gap PR",
-            ),
-        ].compactMap { candidate in
-            guard let value = candidate.value, !value.isEmpty else {
-                return nil
+    /// Returns the apple/container isolation argument for a Compose service.
+    ///
+    /// A shared sandbox currently has one sealed VMNet uplink. It can therefore
+    /// carry host, disabled, or built-in bridge networking, but it cannot
+    /// faithfully represent Compose-created custom network data planes yet.
+    func runtimeIsolationArgument(service: ComposeService) throws -> String? {
+        guard let isolation = service.isolation, !isolation.isEmpty else {
+            return nil
+        }
+        switch isolation {
+        case "default":
+            return nil
+        case "dedicated-vm":
+            return "dedicated-vm"
+        case "shared-vm":
+            let usesBuiltInNetworkMode = isNoNetworkMode(service.networkMode)
+                || isHostNetworkMode(service.networkMode)
+                || isBridgeNetworkMode(service.networkMode)
+            guard service.networks?.isEmpty != false || usesBuiltInNetworkMode else {
+                throw ComposeError.unsupported(
+                    "service '\(service.name)' uses isolation 'shared-vm' with Compose-created networks; shared-vm currently requires network_mode host, none, or bridge",
+                )
             }
-            return ComposeRuntimeUnsupportedValue(
-                composeName: candidate.composeName,
-                value: value,
-                reason: candidate.reason,
+            return "shared-vm"
+        default:
+            throw ComposeError.unsupported(
+                "service '\(service.name)' uses isolation '\(isolation)'; supported values are default, dedicated-vm, and shared-vm",
             )
         }
     }

--- a/Sources/ComposeCore/ComposeOrchestratorValidation.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorValidation.swift
@@ -77,9 +77,7 @@ extension ComposeOrchestrator {
         _ = try runtimeIPCNamespaceArgument(service: service)
         _ = try runtimeUTSNamespaceArgument(service: service)
         _ = try runtimeUserNamespaceArgument(service: service)
-        if let gap = unsupportedRuntimeStringFields(service: service).first {
-            throw ComposeError.unsupported("service '\(service.name)' uses \(gap.composeName) '\(gap.value)'; \(gap.reason)")
-        }
+        _ = try runtimeIsolationArgument(service: service)
         if let gap = unsupportedCPUResourceFields(service: service).first {
             throw ComposeError.unsupported("service '\(service.name)' uses \(gap.composeName) '\(gap.value)'; \(gap.reason)")
         }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorRunTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorRunTests.swift
@@ -1608,6 +1608,58 @@ extension ComposeOrchestratorTests {
         #expect(await resourceManager.requests.isEmpty)
     }
 
+    @Test("run maps shared VM isolation with built-in bridge networking")
+    func runMapsSharedVMIsolationWithBuiltinBridgeNetworking() async throws {
+        let runner = RecordingRunner(responses: [.success])
+        let resourceManager = RecordingContainerResourceManager()
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.isolation = "shared-vm"
+                    $0.networkMode = "bridge"
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(runner: runner, resourceManager: resourceManager)
+            .run(project: project, serviceName: "job", command: ["true"], remove: true)
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.containsSequence(["--network", "default"]))
+        #expect(command.containsSequence(["--isolation", "shared-vm"]))
+        #expect(await resourceManager.requests.isEmpty)
+    }
+
+    @Test("run maps dedicated VM isolation and accepts the default value")
+    func runMapsDedicatedVMIsolationAndAcceptsDefault() async throws {
+        let cases: [(value: String, expectedArgument: String?)] = [
+            (value: "dedicated-vm", expectedArgument: "dedicated-vm"),
+            (value: "default", expectedArgument: nil),
+        ]
+        for testCase in cases {
+            let runner = RecordingRunner(responses: [.success])
+            let project = ComposeProject(
+                name: "demo",
+                services: [
+                    "job": composeService(name: "job", image: "alpine") {
+                        $0.isolation = testCase.value
+                    },
+                ]
+            )
+
+            try await ComposeOrchestrator(runner: runner)
+                .run(project: project, serviceName: "job", command: ["true"], remove: true)
+
+            let command = try #require(runner.commands.first?.arguments)
+            if let expectedArgument = testCase.expectedArgument {
+                #expect(command.containsSequence(["--isolation", expectedArgument]))
+            } else {
+                #expect(!command.contains("--isolation"))
+            }
+        }
+    }
+
     @Test("run maps pid host to container pid argument")
     func runMapsPIDHostToContainerPIDArgument() async throws {
         let runner = RecordingRunner(responses: [.success])
@@ -1633,33 +1685,51 @@ extension ComposeOrchestratorTests {
         #expect(await resourceManager.requests.map(\.name) == ["demo_default"])
     }
 
-    @Test("run rejects unsupported namespace and cgroup fields before creating resources")
-    func runRejectsUnsupportedNamespaceAndCgroupFieldsBeforeCreatingResources() async throws {
-        for testCase in unsupportedRuntimeStringFieldCases() {
-            let runner = RecordingRunner()
-            let project = composeProject(
-                name: "demo",
-                services: [
-                    "job": composeService(name: "job", image: "alpine") {
-                        testCase.configure(&$0)
-                        $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
-                    },
-                ]
-            ) {
-                $0.volumes = ["cache": ComposeVolume(name: "cache")]
-            }
+    @Test("run rejects unsupported isolation before creating resources")
+    func runRejectsUnsupportedIsolationBeforeCreatingResources() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.isolation = "hyperv"
+                },
+            ]
+        )
 
-            do {
-                try await ComposeOrchestrator(runner: runner).run(project: project, serviceName: "job", command: ["true"], remove: true)
-                Issue.record("Expected unsupported \(testCase.composeName) error")
-            } catch let error as ComposeError {
-                #expect(error == .unsupported(testCase.expectedMessage(serviceName: "job")))
-            } catch {
-                Issue.record("Unexpected error: \(error)")
-            }
-
-            #expect(runner.commands.isEmpty)
+        await #expect(throws: ComposeError.unsupported(
+            "service 'job' uses isolation 'hyperv'; supported values are default, dedicated-vm, and shared-vm"
+        )) {
+            try await ComposeOrchestrator(runner: runner)
+                .run(project: project, serviceName: "job", command: ["true"], remove: true)
         }
+        #expect(runner.commands.isEmpty)
+    }
+
+    @Test("run rejects shared VM isolation with Compose-created networks")
+    func runRejectsSharedVMIsolationWithComposeCreatedNetworks() async throws {
+        let runner = RecordingRunner()
+        let resourceManager = RecordingContainerResourceManager()
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "job": composeService(name: "job", image: "alpine") {
+                    $0.isolation = "shared-vm"
+                    $0.networks = ["default"]
+                },
+            ]
+        ) {
+            $0.networks = ["default": ComposeNetwork(name: "default")]
+        }
+
+        await #expect(throws: ComposeError.unsupported(
+            "service 'job' uses isolation 'shared-vm' with Compose-created networks; shared-vm currently requires network_mode host, none, or bridge"
+        )) {
+            try await ComposeOrchestrator(runner: runner, resourceManager: resourceManager)
+                .run(project: project, serviceName: "job", command: ["true"], remove: true)
+        }
+        #expect(runner.commands.isEmpty)
+        #expect(await resourceManager.requests.isEmpty)
     }
 
     @Test("run rejects an unsupported cgroup namespace mode before creating resources")

--- a/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift
@@ -900,28 +900,6 @@ let composeProjectLabel = "com.apple.container.compose.project"
 let composeServiceLabel = "com.apple.container.compose.service"
 let composeProjectConfigFilesLabel = "com.apple.container.compose.project.config-files"
 
-struct UnsupportedRuntimeStringFieldCase: Sendable {
-    let composeName: String
-    let value: String
-    let reason: String
-    let configure: @Sendable (inout ComposeService) -> Void
-
-    func expectedMessage(serviceName: String) -> String {
-        "service '\(serviceName)' uses \(composeName) '\(value)'; \(reason)"
-    }
-}
-
-func unsupportedRuntimeStringFieldCases() -> [UnsupportedRuntimeStringFieldCase] {
-    [
-        UnsupportedRuntimeStringFieldCase(
-            composeName: "isolation",
-            value: "default",
-            reason: "isolation support needs an apple/container runtime gap PR",
-            configure: { $0.isolation = "default" }
-        ),
-    ]
-}
-
 struct UnsupportedCPUResourceFieldCase: Sendable {
     let composeName: String
     let value: String

--- a/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
@@ -1091,6 +1091,33 @@ extension ComposeOrchestratorTests {
         #expect(await resourceManager.requests.isEmpty)
     }
 
+    @Test("up maps shared VM isolation to the built-in runtime network")
+    func upMapsSharedVMIsolationToBuiltinRuntimeNetwork() async throws {
+        let runner = RecordingRunner(responses: [.success])
+        let discoveryManager = RecordingContainerDiscoveryManager()
+        let resourceManager = RecordingContainerResourceManager()
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "alpine") {
+                    $0.isolation = "shared-vm"
+                    $0.networkMode = "bridge"
+                },
+            ]
+        )
+
+        try await ComposeOrchestrator(
+            runner: runner,
+            discoveryManager: discoveryManager,
+            resourceManager: resourceManager
+        ).up(project: project, options: ComposeUpOptions())
+
+        let command = try #require(runner.commands.first?.arguments)
+        #expect(command.containsSequence(["--network", "default"]))
+        #expect(command.containsSequence(["--isolation", "shared-vm"]))
+        #expect(await resourceManager.requests.isEmpty)
+    }
+
     @Test("up maps pid host to container pid argument")
     func upMapsPIDHostToContainerPIDArgument() async throws {
         let runner = RecordingRunner(responses: [.success])
@@ -7905,33 +7932,25 @@ extension ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
-    @Test("up rejects unsupported namespace and cgroup fields before creating resources")
-    func upRejectsUnsupportedNamespaceAndCgroupFieldsBeforeCreatingResources() async throws {
-        for testCase in unsupportedRuntimeStringFieldCases() {
-            let runner = RecordingRunner()
-            let project = composeProject(
-                name: "demo",
-                services: [
-                    "api": composeService(name: "api", image: "example/api") {
-                        testCase.configure(&$0)
-                        $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
-                    },
-                ]
-            ) {
-                $0.volumes = ["cache": ComposeVolume(name: "cache")]
-            }
+    @Test("up rejects unsupported isolation before creating resources")
+    func upRejectsUnsupportedIsolationBeforeCreatingResources() async throws {
+        let runner = RecordingRunner()
+        let project = ComposeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.isolation = "process"
+                },
+            ]
+        )
 
-            do {
-                try await ComposeOrchestrator(runner: runner).up(project: project, options: ComposeUpOptions())
-                Issue.record("Expected unsupported \(testCase.composeName) error")
-            } catch let error as ComposeError {
-                #expect(error == .unsupported(testCase.expectedMessage(serviceName: "api")))
-            } catch {
-                Issue.record("Unexpected error: \(error)")
-            }
-
-            #expect(runner.commands.isEmpty)
+        await #expect(throws: ComposeError.unsupported(
+            "service 'api' uses isolation 'process'; supported values are default, dedicated-vm, and shared-vm"
+        )) {
+            try await ComposeOrchestrator(runner: runner)
+                .up(project: project, options: ComposeUpOptions())
         }
+        #expect(runner.commands.isEmpty)
     }
 
     @Test("up rejects unsupported pid mode before creating resources")

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "3c7c48f64c6120c6f962b31f008b699c77232ff6",
+      "ref": "85ef54862953c11849bad674931070efa18a3c3a",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "c60ba717b990bd9086fd0dd6d073b57004a6dcf8",
+      "ref": "56912c03bc70f8d9559877485bee9dc6ad28dae0",
       "repository": "stephenlclarke/containerization"
     }
   },


### PR DESCRIPTION
## Summary

- project Compose `isolation` onto the native `container` CLI as `dedicated-vm` or `shared-vm`, while preserving `default` as the existing dedicated behavior
- admit shared VM workloads on `network_mode: bridge`, `host`, or `none`, and reject Compose-created custom network data planes before resource side effects
- pin the exact Container and Containerization heads that supply durable shared-sandbox networking and the guest bridge
- cover successful `run` and `up` projection plus unsupported isolation and custom-network rejection

## Verification

- six focused Compose isolation tests passed against the exact merged stack
- `Tools/ci/check-stack-consistency.py`
- scoped SwiftFormat and SwiftLint strict checks
- Swift parse and `git diff --check`
- signed commit verified locally

## Related work

Advances #267 without closing the broader shared-namespace and privileged-isolation epic.

Runtime dependency: stephenlclarke/container#159 (`85ef54862953c11849bad674931070efa18a3c3a`)
Guest networking dependency: stephenlclarke/containerization#42 (`56912c03bc70f8d9559877485bee9dc6ad28dae0`)