### PR TITLE
test(release): isolate nested make fixtures

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -28,6 +28,7 @@ import textwrap
 import time
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).parents[2] / "scripts" / "CONTAINER_STACK_RELEASE.sh"
@@ -4077,10 +4078,32 @@ gh() {
         )
 
     def non_interactive_environment(self) -> dict[str, str]:
-        """Prevent Git fixtures from launching an editor during automated tests."""
+        """Return an environment isolated from interactive and recursive tools."""
         environment = os.environ.copy()
         environment["GIT_EDITOR"] = ":"
+        for variable in (
+            "GNUMAKEFLAGS",
+            "MAKEFLAGS",
+            "MAKELEVEL",
+            "MAKEOVERRIDES",
+            "MFLAGS",
+        ):
+            environment.pop(variable, None)
         return environment
+
+    def test_non_interactive_environment_removes_recursive_make_state(self) -> None:
+        recursive_make_environment = {
+            "GNUMAKEFLAGS": "--warn-undefined-variables",
+            "MAKEFLAGS": "w -- CONTAINER_COMPOSE_CONTAINER=/tmp/candidate/container",
+            "MAKELEVEL": "2",
+            "MAKEOVERRIDES": "CONTAINER_COMPOSE_CONTAINER",
+            "MFLAGS": "-w",
+        }
+        with mock.patch.dict(os.environ, recursive_make_environment):
+            environment = self.non_interactive_environment()
+
+        for variable in recursive_make_environment:
+            self.assertNotIn(variable, environment)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- remove recursive GNU Make control variables from release-policy subprocess environments
- prevent a parent release gate from leaking its explicit Container candidate into a test that intentionally models a fresh top-level Make invocation
- add focused regression coverage for all recursive Make environment variables

Fixes #336.

## Verification

- `env MAKELEVEL=2 MAKEFLAGS='w -- CONTAINER_COMPOSE_CONTAINER=/private/tmp/release-candidate/bin/container' MAKEOVERRIDES=CONTAINER_COMPOSE_CONTAINER MFLAGS=-w python3 -m unittest Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_release_gate_includes_sibling_coverage_and_runtime_integration Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_non_interactive_environment_removes_recursive_make_state`
- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `python3 -m unittest discover Tools/release` (229 passed)

## Release impact

This unblocks the Compose CI checkpoint while preserving the already-successful 0.14.0 sibling-stack checkpoint.