### PR TITLE
test(parity): add isolation performance matrix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -568,7 +568,7 @@ SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -
 .PHONY: docker-compose-phase4-parity
 .PHONY: docker-compose-format-template-actions-parity
 .PHONY: docker-compose-stop-defaults-parity docker-compose-cpu-cfs-parity docker-compose-cpu-shares-parity docker-compose-cpuset-parity docker-compose-pid-namespace-parity docker-compose-cgroup-namespace-parity docker-compose-cgroup-parent-parity docker-compose-ipc-uts-namespace-parity docker-compose-userns-mode-parity docker-compose-privileged-parity docker-compose-network-attachable-parity docker-compose-network-ipv6-parity docker-compose-deploy-job-modes-parity
-.PHONY: docker-compose-up-exit-code-from-parity docker-compose-performance-matrix performance-matrix-harness-test signal-log-reliability-harness-test
+.PHONY: docker-compose-up-exit-code-from-parity docker-compose-performance-matrix performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test
 .PHONY: docker-terminal-session-oracle docker-terminal-session-oracle-update docker-terminal-session-candidate-oracle docker-rest-logging-oracle docker-rest-logging-candidate docker-rest-logging-parity docker-rest-discovery-oracle docker-rest-discovery-candidate docker-rest-discovery-parity docker-rest-image-discovery-oracle docker-rest-image-discovery-candidate docker-rest-image-discovery-parity docker-rest-image-mutation-oracle docker-rest-image-mutation-candidate docker-rest-image-mutation-parity
 .PHONY: pipeline-help pipeline-bootstrap pipeline-runtime-check pipeline-state-init pipeline-lint pipeline-plan pipeline-preflight pipeline pipeline-resume pipeline-status pipeline-self-test pipeline-execute
 
@@ -2631,6 +2631,9 @@ coverage-tools-test:
 performance-matrix-harness-test:
 	$(PYTHON) Tools/parity/test_compose_performance_matrix.py
 
+isolation-performance-harness-test:
+	$(PYTHON) Tools/parity/test_compose_isolation_performance.py
+
 signal-log-reliability-harness-test:
 	$(PYTHON) Tools/parity/test_signal_log_reliability.py
 
@@ -2684,7 +2687,7 @@ worktree-audit-strict:
 
 check: lint core-runtime-neutrality stack-consistency upstream-handoff-registry-check check-licenses
 
-lint: coverage-tools-test performance-matrix-harness-test signal-log-reliability-harness-test
+lint: coverage-tools-test performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test
 	@while IFS= read -r -d '' script; do \
 		bash -n "$$script"; \
 	done < <(find scripts Tools/parity Tools/release -type f \( -name '*.sh' -o -name 'pre-commit.fmt' \) -print0)

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "aeb8f6c13aa4431f8201f93667a0fb2cdd0d91ea"
+        "revision" : "87033463e3c84bbe76ea12c85604393ef3188544"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "08d6da7047b831c2721ad9dbe82040ed9a3d5f73"
+        "revision" : "2b1326247020e749064bfac86a772ccc89e08a4d"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e0b098e10e8413f1a4472ce6c982e43fbf4879a81ad8abeed228a296f5358007",
+  "originHash" : "b90fc504c5b756b79376372c601eef67193c194beffea408040cd7b3b8799e6d",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "a77c91bb2785ef346720f77de02b1dcfaa2c332c"
+        "revision" : "aeb8f6c13aa4431f8201f93667a0fb2cdd0d91ea"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "11062790ce08985b4d7e443e64574e4c2d6b72f7"
+        "revision" : "08d6da7047b831c2721ad9dbe82040ed9a3d5f73"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "85ef54862953c11849bad674931070efa18a3c3a"
+        "revision" : "b65b9b7bc994777cb686c86f21e575b3f240c670"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "56912c03bc70f8d9559877485bee9dc6ad28dae0"
+        "revision" : "11062790ce08985b4d7e443e64574e4c2d6b72f7"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "883b0512a19427ccb79d7b911e7f3ac5ca61f85d7eb1062577af50ee7ecbb7c3",
+  "originHash" : "e0b098e10e8413f1a4472ce6c982e43fbf4879a81ad8abeed228a296f5358007",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "b65b9b7bc994777cb686c86f21e575b3f240c670"
+        "revision" : "a77c91bb2785ef346720f77de02b1dcfaa2c332c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "a77c91bb2785ef346720f77de02b1dcfaa2c332c",
+        revision: "aeb8f6c13aa4431f8201f93667a0fb2cdd0d91ea",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "11062790ce08985b4d7e443e64574e4c2d6b72f7",
+        revision: "08d6da7047b831c2721ad9dbe82040ed9a3d5f73",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "85ef54862953c11849bad674931070efa18a3c3a",
+        revision: "b65b9b7bc994777cb686c86f21e575b3f240c670",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "56912c03bc70f8d9559877485bee9dc6ad28dae0",
+        revision: "11062790ce08985b4d7e443e64574e4c2d6b72f7",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "b65b9b7bc994777cb686c86f21e575b3f240c670",
+        revision: "a77c91bb2785ef346720f77de02b1dcfaa2c332c",
     )
 }()
 

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "aeb8f6c13aa4431f8201f93667a0fb2cdd0d91ea",
+        revision: "87033463e3c84bbe76ea12c85604393ef3188544",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "08d6da7047b831c2721ad9dbe82040ed9a3d5f73",
+        revision: "2b1326247020e749064bfac86a772ccc89e08a4d",
     )
 }()
 

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -325,6 +325,7 @@ select_lane() {
                 env
                 "CONTAINER_BIN=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
+                "CONTAINER_COMPOSE_INIT_IMAGE="
                 "$CONTAINER_COMPOSE" --ansi never --progress quiet
             )
             LANE_PREFIX=sv

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -33,6 +33,7 @@ ISOLATION_TIMEOUT_SECONDS="${ISOLATION_TIMEOUT_SECONDS:-300}"
 ISOLATION_TIMING_MAX_RATIO="${ISOLATION_TIMING_MAX_RATIO:-10}"
 ISOLATION_COMPARABLE_NOISE_PCT="${ISOLATION_COMPARABLE_NOISE_PCT:-5}"
 readonly FIXTURE_IMAGE="${ISOLATION_FIXTURE_IMAGE:-alpine:3.20}"
+readonly FIXTURE_PLATFORM="linux/arm64"
 readonly TIMING_TSV="$ISOLATION_EVIDENCE_DIR/timings.tsv"
 readonly ASSERTION_TSV="$ISOLATION_EVIDENCE_DIR/assertions.tsv"
 readonly SCHEDULE_TSV="$ISOLATION_EVIDENCE_DIR/schedule.tsv"
@@ -279,7 +280,7 @@ select_lane_order() {
 select_lane() {
     case "$1" in
         docker)
-            ACTIVE_COMPOSE=("${DOCKER_COMPOSE_COMMAND[@]}" --ansi never --progress quiet)
+            ACTIVE_COMPOSE=(env "DOCKER_DEFAULT_PLATFORM=" "${DOCKER_COMPOSE_COMMAND[@]}" --ansi never --progress quiet)
             LANE_PREFIX=d
             ;;
         dedicated-vm)
@@ -289,6 +290,7 @@ select_lane() {
                 "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_INIT_IMAGE="
                 "CONTAINER_COMPOSE_NORMALIZER=$NORMALIZER_BINARY"
+                "CONTAINER_DEFAULT_PLATFORM="
                 "$CONTAINER_COMPOSE" --ansi never --progress quiet
             )
             LANE_PREFIX=dv
@@ -300,6 +302,7 @@ select_lane() {
                 "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_INIT_IMAGE="
                 "CONTAINER_COMPOSE_NORMALIZER=$NORMALIZER_BINARY"
+                "CONTAINER_DEFAULT_PLATFORM="
                 "$CONTAINER_COMPOSE" --ansi never --progress quiet
             )
             LANE_PREFIX=sv
@@ -321,6 +324,7 @@ create_fixtures() {
                 for ((index = 1; index <= count; index++)); do
                     printf '  worker%02d:\n' "$index"
                     printf '    image: %s\n' "$FIXTURE_IMAGE"
+                    printf '    platform: %s\n' "$FIXTURE_PLATFORM"
                     printf '    network_mode: bridge\n'
                     [[ -z "$isolation_line" ]] || printf '%s\n' "$isolation_line"
                     printf '    command: ["sh", "-c", "trap '\''exit 0'\'' TERM INT; while :; do sleep 0.1; done"]\n'
@@ -351,7 +355,7 @@ write_fingerprint_candidate() {
     python3 - "$candidate" "$SELF_PATH" "$CONTAINER_COMPOSE" "$CONTAINER_BINARY" "$NORMALIZER_BINARY" \
         "$ISOLATION_REPETITIONS" "$ISOLATION_TIMEOUT_SECONDS" \
         "$ISOLATION_COMPARABLE_NOISE_PCT" "$ISOLATION_TIMING_MAX_RATIO" \
-        "$FIXTURE_IMAGE" "$docker_compose_version" "$DOCKER_BINARY" \
+        "$FIXTURE_IMAGE" "$FIXTURE_PLATFORM" "$docker_compose_version" "$DOCKER_BINARY" \
         "$DOCKER_CONTEXT_NAME" "$DOCKER_ENDPOINT" "$PROJECT_NAMESPACE" \
         "$ISOLATION_WORK_ROOT_CANONICAL" "$ISOLATION_WORK_ROOT_DEVICE" \
         "${COMPOSE_PARALLEL_LIMIT-<unset>}" <<'PY'
@@ -359,7 +363,7 @@ import hashlib, json, platform, subprocess, sys
 from pathlib import Path
 (
     output, harness, compose, container, normalizer, repetitions, timeout, noise,
-    maximum_ratio, fixture_image, docker_compose_version, docker_binary,
+    maximum_ratio, fixture_image, fixture_platform, docker_compose_version, docker_binary,
     docker_context, docker_endpoint, project_namespace, work_root, work_device,
     compose_parallel_limit,
 ) = sys.argv[1:]
@@ -435,6 +439,7 @@ payload = {
     },
     "fixtureImage": {
         "reference": fixture_image,
+        "platform": fixture_platform,
         "commonDigests": common_image_digests,
         "docker": {
             "id": docker_image.get("Id", ""),

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -84,6 +84,8 @@ ENVIRONMENT:
   ISOLATION_TIMING_MAX_RATIO    Candidate regression guard (default: 10).
   ISOLATION_COMPARABLE_NOISE_PCT
                                 Same-host comparison noise band (default: 5).
+  COMPOSE_PARALLEL_LIMIT        Compose engine-operation concurrency setting;
+                                its exact value is fingerprinted for resumption.
 
 Both writable directories must be on internal storage. The harness never
 pulls images: alpine:3.20 must already be warm in Docker and apple/container.
@@ -345,13 +347,15 @@ write_fingerprint_candidate() {
         "$ISOLATION_COMPARABLE_NOISE_PCT" "$ISOLATION_TIMING_MAX_RATIO" \
         "$FIXTURE_IMAGE" "$docker_compose_version" "$DOCKER_BINARY" \
         "$DOCKER_CONTEXT_NAME" "$DOCKER_ENDPOINT" "$PROJECT_NAMESPACE" \
-        "$ISOLATION_WORK_ROOT_CANONICAL" "$ISOLATION_WORK_ROOT_DEVICE" <<'PY'
+        "$ISOLATION_WORK_ROOT_CANONICAL" "$ISOLATION_WORK_ROOT_DEVICE" \
+        "${COMPOSE_PARALLEL_LIMIT-<unset>}" <<'PY'
 import hashlib, json, platform, subprocess, sys
 from pathlib import Path
 (
     output, harness, compose, container, repetitions, timeout, noise,
     maximum_ratio, fixture_image, docker_compose_version, docker_binary,
     docker_context, docker_endpoint, project_namespace, work_root, work_device,
+    compose_parallel_limit,
 ) = sys.argv[1:]
 def sha256(path):
     digest = hashlib.sha256()
@@ -442,6 +446,7 @@ payload = {
         "timeoutSeconds": int(timeout),
         "comparableNoisePercent": float(noise),
         "maximumRatio": float(maximum_ratio),
+        "composeParallelLimit": compose_parallel_limit,
         "projectNamespace": project_namespace,
         "workRoot": {"path": work_root, "device": work_device},
     },

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -587,6 +587,7 @@ record_assertion() {
 
 assert_running_services() {
     local fixture="$1" lane="$2" repetition="$3" project="$4" file="$5" expected="$6" output observed container_id inspection network_summary effective_isolation ipv4_address
+    local expected_network="${project}_default"
     local invalid_isolation=0 missing_ipv4=0 failed=0
     output="$("${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" ps -q)"
     observed="$(printf '%s\n' "$output" | awk 'NF { count += 1 } END { print count + 0 }')"
@@ -602,7 +603,7 @@ assert_running_services() {
             ipv4_address="$("$DOCKER_BINARY" inspect "$container_id" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')"
         else
             inspection="$("$CONTAINER_BINARY" inspect "$container_id")"
-            network_summary="$(printf '%s' "$inspection" | python3 -c 'import json,sys; item=json.load(sys.stdin)[0]; networks=item["status"].get("networks", []); ipv4=next((entry.get("ipv4Address", "") for entry in networks if entry.get("network") == "default"), ""); print(item["configuration"].get("effectiveIsolation", "") + "\t" + ipv4)')"
+            network_summary="$(printf '%s' "$inspection" | python3 -c 'import json,sys; expected=sys.argv[1]; item=json.load(sys.stdin)[0]; networks=item["status"].get("networks", []); ipv4=next((entry.get("ipv4Address", "") for entry in networks if entry.get("network") == expected), ""); print(item["configuration"].get("effectiveIsolation", "") + "\t" + ipv4)' "$expected_network")"
             IFS=$'\t' read -r effective_isolation ipv4_address <<<"$network_summary"
             if [[ "$effective_isolation" != "$lane" ]]; then
                 ((invalid_isolation += 1))

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -588,7 +588,8 @@ record_assertion() {
 
 assert_running_services() {
     local fixture="$1" lane="$2" repetition="$3" project="$4" file="$5" expected="$6" output observed container_id inspection network_summary effective_isolation ipv4_address
-    local expected_network="${project}_default"
+    # Every fixture requests network_mode: bridge, which Container projects onto its built-in default network.
+    local expected_network="default"
     local invalid_isolation=0 missing_ipv4=0 failed=0
     output="$("${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" ps -q)"
     observed="$(printf '%s\n' "$output" | awk 'NF { count += 1 } END { print count + 0 }')"

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -31,7 +31,7 @@ ISOLATION_REPETITIONS="${ISOLATION_REPETITIONS:-6}"
 ISOLATION_TIMEOUT_SECONDS="${ISOLATION_TIMEOUT_SECONDS:-300}"
 ISOLATION_TIMING_MAX_RATIO="${ISOLATION_TIMING_MAX_RATIO:-10}"
 ISOLATION_COMPARABLE_NOISE_PCT="${ISOLATION_COMPARABLE_NOISE_PCT:-5}"
-readonly FIXTURE_IMAGE="alpine:3.20"
+readonly FIXTURE_IMAGE="${ISOLATION_FIXTURE_IMAGE:-alpine:3.20}"
 readonly TIMING_TSV="$ISOLATION_EVIDENCE_DIR/timings.tsv"
 readonly ASSERTION_TSV="$ISOLATION_EVIDENCE_DIR/assertions.tsv"
 readonly SCHEDULE_TSV="$ISOLATION_EVIDENCE_DIR/schedule.tsv"
@@ -78,6 +78,8 @@ ENVIRONMENT:
   ISOLATION_EVIDENCE_DIR        Persistent, resumable evidence directory.
   ISOLATION_WORK_ROOT           Internal-storage fixture directory.
   ISOLATION_REPETITIONS         Timed repetitions per lane (default: 6).
+  ISOLATION_FIXTURE_IMAGE       Warm image reference shared by both runtimes
+                                (default: alpine:3.20).
   ISOLATION_TIMEOUT_SECONDS     Per-operation timeout (default: 300).
   ISOLATION_TIMING_MAX_RATIO    Candidate regression guard (default: 10).
   ISOLATION_COMPARABLE_NOISE_PCT

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -58,6 +58,7 @@ RUN_LOCK_DIR=""
 RUN_LOCK_FD=""
 ISOLATION_WORK_ROOT_CANONICAL=""
 ISOLATION_WORK_ROOT_DEVICE=""
+ACTIVE_CHILD_PID=""
 
 error() { printf 'error: %s\n' "$*" >&2; }
 warning() { printf 'warning: %s\n' "$*" >&2; }
@@ -267,6 +268,16 @@ release_run_lock() {
     [[ -n "$RUN_LOCK_FD" ]] || return
     exec {RUN_LOCK_FD}>&-
     RUN_LOCK_FD=""
+}
+
+# Forwards termination to the active timing supervisor before exiting.
+terminate() {
+    local signal="$1" status="$2"
+    if [[ -n "$ACTIVE_CHILD_PID" ]]; then
+        kill -"$signal" "$ACTIVE_CHILD_PID" 2>/dev/null || true
+        wait "$ACTIVE_CHILD_PID" 2>/dev/null || true
+    fi
+    exit "$status"
 }
 
 select_lane_order() {
@@ -536,24 +547,64 @@ rewrite(assertions, lambda row: row["lane"] == lane and row["repetition"] == rep
 PY
 }
 
+# Discards a partially completed lane rotation so resumed timings preserve the
+# actual counterbalanced execution order.
+prepare_counterbalance_block() {
+    local repetition="$1" count="$2" lane complete_count=0
+    for lane in "${ISOLATION_LANES[@]}"; do
+        sample_is_complete "$lane" "$repetition" "$count" && ((complete_count += 1))
+    done
+    if ((complete_count == 0 || complete_count == ${#ISOLATION_LANES[@]})); then
+        return
+    fi
+    for lane in "${ISOLATION_LANES[@]}"; do
+        remove_incomplete_sample "$lane" "$repetition" "$count"
+    done
+}
+
 run_timed() {
-    local fixture="$1" lane="$2" repetition="$3" schedule_position="$4"
+    local fixture="$1" lane="$2" repetition="$3" schedule_position="$4" child_status
     shift 4
     python3 - "$TIMING_TSV" "$fixture" "$lane" "$repetition" "$schedule_position" \
-        "$ISOLATION_TIMEOUT_SECONDS" "$@" <<'PY'
-import csv, pathlib, shlex, subprocess, sys, time
+        "$ISOLATION_TIMEOUT_SECONDS" "$@" <<'PY' &
+import csv, os, pathlib, shlex, signal, subprocess, sys, time
 timing, fixture, lane, repetition, position, timeout, *command = sys.argv[1:]
 log_directory = pathlib.Path(timing).parent / "logs"
 log_directory.mkdir(parents=True, exist_ok=True)
 log_path = log_directory / f"{fixture}--{lane}--r{repetition}.log"
-started = time.monotonic(); outcome = "success"; diagnostic = ""
+started = time.monotonic(); outcome = "success"; diagnostic = ""; process = None
+def stop_process_group(signum):
+    if process is None or process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signum)
+    except ProcessLookupError:
+        return
+def forward_signal(signum, _frame):
+    if process is not None:
+        stop_process_group(signum)
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            stop_process_group(signal.SIGKILL)
+            process.wait()
+    raise SystemExit(128 + signum)
+for forwarded_signal in (signal.SIGHUP, signal.SIGINT, signal.SIGQUIT, signal.SIGTERM):
+    signal.signal(forwarded_signal, forward_signal)
 try:
     with log_path.open("wb") as log:
-        completed = subprocess.run(command, timeout=float(timeout), check=False, stdout=log, stderr=subprocess.STDOUT)
-    if completed.returncode != 0:
-        outcome = f"exit-{completed.returncode}"
+        process = subprocess.Popen(command, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+        returncode = process.wait(timeout=float(timeout))
+    if returncode != 0:
+        outcome = f"exit-{returncode}"
         diagnostic = log_path.read_text(encoding="utf-8", errors="replace")[-4000:]
 except subprocess.TimeoutExpired as error:
+    stop_process_group(signal.SIGTERM)
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        stop_process_group(signal.SIGKILL)
+        process.wait()
     outcome = "timeout"; diagnostic = str(error)
 duration = time.monotonic() - started
 with open(timing, "a", encoding="utf-8", newline="") as handle:
@@ -563,6 +614,10 @@ if outcome != "success":
     if diagnostic: print(diagnostic, file=sys.stderr)
     raise SystemExit(124 if outcome == "timeout" else 1)
 PY
+    ACTIVE_CHILD_PID=$!
+    if wait "$ACTIVE_CHILD_PID"; then child_status=0; else child_status=$?; fi
+    ACTIVE_CHILD_PID=""
+    return "$child_status"
 }
 
 record_assertion() {
@@ -739,6 +794,7 @@ run_matrix() {
     for ((repetition = 1; repetition <= ISOLATION_REPETITIONS; repetition++)); do
         select_lane_order "$repetition"
         for count in 1 10 50; do
+            prepare_counterbalance_block "$repetition" "$count"
             position=0
             for lane in "${LANE_ORDER[@]}"; do
                 ((position += 1))
@@ -759,10 +815,10 @@ main() {
     initialize_run_namespace
     acquire_run_lock
     trap cleanup EXIT
-    trap 'exit 129' HUP
-    trap 'exit 130' INT
-    trap 'exit 131' QUIT
-    trap 'exit 143' TERM
+    trap 'terminate HUP 129' HUP
+    trap 'terminate INT 130' INT
+    trap 'terminate QUIT 131' QUIT
+    trap 'terminate TERM 143' TERM
     create_fixtures
     run_matrix
 }

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -210,8 +210,8 @@ check_tools() {
     command -v "$CONTAINER_BINARY" >/dev/null 2>&1 || skip_or_fail "container runtime is unavailable: $CONTAINER_BINARY"
     CONTAINER_BINARY="$(command -v "$CONTAINER_BINARY")"
     [[ -x "$NORMALIZER_BINARY" ]] || skip_or_fail "compose-normalizer is not executable: $NORMALIZER_BINARY"
-    NORMALIZER_BINARY="$(canonical_path "$NORMALIZER_BINARY")"
     command -v python3 >/dev/null 2>&1 || skip_or_fail 'python3 is unavailable'
+    NORMALIZER_BINARY="$(canonical_path "$NORMALIZER_BINARY")"
     command -v diskutil >/dev/null 2>&1 || skip_or_fail 'diskutil is unavailable'
     validate_repetitions
     [[ "$ISOLATION_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { error "ISOLATION_TIMEOUT_SECONDS must be a positive integer"; return 2; }

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -1,0 +1,780 @@
+#!/usr/bin/env bash
+#===----------------------------------------------------------------------===#
+# Copyright © 2026 container-compose project authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===----------------------------------------------------------------------===#
+
+# Focused, resumable lifecycle comparison for Docker Compose and the
+# dedicated-vm/shared-vm apple/container isolation modes.
+
+set -euo pipefail
+
+readonly SELF_PATH="${BASH_SOURCE[0]:-$0}"
+REPO_ROOT="$(cd "$(dirname "$SELF_PATH")/../.." && pwd)"
+readonly REPO_ROOT
+STRICT=0
+LIST_FIXTURES=0
+FIXTURE_DIR=""
+CONTAINER_COMPOSE="${CONTAINER_COMPOSE:-$REPO_ROOT/.build/release/compose}"
+CONTAINER_BINARY="${CONTAINER_COMPOSE_CONTAINER:-container}"
+ISOLATION_EVIDENCE_DIR="${ISOLATION_EVIDENCE_DIR:-${TMPDIR:-/private/tmp}/container-compose-isolation-evidence}"
+ISOLATION_WORK_ROOT="${ISOLATION_WORK_ROOT:-${TMPDIR:-/private/tmp}/container-compose-isolation-work}"
+ISOLATION_REPETITIONS="${ISOLATION_REPETITIONS:-6}"
+ISOLATION_TIMEOUT_SECONDS="${ISOLATION_TIMEOUT_SECONDS:-300}"
+ISOLATION_TIMING_MAX_RATIO="${ISOLATION_TIMING_MAX_RATIO:-10}"
+ISOLATION_COMPARABLE_NOISE_PCT="${ISOLATION_COMPARABLE_NOISE_PCT:-5}"
+readonly FIXTURE_IMAGE="alpine:3.20"
+readonly TIMING_TSV="$ISOLATION_EVIDENCE_DIR/timings.tsv"
+readonly ASSERTION_TSV="$ISOLATION_EVIDENCE_DIR/assertions.tsv"
+readonly SCHEDULE_TSV="$ISOLATION_EVIDENCE_DIR/schedule.tsv"
+readonly TIMING_JUNIT="$ISOLATION_EVIDENCE_DIR/timings.junit.xml"
+readonly TIMING_MATRIX="$ISOLATION_EVIDENCE_DIR/timing-matrix.md"
+readonly FINGERPRINT_JSON="$ISOLATION_EVIDENCE_DIR/fingerprints.json"
+readonly ISOLATION_LANES=(docker dedicated-vm shared-vm)
+readonly ISOLATION_FIXTURES=(
+    startup-1-services teardown-1-services
+    startup-10-services teardown-10-services
+    startup-50-services teardown-50-services
+)
+DOCKER_COMPOSE_COMMAND=()
+DOCKER_BINARY=""
+ACTIVE_COMPOSE=()
+LANE_ORDER=()
+LANE_PREFIX=""
+DOCKER_CONTEXT_NAME=""
+DOCKER_ENDPOINT=""
+PROJECT_NAMESPACE=""
+RUN_LOCK_DIR=""
+RUN_LOCK_START=""
+ISOLATION_WORK_ROOT_CANONICAL=""
+ISOLATION_WORK_ROOT_DEVICE=""
+
+error() { printf 'error: %s\n' "$*" >&2; }
+warning() { printf 'warning: %s\n' "$*" >&2; }
+
+usage() {
+    cat <<'EOF'
+USAGE:
+  check-compose-isolation-performance.sh [options]
+
+OPTIONS:
+  --strict         Fail when a required local runtime is unavailable.
+  --list-fixtures  Print the retained fixture identifiers without running.
+  -h, --help       Show this help.
+
+ENVIRONMENT:
+  CONTAINER_COMPOSE             Exact container-compose binary.
+  CONTAINER_COMPOSE_CONTAINER   Exact apple/container binary.
+  DOCKER_COMPOSE                Optional `docker compose` selector; wrappers
+                                and alternate clients are rejected.
+  ISOLATION_EVIDENCE_DIR        Persistent, resumable evidence directory.
+  ISOLATION_WORK_ROOT           Internal-storage fixture directory.
+  ISOLATION_REPETITIONS         Timed repetitions per lane (default: 6).
+  ISOLATION_TIMEOUT_SECONDS     Per-operation timeout (default: 300).
+  ISOLATION_TIMING_MAX_RATIO    Candidate regression guard (default: 10).
+  ISOLATION_COMPARABLE_NOISE_PCT
+                                Same-host comparison noise band (default: 5).
+
+Both writable directories must be on internal storage. The harness never
+pulls images: alpine:3.20 must already be warm in Docker and apple/container.
+Successful samples are checkpointed, so an interrupted run resumes at the
+first incomplete lifecycle pair.
+EOF
+}
+
+parse_args() {
+    while (($# > 0)); do
+        case "$1" in
+            --strict) STRICT=1 ;;
+            --list-fixtures) LIST_FIXTURES=1 ;;
+            -h | --help) usage; exit 0 ;;
+            *) error "unknown argument: $1"; usage >&2; return 2 ;;
+        esac
+        shift
+    done
+}
+
+skip_or_fail() {
+    if ((STRICT == 1)); then error "$1"; return 1; fi
+    warning "$1; skipping Compose isolation performance matrix"
+    exit 0
+}
+
+detect_docker_compose() {
+    command -v docker >/dev/null 2>&1 || skip_or_fail 'Docker CLI is unavailable'
+    DOCKER_BINARY="$(command -v docker)"
+    if [[ -n "${DOCKER_COMPOSE:-}" ]]; then
+        local requested=() requested_binary=""
+        IFS=' ' read -r -a requested <<<"$DOCKER_COMPOSE"
+        [[ "${#requested[@]}" == 2 && "${requested[1]}" == compose ]] || {
+            error "DOCKER_COMPOSE must select the validated Docker CLI as: docker compose"
+            return 2
+        }
+        requested_binary="$(command -v "${requested[0]}" 2>/dev/null || true)"
+        [[ "$requested_binary" == "$DOCKER_BINARY" ]] || {
+            error "DOCKER_COMPOSE must use the same Docker CLI validated by the harness"
+            return 2
+        }
+    fi
+    if ! "$DOCKER_BINARY" compose version >/dev/null 2>&1; then
+        skip_or_fail 'Docker Compose V2 is unavailable'
+    fi
+    DOCKER_COMPOSE_COMMAND=("$DOCKER_BINARY" compose)
+}
+
+# Pins Docker measurements to a live local Unix-socket context.
+require_local_docker_context() {
+    [[ -n "$DOCKER_BINARY" ]] || DOCKER_BINARY="$(command -v docker)"
+    if [[ -n "${DOCKER_CONTEXT:-}" ]]; then
+        DOCKER_CONTEXT_NAME="$DOCKER_CONTEXT"
+        DOCKER_ENDPOINT="$("$DOCKER_BINARY" context inspect "$DOCKER_CONTEXT_NAME" --format '{{(index .Endpoints "docker").Host}}')"
+    elif [[ -n "${DOCKER_HOST:-}" ]]; then
+        DOCKER_CONTEXT_NAME="DOCKER_HOST"
+        DOCKER_ENDPOINT="$DOCKER_HOST"
+    else
+        DOCKER_CONTEXT_NAME="$("$DOCKER_BINARY" context show)"
+        DOCKER_ENDPOINT="$("$DOCKER_BINARY" context inspect "$DOCKER_CONTEXT_NAME" --format '{{(index .Endpoints "docker").Host}}')"
+    fi
+    if [[ "$DOCKER_ENDPOINT" != unix://* ]]; then
+        error "Docker context '$DOCKER_CONTEXT_NAME' is not local: $DOCKER_ENDPOINT"
+        return 1
+    fi
+    local socket_path="${DOCKER_ENDPOINT#unix://}"
+    if [[ ! -S "$socket_path" ]]; then
+        skip_or_fail "Docker context '$DOCKER_CONTEXT_NAME' socket is unavailable: $socket_path"
+    fi
+}
+
+canonical_path() {
+    python3 - "$1" <<'PY'
+import os, sys
+print(os.path.realpath(os.path.expanduser(sys.argv[1])))
+PY
+}
+
+storage_backing_device() {
+    local path existing_path
+    path="$(canonical_path "$1")"
+    existing_path="$(python3 - "$path" <<'PY'
+import pathlib, sys
+path = pathlib.Path(sys.argv[1])
+while not path.exists() and path != path.parent:
+    path = path.parent
+print(path)
+PY
+)"
+    df -P "$existing_path" | awk 'END { print $1 }'
+}
+
+require_internal_storage() {
+    local label="$1" path device location
+    path="$(canonical_path "$2")"
+    device="$(storage_backing_device "$path")"
+    location="$(diskutil info "$device" 2>/dev/null | awk -F: '$1 ~ /^[[:space:]]*Device Location$/ { value=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", value); print value }')"
+    if [[ "$location" != Internal ]]; then
+        error "$label must be on internal storage, not $path ($device: ${location:-unsupported})"
+        return 1
+    fi
+}
+
+validate_repetitions() {
+    [[ "$ISOLATION_REPETITIONS" =~ ^[1-9][0-9]*$ ]] || {
+        error "ISOLATION_REPETITIONS must be a positive integer"
+        return 2
+    }
+    if ((ISOLATION_REPETITIONS % 3 != 0)); then
+        error "ISOLATION_REPETITIONS must contain complete three-run counterbalance cycles"
+        return 2
+    fi
+}
+
+check_tools() {
+    detect_docker_compose
+    require_local_docker_context
+    "$DOCKER_BINARY" info >/dev/null 2>&1 || skip_or_fail 'Docker Engine is unavailable'
+    [[ -x "$CONTAINER_COMPOSE" ]] || skip_or_fail "container-compose binary is not executable: $CONTAINER_COMPOSE"
+    command -v "$CONTAINER_BINARY" >/dev/null 2>&1 || skip_or_fail "container runtime is unavailable: $CONTAINER_BINARY"
+    CONTAINER_BINARY="$(command -v "$CONTAINER_BINARY")"
+    command -v python3 >/dev/null 2>&1 || skip_or_fail 'python3 is unavailable'
+    command -v diskutil >/dev/null 2>&1 || skip_or_fail 'diskutil is unavailable'
+    validate_repetitions
+    [[ "$ISOLATION_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || { error "ISOLATION_TIMEOUT_SECONDS must be a positive integer"; return 2; }
+    [[ "$ISOLATION_TIMING_MAX_RATIO" =~ ^[1-9][0-9]*(\.[0-9]+)?$ ]] || { error "ISOLATION_TIMING_MAX_RATIO must be positive"; return 2; }
+    [[ "$ISOLATION_COMPARABLE_NOISE_PCT" =~ ^[0-9]+(\.[0-9]+)?$ ]] || { error "ISOLATION_COMPARABLE_NOISE_PCT must be zero or positive"; return 2; }
+    require_internal_storage ISOLATION_EVIDENCE_DIR "$ISOLATION_EVIDENCE_DIR"
+    require_internal_storage ISOLATION_WORK_ROOT "$ISOLATION_WORK_ROOT"
+    ISOLATION_WORK_ROOT_CANONICAL="$(canonical_path "$ISOLATION_WORK_ROOT")"
+    ISOLATION_WORK_ROOT_DEVICE="$(storage_backing_device "$ISOLATION_WORK_ROOT_CANONICAL")"
+    "${DOCKER_COMPOSE_COMMAND[@]}" version >/dev/null
+    "$CONTAINER_BINARY" system status >/dev/null || skip_or_fail 'apple/container system is unavailable'
+    "$DOCKER_BINARY" image inspect "$FIXTURE_IMAGE" >/dev/null 2>&1 || skip_or_fail "$FIXTURE_IMAGE is not warm in Docker; pull it before quiescing the host"
+    "$CONTAINER_BINARY" image inspect "$FIXTURE_IMAGE" >/dev/null 2>&1 || skip_or_fail "$FIXTURE_IMAGE is not warm in apple/container; pull or load it before quiescing the host"
+}
+
+# Derives a stable, evidence-specific Compose project namespace.
+initialize_run_namespace() {
+    local canonical_evidence
+    mkdir -p "$ISOLATION_EVIDENCE_DIR"
+    canonical_evidence="$(canonical_path "$ISOLATION_EVIDENCE_DIR")"
+    PROJECT_NAMESPACE="$(printf '%s' "$canonical_evidence" | shasum -a 256 | cut -c1-12)"
+    RUN_LOCK_DIR="$ISOLATION_EVIDENCE_DIR/.run-lock"
+}
+
+# Returns a stable identity for a process instead of trusting a recyclable PID.
+process_start_identity() {
+    ps -o lstart= -p "$1" 2>/dev/null | awk '{$1=$1; print}'
+}
+
+write_run_lock_identity() {
+    if [[ -z "$RUN_LOCK_START" ]]; then
+        RUN_LOCK_START="$(process_start_identity "$$" || true)"
+    fi
+    if [[ -z "$RUN_LOCK_START" ]]; then
+        rm -f "$RUN_LOCK_DIR/pid" "$RUN_LOCK_DIR/start"
+        rmdir "$RUN_LOCK_DIR" 2>/dev/null || true
+        error "could not determine the isolation benchmark process identity"
+        return 1
+    fi
+    printf '%s\n' "$$" >"$RUN_LOCK_DIR/pid"
+    printf '%s\n' "$RUN_LOCK_START" >"$RUN_LOCK_DIR/start"
+}
+
+# Claims the namespace or recovers a lock left by a dead process.
+acquire_run_lock() {
+    RUN_LOCK_START="$(process_start_identity "$$" || true)"
+    if [[ -z "$RUN_LOCK_START" ]]; then
+        error "could not determine the isolation benchmark process identity"
+        return 1
+    fi
+    if mkdir "$RUN_LOCK_DIR" 2>/dev/null; then
+        write_run_lock_identity
+        return
+    fi
+
+    local owner="" owner_start="" current_start=""
+    if [[ ! -f "$RUN_LOCK_DIR/pid" || ! -f "$RUN_LOCK_DIR/start" ]]; then
+        error "isolation benchmark lock is still being initialized: $RUN_LOCK_DIR"
+        return 1
+    fi
+    [[ -f "$RUN_LOCK_DIR/pid" ]] && owner="$(<"$RUN_LOCK_DIR/pid")"
+    [[ -f "$RUN_LOCK_DIR/start" ]] && owner_start="$(<"$RUN_LOCK_DIR/start")"
+    if [[ "$owner" =~ ^[1-9][0-9]*$ ]] && kill -0 "$owner" 2>/dev/null; then
+        current_start="$(process_start_identity "$owner" || true)"
+    fi
+    if [[ -n "$owner_start" && "$current_start" == "$owner_start" ]]; then
+        error "another isolation benchmark owns namespace $PROJECT_NAMESPACE (pid $owner)"
+        return 1
+    fi
+
+    rm -f "$RUN_LOCK_DIR/pid" "$RUN_LOCK_DIR/start"
+    rmdir "$RUN_LOCK_DIR" 2>/dev/null || {
+        error "isolation benchmark lock is not recoverable: $RUN_LOCK_DIR"
+        return 1
+    }
+    mkdir "$RUN_LOCK_DIR"
+    write_run_lock_identity
+}
+
+# Releases only the lock owned by this harness process.
+release_run_lock() {
+    [[ -n "$RUN_LOCK_DIR" && -d "$RUN_LOCK_DIR" ]] || return
+    local owner="" owner_start="" current_start=""
+    [[ -f "$RUN_LOCK_DIR/pid" ]] && owner="$(<"$RUN_LOCK_DIR/pid")"
+    [[ -f "$RUN_LOCK_DIR/start" ]] && owner_start="$(<"$RUN_LOCK_DIR/start")"
+    current_start="$(process_start_identity "$$" || true)"
+    [[ "$owner" == "$$" && -n "$RUN_LOCK_START" && "$owner_start" == "$RUN_LOCK_START" && "$current_start" == "$RUN_LOCK_START" ]] || return
+    rm -f "$RUN_LOCK_DIR/pid" "$RUN_LOCK_DIR/start"
+    rmdir "$RUN_LOCK_DIR"
+}
+
+select_lane_order() {
+    case "$((($1 - 1) % 3))" in
+        0) LANE_ORDER=(docker dedicated-vm shared-vm) ;;
+        1) LANE_ORDER=(dedicated-vm shared-vm docker) ;;
+        2) LANE_ORDER=(shared-vm docker dedicated-vm) ;;
+    esac
+}
+
+select_lane() {
+    case "$1" in
+        docker)
+            ACTIVE_COMPOSE=("${DOCKER_COMPOSE_COMMAND[@]}" --ansi never --progress quiet)
+            LANE_PREFIX=d
+            ;;
+        dedicated-vm)
+            ACTIVE_COMPOSE=(
+                env
+                "CONTAINER_BIN=$CONTAINER_BINARY"
+                "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
+                "$CONTAINER_COMPOSE" --ansi never --progress quiet
+            )
+            LANE_PREFIX=dv
+            ;;
+        shared-vm)
+            ACTIVE_COMPOSE=(
+                env
+                "CONTAINER_BIN=$CONTAINER_BINARY"
+                "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
+                "$CONTAINER_COMPOSE" --ansi never --progress quiet
+            )
+            LANE_PREFIX=sv
+            ;;
+        *) error "unknown lane: $1"; return 2 ;;
+    esac
+}
+
+create_fixtures() {
+    local count index lane isolation_line
+    mkdir -p "$ISOLATION_WORK_ROOT"
+    FIXTURE_DIR="$(mktemp -d "$ISOLATION_WORK_ROOT/fixtures.XXXXXX")"
+    for count in 1 10 50; do
+        for lane in "${ISOLATION_LANES[@]}"; do
+            isolation_line=""
+            [[ "$lane" == docker ]] || isolation_line="    isolation: $lane"
+            {
+                printf 'services:\n'
+                for ((index = 1; index <= count; index++)); do
+                    printf '  worker%02d:\n' "$index"
+                    printf '    image: %s\n' "$FIXTURE_IMAGE"
+                    printf '    network_mode: bridge\n'
+                    [[ -z "$isolation_line" ]] || printf '%s\n' "$isolation_line"
+                    printf '    command: ["sh", "-c", "trap '\''exit 0'\'' TERM INT; while :; do sleep 0.1; done"]\n'
+                    printf '    stop_grace_period: 5s\n'
+                done
+            } >"$FIXTURE_DIR/services-$count-$lane.yml"
+        done
+    done
+}
+
+cleanup() {
+    local count lane project file
+    for count in 1 10 50; do
+        for lane in "${ISOLATION_LANES[@]}"; do
+            select_lane "$lane"
+            project="cc-iso-$PROJECT_NAMESPACE-$LANE_PREFIX-$count"
+            file="$FIXTURE_DIR/services-$count-$lane.yml"
+            [[ -f "$file" ]] && "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" down --volumes --remove-orphans >/dev/null 2>&1 || true
+        done
+    done
+    [[ -z "$FIXTURE_DIR" ]] || rm -rf "$FIXTURE_DIR"
+    release_run_lock
+}
+
+write_fingerprint_candidate() {
+    local candidate="$1" docker_compose_version
+    docker_compose_version="$("${DOCKER_COMPOSE_COMMAND[@]}" version)"
+    python3 - "$candidate" "$SELF_PATH" "$CONTAINER_COMPOSE" "$CONTAINER_BINARY" \
+        "$ISOLATION_REPETITIONS" "$ISOLATION_TIMEOUT_SECONDS" \
+        "$ISOLATION_COMPARABLE_NOISE_PCT" "$ISOLATION_TIMING_MAX_RATIO" \
+        "$FIXTURE_IMAGE" "$docker_compose_version" "$DOCKER_BINARY" \
+        "$DOCKER_CONTEXT_NAME" "$DOCKER_ENDPOINT" "$PROJECT_NAMESPACE" \
+        "$ISOLATION_WORK_ROOT_CANONICAL" "$ISOLATION_WORK_ROOT_DEVICE" <<'PY'
+import hashlib, json, platform, subprocess, sys
+from pathlib import Path
+(
+    output, harness, compose, container, repetitions, timeout, noise,
+    maximum_ratio, fixture_image, docker_compose_version, docker_binary,
+    docker_context, docker_endpoint, project_namespace, work_root, work_device,
+) = sys.argv[1:]
+def sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+def command(*arguments):
+    return subprocess.run(arguments, check=False, capture_output=True, text=True).stdout.strip()
+def required_json_command(*arguments):
+    completed = subprocess.run(arguments, check=False, capture_output=True, text=True)
+    if completed.returncode != 0:
+        raise SystemExit(f"{' '.join(arguments)} failed: {completed.stderr.strip()}")
+    return json.loads(completed.stdout)
+def canonical_json_sha256(value):
+    encoded = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+docker_images = required_json_command(docker_binary, "image", "inspect", fixture_image)
+container_images = required_json_command(container, "image", "inspect", fixture_image)
+docker_info = required_json_command(docker_binary, "info", "--format", "{{json .}}")
+container_status = required_json_command(container, "system", "status", "--format", "json")
+container_properties = required_json_command(
+    container, "system", "property", "list", "--format", "json"
+)
+if len(docker_images) != 1 or len(container_images) != 1:
+    raise SystemExit("fixture image inspection must resolve exactly one image per runtime")
+docker_image, container_image = docker_images[0], container_images[0]
+docker_repo_digests = sorted(
+    item.rsplit("@", 1)[-1]
+    for item in docker_image.get("RepoDigests", [])
+    if "@" in item
+)
+docker_resolved_digests = set(docker_repo_digests)
+if docker_image.get("Id"):
+    docker_resolved_digests.add(docker_image["Id"])
+container_descriptor = container_image["configuration"]["descriptor"]["digest"]
+container_variant_digests = sorted(
+    variant["digest"] for variant in container_image.get("variants", [])
+)
+container_resolved_digests = {container_descriptor, *container_variant_digests}
+common_image_digests = sorted(docker_resolved_digests & container_resolved_digests)
+if not common_image_digests:
+    raise SystemExit(
+        "Docker and apple/container fixture images do not share a resolved digest"
+    )
+payload = {
+    "schemaVersion": 2,
+    "harness": {"path": str(Path(harness).resolve()), "sha256": sha256(harness)},
+    "compose": {"path": str(Path(compose).resolve()), "sha256": sha256(compose), "version": command(compose, "version")},
+    "container": {"path": str(Path(container).resolve()), "sha256": sha256(container), "version": command(container, "--version")},
+    "dockerCLI": {"path": str(Path(docker_binary).resolve()), "sha256": sha256(docker_binary)},
+    "dockerCompose": docker_compose_version,
+    "dockerEngine": command(docker_binary, "version", "--format", "{{.Server.Version}}"),
+    "dockerAuthority": {
+        key: docker_info[key]
+        for key in (
+            "ID", "Name", "Driver", "DockerRootDir", "NCPU", "MemTotal",
+            "OperatingSystem", "OSType", "Architecture", "KernelVersion",
+            "SecurityOptions", "CgroupDriver", "CgroupVersion", "ServerVersion",
+        )
+        if key in docker_info
+    },
+    "containerAuthority": {
+        "status": container_status,
+        "properties": container_properties,
+    },
+    "dockerReference": {
+        "context": docker_context,
+        "endpoint": docker_endpoint,
+    },
+    "fixtureImage": {
+        "reference": fixture_image,
+        "commonDigests": common_image_digests,
+        "docker": {
+            "id": docker_image.get("Id", ""),
+            "repoDigests": docker_repo_digests,
+            "inspectionSha256": canonical_json_sha256(docker_image),
+        },
+        "container": {
+            "descriptor": container_descriptor,
+            "variantDigests": container_variant_digests,
+            "inspectionSha256": canonical_json_sha256(container_image),
+        },
+    },
+    "host": {"machine": platform.machine(), "macOS": platform.mac_ver()[0], "model": command("sysctl", "-n", "hw.model")},
+    "settings": {
+        "repetitions": int(repetitions),
+        "timeoutSeconds": int(timeout),
+        "comparableNoisePercent": float(noise),
+        "maximumRatio": float(maximum_ratio),
+        "projectNamespace": project_namespace,
+        "workRoot": {"path": work_root, "device": work_device},
+    },
+}
+Path(output).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
+initialize_evidence() {
+    local candidate
+    mkdir -p "$ISOLATION_EVIDENCE_DIR"
+    candidate="$(mktemp "$ISOLATION_EVIDENCE_DIR/fingerprints.XXXXXX")"
+    write_fingerprint_candidate "$candidate"
+    if [[ -f "$FINGERPRINT_JSON" ]] && ! cmp -s "$candidate" "$FINGERPRINT_JSON"; then
+        rm -f "$candidate"
+        error "evidence fingerprints changed; choose a new ISOLATION_EVIDENCE_DIR instead of mixing runs"
+        return 1
+    fi
+    mv "$candidate" "$FINGERPRINT_JSON"
+    if [[ ! -f "$TIMING_TSV" ]]; then
+        printf 'fixture\tlane\trepetition\tschedule_position\tdirection\tduration_seconds\toutcome\tcommand\n' >"$TIMING_TSV"
+    fi
+    if [[ ! -f "$ASSERTION_TSV" ]]; then
+        printf 'fixture\tlane\trepetition\tassertion\tobserved\toutcome\n' >"$ASSERTION_TSV"
+    fi
+    printf 'repetition\tschedule_position\tlane\n' >"$SCHEDULE_TSV"
+    local repetition position lane
+    for ((repetition = 1; repetition <= ISOLATION_REPETITIONS; repetition++)); do
+        select_lane_order "$repetition"
+        position=0
+        for lane in "${LANE_ORDER[@]}"; do
+            ((position += 1))
+            printf '%s\t%s\t%s\n' "$repetition" "$position" "$lane" >>"$SCHEDULE_TSV"
+        done
+    done
+}
+
+sample_is_complete() {
+    python3 - "$TIMING_TSV" "$ASSERTION_TSV" "$1" "$2" "$3" <<'PY'
+import csv, sys
+path, assertion_path, lane, repetition, count = sys.argv[1:]
+wanted = {f"startup-{count}-services", f"teardown-{count}-services"}
+with open(path, encoding="utf-8", newline="") as handle:
+    rows = [row for row in csv.DictReader(handle, delimiter="\t") if row["lane"] == lane and row["repetition"] == repetition and row["outcome"] == "success"]
+with open(assertion_path, encoding="utf-8", newline="") as handle:
+    assertions = [row for row in csv.DictReader(handle, delimiter="\t") if row["lane"] == lane and row["repetition"] == repetition and row["outcome"] == "pass"]
+actual = {(row["fixture"], row["assertion"]) for row in assertions}
+required = {
+    (f"startup-{count}-services", "running-service-count"),
+    (f"startup-{count}-services", "bridge-ipv4"),
+    (f"teardown-{count}-services", "remaining-service-count"),
+}
+if lane != "docker":
+    required.add((f"startup-{count}-services", "effective-isolation"))
+raise SystemExit(0 if {row["fixture"] for row in rows} >= wanted and actual >= required else 1)
+PY
+}
+
+remove_incomplete_sample() {
+    python3 - "$TIMING_TSV" "$ASSERTION_TSV" "$1" "$2" "$3" <<'PY'
+import csv, pathlib, sys
+timing, assertions = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+lane, repetition, count = sys.argv[3:]
+wanted = {f"startup-{count}-services", f"teardown-{count}-services"}
+def rewrite(path, predicate):
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle, delimiter="\t")
+        fields = reader.fieldnames
+        rows = [row for row in reader if not predicate(row)]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        writer.writeheader(); writer.writerows(rows)
+rewrite(timing, lambda row: row["lane"] == lane and row["repetition"] == repetition and row["fixture"] in wanted)
+rewrite(assertions, lambda row: row["lane"] == lane and row["repetition"] == repetition and row["fixture"].endswith(f"-{count}-services"))
+PY
+}
+
+run_timed() {
+    local fixture="$1" lane="$2" repetition="$3" schedule_position="$4"
+    shift 4
+    python3 - "$TIMING_TSV" "$fixture" "$lane" "$repetition" "$schedule_position" \
+        "$ISOLATION_TIMEOUT_SECONDS" "$@" <<'PY'
+import csv, pathlib, shlex, subprocess, sys, time
+timing, fixture, lane, repetition, position, timeout, *command = sys.argv[1:]
+log_directory = pathlib.Path(timing).parent / "logs"
+log_directory.mkdir(parents=True, exist_ok=True)
+log_path = log_directory / f"{fixture}--{lane}--r{repetition}.log"
+started = time.monotonic(); outcome = "success"; diagnostic = ""
+try:
+    with log_path.open("wb") as log:
+        completed = subprocess.run(command, timeout=float(timeout), check=False, stdout=log, stderr=subprocess.STDOUT)
+    if completed.returncode != 0:
+        outcome = f"exit-{completed.returncode}"
+        diagnostic = log_path.read_text(encoding="utf-8", errors="replace")[-4000:]
+except subprocess.TimeoutExpired as error:
+    outcome = "timeout"; diagnostic = str(error)
+duration = time.monotonic() - started
+with open(timing, "a", encoding="utf-8", newline="") as handle:
+    csv.writer(handle, delimiter="\t", lineterminator="\n").writerow([fixture, lane, repetition, position, "lower-is-better", f"{duration:.9f}", outcome, shlex.join(command)])
+print(f"{fixture} {lane} repetition {repetition}: {duration:.3f}s ({outcome})")
+if outcome != "success":
+    if diagnostic: print(diagnostic, file=sys.stderr)
+    raise SystemExit(124 if outcome == "timeout" else 1)
+PY
+}
+
+record_assertion() {
+    printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$1" "$2" "$3" "$4" "$5" "$6" >>"$ASSERTION_TSV"
+}
+
+assert_running_services() {
+    local fixture="$1" lane="$2" repetition="$3" project="$4" file="$5" expected="$6" output observed container_id inspection network_summary effective_isolation ipv4_address
+    local invalid_isolation=0 missing_ipv4=0 failed=0
+    output="$("${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" ps -q)"
+    observed="$(printf '%s\n' "$output" | awk 'NF { count += 1 } END { print count + 0 }')"
+    if [[ "$observed" != "$expected" ]]; then
+        record_assertion "$fixture" "$lane" "$repetition" running-service-count "$observed" fail
+        error "$fixture $lane retained $observed running services; expected $expected"
+        return 1
+    fi
+    record_assertion "$fixture" "$lane" "$repetition" running-service-count "$observed" pass
+    while IFS= read -r container_id; do
+        [[ -n "$container_id" ]] || continue
+        if [[ "$lane" == docker ]]; then
+            ipv4_address="$("$DOCKER_BINARY" inspect "$container_id" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')"
+        else
+            inspection="$("$CONTAINER_BINARY" inspect "$container_id")"
+            network_summary="$(printf '%s' "$inspection" | python3 -c 'import json,sys; item=json.load(sys.stdin)[0]; networks=item["status"].get("networks", []); ipv4=next((entry.get("ipv4Address", "") for entry in networks if entry.get("network") == "default"), ""); print(item["configuration"].get("effectiveIsolation", "") + "\t" + ipv4)')"
+            IFS=$'\t' read -r effective_isolation ipv4_address <<<"$network_summary"
+            if [[ "$effective_isolation" != "$lane" ]]; then
+                ((invalid_isolation += 1))
+                error "$fixture $lane container $container_id reported effective isolation '$effective_isolation'"
+            fi
+        fi
+        if [[ -z "$ipv4_address" ]]; then
+            ((missing_ipv4 += 1))
+            error "$fixture $lane container $container_id has no global bridge IPv4 address"
+        fi
+    done <<<"$output"
+    if [[ "$lane" != docker ]]; then
+        if ((invalid_isolation > 0)); then
+            record_assertion "$fixture" "$lane" "$repetition" effective-isolation "$invalid_isolation invalid of $observed" fail
+            failed=1
+        else
+            record_assertion "$fixture" "$lane" "$repetition" effective-isolation "$observed of $observed valid" pass
+        fi
+    fi
+    if ((missing_ipv4 > 0)); then
+        record_assertion "$fixture" "$lane" "$repetition" bridge-ipv4 "$missing_ipv4 missing of $observed" fail
+        failed=1
+    else
+        record_assertion "$fixture" "$lane" "$repetition" bridge-ipv4 "$observed of $observed present" pass
+    fi
+    return "$failed"
+}
+
+assert_stopped_services() {
+    local fixture="$1" lane="$2" repetition="$3" project="$4" file="$5" output observed
+    output="$("${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" ps --all -q)"
+    observed="$(printf '%s\n' "$output" | awk 'NF { count += 1 } END { print count + 0 }')"
+    if [[ "$observed" != 0 ]]; then
+        record_assertion "$fixture" "$lane" "$repetition" remaining-service-count "$observed" fail
+        error "$fixture $lane retained $observed services after down"
+        return 1
+    fi
+    record_assertion "$fixture" "$lane" "$repetition" remaining-service-count "$observed" pass
+}
+
+run_lifecycle_lane() {
+    local lane="$1" repetition="$2" position="$3" count="$4" file project
+    if sample_is_complete "$lane" "$repetition" "$count"; then
+        printf 'resume: %s repetition %s %s services already complete\n' "$lane" "$repetition" "$count"
+        return
+    fi
+    remove_incomplete_sample "$lane" "$repetition" "$count"
+    select_lane "$lane"
+    project="cc-iso-$PROJECT_NAMESPACE-$LANE_PREFIX-$count"
+    file="$FIXTURE_DIR/services-$count-$lane.yml"
+    "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" down --volumes --remove-orphans >/dev/null 2>&1 || true
+    run_timed "startup-$count-services" "$lane" "$repetition" "$position" \
+        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up -d --pull never
+    assert_running_services "startup-$count-services" "$lane" "$repetition" "$project" "$file" "$count"
+    run_timed "teardown-$count-services" "$lane" "$repetition" "$position" \
+        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" down --volumes --remove-orphans
+    assert_stopped_services "teardown-$count-services" "$lane" "$repetition" "$project" "$file"
+}
+
+finalize_evidence() {
+    python3 - "$TIMING_TSV" "$ASSERTION_TSV" "$TIMING_JUNIT" "$TIMING_MATRIX" \
+        "$ISOLATION_TIMING_MAX_RATIO" "$ISOLATION_COMPARABLE_NOISE_PCT" \
+        "$ISOLATION_REPETITIONS" "${ISOLATION_FIXTURES[@]}" <<'PY'
+import csv, math, pathlib, statistics, sys, xml.etree.ElementTree as ET
+from collections import defaultdict
+timing, assertion, junit, matrix = map(pathlib.Path, sys.argv[1:5])
+threshold, noise = float(sys.argv[5]), 1 + float(sys.argv[6]) / 100
+repetitions, expected = int(sys.argv[7]), sys.argv[8:]
+lanes = ("docker", "dedicated-vm", "shared-vm")
+rows = list(csv.DictReader(timing.open(encoding="utf-8"), delimiter="\t"))
+assertions = list(csv.DictReader(assertion.open(encoding="utf-8"), delimiter="\t"))
+grouped = defaultdict(lambda: defaultdict(list))
+for row in rows: grouped[row["fixture"]][row["lane"]].append(row)
+def p95(values): return sorted(values)[math.ceil(len(values) * .95) - 1]
+def expected_position(lane, repetition):
+    order = lanes[(repetition - 1) % 3:] + lanes[:(repetition - 1) % 3]
+    return order.index(lane) + 1
+failures, failed_test_cases, table = [], 0, []
+suite = ET.Element("testsuite", name="compose-isolation-performance", tests=str(len(expected) * 2))
+for fixture in expected:
+    lane_rows = {lane: grouped[fixture].get(lane, []) for lane in lanes}
+    all_rows = [row for lane in lanes for row in lane_rows[lane]]
+    valid = all(len(lane_rows[lane]) == repetitions for lane in lanes)
+    valid = valid and all(row["outcome"] == "success" and row["direction"] == "lower-is-better" for row in all_rows)
+    valid = valid and all(row["schedule_position"] == str(expected_position(row["lane"], int(row["repetition"]))) for row in all_rows)
+    fixture_assertions = [row for row in assertions if row["fixture"] == fixture]
+    actual_assertions = {
+        (row["lane"], int(row["repetition"]), row["assertion"])
+        for row in fixture_assertions
+        if row["outcome"] == "pass"
+    }
+    required_assertions = {
+        (lane, repetition, name)
+        for lane in lanes
+        for repetition in range(1, repetitions + 1)
+        for name in (
+            ({"running-service-count", "bridge-ipv4"} | ({"effective-isolation"} if lane != "docker" else set()))
+            if fixture.startswith("startup-")
+            else {"remaining-service-count"}
+        )
+    }
+    valid = valid and actual_assertions >= required_assertions
+    valid = valid and all(row["outcome"] == "pass" for row in fixture_assertions)
+    if not valid:
+        reason = "missing, failed, non-counterbalanced, or functionally unasserted samples"
+        failures.append(f"{fixture}: {reason}")
+        for candidate in lanes[1:]:
+            case = ET.SubElement(suite, "testcase", classname="parity.isolation", name=f"{fixture}-{candidate}")
+            ET.SubElement(case, "failure", message=reason).text = reason
+            failed_test_cases += 1
+        table.append((fixture, *("n/a",) * 12, "FAIL"))
+        continue
+    stats = {}
+    for lane in lanes:
+        values = [float(row["duration_seconds"]) for row in lane_rows[lane]]
+        stats[lane] = (statistics.median(values), p95(values))
+    dm, dp = stats["docker"]
+    row = [fixture, f"{dm:.3f}", f"{dp:.3f}"]
+    guard = "PASS"
+    for candidate in lanes[1:]:
+        cm, cp = stats[candidate]
+        mr, pr = (cm / dm if dm else float("inf")), (cp / dp if dp else float("inf"))
+        comparable = "MET" if mr <= noise and pr <= noise else "NOT MET"
+        case = ET.SubElement(suite, "testcase", classname="parity.isolation", name=f"{fixture}-{candidate}", time=f"{cm:.9f}")
+        ET.SubElement(case, "system-out").text = "\n".join(f"repetition={sample['repetition']} position={sample['schedule_position']} duration={sample['duration_seconds']}" for sample in lane_rows[candidate])
+        if mr >= threshold or pr >= threshold:
+            reason = f"median/P95 ratios are {mr:.2f}x/{pr:.2f}x; threshold is <{threshold:g}x"
+            ET.SubElement(case, "failure", message=reason).text = reason
+            failures.append(f"{fixture} {candidate}: {reason}")
+            failed_test_cases += 1
+            guard = "FAIL"
+        row.extend((f"{cm:.3f}", f"{cp:.3f}", f"{mr:.2f}x", f"{pr:.2f}x", comparable))
+    row.append(guard); table.append(tuple(row))
+suite.set("failures", str(failed_test_cases))
+ET.ElementTree(suite).write(junit, encoding="utf-8", xml_declaration=True)
+lines = ["# Compose Isolation Performance Matrix", "", "Warm-image same-host lifecycle samples using explicit built-in bridge networking. Successful rows include service-count and guest IPv4 assertions. Ratios are relative to Docker; lower is better.", "", "| Fixture | Docker median | Docker P95 | Dedicated median | Dedicated P95 | Dedicated median ratio | Dedicated P95 ratio | Dedicated comparable | Shared median | Shared P95 | Shared median ratio | Shared P95 ratio | Shared comparable | Guard |", "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | ---: | ---: | ---: | ---: | --- | --- |"]
+lines += ["| " + " | ".join(row) + " |" for row in table]
+lines += ["", "Raw timings, functional assertions, the counterbalanced schedule, and exact fingerprints are retained beside this summary.", ""]
+matrix.write_text("\n".join(lines), encoding="utf-8")
+print("\n".join(lines))
+if failures: raise SystemExit("\n".join(failures))
+PY
+}
+
+run_matrix() {
+    local repetition count lane position
+    initialize_evidence
+    for ((repetition = 1; repetition <= ISOLATION_REPETITIONS; repetition++)); do
+        select_lane_order "$repetition"
+        for count in 1 10 50; do
+            position=0
+            for lane in "${LANE_ORDER[@]}"; do
+                ((position += 1))
+                run_lifecycle_lane "$lane" "$repetition" "$position" "$count"
+            done
+        done
+    done
+    finalize_evidence
+}
+
+main() {
+    parse_args "$@"
+    if ((LIST_FIXTURES == 1)); then
+        printf '%s\n' "${ISOLATION_FIXTURES[@]}"
+        return
+    fi
+    check_tools
+    initialize_run_namespace
+    acquire_run_lock
+    trap cleanup EXIT INT TERM
+    create_fixtures
+    run_matrix
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -53,7 +53,7 @@ DOCKER_CONTEXT_NAME=""
 DOCKER_ENDPOINT=""
 PROJECT_NAMESPACE=""
 RUN_LOCK_DIR=""
-RUN_LOCK_START=""
+RUN_LOCK_FD=""
 ISOLATION_WORK_ROOT_CANONICAL=""
 ISOLATION_WORK_ROOT_DEVICE=""
 
@@ -230,71 +230,36 @@ initialize_run_namespace() {
     RUN_LOCK_DIR="$ISOLATION_EVIDENCE_DIR/.run-lock"
 }
 
-# Returns a stable identity for a process instead of trusting a recyclable PID.
-process_start_identity() {
-    ps -o lstart= -p "$1" 2>/dev/null | awk '{$1=$1; print}'
-}
-
-write_run_lock_identity() {
-    if [[ -z "$RUN_LOCK_START" ]]; then
-        RUN_LOCK_START="$(process_start_identity "$$" || true)"
-    fi
-    if [[ -z "$RUN_LOCK_START" ]]; then
-        rm -f "$RUN_LOCK_DIR/pid" "$RUN_LOCK_DIR/start"
-        rmdir "$RUN_LOCK_DIR" 2>/dev/null || true
-        error "could not determine the isolation benchmark process identity"
-        return 1
-    fi
-    printf '%s\n' "$$" >"$RUN_LOCK_DIR/pid"
-    printf '%s\n' "$RUN_LOCK_START" >"$RUN_LOCK_DIR/start"
-}
-
-# Claims the namespace or recovers a lock left by a dead process.
+# Hold an operating-system advisory lock for this shell's lifetime. The empty
+# lock file is deliberately retained: ownership is the live file-description
+# lock, so crashes, incomplete publication, and PID reuse cannot leave stale
+# ownership behind or create a recovery race.
 acquire_run_lock() {
-    RUN_LOCK_START="$(process_start_identity "$$" || true)"
-    if [[ -z "$RUN_LOCK_START" ]]; then
-        error "could not determine the isolation benchmark process identity"
-        return 1
-    fi
-    if mkdir "$RUN_LOCK_DIR" 2>/dev/null; then
-        write_run_lock_identity
-        return
-    fi
+    [[ -z "$RUN_LOCK_FD" ]] || return 0
+    exec {RUN_LOCK_FD}>"$RUN_LOCK_DIR"
+    if ! python3 - "$RUN_LOCK_FD" <<'PY'
+import fcntl
+import sys
 
-    local owner="" owner_start="" current_start=""
-    if [[ ! -f "$RUN_LOCK_DIR/pid" || ! -f "$RUN_LOCK_DIR/start" ]]; then
-        error "isolation benchmark lock is still being initialized: $RUN_LOCK_DIR"
+try:
+    fcntl.flock(int(sys.argv[1]), fcntl.LOCK_EX | fcntl.LOCK_NB)
+except BlockingIOError:
+    raise SystemExit(1)
+PY
+    then
+        exec {RUN_LOCK_FD}>&-
+        RUN_LOCK_FD=""
+        error "another isolation benchmark owns namespace $PROJECT_NAMESPACE"
         return 1
     fi
-    [[ -f "$RUN_LOCK_DIR/pid" ]] && owner="$(<"$RUN_LOCK_DIR/pid")"
-    [[ -f "$RUN_LOCK_DIR/start" ]] && owner_start="$(<"$RUN_LOCK_DIR/start")"
-    if [[ "$owner" =~ ^[1-9][0-9]*$ ]] && kill -0 "$owner" 2>/dev/null; then
-        current_start="$(process_start_identity "$owner" || true)"
-    fi
-    if [[ -n "$owner_start" && "$current_start" == "$owner_start" ]]; then
-        error "another isolation benchmark owns namespace $PROJECT_NAMESPACE (pid $owner)"
-        return 1
-    fi
-
-    rm -f "$RUN_LOCK_DIR/pid" "$RUN_LOCK_DIR/start"
-    rmdir "$RUN_LOCK_DIR" 2>/dev/null || {
-        error "isolation benchmark lock is not recoverable: $RUN_LOCK_DIR"
-        return 1
-    }
-    mkdir "$RUN_LOCK_DIR"
-    write_run_lock_identity
 }
 
-# Releases only the lock owned by this harness process.
+# Closing the owning descriptor releases the lock even after an interrupted
+# run. Keep the inode so concurrent contenders never race an unlink/recreate.
 release_run_lock() {
-    [[ -n "$RUN_LOCK_DIR" && -d "$RUN_LOCK_DIR" ]] || return
-    local owner="" owner_start="" current_start=""
-    [[ -f "$RUN_LOCK_DIR/pid" ]] && owner="$(<"$RUN_LOCK_DIR/pid")"
-    [[ -f "$RUN_LOCK_DIR/start" ]] && owner_start="$(<"$RUN_LOCK_DIR/start")"
-    current_start="$(process_start_identity "$$" || true)"
-    [[ "$owner" == "$$" && -n "$RUN_LOCK_START" && "$owner_start" == "$RUN_LOCK_START" && "$current_start" == "$RUN_LOCK_START" ]] || return
-    rm -f "$RUN_LOCK_DIR/pid" "$RUN_LOCK_DIR/start"
-    rmdir "$RUN_LOCK_DIR"
+    [[ -n "$RUN_LOCK_FD" ]] || return
+    exec {RUN_LOCK_FD}>&-
+    RUN_LOCK_FD=""
 }
 
 select_lane_order() {
@@ -316,6 +281,7 @@ select_lane() {
                 env
                 "CONTAINER_BIN=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
+                "CONTAINER_COMPOSE_INIT_IMAGE="
                 "$CONTAINER_COMPOSE" --ansi never --progress quiet
             )
             LANE_PREFIX=dv
@@ -775,7 +741,11 @@ main() {
     check_tools
     initialize_run_namespace
     acquire_run_lock
-    trap cleanup EXIT INT TERM
+    trap cleanup EXIT
+    trap 'exit 129' HUP
+    trap 'exit 130' INT
+    trap 'exit 131' QUIT
+    trap 'exit 143' TERM
     create_fixtures
     run_matrix
 }

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -574,7 +574,7 @@ log_directory.mkdir(parents=True, exist_ok=True)
 log_path = log_directory / f"{fixture}--{lane}--r{repetition}.log"
 started = time.monotonic(); outcome = "success"; diagnostic = ""; process = None
 def stop_process_group(signum):
-    if process is None or process.poll() is not None:
+    if process is None:
         return
     try:
         os.killpg(process.pid, signum)
@@ -586,7 +586,9 @@ def forward_signal(signum, _frame):
         try:
             process.wait(timeout=5)
         except subprocess.TimeoutExpired:
-            stop_process_group(signal.SIGKILL)
+            pass
+        stop_process_group(signal.SIGKILL)
+        if process.poll() is None:
             process.wait()
     raise SystemExit(128 + signum)
 for forwarded_signal in (signal.SIGHUP, signal.SIGINT, signal.SIGQUIT, signal.SIGTERM):
@@ -603,7 +605,9 @@ except subprocess.TimeoutExpired as error:
     try:
         process.wait(timeout=5)
     except subprocess.TimeoutExpired:
-        stop_process_group(signal.SIGKILL)
+        pass
+    stop_process_group(signal.SIGKILL)
+    if process.poll() is None:
         process.wait()
     outcome = "timeout"; diagnostic = str(error)
 duration = time.monotonic() - started

--- a/Tools/parity/check-compose-isolation-performance.sh
+++ b/Tools/parity/check-compose-isolation-performance.sh
@@ -25,6 +25,7 @@ LIST_FIXTURES=0
 FIXTURE_DIR=""
 CONTAINER_COMPOSE="${CONTAINER_COMPOSE:-$REPO_ROOT/.build/release/compose}"
 CONTAINER_BINARY="${CONTAINER_COMPOSE_CONTAINER:-container}"
+NORMALIZER_BINARY="${CONTAINER_COMPOSE_NORMALIZER:-$REPO_ROOT/Tools/compose-normalizer/compose-normalizer}"
 ISOLATION_EVIDENCE_DIR="${ISOLATION_EVIDENCE_DIR:-${TMPDIR:-/private/tmp}/container-compose-isolation-evidence}"
 ISOLATION_WORK_ROOT="${ISOLATION_WORK_ROOT:-${TMPDIR:-/private/tmp}/container-compose-isolation-work}"
 ISOLATION_REPETITIONS="${ISOLATION_REPETITIONS:-6}"
@@ -73,6 +74,7 @@ OPTIONS:
 ENVIRONMENT:
   CONTAINER_COMPOSE             Exact container-compose binary.
   CONTAINER_COMPOSE_CONTAINER   Exact apple/container binary.
+  CONTAINER_COMPOSE_NORMALIZER  Exact compose-normalizer binary.
   DOCKER_COMPOSE                Optional `docker compose` selector; wrappers
                                 and alternate clients are rejected.
   ISOLATION_EVIDENCE_DIR        Persistent, resumable evidence directory.
@@ -207,6 +209,8 @@ check_tools() {
     [[ -x "$CONTAINER_COMPOSE" ]] || skip_or_fail "container-compose binary is not executable: $CONTAINER_COMPOSE"
     command -v "$CONTAINER_BINARY" >/dev/null 2>&1 || skip_or_fail "container runtime is unavailable: $CONTAINER_BINARY"
     CONTAINER_BINARY="$(command -v "$CONTAINER_BINARY")"
+    [[ -x "$NORMALIZER_BINARY" ]] || skip_or_fail "compose-normalizer is not executable: $NORMALIZER_BINARY"
+    NORMALIZER_BINARY="$(canonical_path "$NORMALIZER_BINARY")"
     command -v python3 >/dev/null 2>&1 || skip_or_fail 'python3 is unavailable'
     command -v diskutil >/dev/null 2>&1 || skip_or_fail 'diskutil is unavailable'
     validate_repetitions
@@ -284,6 +288,7 @@ select_lane() {
                 "CONTAINER_BIN=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_INIT_IMAGE="
+                "CONTAINER_COMPOSE_NORMALIZER=$NORMALIZER_BINARY"
                 "$CONTAINER_COMPOSE" --ansi never --progress quiet
             )
             LANE_PREFIX=dv
@@ -294,6 +299,7 @@ select_lane() {
                 "CONTAINER_BIN=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_CONTAINER=$CONTAINER_BINARY"
                 "CONTAINER_COMPOSE_INIT_IMAGE="
+                "CONTAINER_COMPOSE_NORMALIZER=$NORMALIZER_BINARY"
                 "$CONTAINER_COMPOSE" --ansi never --progress quiet
             )
             LANE_PREFIX=sv
@@ -342,7 +348,7 @@ cleanup() {
 write_fingerprint_candidate() {
     local candidate="$1" docker_compose_version
     docker_compose_version="$("${DOCKER_COMPOSE_COMMAND[@]}" version)"
-    python3 - "$candidate" "$SELF_PATH" "$CONTAINER_COMPOSE" "$CONTAINER_BINARY" \
+    python3 - "$candidate" "$SELF_PATH" "$CONTAINER_COMPOSE" "$CONTAINER_BINARY" "$NORMALIZER_BINARY" \
         "$ISOLATION_REPETITIONS" "$ISOLATION_TIMEOUT_SECONDS" \
         "$ISOLATION_COMPARABLE_NOISE_PCT" "$ISOLATION_TIMING_MAX_RATIO" \
         "$FIXTURE_IMAGE" "$docker_compose_version" "$DOCKER_BINARY" \
@@ -352,7 +358,7 @@ write_fingerprint_candidate() {
 import hashlib, json, platform, subprocess, sys
 from pathlib import Path
 (
-    output, harness, compose, container, repetitions, timeout, noise,
+    output, harness, compose, container, normalizer, repetitions, timeout, noise,
     maximum_ratio, fixture_image, docker_compose_version, docker_binary,
     docker_context, docker_endpoint, project_namespace, work_root, work_device,
     compose_parallel_limit,
@@ -402,10 +408,11 @@ if not common_image_digests:
         "Docker and apple/container fixture images do not share a resolved digest"
     )
 payload = {
-    "schemaVersion": 2,
+    "schemaVersion": 3,
     "harness": {"path": str(Path(harness).resolve()), "sha256": sha256(harness)},
     "compose": {"path": str(Path(compose).resolve()), "sha256": sha256(compose), "version": command(compose, "version")},
     "container": {"path": str(Path(container).resolve()), "sha256": sha256(container), "version": command(container, "--version")},
+    "normalizer": {"path": str(Path(normalizer).resolve()), "sha256": sha256(normalizer)},
     "dockerCLI": {"path": str(Path(docker_binary).resolve()), "sha256": sha256(docker_binary)},
     "dockerCompose": docker_compose_version,
     "dockerEngine": command(docker_binary, "version", "--format", "{{.Server.Version}}"),

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -295,7 +295,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             container.write_text(
                 "#!/bin/sh\n"
                 "if [ \"$2\" = service-one ]; then\n"
-                "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"shared-vm\"},\"status\":{\"networks\":[{\"network\":\"default\",\"ipv4Address\":\"192.0.2.1\"}]}}]'\n"
+                "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"shared-vm\"},\"status\":{\"networks\":[{\"network\":\"project_default\",\"ipv4Address\":\"192.0.2.1\"}]}}]'\n"
                 "else\n"
                 "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"dedicated-vm\"},\"status\":{\"networks\":[]}}]'\n"
                 "fi\n",

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -446,10 +446,16 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
                 alive = [
                     pid
                     for pid in pids
-                    if subprocess.run(
-                        ["ps", "-p", str(pid)], capture_output=True, check=False
-                    ).returncode
-                    == 0
+                    if (
+                        (status := subprocess.run(
+                            ["ps", "-o", "stat=", "-p", str(pid)],
+                            capture_output=True,
+                            check=False,
+                            text=True,
+                        )).returncode
+                        == 0
+                        and not status.stdout.lstrip().startswith("Z")
+                    )
                 ]
                 if not alive:
                     break

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -23,8 +23,10 @@ import csv
 import hashlib
 import json
 import os
+import signal
 import subprocess
 import tempfile
+import time
 import unittest
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -369,6 +371,95 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 143)
         self.assertEqual(result.stdout.splitlines(), ["cleanup"])
 
+    def test_termination_reaches_the_active_timed_command(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            root = Path(directory)
+            ready = root / "ready"
+            terminated = root / "terminated"
+            child = root / "child"
+            child.write_text(
+                "#!/bin/sh\n"
+                f"trap 'printf terminated > {terminated}; exit 143' TERM\n"
+                f"printf ready > {ready}\n"
+                "while :; do sleep 1; done\n",
+                encoding="utf-8",
+            )
+            child.chmod(0o755)
+            owner = subprocess.Popen(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; trap "terminate TERM 143" TERM; '
+                    'run_timed startup-1-services shared-vm 1 1 "$2"',
+                    "_",
+                    HARNESS,
+                    child,
+                ],
+                cwd=REPOSITORY,
+                env={
+                    **os.environ,
+                    "ISOLATION_EVIDENCE_DIR": directory,
+                    "ISOLATION_TIMEOUT_SECONDS": "30",
+                },
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            deadline = time.monotonic() + 5
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.05)
+            self.assertTrue(ready.exists(), "timed child did not start")
+            owner.send_signal(signal.SIGTERM)
+            stdout, stderr = owner.communicate(timeout=8)
+            was_terminated = terminated.exists()
+
+        self.assertEqual(owner.returncode, 143, stderr)
+        self.assertTrue(was_terminated, stdout + stderr)
+
+    def test_timeout_terminates_the_active_command_group(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            root = Path(directory)
+            pid_file = root / "pids"
+            child = root / "child"
+            child.write_text(
+                "#!/bin/sh\n"
+                "trap 'exit 143' TERM\n"
+                "sleep 30 &\n"
+                f"printf '%s %s' \"$$\" \"$!\" > {pid_file}\n"
+                "wait\n",
+                encoding="utf-8",
+            )
+            child.chmod(0o755)
+            started = time.monotonic()
+            result = self.source(
+                f'run_timed startup-1-services shared-vm 1 1 "{child}"',
+                environment={
+                    "ISOLATION_EVIDENCE_DIR": directory,
+                    "ISOLATION_TIMEOUT_SECONDS": "1",
+                },
+            )
+            duration = time.monotonic() - started
+            outcome = (root / "timings.tsv").read_text(encoding="utf-8").split("\t")[6]
+            pids = [int(value) for value in pid_file.read_text(encoding="utf-8").split()]
+            deadline = time.monotonic() + 2
+            while time.monotonic() < deadline:
+                alive = [
+                    pid
+                    for pid in pids
+                    if subprocess.run(
+                        ["ps", "-p", str(pid)], capture_output=True, check=False
+                    ).returncode
+                    == 0
+                ]
+                if not alive:
+                    break
+                time.sleep(0.05)
+
+        self.assertEqual(result.returncode, 124, result.stderr)
+        self.assertLess(duration, 4)
+        self.assertEqual(outcome, "timeout")
+        self.assertEqual(alive, [])
+
     def test_teardown_counts_stopped_containers(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
             compose = Path(directory) / "compose"
@@ -592,6 +683,52 @@ class IsolationPerformanceEvidenceTests(unittest.TestCase):
             )
 
         self.assertNotEqual(result.returncode, 0)
+
+    def test_partial_rotation_is_discarded_before_resume(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            evidence = Path(directory)
+            self.write_samples(
+                evidence,
+                omitted=("teardown-1-services", "shared-vm", 1),
+            )
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; prepare_counterbalance_block 1 1',
+                    "_",
+                    HARNESS,
+                ],
+                cwd=REPOSITORY,
+                env=self.environment(evidence),
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            with (evidence / "timings.tsv").open(
+                encoding="utf-8", newline=""
+            ) as handle:
+                timings = list(csv.DictReader(handle, delimiter="\t"))
+            with (evidence / "assertions.tsv").open(
+                encoding="utf-8", newline=""
+            ) as handle:
+                assertions = list(csv.DictReader(handle, delimiter="\t"))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(
+            any(
+                row["repetition"] == "1"
+                and row["fixture"].endswith("-1-services")
+                for row in timings
+            )
+        )
+        self.assertFalse(
+            any(
+                row["repetition"] == "1"
+                and row["fixture"].endswith("-1-services")
+                for row in assertions
+            )
+        )
 
     def write_samples(
         self,

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -186,6 +186,28 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("skipping Compose isolation performance matrix", result.stderr)
 
+    def test_missing_python_skips_before_normalizer_canonicalization(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            tools = Path(directory)
+            for name in ("compose", "container", "docker", "normalizer"):
+                tool = tools / name
+                tool.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                tool.chmod(0o755)
+            result = self.source(
+                f'PATH="{tools}"; '
+                "detect_docker_compose() { DOCKER_BINARY=\"$PATH/docker\"; "
+                "DOCKER_COMPOSE_COMMAND=(\"$DOCKER_BINARY\" compose); }; "
+                "require_local_docker_context() { :; }; "
+                "CONTAINER_COMPOSE=\"$PATH/compose\"; "
+                "CONTAINER_BINARY=container; "
+                "NORMALIZER_BINARY=\"$PATH/normalizer\"; "
+                "STRICT=0; check_tools"
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("python3 is unavailable", result.stderr)
+        self.assertNotIn("command not found", result.stderr)
+
     def test_namespace_is_stable_per_evidence_directory(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
             first = Path(directory) / "first"

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -116,13 +116,17 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
         self.assertIn("is not local", result.stderr)
 
     def test_remote_docker_host_override_is_rejected(self) -> None:
-        result = self.source(
-            "require_local_docker_context",
-            environment={
-                "DOCKER_CONTEXT": "",
-                "DOCKER_HOST": "ssh://benchmark.example",
-            },
-        )
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            docker = Path(directory) / "docker"
+            docker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            docker.chmod(0o755)
+            result = self.source(
+                f'PATH="{directory}:$PATH"; require_local_docker_context',
+                environment={
+                    "DOCKER_CONTEXT": "",
+                    "DOCKER_HOST": "ssh://benchmark.example",
+                },
+            )
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("DOCKER_HOST", result.stderr)
@@ -202,31 +206,41 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
 
     def test_live_namespace_owner_blocks_a_second_run(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
-            lock = Path(directory) / ".run-lock"
-            lock.mkdir()
-            (lock / "pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
-            process_start = " ".join(
-                subprocess.run(
-                    ["ps", "-o", "lstart=", "-p", str(os.getpid())],
-                    capture_output=True,
-                    check=True,
-                    text=True,
-                ).stdout.split()
+            owner = subprocess.Popen(
+                [
+                    "bash",
+                    "-c",
+                    f'source "{HARNESS}"; '
+                    f'ISOLATION_EVIDENCE_DIR="{directory}"; '
+                    "initialize_run_namespace; acquire_run_lock; "
+                    "printf 'acquired\\n'; sleep 30",
+                ],
+                cwd=REPOSITORY,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
             )
-            (lock / "start").write_text(f"{process_start}\n", encoding="utf-8")
-            result = self.source(
-                f'ISOLATION_EVIDENCE_DIR="{directory}"; initialize_run_namespace; acquire_run_lock'
-            )
+            try:
+                self.assertIsNotNone(owner.stdout)
+                self.assertEqual(owner.stdout.readline().strip(), "acquired")
+                result = self.source(
+                    f'ISOLATION_EVIDENCE_DIR="{directory}"; '
+                    "initialize_run_namespace; acquire_run_lock"
+                )
+            finally:
+                owner.terminate()
+                owner.communicate(timeout=5)
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("another isolation benchmark owns namespace", result.stderr)
 
-    def test_recycled_live_pid_lock_is_recovered(self) -> None:
+    def test_retained_lock_file_is_recoverable_after_owner_exit(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
-            lock = Path(directory) / ".run-lock"
-            lock.mkdir()
-            (lock / "pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
-            (lock / "start").write_text("stale process identity\n", encoding="utf-8")
+            owner = self.source(
+                f'ISOLATION_EVIDENCE_DIR="{directory}"; '
+                "initialize_run_namespace; acquire_run_lock"
+            )
+            self.assertEqual(owner.returncode, 0, owner.stderr)
             result = self.source(
                 f'ISOLATION_EVIDENCE_DIR="{directory}"; initialize_run_namespace; '
                 "acquire_run_lock; release_run_lock"
@@ -234,16 +248,15 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_initializing_namespace_lock_is_not_recovered(self) -> None:
+    def test_empty_lock_file_does_not_create_stale_ownership(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
-            (Path(directory) / ".run-lock").mkdir()
+            (Path(directory) / ".run-lock").touch()
             result = self.source(
                 f'ISOLATION_EVIDENCE_DIR="{directory}"; initialize_run_namespace; '
-                "acquire_run_lock"
+                "acquire_run_lock; release_run_lock"
             )
 
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("lock is still being initialized", result.stderr)
+        self.assertEqual(result.returncode, 0, result.stderr)
 
     def test_candidate_lane_pins_the_fingerprinted_container_client(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
@@ -264,7 +277,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.splitlines(), [str(selected), str(selected)])
 
-    def test_shared_vm_lane_does_not_project_the_runtime_bootstrap_init_image(self) -> None:
+    def test_candidate_lanes_do_not_project_the_runtime_bootstrap_init_image(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
             compose = Path(directory) / "compose"
             compose.write_text(
@@ -273,14 +286,30 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
                 encoding="utf-8",
             )
             compose.chmod(0o755)
-            result = self.source(
-                f'CONTAINER_COMPOSE="{compose}"; '
-                'select_lane shared-vm; "${ACTIVE_COMPOSE[@]}"',
-                environment={"CONTAINER_COMPOSE_INIT_IMAGE": "vminit:runtime-bootstrap"},
-            )
+            for lane in ("dedicated-vm", "shared-vm"):
+                with self.subTest(lane=lane):
+                    result = self.source(
+                        f'CONTAINER_COMPOSE="{compose}"; '
+                        f'select_lane {lane}; "${{ACTIVE_COMPOSE[@]}}"',
+                        environment={"CONTAINER_COMPOSE_INIT_IMAGE": "vminit:runtime-bootstrap"},
+                    )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "")
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout.strip(), "")
+
+    def test_termination_signal_exits_after_one_cleanup(self) -> None:
+        result = self.source(
+            "cleanup() { printf 'cleanup\\n'; }; "
+            "check_tools() { :; }; "
+            "initialize_run_namespace() { :; }; "
+            "acquire_run_lock() { :; }; "
+            "create_fixtures() { :; }; "
+            'run_matrix() { kill -TERM "$$"; printf "continued\\n"; }; '
+            "main"
+        )
+
+        self.assertEqual(result.returncode, 143)
+        self.assertEqual(result.stdout.splitlines(), ["cleanup"])
 
     def test_teardown_counts_stopped_containers(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -285,7 +285,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             compose = Path(directory) / "compose"
             compose.write_text(
                 "#!/bin/sh\n"
-                "printf '%s\\n%s\\n%s\\n' \"$CONTAINER_BIN\" \"$CONTAINER_COMPOSE_CONTAINER\" \"$CONTAINER_COMPOSE_NORMALIZER\"\n",
+                "printf '%s\\n%s\\n%s\\n%s\\n' \"$CONTAINER_BIN\" \"$CONTAINER_COMPOSE_CONTAINER\" \"$CONTAINER_COMPOSE_NORMALIZER\" \"${CONTAINER_DEFAULT_PLATFORM-unset}\"\n",
                 encoding="utf-8",
             )
             compose.chmod(0o755)
@@ -304,8 +304,36 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(
             result.stdout.splitlines(),
-            [str(selected), str(selected), str(normalizer)],
+            [str(selected), str(selected), str(normalizer), ""],
         )
+
+    def test_docker_lane_clears_an_inherited_default_platform(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            docker = Path(directory) / "docker"
+            docker.write_text(
+                "#!/bin/sh\nprintf '%s\\n' \"${DOCKER_DEFAULT_PLATFORM-unset}\"\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            result = self.source(
+                f'DOCKER_COMPOSE_COMMAND=("{docker}" compose); '
+                'select_lane docker; "${ACTIVE_COMPOSE[@]}"',
+                environment={"DOCKER_DEFAULT_PLATFORM": "linux/amd64"},
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+
+    def test_every_fixture_pins_the_arm64_platform(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            result = self.source(
+                f'ISOLATION_WORK_ROOT="{directory}"; create_fixtures; '
+                'for file in "$FIXTURE_DIR"/*.yml; do '
+                'grep -q "platform: linux/arm64" "$file" || exit 1; done'
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
 
     def test_candidate_lanes_do_not_project_the_runtime_bootstrap_init_image(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
@@ -451,6 +479,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             payload["fixtureImage"]["reference"],
             "isolation-fixture/alpine:3.20",
         )
+        self.assertEqual(payload["fixtureImage"]["platform"], "linux/arm64")
         self.assertEqual(payload["fixtureImage"]["commonDigests"], [digest])
         self.assertEqual(payload["dockerReference"]["context"], "fixture-context")
         self.assertEqual(

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -258,24 +258,32 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
 
-    def test_candidate_lane_pins_the_fingerprinted_container_client(self) -> None:
+    def test_candidate_lane_pins_the_fingerprinted_executables(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
             compose = Path(directory) / "compose"
             compose.write_text(
                 "#!/bin/sh\n"
-                "printf '%s\\n%s\\n' \"$CONTAINER_BIN\" \"$CONTAINER_COMPOSE_CONTAINER\"\n",
+                "printf '%s\\n%s\\n%s\\n' \"$CONTAINER_BIN\" \"$CONTAINER_COMPOSE_CONTAINER\" \"$CONTAINER_COMPOSE_NORMALIZER\"\n",
                 encoding="utf-8",
             )
             compose.chmod(0o755)
             selected = Path(directory) / "selected-container"
+            normalizer = Path(directory) / "selected-normalizer"
             result = self.source(
                 f'CONTAINER_COMPOSE="{compose}"; CONTAINER_BINARY="{selected}"; '
+                f'NORMALIZER_BINARY="{normalizer}"; '
                 'select_lane shared-vm; "${ACTIVE_COMPOSE[@]}"',
-                environment={"CONTAINER_BIN": "/tmp/unfingerprinted-container"},
+                environment={
+                    "CONTAINER_BIN": "/tmp/unfingerprinted-container",
+                    "CONTAINER_COMPOSE_NORMALIZER": "/tmp/unfingerprinted-normalizer",
+                },
             )
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.splitlines(), [str(selected), str(selected)])
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [str(selected), str(selected), str(normalizer)],
+        )
 
     def test_candidate_lanes_do_not_project_the_runtime_bootstrap_init_image(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
@@ -399,6 +407,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             result = self.source(
                 'CONTAINER_COMPOSE=/usr/bin/true; '
                 f'CONTAINER_BINARY="{container}"; '
+                'NORMALIZER_BINARY=/usr/bin/true; '
                 f'PATH="{binary_directory}:$PATH"; '
                 'DOCKER_COMPOSE_COMMAND=(true); '
                 f'DOCKER_BINARY="{docker}"; '
@@ -427,6 +436,11 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
         )
         self.assertEqual(payload["settings"]["projectNamespace"], "fixture-namespace")
         self.assertEqual(payload["settings"]["composeParallelLimit"], "4")
+        self.assertEqual(payload["normalizer"]["path"], "/usr/bin/true")
+        self.assertEqual(
+            payload["normalizer"]["sha256"],
+            hashlib.sha256(Path("/usr/bin/true").read_bytes()).hexdigest(),
+        )
         self.assertEqual(payload["dockerAuthority"]["NCPU"], 8)
         self.assertEqual(payload["containerAuthority"]["status"]["status"], "running")
         self.assertEqual(

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -313,7 +313,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             container.write_text(
                 "#!/bin/sh\n"
                 "if [ \"$2\" = service-one ]; then\n"
-                "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"shared-vm\"},\"status\":{\"networks\":[{\"network\":\"project_default\",\"ipv4Address\":\"192.0.2.1\"}]}}]'\n"
+                "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"shared-vm\"},\"status\":{\"networks\":[{\"network\":\"default\",\"ipv4Address\":\"192.0.2.1\"}]}}]'\n"
                 "else\n"
                 "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"dedicated-vm\"},\"status\":{\"networks\":[]}}]'\n"
                 "fi\n",
@@ -328,6 +328,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             )
 
         self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("service-one has no global bridge IPv4 address", result.stderr)
         self.assertIn("service-two reported effective isolation", result.stderr)
         self.assertIn("service-two has no global bridge IPv4 address", result.stderr)
 

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -409,7 +409,8 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
                 'ISOLATION_WORK_ROOT_DEVICE=/dev/disk-fixture; '
                 f'write_fingerprint_candidate "{candidate}"',
                 environment={
-                    "ISOLATION_FIXTURE_IMAGE": "isolation-fixture/alpine:3.20"
+                    "COMPOSE_PARALLEL_LIMIT": "4",
+                    "ISOLATION_FIXTURE_IMAGE": "isolation-fixture/alpine:3.20",
                 },
             )
             payload = json.loads(candidate.read_text(encoding="utf-8"))
@@ -425,6 +426,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             payload["dockerReference"]["endpoint"], "unix:///fixture/docker.sock"
         )
         self.assertEqual(payload["settings"]["projectNamespace"], "fixture-namespace")
+        self.assertEqual(payload["settings"]["composeParallelLimit"], "4")
         self.assertEqual(payload["dockerAuthority"]["NCPU"], 8)
         self.assertEqual(payload["containerAuthority"]["status"]["status"], "running")
         self.assertEqual(

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -424,7 +424,7 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
             child.write_text(
                 "#!/bin/sh\n"
                 "trap 'exit 143' TERM\n"
-                "sleep 30 &\n"
+                "sh -c 'trap \"\" TERM; while :; do sleep 1; done' &\n"
                 f"printf '%s %s' \"$$\" \"$!\" > {pid_file}\n"
                 "wait\n",
                 encoding="utf-8",

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -359,12 +359,18 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
                 'PROJECT_NAMESPACE=fixture-namespace; '
                 'ISOLATION_WORK_ROOT_CANONICAL=/private/tmp/fixture-work; '
                 'ISOLATION_WORK_ROOT_DEVICE=/dev/disk-fixture; '
-                f'write_fingerprint_candidate "{candidate}"'
+                f'write_fingerprint_candidate "{candidate}"',
+                environment={
+                    "ISOLATION_FIXTURE_IMAGE": "isolation-fixture/alpine:3.20"
+                },
             )
             payload = json.loads(candidate.read_text(encoding="utf-8"))
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(payload["fixtureImage"]["reference"], "alpine:3.20")
+        self.assertEqual(
+            payload["fixtureImage"]["reference"],
+            "isolation-fixture/alpine:3.20",
+        )
         self.assertEqual(payload["fixtureImage"]["commonDigests"], [digest])
         self.assertEqual(payload["dockerReference"]["context"], "fixture-context")
         self.assertEqual(

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -1,0 +1,567 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Focused tests for the resumable Compose isolation benchmark."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).parents[2]
+HARNESS = REPOSITORY / "Tools" / "parity" / "check-compose-isolation-performance.sh"
+FIXTURES = [
+    "startup-1-services",
+    "teardown-1-services",
+    "startup-10-services",
+    "teardown-10-services",
+    "startup-50-services",
+    "teardown-50-services",
+]
+LANES = ("docker", "dedicated-vm", "shared-vm")
+
+
+class IsolationPerformanceInventoryTests(unittest.TestCase):
+    def test_fixture_inventory_is_focused_and_stable(self) -> None:
+        result = subprocess.run(
+            [HARNESS, "--list-fixtures"],
+            cwd=REPOSITORY,
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+
+        self.assertEqual(result.stdout.splitlines(), FIXTURES)
+
+    def test_three_lane_schedule_rotates_each_lane_through_each_position(self) -> None:
+        result = self.source("for r in 1 2 3; do select_lane_order $r; printf '%s\\n' \"${LANE_ORDER[*]}\"; done")
+
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                "docker dedicated-vm shared-vm",
+                "dedicated-vm shared-vm docker",
+                "shared-vm docker dedicated-vm",
+            ],
+        )
+
+    def test_external_ssd_is_rejected_for_timed_files(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            tools = self.storage_tools(Path(directory), "External")
+            result = self.source(
+                f'PATH="{tools}:$PATH"; require_internal_storage work "{directory}"'
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("must be on internal storage", result.stderr)
+
+    def test_internal_storage_is_accepted_for_timed_files(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            tools = self.storage_tools(Path(directory), "Internal")
+            result = self.source(
+                f'PATH="{tools}:$PATH"; require_internal_storage work "{directory}"'
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_repetitions_require_complete_counterbalance_cycles(self) -> None:
+        result = self.source(
+            "ISOLATION_REPETITIONS=4; validate_repetitions"
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("complete three-run", result.stderr)
+
+    def test_remote_docker_context_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            docker = Path(directory) / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1 $2\" = \"context show\" ]; then\n"
+                "  printf '%s\\n' remote\n"
+                "else\n"
+                "  printf '%s\\n' tcp://benchmark.example:2376\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            result = self.source(
+                f'PATH="{directory}:$PATH"; require_local_docker_context',
+                environment={"DOCKER_CONTEXT": "", "DOCKER_HOST": ""},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("is not local", result.stderr)
+
+    def test_remote_docker_host_override_is_rejected(self) -> None:
+        result = self.source(
+            "require_local_docker_context",
+            environment={
+                "DOCKER_CONTEXT": "",
+                "DOCKER_HOST": "ssh://benchmark.example",
+            },
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("DOCKER_HOST", result.stderr)
+
+    def test_docker_context_override_takes_precedence_over_docker_host(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            docker = Path(directory) / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' tcp://benchmark.example:2376\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            result = self.source(
+                f'PATH="{directory}:$PATH"; require_local_docker_context',
+                environment={
+                    "DOCKER_CONTEXT": "remote-context",
+                    "DOCKER_HOST": "unix:///private/tmp/docker.sock",
+                },
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("remote-context", result.stderr)
+        self.assertIn("is not local", result.stderr)
+
+    def test_docker_compose_wrapper_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            docker = Path(directory) / "docker"
+            wrapper = Path(directory) / "compose-wrapper"
+            docker.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            wrapper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            docker.chmod(0o755)
+            wrapper.chmod(0o755)
+            result = self.source(
+                f'PATH="{directory}:$PATH"; DOCKER_COMPOSE="{wrapper} compose"; '
+                "detect_docker_compose"
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("same Docker CLI", result.stderr)
+
+    def test_stopped_local_docker_skips_in_non_strict_mode(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            docker = Path(directory) / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' unix:///private/tmp/missing-docker-benchmark.sock\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            result = self.source(
+                f'PATH="{directory}:$PATH"; DOCKER_BINARY="{docker}"; '
+                "STRICT=0; require_local_docker_context",
+                environment={"DOCKER_CONTEXT": "", "DOCKER_HOST": ""},
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("skipping Compose isolation performance matrix", result.stderr)
+
+    def test_namespace_is_stable_per_evidence_directory(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            first = Path(directory) / "first"
+            second = Path(directory) / "second"
+            first_result = self.source(
+                f'ISOLATION_EVIDENCE_DIR="{first}"; initialize_run_namespace; printf "%s" "$PROJECT_NAMESPACE"'
+            )
+            repeated_result = self.source(
+                f'ISOLATION_EVIDENCE_DIR="{first}"; initialize_run_namespace; printf "%s" "$PROJECT_NAMESPACE"'
+            )
+            second_result = self.source(
+                f'ISOLATION_EVIDENCE_DIR="{second}"; initialize_run_namespace; printf "%s" "$PROJECT_NAMESPACE"'
+            )
+
+        self.assertEqual(first_result.returncode, 0, first_result.stderr)
+        self.assertEqual(first_result.stdout, repeated_result.stdout)
+        self.assertNotEqual(first_result.stdout, second_result.stdout)
+
+    def test_live_namespace_owner_blocks_a_second_run(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            lock = Path(directory) / ".run-lock"
+            lock.mkdir()
+            (lock / "pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+            process_start = " ".join(
+                subprocess.run(
+                    ["ps", "-o", "lstart=", "-p", str(os.getpid())],
+                    capture_output=True,
+                    check=True,
+                    text=True,
+                ).stdout.split()
+            )
+            (lock / "start").write_text(f"{process_start}\n", encoding="utf-8")
+            result = self.source(
+                f'ISOLATION_EVIDENCE_DIR="{directory}"; initialize_run_namespace; acquire_run_lock'
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("another isolation benchmark owns namespace", result.stderr)
+
+    def test_recycled_live_pid_lock_is_recovered(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            lock = Path(directory) / ".run-lock"
+            lock.mkdir()
+            (lock / "pid").write_text(f"{os.getpid()}\n", encoding="utf-8")
+            (lock / "start").write_text("stale process identity\n", encoding="utf-8")
+            result = self.source(
+                f'ISOLATION_EVIDENCE_DIR="{directory}"; initialize_run_namespace; '
+                "acquire_run_lock; release_run_lock"
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_initializing_namespace_lock_is_not_recovered(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            (Path(directory) / ".run-lock").mkdir()
+            result = self.source(
+                f'ISOLATION_EVIDENCE_DIR="{directory}"; initialize_run_namespace; '
+                "acquire_run_lock"
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("lock is still being initialized", result.stderr)
+
+    def test_candidate_lane_pins_the_fingerprinted_container_client(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            compose = Path(directory) / "compose"
+            compose.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n%s\\n' \"$CONTAINER_BIN\" \"$CONTAINER_COMPOSE_CONTAINER\"\n",
+                encoding="utf-8",
+            )
+            compose.chmod(0o755)
+            selected = Path(directory) / "selected-container"
+            result = self.source(
+                f'CONTAINER_COMPOSE="{compose}"; CONTAINER_BINARY="{selected}"; '
+                'select_lane shared-vm; "${ACTIVE_COMPOSE[@]}"',
+                environment={"CONTAINER_BIN": "/tmp/unfingerprinted-container"},
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.splitlines(), [str(selected), str(selected)])
+
+    def test_teardown_counts_stopped_containers(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            compose = Path(directory) / "compose"
+            compose.write_text(
+                "#!/bin/sh\n"
+                "case \" $* \" in\n"
+                "  *\" ps --all -q \"*) printf '%s\\n' stopped-container ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            compose.chmod(0o755)
+            result = self.source(
+                f'ACTIVE_COMPOSE=("{compose}"); '
+                "assert_stopped_services teardown-1-services docker 1 project fixture.yml",
+                environment={"ISOLATION_EVIDENCE_DIR": directory},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("retained 1 services", result.stderr)
+
+    def test_every_service_is_checked_for_isolation_and_networking(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            compose = Path(directory) / "compose"
+            container = Path(directory) / "container"
+            compose.write_text(
+                "#!/bin/sh\nprintf '%s\\n' service-one service-two\n",
+                encoding="utf-8",
+            )
+            container.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$2\" = service-one ]; then\n"
+                "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"shared-vm\"},\"status\":{\"networks\":[{\"network\":\"default\",\"ipv4Address\":\"192.0.2.1\"}]}}]'\n"
+                "else\n"
+                "  printf '%s\\n' '[{\"configuration\":{\"effectiveIsolation\":\"dedicated-vm\"},\"status\":{\"networks\":[]}}]'\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            compose.chmod(0o755)
+            container.chmod(0o755)
+            result = self.source(
+                f'ACTIVE_COMPOSE=("{compose}"); CONTAINER_BINARY="{container}"; '
+                "assert_running_services startup-2-services shared-vm 1 project fixture.yml 2",
+                environment={"ISOLATION_EVIDENCE_DIR": directory},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("service-two reported effective isolation", result.stderr)
+        self.assertIn("service-two has no global bridge IPv4 address", result.stderr)
+
+    def test_fingerprint_covers_harness_fixture_and_evaluation_settings(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            root = Path(directory)
+            candidate = root / "fingerprint.json"
+            binary_directory = root / "bin"
+            binary_directory.mkdir()
+            digest = "sha256:fixture"
+            docker = binary_directory / "docker"
+            docker.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1 $2\" = \"image inspect\" ]; then\n"
+                f"  printf '%s\\n' '[{{\"Id\":\"{digest}\",\"RepoDigests\":[\"alpine@{digest}\"]}}]'\n"
+                "elif [ \"$1 $2\" = \"info --format\" ]; then\n"
+                "  printf '%s\\n' '{\"ID\":\"docker-fixture\",\"NCPU\":8,\"MemTotal\":17179869184}'\n"
+                "else\n"
+                "  printf '%s\\n' 'fixture-docker-version'\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            container = binary_directory / "container"
+            container.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1 $2\" = \"image inspect\" ]; then\n"
+                f"  printf '%s\\n' '[{{\"configuration\":{{\"descriptor\":{{\"digest\":\"{digest}\"}}}},\"variants\":[{{\"digest\":\"{digest}\"}}]}}]'\n"
+                "elif [ \"$1 $2 $3 $4\" = \"system status --format json\" ]; then\n"
+                "  printf '%s\\n' '{\"status\":\"running\",\"apiServerCommit\":\"fixture\"}'\n"
+                "elif [ \"$1 $2 $3 $4 $5\" = \"system property list --format json\" ]; then\n"
+                "  printf '%s\\n' '{\"container\":{\"cpus\":8,\"memoryInBytes\":17179869184}}'\n"
+                "else\n"
+                "  printf '%s\\n' 'fixture-container-version'\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            docker.chmod(0o755)
+            container.chmod(0o755)
+            result = self.source(
+                'CONTAINER_COMPOSE=/usr/bin/true; '
+                f'CONTAINER_BINARY="{container}"; '
+                f'PATH="{binary_directory}:$PATH"; '
+                'DOCKER_COMPOSE_COMMAND=(true); '
+                f'DOCKER_BINARY="{docker}"; '
+                'DOCKER_CONTEXT_NAME=fixture-context; '
+                'DOCKER_ENDPOINT=unix:///fixture/docker.sock; '
+                'PROJECT_NAMESPACE=fixture-namespace; '
+                'ISOLATION_WORK_ROOT_CANONICAL=/private/tmp/fixture-work; '
+                'ISOLATION_WORK_ROOT_DEVICE=/dev/disk-fixture; '
+                f'write_fingerprint_candidate "{candidate}"'
+            )
+            payload = json.loads(candidate.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(payload["fixtureImage"]["reference"], "alpine:3.20")
+        self.assertEqual(payload["fixtureImage"]["commonDigests"], [digest])
+        self.assertEqual(payload["dockerReference"]["context"], "fixture-context")
+        self.assertEqual(
+            payload["dockerReference"]["endpoint"], "unix:///fixture/docker.sock"
+        )
+        self.assertEqual(payload["settings"]["projectNamespace"], "fixture-namespace")
+        self.assertEqual(payload["dockerAuthority"]["NCPU"], 8)
+        self.assertEqual(payload["containerAuthority"]["status"]["status"], "running")
+        self.assertEqual(
+            payload["settings"]["workRoot"],
+            {"path": "/private/tmp/fixture-work", "device": "/dev/disk-fixture"},
+        )
+        self.assertEqual(payload["settings"]["maximumRatio"], 10)
+        self.assertEqual(
+            payload["harness"]["sha256"],
+            hashlib.sha256(HARNESS.read_bytes()).hexdigest(),
+        )
+
+    def storage_tools(self, root: Path, location: str) -> Path:
+        tools = root / "bin"
+        tools.mkdir()
+        df = tools / "df"
+        df.write_text(
+            "#!/bin/sh\n"
+            "printf '%s\\n' 'Filesystem 512-blocks Used Available Capacity Mounted on'\n"
+            "printf '%s\\n' '/dev/disk-test 1 1 1 1% /'\n",
+            encoding="utf-8",
+        )
+        diskutil = tools / "diskutil"
+        diskutil.write_text(
+            "#!/bin/sh\n"
+            f"printf '%s\\n' '   Device Location: {location}'\n",
+            encoding="utf-8",
+        )
+        df.chmod(0o755)
+        diskutil.chmod(0o755)
+        return tools
+
+    def source(
+        self,
+        command: str,
+        environment: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        source_environment = dict(os.environ)
+        source_environment.update(environment or {})
+        return subprocess.run(
+            ["bash", "-c", f'source "$1"; {command}', "_", HARNESS],
+            cwd=REPOSITORY,
+            env=source_environment,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+
+class IsolationPerformanceEvidenceTests(unittest.TestCase):
+    def test_finalizer_accepts_complete_counterbalanced_samples(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            evidence = Path(directory)
+            self.write_samples(evidence)
+
+            result = self.finalize(evidence)
+            matrix = (evidence / "timing-matrix.md").read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(matrix.count("| MET |"), len(FIXTURES) * 2)
+        self.assertEqual(matrix.count("| PASS |"), len(FIXTURES))
+
+    def test_finalizer_rejects_a_non_counterbalanced_sample(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            evidence = Path(directory)
+            self.write_samples(
+                evidence,
+                schedule_override={("startup-10-services", "shared-vm", 2): 1},
+            )
+
+            result = self.finalize(evidence)
+            suite = ET.parse(evidence / "timings.junit.xml").getroot()
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("startup-10-services", result.stderr)
+        self.assertEqual(suite.attrib["failures"], "2")
+        self.assertEqual(len(suite.findall(".//failure")), 2)
+
+    def test_checkpoint_requires_both_lifecycle_timings(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            evidence = Path(directory)
+            self.write_samples(evidence, omitted=("teardown-1-services", "shared-vm", 1))
+            environment = self.environment(evidence)
+
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; sample_is_complete shared-vm 1 1',
+                    "_",
+                    HARNESS,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+
+    def write_samples(
+        self,
+        evidence: Path,
+        omitted: tuple[str, str, int] | None = None,
+        schedule_override: dict[tuple[str, str, int], int] | None = None,
+    ) -> None:
+        evidence.mkdir(parents=True, exist_ok=True)
+        schedule_override = schedule_override or {}
+        with (evidence / "timings.tsv").open(
+            "w", encoding="utf-8", newline=""
+        ) as handle:
+            writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+            writer.writerow(
+                [
+                    "fixture",
+                    "lane",
+                    "repetition",
+                    "schedule_position",
+                    "direction",
+                    "duration_seconds",
+                    "outcome",
+                    "command",
+                ]
+            )
+            for fixture in FIXTURES:
+                for repetition in (1, 2, 3):
+                    order = LANES[(repetition - 1) % 3 :] + LANES[: (repetition - 1) % 3]
+                    for lane in LANES:
+                        if omitted == (fixture, lane, repetition):
+                            continue
+                        position = schedule_override.get(
+                            (fixture, lane, repetition), order.index(lane) + 1
+                        )
+                        duration = 1.0 if lane == "docker" else 0.95
+                        writer.writerow(
+                            [
+                                fixture,
+                                lane,
+                                repetition,
+                                position,
+                                "lower-is-better",
+                                f"{duration:.9f}",
+                                "success",
+                                "fixture-command",
+                            ]
+                        )
+        with (evidence / "assertions.tsv").open(
+            "w", encoding="utf-8", newline=""
+        ) as handle:
+            writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+            writer.writerow(
+                ["fixture", "lane", "repetition", "assertion", "observed", "outcome"]
+            )
+            for fixture in FIXTURES:
+                for repetition in (1, 2, 3):
+                    for lane in LANES:
+                        assertions = (
+                            ("running-service-count", "bridge-ipv4")
+                            if fixture.startswith("startup-")
+                            else ("remaining-service-count",)
+                        )
+                        if fixture.startswith("startup-") and lane != "docker":
+                            assertions += ("effective-isolation",)
+                        for assertion in assertions:
+                            writer.writerow(
+                                [fixture, lane, repetition, assertion, "valid", "pass"]
+                            )
+
+    def environment(self, evidence: Path) -> dict[str, str]:
+        environment = dict(os.environ)
+        environment.update(
+            {
+                "ISOLATION_COMPARABLE_NOISE_PCT": "5",
+                "ISOLATION_EVIDENCE_DIR": str(evidence),
+                "ISOLATION_REPETITIONS": "3",
+                "ISOLATION_TIMING_MAX_RATIO": "10",
+            }
+        )
+        return environment
+
+    def finalize(self, evidence: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", 'source "$1"; finalize_evidence', "_", HARNESS],
+            cwd=REPOSITORY,
+            env=self.environment(evidence),
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/parity/test_compose_isolation_performance.py
+++ b/Tools/parity/test_compose_isolation_performance.py
@@ -264,6 +264,24 @@ class IsolationPerformanceInventoryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.splitlines(), [str(selected), str(selected)])
 
+    def test_shared_vm_lane_does_not_project_the_runtime_bootstrap_init_image(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
+            compose = Path(directory) / "compose"
+            compose.write_text(
+                "#!/bin/sh\n"
+                "printf '%s\\n' \"${CONTAINER_COMPOSE_INIT_IMAGE-unset}\"\n",
+                encoding="utf-8",
+            )
+            compose.chmod(0o755)
+            result = self.source(
+                f'CONTAINER_COMPOSE="{compose}"; '
+                'select_lane shared-vm; "${ACTIVE_COMPOSE[@]}"',
+                environment={"CONTAINER_COMPOSE_INIT_IMAGE": "vminit:runtime-bootstrap"},
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "")
+
     def test_teardown_counts_stopped_containers(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-isolation-test-") as directory:
             compose = Path(directory) / "compose"

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "85ef54862953c11849bad674931070efa18a3c3a",
+      "ref": "b65b9b7bc994777cb686c86f21e575b3f240c670",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "56912c03bc70f8d9559877485bee9dc6ad28dae0",
+      "ref": "11062790ce08985b4d7e443e64574e4c2d6b72f7",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "a77c91bb2785ef346720f77de02b1dcfaa2c332c",
+      "ref": "aeb8f6c13aa4431f8201f93667a0fb2cdd0d91ea",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "11062790ce08985b4d7e443e64574e4c2d6b72f7",
+      "ref": "08d6da7047b831c2721ad9dbe82040ed9a3d5f73",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "aeb8f6c13aa4431f8201f93667a0fb2cdd0d91ea",
+      "ref": "87033463e3c84bbe76ea12c85604393ef3188544",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "08d6da7047b831c2721ad9dbe82040ed9a3d5f73",
+      "ref": "2b1326247020e749064bfac86a772ccc89e08a4d",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "b65b9b7bc994777cb686c86f21e575b3f240c670",
+      "ref": "a77c91bb2785ef346720f77de02b1dcfaa2c332c",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

- add a resumable, counterbalanced Docker/dedicated/shared-VM lifecycle matrix;
- retain exact harness, binary, host, validated local Docker authority, active runtime configuration, resolved image, work-root device, settings, schedule, timing, assertion, log, JUnit, and Markdown evidence;
- require the timed reference lane to use the same `docker compose` CLI whose local Unix-socket daemon is validated and fingerprinted;
- assert service counts, effective isolation, and built-in bridge IPv4 behavior for every service in 1/10/50-service starts and teardowns;
- require internal storage and a warm image with one shared resolved digest;
- namespace projects per evidence directory and reject concurrent ownership with a crash-safe advisory lock;
- discard a partially completed three-lane rotation before resuming so recorded schedule positions remain real;
- forward interruption and timeout to the complete active timed process group;
- reject checkpoint reuse whenever the harness or any evaluation input changes;
- pin and fingerprint the exact `compose-normalizer` executable used by both candidate lanes;
- pin every fixture to `linux/arm64` while clearing inherited runtime platform defaults; and
- require complete three-run counterbalance cycles with internally consistent JUnit totals.

This is the focused isolation lane of #278. It measures the broader performance contract but does not claim that Docker parity is complete.

## Exact stack

- Compose PR and live matrix evidence head: `be8957af67f3f28f61bc9592bb78f81c687e7a83`
- Container: `87033463e3c84bbe76ea12c85604393ef3188544` (stephenlclarke/container#167)
- Containerization: `2b1326247020e749064bfac86a772ccc89e08a4d`
- compose-normalizer SHA-256: `96a190d8e80ec08268cf91d8ba7fedf7a8fef52e1537e0685e1033086b06db54`
- Fixture digest: `sha256:5c2987750228f21fa5e602dbc36c4535b34deed426b8f13806c0e2dfbf9b1fba`
- Retained evidence: `/private/tmp/container-compose-be8957af-evidence-final.Ty8Ts1`

## Verification

- `make isolation-performance-harness-test` — 29 passed
- changed `COMPOSE_PARALLEL_LIMIT` values and normalizer executables are fingerprinted, so resumed samples cannot mix concurrency settings or normalization implementations
- missing Python now follows the documented non-strict skip path before any Python-backed path resolution
- focused interruption tests prove active-command signal forwarding, bounded timeout cleanup, and atomic counterbalance-block resumption
- `python3 -m unittest Tools.parity.test_compose_isolation_performance.IsolationPerformanceInventoryTests.test_every_service_is_checked_for_isolation_and_networking` — passed
- `bash -n Tools/parity/check-compose-isolation-performance.sh`
- `shellcheck Tools/parity/check-compose-isolation-performance.sh`
- `swift package resolve` — exact Container and Containerization checkouts verified
- `swift build -c release --product compose -Xswiftc -warnings-as-errors` — passed
- `git diff --check`

## Live matrix

The final counterbalanced three-repetition run retained 54 successful lifecycle timings and 99 passing functional assertions. Every dedicated/shared service exposed the requested effective isolation and the expected built-in bridge IPv4 address.

| Fixture | Docker median | Dedicated median | Shared median | Guard |
| --- | ---: | ---: | ---: | --- |
| startup-1-services | 0.177s | 1.191s | 1.129s | pass |
| teardown-1-services | 0.233s | 0.663s | 0.611s | pass |
| startup-10-services | 0.379s | 2.021s | 5.858s | fail: shared median 15.46x |
| teardown-10-services | 0.394s | 1.683s | 0.787s | pass |
| startup-50-services | 1.655s | 12.525s | 26.746s | fail: shared median 16.16x |
| teardown-50-services | 1.741s | 6.382s | 1.189s | pass |

Relative to the preceding exact baseline, shared startup improves by about 1.1% at 10 services (5.925s to 5.858s) and by about 4.5% at 50 services (28.010s to 26.746s). The harness intentionally exits non-zero because the configured `<10x` Docker threshold is not yet satisfied; that measured gap remains tracked by #278 rather than being hidden by this PR.
