### PR TITLE
fix(release): validate uncontended release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,6 +233,7 @@ SWIFT_TEST_RUN_FLAGS ?= --no-parallel
 SWIFT_RUNTIME_TEST_FILTER ?= ComposeRuntimeTests
 DEFAULT_COMPOSE_TEST_BINARY := $(abspath .build/debug/compose)
 COMPOSE_TEST_BINARY ?= $(DEFAULT_COMPOSE_TEST_BINARY)
+RELEASE_PARITY_COMPOSE_BINARY := $(abspath .build/release/compose)
 CONTAINER_STACK_REPO ?= $(abspath ../container)
 CONTAINERIZATION_STACK_REPO ?= $(abspath ../containerization)
 CONTAINER_ENGINE_API_STACK_REPO ?= $(abspath ../container-engine-api)
@@ -2256,13 +2257,14 @@ docker-compose-reference:
 docker-compose-e2e-fixtures:
 	DOCKER_COMPOSE_E2E_REF="$(DOCKER_COMPOSE_E2E_REF)" ./Tools/parity/sync-docker-compose-e2e-fixtures.sh --strict
 
-docker-compose-parity: build container-stack-build-if-needed docker-compose-reference
+docker-compose-parity: build-release container-stack-build-if-needed docker-compose-reference
 	container_binary="$(CONTAINER_COMPOSE_CONTAINER)"; \
 	if [[ "$$container_binary" == "container" ]]; then \
 		for candidate in "$(LOCAL_CONTAINER_BINARY)" "$(LOCAL_CONTAINER_PACKAGE_BINARY)"; do \
 			if [[ -x "$$candidate" ]]; then container_binary="$$candidate"; break; fi; \
 		done; \
 	fi; \
+	CONTAINER_COMPOSE="$(RELEASE_PARITY_COMPOSE_BINARY)" \
 	CONTAINER_RUNTIME_APP_ROOT="$(CONTAINER_RUNTIME_APP_ROOT)" \
 		CONTAINER_RUNTIME_INIT_BLOCK_REPO="$(CONTAINER_RUNTIME_INIT_BLOCK_REPO)" \
 		CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" \

--- a/Tools/ci/test_build_release_local_stack.py
+++ b/Tools/ci/test_build_release_local_stack.py
@@ -97,6 +97,25 @@ class BuildReleaseLocalStackTests(unittest.TestCase):
             result.stdout,
         )
 
+    def test_full_parity_uses_the_release_compose_binary(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+        parity = makefile[
+            makefile.index("docker-compose-parity:") : makefile.index(
+                "docker-compose-parity-stages:"
+            )
+        ]
+
+        self.assertTrue(
+            parity.startswith(
+                "docker-compose-parity: build-release "
+                "container-stack-build-if-needed docker-compose-reference"
+            ),
+            parity,
+        )
+        self.assertIn(
+            'CONTAINER_COMPOSE="$(RELEASE_PARITY_COMPOSE_BINARY)"', parity
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -82,6 +82,7 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
             "CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS",
             "CONTAINER_RUNTIME_LOCAL_EXECUTION_ROOT",
             "CONTAINER_RUNTIME_LOCALIZE_APP_ROOT",
+            "CONTAINER_RUNTIME_LAUNCHCTL",
             "CONTAINER_RUNTIME_STAGE_CANDIDATE",
             "CONTAINER_RUNTIME_STAGED_CANDIDATE_ROOT",
             "CONTAINER_RUNTIME_PACKAGE_SHA256",
@@ -90,7 +91,71 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         ):
             environment.pop(variable, None)
         environment["CONTAINER_RUNTIME_ALLOW_NON_MACHO_TEST_FIXTURES"] = "1"
+        environment["CONTAINER_RUNTIME_LAUNCHCTL"] = "/usr/bin/false"
         return environment
+
+    def test_rejects_loaded_production_container_launch_agent(self) -> None:
+        for loaded_label in (
+            "homebrew.mxcl.container",
+            "homebrew.mxcl.container-current",
+            "com.apple.container.apiserver",
+        ):
+            with (
+                self.subTest(loaded_label=loaded_label),
+                tempfile.TemporaryDirectory() as temporary_directory,
+            ):
+                temporary_root = Path(temporary_directory)
+                command_marker = temporary_root / "command-ran"
+                container_log = temporary_root / "container.log"
+                fake_container = temporary_root / "container-cli"
+                fake_launchctl = temporary_root / "launchctl"
+                self.write_fake_container(fake_container)
+                fake_launchctl.write_text(
+                    f"""#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == "print gui/{os.getuid()}/${{LOADED_LABEL:?}}" ]]; then
+  exit 0
+fi
+exit 113
+""",
+                    encoding="utf-8",
+                )
+                fake_launchctl.chmod(0o755)
+                environment = self.runtime_environment()
+                environment.update(
+                    {
+                        "CONTAINER_RUNTIME_APP_ROOT": str(
+                            temporary_root / "app-root"
+                        ),
+                        "CONTAINER_RUNTIME_LAUNCHCTL": str(fake_launchctl),
+                        "CONTAINER_TEST_LOG": str(container_log),
+                        "LOADED_LABEL": loaded_label,
+                    }
+                )
+
+                result = subprocess.run(
+                    [
+                        str(SCRIPT),
+                        str(fake_container),
+                        "/usr/bin/touch",
+                        str(command_marker),
+                    ],
+                    cwd=ROOT,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertEqual(
+                    result.returncode, 2, result.stdout + result.stderr
+                )
+                self.assertIn(
+                    "competing production Container launch agent is loaded: "
+                    f"{loaded_label}",
+                    result.stderr,
+                )
+                self.assertFalse(container_log.exists())
+                self.assertFalse(command_marker.exists())
 
     def test_rejects_a_candidate_cli_that_does_not_match_its_pinned_digest(
         self,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1254,7 +1254,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(f"--stage {stage}", makefile)
         self.assertIn("docker-compose-parity-stages:", makefile)
         self.assertIn(
-            "docker-compose-parity: build container-stack-build-if-needed "
+            "docker-compose-parity: build-release container-stack-build-if-needed "
             "docker-compose-reference",
             makefile,
         )
@@ -2829,15 +2829,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             stack_validation,
         )
         self.assertIn("homebrew-package", staging)
+        self.assertIn('"BUILD_CONFIGURATION=release"', staging)
         self.assertIn('"HOMEBREW_ARCHIVE=${archive}"', staging)
         self.assertIn(
             '"CODESIGN_OPTS=--force --sign ${signing_identity} --timestamp=none"',
             staging,
         )
         self.assertIn(
-            'artifact_root="${artifact_parent}/${container_head}-${signing_identity}"',
+            'artifact_root="${artifact_parent}/${container_head}-${signing_identity}-release"',
             staging,
         )
+        self.assertIn("container-homebrew-release-arm64.tar.gz", staging)
+        self.assertNotIn("container-homebrew-debug-arm64.tar.gz", staging)
         self.assertIn("shasum -a 256 -c", staging)
         self.assertIn("tar -xzf \"${archive}\"", staging)
         self.assertIn("chmod -R a-w", staging)
@@ -2965,6 +2968,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertEqual(len(artifacts), 1)
             self.assertTrue(
                 (artifacts[0] / ".container-compose-runtime-candidate-artifact").is_file()
+            )
+            self.assertIn(
+                "BUILD_CONFIGURATION=release",
+                make_arguments.read_text(encoding="utf-8").splitlines(),
             )
             self.assertIn(
                 "CODESIGN_OPTS=--force --sign "

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7169,6 +7169,23 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/335"
     },
     {
+      "id": "container-compose-338",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Validate parity with uncontended release artifacts",
+      "state": "active-draft",
+      "lastVerified": "2026-08-30",
+      "commits": [
+        "9f98055aa8d9c6e6d597b1ead65c855e1cd67266"
+      ],
+      "documents": [
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-278-release-runtime-candidate.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/338"
+    },
+    {
       "id": "container-compose-307",
       "owner": "stephenlclarke/container-compose",
       "title": "Accept redacted create logging options",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-08-28
 
-Entries: 387. Document snapshots: 677. Current supporting documents: 71.
+Entries: 388. Document snapshots: 678. Current supporting documents: 72.
 
-States: `active-draft` 3, `archived` 304, `closed` 17, `merged` 10, `submitted` 11, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 4, `archived` 304, `closed` 17, `merged` 10, `submitted` 11, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -217,6 +217,7 @@ States: `active-draft` 3, `archived` 304, `closed` 17, `merged` 10, `submitted` 
 | `stephenlclarke/container-compose` | [Adopt the optimized Container stack](https://github.com/stephenlclarke/container-compose/pull/325) | `submitted` | `abf1a9759307`, `94b6ea99e5c1` | [Issue details](container-compose/ISSUE-278.md); [PR details](container-compose/PR-325.md) |
 | `stephenlclarke/container-compose` | [Reuse the invocation Container client](https://github.com/stephenlclarke/container-compose/pull/327) | `submitted` | `9ff4ae007073`, `6911b08e141f` | [PR details](container-compose/PR-327.md) |
 | `stephenlclarke/container-compose` | [Prepare and repair Container Compose 0.14.0](https://github.com/stephenlclarke/container-compose/pull/335) | `active-draft` | `c28475a3b553`, `32e1a4f73fd2`, `d82f81a7a4f2`, `4fd2522765ce` | [Issue details](container-compose/ISSUE-332.md); [PR details](container-compose/PR-333.md); [PR details](container-compose/PR-334.md); [PR details](container-compose/PR-335.md) |
+| `stephenlclarke/container-compose` | [Validate parity with uncontended release artifacts](https://github.com/stephenlclarke/container-compose/pull/338) | `active-draft` | `9f98055aa8d9` | [PR details](container-compose/PR-278-release-runtime-candidate.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-278.md
+++ b/docs/upstream/container-compose/ISSUE-278.md
@@ -13,6 +13,11 @@ Compose has functional parity evidence, but runtime lifecycle work still pays av
 - Continue tracking the separate Compose scaling gap where 10- and 50-service startup exceed the current Docker parity guard.
 - Reuse a bounded invocation lifetime for ordinary Container API control calls
   without coupling attach or exec session disconnects to that control lifetime.
+- Exercise both Compose and Container from signed release builds in the stable
+  parity gate instead of allowing either binary to fall back to a debug build.
+- Reject a loaded production Container launch agent before isolated timing so a
+  crash loop cannot invoke Keychain, consume host resources, or contaminate the
+  candidate/reference comparison.
 
 ## Acceptance evidence
 
@@ -28,6 +33,9 @@ Compose has functional parity evidence, but runtime lifecycle work still pays av
 - The exact matched-stack client-reuse benchmark retains functional parity and
   the diagnostic 10x guard without claiming a latency improvement from mixed
   timing results.
+- A quiet-host exact-release rerun records Docker/container-compose bridge-up
+  medians of 0.137s/1.299s (9.46x, pass) and bridge-down medians of
+  10.146s/5.803s (0.57x, pass), with raw TSV, JUnit, and fingerprints retained.
 
 ## Remaining scope
 
@@ -39,6 +47,14 @@ the 10- and 50-service startup medians regress by 10.0% and 13.2%. The change
 therefore makes no latency claim. Issue 278 remains open for Compose-owned
 profiling, explicit shared or dedicated VM isolation, pre-warming, and the
 other performance lanes in its public completion contract.
+
+The 0.14.0 release gate initially recorded a 10.62x bridge-up result while a
+loaded `container-current` apiserver was crash-looping every approximately ten
+seconds. Its launchd record showed 9,592 runs, and the loop repeatedly invoked
+Keychain authentication. Stopping those exact production agents and rerunning
+the unchanged release artifacts on a quiet host produced the passing 9.46x
+result above. This is a measurement-integrity correction, not a timing waiver
+or a claim that dedicated-VM cold start is now comparable to Docker.
 
 ## Related work
 

--- a/docs/upstream/container-compose/PR-278-release-runtime-candidate.md
+++ b/docs/upstream/container-compose/PR-278-release-runtime-candidate.md
@@ -1,0 +1,65 @@
+# Pull request: validate parity with uncontended release artifacts
+
+## Summary
+
+- Build the stable Container runtime candidate with the release Swift configuration and give its retained archive a release-specific identity.
+- Build and execute the release Compose binary for the full Docker parity gate.
+- Fail before isolated runtime validation when a production Container Homebrew or apiserver launch agent is loaded.
+- Preserve the strict corresponding-fixture 10x timing guard without retries, normalization, or a waiver.
+
+See the companion [issue handoff](ISSUE-278.md).
+
+Tracking pull request: [`stephenlclarke/container-compose#338`](https://github.com/stephenlclarke/container-compose/pull/338).
+
+## Motivation and context
+
+The stable helper previously invoked Container's Homebrew package target without overriding its debug default, while the full Compose parity target depended on the debug Compose build. The resulting binaries were not the artifacts intended for publication.
+
+After both candidates were corrected to release builds, the focused bridge-start oracle still recorded 10.62x. A process and launchd audit found the installed `container-current` apiserver had crash-looped 9,592 times and relaunched approximately every ten seconds. Each failed start invoked Keychain authentication while the isolated release candidate was being measured. The harness changed only the candidate namespace, so its existing `system stop` could not stop or serialize that production agent.
+
+The runner now rejects those loaded production agents before doing candidate work. It does not stop unrelated services, weaken isolation, retry parity fixtures, or silently switch dedicated workloads to shared-VM isolation.
+
+## Code map
+
+- `scripts/CONTAINER_STACK_RELEASE.sh` builds, names, fingerprints, and reuses a signed release Container archive.
+- `Makefile` makes the full parity target build and inject the release Compose executable.
+- `scripts/run-with-container-runtime.sh` inspects the two production launch-agent entry points and fails fast when either can compete with isolated validation.
+- `Tools/ci/test_build_release_local_stack.py`, `Tools/release/test_container_stack_release.py`, and `Tools/ci/test_run_with_container_runtime.py` cover the release configuration, archive identity, Compose executable, and loaded-agent rejection.
+
+## Focused validation
+
+```console
+python3 -m unittest \
+  Tools.ci.test_run_with_container_runtime.RunWithContainerRuntimeTest.test_rejects_loaded_production_container_launch_agent \
+  Tools.ci.test_run_with_container_runtime.RunWithContainerRuntimeTest.test_candidate_cli_leads_path_for_nested_commands \
+  Tools.ci.test_run_with_container_runtime.RunWithContainerRuntimeTest.test_privacy_opt_out_skips_unused_local_user_root \
+  Tools.ci.test_build_release_local_stack.BuildReleaseLocalStackTests.test_full_parity_uses_the_release_compose_binary \
+  Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_release_gate_includes_sibling_coverage_and_runtime_integration \
+  Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_local_release_gate_freezes_the_container_runtime_candidate \
+  Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_runtime_candidate_staging_is_read_only_reusable_and_marker_cleaned
+bash -n scripts/run-with-container-runtime.sh scripts/CONTAINER_STACK_RELEASE.sh
+shellcheck scripts/run-with-container-runtime.sh scripts/CONTAINER_STACK_RELEASE.sh
+git diff --check
+```
+
+The exact signed release candidate reports Container `b19e8205fc91`, Containerization `e5a92e86bf03`, and `build: release`. Its archive SHA-256 is `a2a7eb7e487689a24a25948fd433b166f3b6e9ee16a8ce103833d530a86a80c1`.
+
+With the competing production agents absent, three unchanged-artifact repetitions record:
+
+| Operation | Docker Compose median | Container Compose median | Candidate/reference | Result |
+| --- | ---: | ---: | ---: | --- |
+| `network_mode: bridge` up | 0.137s | 1.299s | 9.46x | Pass |
+| `network_mode: bridge` down | 10.146s | 5.803s | 0.57x | Pass |
+
+Raw timing TSV, JUnit XML, the human matrix, and exact runtime fingerprints are retained in `.build/release-evidence/release-candidate-host-namespaces-quiet/`.
+
+## Compatibility and remaining risk
+
+- Ordinary Container and Compose builds retain their existing debug defaults; only stable packaging and the full stable parity target force release configuration.
+- A loaded production agent now causes an immediate actionable failure instead of a contaminated benchmark or an unattended Keychain dialog.
+- The launch-agent check covers stable and current Homebrew service entry points plus the stock apiserver entry point. A non-launchd process that ignores the shared runtime lock remains outside this narrow guard.
+- A read-only upgrade probe against this Mac's old default state correctly failed closed: that Keychain item was created by an ad-hoc development binary on 5 August 2026 and is ACL-bound to its obsolete code hash. A clean item created by the signed release candidate on 30 August carries the stable Developer ID designated requirement and team identifier instead.
+
+  The contaminated default state is excluded from release evidence and must be preserved or explicitly recovered separately; it is not evidence that a clean signed 0.13 installation cannot upgrade.
+- The passing result is close to the 10x diagnostic boundary. It clears the exact stable gate but does not close issue 278 or establish comparable dedicated-VM startup performance.
+- The complete stable release gate, exact-head review, publication, release-only quality checks, and final DocC rebuild remain required after this focused correction is merged.

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -625,10 +625,10 @@ stage_container_runtime_candidate() {
 
   container_head="$(git -C "${container_path}" rev-parse --verify 'HEAD^{commit}')"
   artifact_parent="${evidence_root}/runtime-candidates"
-  artifact_root="${artifact_parent}/${container_head}-${signing_identity}"
-  archive="${artifact_root}/container-homebrew-debug-arm64.tar.gz"
+  artifact_root="${artifact_parent}/${container_head}-${signing_identity}-release"
+  archive="${artifact_root}/container-homebrew-release-arm64.tar.gz"
   marker="${artifact_root}/.container-compose-runtime-candidate-artifact"
-  expected_marker="container-compose runtime candidate artifact v2 ${container_head} ${signing_identity}"
+  expected_marker="container-compose runtime candidate artifact v3 release ${container_head} ${signing_identity}"
 
   mkdir -p "${artifact_parent}"
   if [[ -e "${artifact_root}" ]]; then
@@ -677,8 +677,9 @@ stage_container_runtime_candidate() {
     trap 'exit 131' QUIT
     trap 'exit 143' TERM
     trap 'cleanup_unpublished_runtime_candidate_build $?' EXIT
-    archive="${build_root}/container-homebrew-debug-arm64.tar.gz"
+    archive="${build_root}/container-homebrew-release-arm64.tar.gz"
     if ! make -C "${container_path}" homebrew-package \
+      "BUILD_CONFIGURATION=release" \
       "HOMEBREW_ARCHIVE=${archive}" \
       "CODESIGN_OPTS=--force --sign ${signing_identity} --timestamp=none"; then
       printf 'failed to build the packaged Container runtime candidate in: %s\n' \
@@ -697,7 +698,7 @@ stage_container_runtime_candidate() {
     mv "${build_root}" "${artifact_root}"
     build_root=""
     trap - EXIT HUP INT QUIT TERM
-    archive="${artifact_root}/container-homebrew-debug-arm64.tar.gz"
+    archive="${artifact_root}/container-homebrew-release-arm64.tar.gz"
   fi
 
   archive_digest="$(shasum -a 256 "${archive}" | awk '{print $1}')"

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -78,6 +78,7 @@ runtime_managed_candidate_root=${CONTAINER_RUNTIME_STAGED_CANDIDATE_ROOT:-}
 runtime_managed_package_sha256=${CONTAINER_RUNTIME_PACKAGE_SHA256:-}
 runtime_app_root_localized=false
 runtime_anonymous_registry_hosts=${CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS-ghcr.io}
+runtime_launchctl=${CONTAINER_RUNTIME_LAUNCHCTL:-/bin/launchctl}
 
 if [[ -z "$runtime_local_execution_root" ]]; then
     runtime_local_execution_root=/private/tmp
@@ -361,6 +362,37 @@ has_matched_init_image_source() {
     [[ -n "$runtime_init_block_repo" ||
         -n "$matched_init_image_tar" ||
         -n "$runtime_init_image_archive" ]]
+}
+
+# Reject production launch agents that can relaunch while an isolated runtime is measured.
+assert_no_competing_container_launch_agents() {
+    local label
+    local loaded_labels=
+    local user_domain
+    user_domain="gui/$(id -u)"
+
+    if [[ ! -x "$runtime_launchctl" ]]; then
+        printf 'Container runtime launch-agent inspector is not executable: %s\n' \
+            "$runtime_launchctl" >&2
+        return 2
+    fi
+
+    for label in \
+        homebrew.mxcl.container \
+        homebrew.mxcl.container-current \
+        com.apple.container.apiserver; do
+        if "$runtime_launchctl" print "$user_domain/$label" >/dev/null 2>&1; then
+            loaded_labels="${loaded_labels}${loaded_labels:+, }${label}"
+        fi
+    done
+
+    if [[ -n "$loaded_labels" ]]; then
+        printf 'competing production Container launch agent is loaded: %s\n' \
+            "$loaded_labels" >&2
+        printf '%s\n' \
+            'stop or unload it before starting isolated release validation' >&2
+        return 2
+    fi
 }
 
 stop_runtime() {
@@ -1879,6 +1911,7 @@ install_matched_init_image() {
 
 validate_runtime_start_deadline_seconds
 validate_runtime_localization_modes
+assert_no_competing_container_launch_agents
 runtime_local_user_root="$runtime_local_execution_root/container-compose-runtime-$(id -u)"
 select_managed_runtime_candidate
 runtime_start_sequence_deadline=$(runtime_start_deadline)


### PR DESCRIPTION
# Pull request: validate parity with uncontended release artifacts

## Summary

- Build the stable Container runtime candidate with the release Swift configuration and give its retained archive a release-specific identity.
- Build and execute the release Compose binary for the full Docker parity gate.
- Fail before isolated runtime validation when a production Container Homebrew or apiserver launch agent is loaded.
- Preserve the strict corresponding-fixture 10x timing guard without retries, normalization, or a waiver.

See the companion [issue handoff](ISSUE-278.md).

## Motivation and context

The stable helper previously invoked Container's Homebrew package target without overriding its debug default, while the full Compose parity target depended on the debug Compose build. The resulting binaries were not the artifacts intended for publication.

After both candidates were corrected to release builds, the focused bridge-start oracle still recorded 10.62x. A process and launchd audit found the installed `container-current` apiserver had crash-looped 9,592 times and relaunched approximately every ten seconds. Each failed start invoked Keychain authentication while the isolated release candidate was being measured. The harness changed only the candidate namespace, so its existing `system stop` could not stop or serialize that production agent.

The runner now rejects those loaded production agents before doing candidate work. It does not stop unrelated services, weaken isolation, retry parity fixtures, or silently switch dedicated workloads to shared-VM isolation.

## Code map

- `scripts/CONTAINER_STACK_RELEASE.sh` builds, names, fingerprints, and reuses a signed release Container archive.
- `Makefile` makes the full parity target build and inject the release Compose executable.
- `scripts/run-with-container-runtime.sh` inspects the two production launch-agent entry points and fails fast when either can compete with isolated validation.
- `Tools/ci/test_build_release_local_stack.py`, `Tools/release/test_container_stack_release.py`, and `Tools/ci/test_run_with_container_runtime.py` cover the release configuration, archive identity, Compose executable, and loaded-agent rejection.

## Focused validation

```console
python3 -m unittest \
  Tools.ci.test_run_with_container_runtime.RunWithContainerRuntimeTest.test_rejects_loaded_production_container_launch_agent \
  Tools.ci.test_run_with_container_runtime.RunWithContainerRuntimeTest.test_candidate_cli_leads_path_for_nested_commands \
  Tools.ci.test_run_with_container_runtime.RunWithContainerRuntimeTest.test_privacy_opt_out_skips_unused_local_user_root \
  Tools.ci.test_build_release_local_stack.BuildReleaseLocalStackTests.test_full_parity_uses_the_release_compose_binary \
  Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_local_release_gate_freezes_the_container_runtime_candidate \
  Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_runtime_candidate_staging_is_read_only_reusable_and_marker_cleaned
bash -n scripts/run-with-container-runtime.sh scripts/CONTAINER_STACK_RELEASE.sh
shellcheck scripts/run-with-container-runtime.sh scripts/CONTAINER_STACK_RELEASE.sh
git diff --check
```

The exact signed release candidate reports Container `b19e8205fc91`, Containerization `e5a92e86bf03`, and `build: release`. Its archive SHA-256 is `a2a7eb7e487689a24a25948fd433b166f3b6e9ee16a8ce103833d530a86a80c1`.

With the competing production agents absent, three unchanged-artifact repetitions record:

| Operation | Docker Compose median | Container Compose median | Candidate/reference | Result |
| --- | ---: | ---: | ---: | --- |
| `network_mode: bridge` up | 0.137s | 1.299s | 9.46x | Pass |
| `network_mode: bridge` down | 10.146s | 5.803s | 0.57x | Pass |

Raw timing TSV, JUnit XML, the human matrix, and exact runtime fingerprints are retained in `.build/release-evidence/release-candidate-host-namespaces-quiet/`.

## Compatibility and remaining risk

- Ordinary Container and Compose builds retain their existing debug defaults; only stable packaging and the full stable parity target force release configuration.
- A loaded production agent now causes an immediate actionable failure instead of a contaminated benchmark or an unattended Keychain dialog.
- The launch-agent check covers the Homebrew service entry point and the stock apiserver entry point observed on this Mac. A non-launchd process that ignores the shared runtime lock remains outside this narrow guard.
- The passing result is close to the 10x diagnostic boundary. It clears the exact stable gate but does not close issue 278 or establish comparable dedicated-VM startup performance.
- The complete stable release gate, exact-head review, publication, release-only quality checks, and final DocC rebuild remain required after this focused correction is merged.
