### PR TITLE
fix(release): quiesce competing validation workers

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2266,6 +2266,1093 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("sysctl -n kern.hv_support", self.script)
         self.assertIn("kern.hv_support=1", self.script)
 
+    def test_local_release_gate_holds_runtime_lock_across_quiescence(self) -> None:
+        local_gate = self.script[
+            self.script.index("run_local_release_gate() {") : self.script.index(
+                "# Verify that Apple remotes cannot be pushed"
+            )
+        ]
+        host_release = self.script[
+            self.script.index("release_local_release_gate_host_state() {") : self.script.index(
+                "# Stop cooperating Container-family workers"
+            )
+        ]
+
+        self.assertLess(
+            local_gate.index("acquire_container_runtime_lock"),
+            local_gate.index("quiesce_local_release_workers"),
+        )
+        self.assertLess(
+            local_gate.index("quiesce_local_release_workers"),
+            local_gate.index('run_local_release_gate_command env'),
+        )
+        self.assertIn("release_local_release_gate_host_state", local_gate)
+        self.assertLess(
+            host_release.index("restore_quiesced_release_launch_agents"),
+            host_release.index("release_container_runtime_lock"),
+        )
+        cleanup = local_gate[
+            local_gate.index("cleanup_local_release_gate_roots() {") : local_gate.index(
+                "trap cleanup_local_release_gate_roots EXIT"
+            )
+        ]
+        self.assertLess(
+            cleanup.index("trap '' HUP INT QUIT TERM"),
+            cleanup.index("cleanup_local_release_gate_resources"),
+        )
+
+    def test_local_release_gate_retains_runtime_lock_until_restore_retry_succeeds(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "homebrew.mxcl.devcontainer"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            state = root / "loaded"
+            attempts = root / "attempts"
+            attempts.write_text("0\n", encoding="utf-8")
+            list_attempts = root / "list-attempts"
+            list_attempts.write_text("0\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list)
+    list_attempt="$(( $(cat "${FAKE_LAUNCHCTL_LIST_ATTEMPTS:?}") + 1 ))"
+    printf '%s\n' "${list_attempt}" > "${FAKE_LAUNCHCTL_LIST_ATTEMPTS}"
+    if [[ -s "${FAKE_LAUNCHCTL_STATE:?}" ]] && ((list_attempt >= 4)); then
+      awk '{ print "123 0 " $0 }' "${FAKE_LAUNCHCTL_STATE}"
+    fi
+    ;;
+  bootstrap)
+    label="$(basename "${3}" .plist)"
+    attempt="$(( $(cat "${FAKE_LAUNCHCTL_ATTEMPTS:?}") + 1 ))"
+    printf '%s\n' "${attempt}" > "${FAKE_LAUNCHCTL_ATTEMPTS}"
+    printf 'bootstrap %s %s\n' "${label}" "${attempt}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    printf '%s\n' "${label}" > "${FAKE_LAUNCHCTL_STATE}"
+    ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "if release_local_release_gate_host_state; then exit 99; fi\n"
+                "if grep -q '^release$' \"${FAKE_LAUNCHCTL_LOG}\"; then exit 98; fi\n"
+                "release_local_release_gate_host_state",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_QUIESCED_LABELS=({shlex.quote(label)})\n"
+                    f"RELEASE_QUIESCED_PLISTS=({shlex.quote(str(plist))})\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=2\n"
+                    "sleep() { :; }\n"
+                    "release_devcontainer_engine_is_ready() { return 0; }\n"
+                    "release_container_runtime_lock() { "
+                    "printf 'release\\n' >> \"${FAKE_LAUNCHCTL_LOG}\"; }\n"
+                    f"export FAKE_LAUNCHCTL_STATE={shlex.quote(str(state))}\n"
+                    f"export FAKE_LAUNCHCTL_ATTEMPTS={shlex.quote(str(attempts))}\n"
+                    f"export FAKE_LAUNCHCTL_LIST_ATTEMPTS={shlex.quote(str(list_attempts))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                [
+                    f"bootstrap {label} 1",
+                    "release",
+                ],
+            )
+
+    def test_restore_retry_reuses_the_original_elapsed_deadline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "homebrew.mxcl.devcontainer"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf 'list\n' >> "${FAKE_LAUNCHCTL_LOG:?}"
+sleep 5
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            started = time.monotonic()
+            result = self.run_release_function(
+                root,
+                "if release_local_release_gate_host_state; then exit 99; fi\n"
+                "first_count=\"$(wc -l < \"${FAKE_LAUNCHCTL_LOG}\")\"\n"
+                "if release_local_release_gate_host_state; then exit 98; fi\n"
+                "second_count=\"$(wc -l < \"${FAKE_LAUNCHCTL_LOG}\")\"\n"
+                "test \"$second_count\" -eq \"$first_count\"\n"
+                "test ${#RELEASE_QUIESCED_DEADLINES[@]} -eq 1\n"
+                "test ${RELEASE_QUIESCED_DEADLINES[0]} -le $SECONDS",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_QUIESCED_LABELS=({shlex.quote(label)})\n"
+                    f"RELEASE_QUIESCED_PLISTS=({shlex.quote(str(plist))})\n"
+                    "RELEASE_QUIESCED_DEADLINES=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=2\n"
+                    "RELEASE_RESTORE_TIMEOUT_SECONDS=1\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=1\n"
+                    "release_container_runtime_lock() {\n"
+                    "  printf 'released\\n' >> \"${FAKE_LAUNCHCTL_LOG:?}\"\n"
+                    "}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+            elapsed = time.monotonic() - started
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(log.read_text(encoding="utf-8"), "list\n")
+            self.assertLess(elapsed, 4.0)
+
+    def test_local_release_gate_fails_closed_when_bootout_inspection_fails(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            launch_agents = home / "Library" / "LaunchAgents"
+            launch_agents.mkdir(parents=True)
+            label = "homebrew.mxcl.devcontainer"
+            (launch_agents / f"{label}.plist").write_text(
+                "fixture\n", encoding="utf-8"
+            )
+            list_attempts = root / "list-attempts"
+            list_attempts.write_text("0\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list)
+    attempt="$(( $(cat "${FAKE_LIST_ATTEMPTS:?}") + 1 ))"
+    printf '%s\n' "${attempt}" > "${FAKE_LIST_ATTEMPTS}"
+    if ((attempt == 1)); then
+      printf '123 0 %s\n' "${FAKE_LABEL:?}"
+    else
+      exit 2
+    fi
+    ;;
+  bootout)
+    printf 'bootout %s\n' "${2##*/}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    exit 2
+    ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "if quiesce_local_release_workers; then exit 99; fi",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(home))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_QUIESCED_LABELS=()\n"
+                    "RELEASE_QUIESCED_PLISTS=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_QUIESCE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=1\n"
+                    f"export FAKE_LABEL={shlex.quote(label)}\n"
+                    f"export FAKE_LIST_ATTEMPTS={shlex.quote(str(list_attempts))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn(
+                "failed to quiesce or prove absence",
+                result.stderr,
+            )
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                [f"bootout {label}"],
+            )
+
+    def test_restore_requires_a_live_launch_agent_process(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "homebrew.mxcl.devcontainer"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list) printf -- '- 0 %s\n' "${FAKE_LABEL:?}" ;;
+  kickstart) printf 'kickstart %s\n' "${3##*/}" >> "${FAKE_LAUNCHCTL_LOG:?}" ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "for attempt in 1 2; do "
+                "restore_status=0; restore_quiesced_release_launch_agents "
+                "|| restore_status=$?; "
+                "test $restore_status -eq 1; done; "
+                "test ${#RELEASE_QUIESCED_LABELS[@]} -eq 1",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_QUIESCED_LABELS=({shlex.quote(label)})\n"
+                    f"RELEASE_QUIESCED_PLISTS=({shlex.quote(str(plist))})\n"
+                    "RELEASE_QUIESCED_ACTION_STARTED=()\n"
+                    "RELEASE_QUIESCED_RESTARTED_UNREADY=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=3\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=1\n"
+                    "sleep() { :; }\n"
+                    f"export FAKE_LABEL={shlex.quote(label)}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("failed to restore release launch agent", result.stderr)
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                [f"kickstart {label}"],
+            )
+
+    def test_runner_restore_requires_online_registration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "actions.runner.owner-container-compose.release-host"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == list ]]; then
+  printf '123 0 %s\n' "${FAKE_LABEL:?}"
+  exit 0
+fi
+exit 2
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                f"if release_launch_agent_is_healthy {shlex.quote(label)}; "
+                "then exit 99; fi",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "competing_release_runner_is_online() { return 1; }\n"
+                    f"export FAKE_LABEL={shlex.quote(label)}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_runner_restore_does_not_restart_live_process_on_query_failure(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "actions.runner.owner-container-compose.release-host"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list) printf '123 0 %s\n' "${FAKE_LABEL:?}" ;;
+  kickstart) printf 'kickstart\n' >> "${FAKE_LAUNCHCTL_LOG:?}" ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "restore_status=0; restore_quiesced_release_launch_agents "
+                "|| restore_status=$?; test $restore_status -eq 1; "
+                "test ${#RELEASE_QUIESCED_LABELS[@]} -eq 1",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_QUIESCED_LABELS=({shlex.quote(label)})\n"
+                    f"RELEASE_QUIESCED_PLISTS=({shlex.quote(str(plist))})\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=3\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=2\n"
+                    "sleep() { :; }\n"
+                    "competing_release_runner_is_online() { return 2; }\n"
+                    f"export FAKE_LABEL={shlex.quote(label)}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertFalse(
+                log.exists(),
+                "indeterminate state must not restart a live runner",
+            )
+
+    def test_devcontainer_restore_requires_a_responsive_public_socket(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            calls = root / "curl.log"
+            response = root / "curl.response"
+            response.write_text("OK\n200", encoding="utf-8")
+            devcontainer = root / "devcontainer"
+            devcontainer.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == 'context --format value' ]]
+printf 'unix:///tmp/devcontainer-test/docker.sock\n'
+""",
+                encoding="utf-8",
+            )
+            devcontainer.chmod(0o755)
+            curl = root / "curl"
+            curl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "${FAKE_CURL_LOG:?}"
+cat "${FAKE_CURL_RESPONSE:?}"
+""",
+                encoding="utf-8",
+            )
+            curl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "release_devcontainer_engine_is_ready",
+                shell_setup=(
+                    f"RELEASE_DEVCONTAINER_CLI={shlex.quote(str(devcontainer))}\n"
+                    f"RELEASE_CURL={shlex.quote(str(curl))}\n"
+                    f"export FAKE_CURL_LOG={shlex.quote(str(calls))}\n"
+                    f"export FAKE_CURL_RESPONSE={shlex.quote(str(response))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            curl_call = calls.read_text(encoding="utf-8")
+            self.assertIn("--unix-socket /tmp/devcontainer-test/docker.sock", curl_call)
+            self.assertIn("http://localhost/_ping", curl_call)
+
+            response.write_text("Unavailable\n503", encoding="utf-8")
+            failed = self.run_release_function(
+                root,
+                "release_devcontainer_engine_is_ready",
+                shell_setup=(
+                    f"RELEASE_DEVCONTAINER_CLI={shlex.quote(str(devcontainer))}\n"
+                    f"RELEASE_CURL={shlex.quote(str(curl))}\n"
+                    f"export FAKE_CURL_LOG={shlex.quote(str(calls))}\n"
+                    f"export FAKE_CURL_RESPONSE={shlex.quote(str(response))}"
+                ),
+            )
+            self.assertEqual(failed.returncode, 1, failed.stdout + failed.stderr)
+
+    def test_runner_restore_restarts_once_after_offline_grace(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "actions.runner.owner-container-compose.release-host"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            observations = root / "observations"
+            observations.write_text("0\n", encoding="utf-8")
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list)
+    if [[ -s "${FAKE_LAUNCHCTL_LOG:?}" ]]; then
+      printf '%s\n' "- 0 ${FAKE_LABEL:?}"
+    else
+      printf '123 0 %s\n' "${FAKE_LABEL:?}"
+    fi
+    ;;
+  kickstart) printf 'kickstart %s\n' "${3##*/}" >> "${FAKE_LAUNCHCTL_LOG:?}" ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "restore_status=0; restore_quiesced_release_launch_agents "
+                "|| restore_status=$?; test $restore_status -eq 1; "
+                "test ${#RELEASE_QUIESCED_LABELS[@]} -eq 1",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_QUIESCED_LABELS=({shlex.quote(label)})\n"
+                    f"RELEASE_QUIESCED_PLISTS=({shlex.quote(str(plist))})\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=4\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=2\n"
+                    "sleep() { :; }\n"
+                    "competing_release_runner_is_online() {\n"
+                    "  count=$(( $(cat \"${FAKE_OBSERVATIONS:?}\") + 1 ))\n"
+                    "  printf '%s\\n' \"$count\" > \"${FAKE_OBSERVATIONS}\"\n"
+                    "  return 1\n"
+                    "}\n"
+                    f"export FAKE_LABEL={shlex.quote(label)}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}\n"
+                    f"export FAKE_OBSERVATIONS={shlex.quote(str(observations))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                [f"kickstart {label}"],
+            )
+            self.assertEqual(observations.read_text(encoding="utf-8"), "2\n")
+
+    def test_runner_restore_retry_retains_the_used_restart(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "actions.runner.owner-container-compose.release-host"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list) printf '123 0 %s\n' "${FAKE_LABEL:?}" ;;
+  kickstart) printf 'kickstart %s\n' "${3##*/}" >> "${FAKE_LAUNCHCTL_LOG:?}" ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "for attempt in 1 2; do "
+                "restore_status=0; restore_quiesced_release_launch_agents "
+                "|| restore_status=$?; test $restore_status -eq 1; done; "
+                "test ${RELEASE_QUIESCED_ACTION_STARTED[0]} -eq 1; "
+                "test ${RELEASE_QUIESCED_RESTARTED_UNREADY[0]} -eq 1",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_QUIESCED_LABELS=({shlex.quote(label)})\n"
+                    f"RELEASE_QUIESCED_PLISTS=({shlex.quote(str(plist))})\n"
+                    "RELEASE_QUIESCED_ACTION_STARTED=()\n"
+                    "RELEASE_QUIESCED_DEADLINES=()\n"
+                    "RELEASE_QUIESCED_RESTARTED_UNREADY=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_RESTORE_TIMEOUT_SECONDS=60\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=1\n"
+                    "competing_release_runner_is_online() { return 1; }\n"
+                    f"export FAKE_LABEL={shlex.quote(label)}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                [f"kickstart {label}"],
+            )
+
+    def test_devcontainer_restore_probe_has_an_elapsed_deadline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            devcontainer = root / "devcontainer"
+            devcontainer.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+sleep 5
+printf 'unix:///tmp/late/docker.sock\n'
+""",
+                encoding="utf-8",
+            )
+            devcontainer.chmod(0o755)
+
+            started = time.monotonic()
+            result = self.run_release_function(
+                root,
+                "probe_status=0; "
+                "release_devcontainer_engine_is_ready $((SECONDS + 1)) "
+                "|| probe_status=$?; test $probe_status -eq 2",
+                shell_setup=(
+                    f"RELEASE_DEVCONTAINER_CLI={shlex.quote(str(devcontainer))}\n"
+                    "RELEASE_CURL=/usr/bin/curl"
+                ),
+            )
+            elapsed = time.monotonic() - started
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertLess(elapsed, 4.0)
+            self.assertIn(
+                "cannot resolve restored devcontainer endpoint",
+                result.stderr,
+            )
+
+    def test_runner_restore_query_has_an_elapsed_deadline(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            calls = root / "gh.log"
+            github = root / "gh"
+            github.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" > "${FAKE_GH_LOG:?}"
+if [[ "${FAKE_GH_SLOW:-0}" == 1 ]]; then
+  sleep 5
+fi
+printf 'online\n'
+""",
+                encoding="utf-8",
+            )
+            github.chmod(0o755)
+            label = "actions.runner.owner-container-compose.release-host"
+
+            healthy = self.run_release_function(
+                root,
+                f"competing_release_runner_is_online {shlex.quote(label)} "
+                "$((SECONDS + 5))",
+                shell_setup=(
+                    f"RELEASE_GITHUB_CLI={shlex.quote(str(github))}\n"
+                    f"export FAKE_GH_LOG={shlex.quote(str(calls))}"
+                ),
+            )
+            self.assertEqual(healthy.returncode, 0, healthy.stdout + healthy.stderr)
+            self.assertIn(
+                "repos/owner/container-compose/actions/runners?per_page=100",
+                calls.read_text(encoding="utf-8"),
+            )
+
+            started = time.monotonic()
+            expired = self.run_release_function(
+                root,
+                "probe_status=0; "
+                f"competing_release_runner_is_online {shlex.quote(label)} "
+                "$((SECONDS + 1)) || probe_status=$?; test $probe_status -eq 2",
+                shell_setup=(
+                    f"RELEASE_GITHUB_CLI={shlex.quote(str(github))}\n"
+                    "export FAKE_GH_SLOW=1\n"
+                    f"export FAKE_GH_LOG={shlex.quote(str(calls))}"
+                ),
+            )
+            elapsed = time.monotonic() - started
+            self.assertEqual(expired.returncode, 0, expired.stdout + expired.stderr)
+            self.assertLess(elapsed, 4.0)
+
+    def test_host_state_restoration_ignores_follow_up_termination(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "cleanup.log"
+
+            result = self.run_release_function(
+                root,
+                "release_local_release_gate_host_state; printf 'survived\\n'",
+                shell_setup=(
+                    "restore_quiesced_release_launch_agents() {\n"
+                    "  kill -TERM $$\n"
+                    "  printf 'restored\\n' >> \"${FAKE_CLEANUP_LOG:?}\"\n"
+                    "}\n"
+                    "release_container_runtime_lock() {\n"
+                    "  printf 'released\\n' >> \"${FAKE_CLEANUP_LOG:?}\"\n"
+                    "}\n"
+                    f"export FAKE_CLEANUP_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("survived", result.stdout)
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                ["restored", "released"],
+            )
+
+    def test_local_release_gate_quiesces_and_restores_competing_workers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            launch_agents = home / "Library" / "LaunchAgents"
+            launch_agents.mkdir(parents=True)
+            labels = (
+                "homebrew.mxcl.devcontainer",
+                "actions.runner.owner-devcontainer.release-host",
+                "actions.runner.owner-container-compose.release-host",
+            )
+            for label in labels:
+                (launch_agents / f"{label}.plist").write_text(
+                    "fixture\n", encoding="utf-8"
+                )
+
+            state = root / "loaded"
+            state.write_text(
+                "\n".join((*labels, "com.example.unrelated")) + "\n",
+                encoding="utf-8",
+            )
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+state="${FAKE_LAUNCHCTL_STATE:?}"
+log="${FAKE_LAUNCHCTL_LOG:?}"
+case "${1:-}" in
+  list)
+    awk '{ print "123 0 " $0 }' "${state}"
+    ;;
+  print)
+    label="${2##*/}"
+    grep -Fxq "${label}" "${state}"
+    ;;
+  bootout)
+    label="${2##*/}"
+    printf 'bootout %s\n' "${label}" >> "${log}"
+    awk -v label="${label}" '$0 != label' "${state}" > "${state}.next"
+    mv "${state}.next" "${state}"
+    ;;
+  bootstrap)
+    label="$(basename "${3}" .plist)"
+    printf 'bootstrap %s\n' "${label}" >> "${log}"
+    printf '%s\n' "${label}" >> "${state}"
+    ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "quiesce_local_release_workers; "
+                "restore_quiesced_release_launch_agents",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(home))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_QUIESCED_LABELS=()\n"
+                    "RELEASE_QUIESCED_PLISTS=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_QUIESCE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=3\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=2\n"
+                    "prepare_competing_release_runner_for_bootout() { return 0; }\n"
+                    "competing_release_runner_is_online() { return 0; }\n"
+                    "release_devcontainer_engine_is_ready() { return 0; }\n"
+                    f"export FAKE_LAUNCHCTL_STATE={shlex.quote(str(state))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            operations = log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                operations,
+                [
+                    *(f"bootout {label}" for label in labels),
+                    *(f"bootstrap {label}" for label in reversed(labels)),
+                ],
+            )
+            self.assertEqual(
+                set(state.read_text(encoding="utf-8").splitlines()),
+                {*labels, "com.example.unrelated"},
+            )
+
+    def test_local_release_gate_keeps_its_current_hosted_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            launch_agents = home / "Library" / "LaunchAgents"
+            launch_agents.mkdir(parents=True)
+            current = "actions.runner.owner-container-compose.release-host"
+            competitor = "homebrew.mxcl.devcontainer"
+            (launch_agents / f"{competitor}.plist").write_text(
+                "fixture\n", encoding="utf-8"
+            )
+            state = root / "loaded"
+            state.write_text(f"{current}\n{competitor}\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list) awk '{ print "123 0 " $0 }' "${FAKE_LAUNCHCTL_STATE:?}" ;;
+  print) grep -Fxq "${2##*/}" "${FAKE_LAUNCHCTL_STATE:?}" ;;
+  bootout)
+    label="${2##*/}"
+    printf 'bootout %s\n' "${label}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    awk -v label="${label}" '$0 != label' "${FAKE_LAUNCHCTL_STATE}" > "${FAKE_LAUNCHCTL_STATE}.next"
+    mv "${FAKE_LAUNCHCTL_STATE}.next" "${FAKE_LAUNCHCTL_STATE}"
+    ;;
+  bootstrap)
+    label="$(basename "${3}" .plist)"
+    printf 'bootstrap %s\n' "${label}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    printf '%s\n' "${label}" >> "${FAKE_LAUNCHCTL_STATE}"
+    ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "quiesce_local_release_workers; "
+                "restore_quiesced_release_launch_agents",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(home))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_QUIESCE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=3\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=2\n"
+                    "release_devcontainer_engine_is_ready() { return 0; }\n"
+                    "export GITHUB_ACTIONS=true\n"
+                    "export GITHUB_REPOSITORY=owner/container-compose\n"
+                    "export RUNNER_NAME=release-host\n"
+                    f"export FAKE_LAUNCHCTL_STATE={shlex.quote(str(state))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            operations = log.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                operations,
+                [f"bootout {competitor}", f"bootstrap {competitor}"],
+            )
+            self.assertIn(current, state.read_text(encoding="utf-8").splitlines())
+
+    def test_local_release_gate_refuses_to_bootout_an_active_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            launch_agents = home / "Library" / "LaunchAgents"
+            launch_agents.mkdir(parents=True)
+            label = "actions.runner.owner-container-compose.release-host"
+            (launch_agents / f"{label}.plist").write_text(
+                "fixture\n", encoding="utf-8"
+            )
+            state = root / "loaded"
+            state.write_text(f"{label}\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list) awk '{ print "123 0 " $0 }' "${FAKE_LAUNCHCTL_STATE:?}" ;;
+  print) grep -Fxq "${2##*/}" "${FAKE_LAUNCHCTL_STATE:?}" ;;
+  bootout) printf 'bootout %s\n' "${2##*/}" >> "${FAKE_LAUNCHCTL_LOG:?}" ;;
+  bootstrap) printf 'bootstrap %s\n' "$(basename "${3}" .plist)" >> "${FAKE_LAUNCHCTL_LOG:?}" ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "if quiesce_local_release_workers; then exit 99; fi",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(home))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_QUIESCE_POLL_SECONDS=0\n"
+                    "prepare_competing_release_runner_for_bootout() { return 3; }\n"
+                    "RELEASE_QUIESCED_LABELS=()\n"
+                    "RELEASE_QUIESCED_PLISTS=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    f"export FAKE_LAUNCHCTL_STATE={shlex.quote(str(state))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("refusing to interrupt active", result.stderr)
+            self.assertFalse(log.exists(), "active runner must not be mutated")
+            self.assertEqual(state.read_text(encoding="utf-8"), f"{label}\n")
+
+    def test_competing_release_runner_activity_uses_exact_registration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            calls = root / "github-api.log"
+            label = "actions.runner.owner-container-compose.release-host"
+
+            result = self.run_release_function(
+                root,
+                f"competing_release_runner_is_busy {shlex.quote(label)}",
+                shell_setup=(
+                    "github_cli() {\n"
+                    "  printf '%s\\n' \"$*\" >> \"${FAKE_GITHUB_API_LOG:?}\"\n"
+                    "  printf 'true\\n'\n"
+                    "}\n"
+                    f"export FAKE_GITHUB_API_LOG={shlex.quote(str(calls))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn(
+                "repos/owner/container-compose/actions/runners?per_page=100",
+                calls.read_text(encoding="utf-8"),
+            )
+
+    def test_runner_drain_rechecks_activity_while_listener_is_suspended(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "signals.log"
+            activity = root / "activity"
+            activity.write_text("0\n", encoding="utf-8")
+            stop_observations = root / "stop-observations"
+            stop_observations.write_text("0\n", encoding="utf-8")
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == print ]]; then
+  printf 'pid = 4242\n'
+  exit 0
+fi
+exit 2
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+            process_inspector = root / "ps"
+            process_inspector.write_text(
+                f"""#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  '-o uid= -p 4242') printf '%s\\n' '{os.getuid()}' ;;
+  '-o pgid= -p 4242') printf '4242\\n' ;;
+  '-axo pgid=,state=,command=')
+    count="$(( $(cat "${{FAKE_STOP_OBSERVATIONS:?}}") + 1 ))"
+    printf '%s\\n' "$count" > "${{FAKE_STOP_OBSERVATIONS}}"
+    if ((count == 1)); then
+      printf '4242 R /runner/bin/Runner.Listener run\\n'
+    else
+      printf '4242 T /runner/bin/Runner.Listener run\\n'
+    fi
+    ;;
+  '-axo pgid=,command=') printf '4242 /runner/bin/Runner.Listener run\\n' ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            process_inspector.chmod(0o755)
+            signaler = root / "kill"
+            signaler.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_SIGNAL_LOG:?}"
+""",
+                encoding="utf-8",
+            )
+            signaler.chmod(0o755)
+            label = "actions.runner.owner-container-compose.release-host"
+
+            result = self.run_release_function(
+                root,
+                f"if prepare_competing_release_runner_for_bootout {shlex.quote(label)}; then exit 99; fi",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_PS={shlex.quote(str(process_inspector))}\n"
+                    f"RELEASE_KILL={shlex.quote(str(signaler))}\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=2\n"
+                    "RELEASE_QUIESCE_POLL_SECONDS=0\n"
+                    "competing_release_runner_is_busy() {\n"
+                    "  value=\"$(cat \"${FAKE_RUNNER_ACTIVITY:?}\")\"\n"
+                    "  printf '%s\\n' \"$((value + 1))\" > \"${FAKE_RUNNER_ACTIVITY}\"\n"
+                    "  ((value > 0))\n"
+                    "}\n"
+                    f"export FAKE_RUNNER_ACTIVITY={shlex.quote(str(activity))}\n"
+                    f"export FAKE_STOP_OBSERVATIONS={shlex.quote(str(stop_observations))}\n"
+                    f"export FAKE_SIGNAL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                ["-STOP -4242", "-CONT -4242"],
+            )
+            self.assertEqual(
+                stop_observations.read_text(encoding="utf-8"),
+                "2\n",
+            )
+
+    def test_runner_drain_fails_closed_when_process_inspection_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "signals.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == print ]]; then
+  printf 'pid = 4242\n'
+  exit 0
+fi
+exit 2
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+            process_inspector = root / "ps"
+            process_inspector.write_text(
+                f"""#!/usr/bin/env bash
+set -euo pipefail
+case "$*" in
+  '-o uid= -p 4242') printf '%s\n' '{os.getuid()}' ;;
+  '-o pgid= -p 4242') printf '4242\n' ;;
+  '-axo pgid=,state=,command=') printf '4242 T /runner/bin/Runner.Listener run\n' ;;
+  '-axo pgid=,command=') exit 2 ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            process_inspector.chmod(0o755)
+            signaler = root / "kill"
+            signaler.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_SIGNAL_LOG:?}"
+""",
+                encoding="utf-8",
+            )
+            signaler.chmod(0o755)
+            label = "actions.runner.owner-container-compose.release-host"
+
+            result = self.run_release_function(
+                root,
+                "runner_status=0; "
+                f"prepare_competing_release_runner_for_bootout {shlex.quote(label)} "
+                "|| runner_status=$?; test $runner_status -eq 2",
+                shell_setup=(
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_PS={shlex.quote(str(process_inspector))}\n"
+                    f"RELEASE_KILL={shlex.quote(str(signaler))}\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "competing_release_runner_is_busy() { return 1; }\n"
+                    f"export FAKE_SIGNAL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn(
+                "cannot inspect competing release runner process group: 4242",
+                result.stderr,
+            )
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                ["-STOP -4242", "-CONT -4242"],
+            )
+
+    def test_local_release_gate_rejects_a_worker_that_does_not_stop(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            launch_agents = home / "Library" / "LaunchAgents"
+            launch_agents.mkdir(parents=True)
+            label = "homebrew.mxcl.devcontainer"
+            (launch_agents / f"{label}.plist").write_text(
+                "fixture\n", encoding="utf-8"
+            )
+            state = root / "loaded"
+            state.write_text(f"{label}\n", encoding="utf-8")
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list) awk '{ print "123 0 " $0 }' "${FAKE_LAUNCHCTL_STATE:?}" ;;
+  print) grep -Fxq "${2##*/}" "${FAKE_LAUNCHCTL_STATE:?}" ;;
+  bootout)
+    label="${2##*/}"
+    printf 'bootout %s\n' "${label}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    ;;
+  bootstrap)
+    label="$(basename "${3}" .plist)"
+    printf 'bootstrap %s\n' "${label}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    printf '%s\n' "${label}" >> "${FAKE_LAUNCHCTL_STATE:?}"
+    ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "if quiesce_local_release_workers; then exit 99; fi",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(home))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_QUIESCE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=3\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=2\n"
+                    "release_devcontainer_engine_is_ready() { return 0; }\n"
+                    f"export FAKE_LAUNCHCTL_STATE={shlex.quote(str(state))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn("did not quiesce", result.stderr)
+            self.assertEqual(
+                log.read_text(encoding="utf-8").splitlines(),
+                [f"bootout {label}"],
+            )
+            self.assertEqual(state.read_text(encoding="utf-8"), f"{label}\n")
+
     def test_local_release_gate_keeps_llvm_profiles_out_of_source_checkouts(self) -> None:
         local_gate = self.script[
             self.script.index("run_local_release_gate() {") : self.script.index(

--- a/docs/upstream/container-compose/ISSUE-278.md
+++ b/docs/upstream/container-compose/ISSUE-278.md
@@ -18,6 +18,11 @@ Compose has functional parity evidence, but runtime lifecycle work still pays av
 - Reject a loaded production Container launch agent before isolated timing so a
   crash loop cannot invoke Keychain, consume host resources, or contaminate the
   candidate/reference comparison.
+- Hold the host-wide runtime lock while quiescing and restoring cooperating
+  Compose and devcontainer release workers around the authoritative local
+  gate, while preserving the runner that owns a hosted job.
+- Atomically drain idle competing Actions runners before removal; leave active
+  runners untouched and fail closed when activity cannot be established.
 
 ## Acceptance evidence
 
@@ -36,6 +41,27 @@ Compose has functional parity evidence, but runtime lifecycle work still pays av
 - A quiet-host exact-release rerun records Docker/container-compose bridge-up
   medians of 0.137s/1.299s (9.46x, pass) and bridge-down medians of
   10.146s/5.803s (0.57x, pass), with raw TSV, JUnit, and fingerprints retained.
+- Focused release-policy and runtime-lock tests plus a live launchd exercise
+  prove that every installed cooperating worker is absent during the complete
+  locked window and is restored before the next gate acquires the lock; Colima
+  remains available as the Docker reference.
+- Focused assignment-race evidence proves GitHub activity is rechecked while
+  every visible member of the idle listener process group is observably
+  stopped, active work is never booted out, a failed local process snapshot is
+  treated as indeterminate, and every suspended runner is resumed on failure
+  or EXIT cleanup.
+- Focused launchd failure and recovery evidence proves an inspection error is
+  never treated as absence, crash-looping services do not satisfy restoration,
+  Actions recovery requires the exact registration to be online, and the
+  devcontainer engine must answer its public socket health endpoint.
+- Recovery enforces a configurable elapsed readiness deadline, bounds every
+  external probe and action by its remaining time, and performs at most one
+  restart of a live but definitively unready service after a bounded grace
+  period. A
+  replacement with no PID yet is allowed to start without repeated restart,
+  the original deadline and issued-action state are retained across an EXIT
+  retry, and follow-up termination signals cannot interrupt candidate cleanup
+  or host restoration once EXIT recovery begins.
 
 ## Remaining scope
 
@@ -56,6 +82,17 @@ the unchanged release artifacts on a quiet host produced the passing 9.46x
 result above. This is a measurement-integrity correction, not a timing waiver
 or a claim that dedicated-VM cold start is now comparable to Docker.
 
+A later complete 0.14.0 gate correctly stopped at 11.63x (1.511s candidate,
+0.130s Docker) with the same immutable release artifacts that passed at 9.46x.
+The local Compose and devcontainer self-hosted runner services plus the
+devcontainer engine were still loaded because the preflight covered only
+production Container agents. Pull request 339 closes that executable contract
+gap: a direct release owns the host-wide runtime lock while it temporarily
+atomically drains, unloads, and recoverably restores all three cooperating
+services; a hosted release preserves only its own runner. Active competing
+jobs are left untouched and make the gate fail closed. The failed raw sample
+remains retained and the 10x threshold remains unchanged.
+
 ## Related work
 
 This handoff records [issue 278](https://github.com/stephenlclarke/container-compose/issues/278). Its implementation dependencies are [Containerization pull request 37](https://github.com/stephenlclarke/containerization/pull/37), [builder-shim pull request 12](https://github.com/stephenlclarke/container-builder-shim/pull/12), and [Container pull request 142](https://github.com/stephenlclarke/container/pull/142). The Compose-owned client reuse is [pull request 327](https://github.com/stephenlclarke/container-compose/pull/327).
@@ -65,3 +102,6 @@ The later 0.14.0 optimization chain is listed in the
 Its live 28 August 2026 audit found no submitted Apple upstream PR containing a
 benchmarked Container, Containerization, builder-shim, or Compose optimization;
 the stock-Apple `upstream/pr-*` branches remain unsubmitted candidates.
+
+Release-host measurement integrity is continued by
+[pull request 339](https://github.com/stephenlclarke/container-compose/pull/339).

--- a/docs/upstream/container-compose/PR-278-release-runtime-candidate.md
+++ b/docs/upstream/container-compose/PR-278-release-runtime-candidate.md
@@ -5,11 +5,19 @@
 - Build the stable Container runtime candidate with the release Swift configuration and give its retained archive a release-specific identity.
 - Build and execute the release Compose binary for the full Docker parity gate.
 - Fail before isolated runtime validation when a production Container Homebrew or apiserver launch agent is loaded.
+- Hold the host-wide runtime lock while temporarily stopping and later
+  restoring cooperating Compose and devcontainer launch agents around a direct
+  local release gate; a hosted gate preserves only its own runner.
+- Atomically drain idle competing Actions runners and fail closed without
+  mutation when GitHub reports an active or indeterminate job.
 - Preserve the strict corresponding-fixture 10x timing guard without retries, normalization, or a waiver.
 
 See the companion [issue handoff](ISSUE-278.md).
 
-Tracking pull request: [`stephenlclarke/container-compose#338`](https://github.com/stephenlclarke/container-compose/pull/338).
+Tracking pull requests:
+
+- [`stephenlclarke/container-compose#338`](https://github.com/stephenlclarke/container-compose/pull/338)
+- [`stephenlclarke/container-compose#339`](https://github.com/stephenlclarke/container-compose/pull/339)
 
 ## Motivation and context
 
@@ -19,9 +27,26 @@ After both candidates were corrected to release builds, the focused bridge-start
 
 The runner now rejects those loaded production agents before doing candidate work. It does not stop unrelated services, weaken isolation, retry parity fixtures, or silently switch dedicated workloads to shared-VM isolation.
 
+The subsequent complete release gate stopped at 11.63x with the exact same
+release artifacts. The executable preflight had not encoded the already
+documented requirement to quiesce non-production Container-family workers: the
+Compose release runner, devcontainer release runner, and Homebrew devcontainer
+engine were all loaded. Pull request 339 makes that state transition explicit,
+recoverable, and serialized with every other runtime user. Colima is
+deliberately retained because it is the Docker reference, not a competing
+Container-family worker.
+
 ## Code map
 
 - `scripts/CONTAINER_STACK_RELEASE.sh` builds, names, fingerprints, and reuses a signed release Container archive.
+- The same release helper records the loaded cooperating-worker set, unloads it
+  only after acquiring the existing host-wide runtime lock, and restores
+  exactly that set before releasing the lock on success, failure, or signal
+  cleanup.
+- For Actions runners, the helper checks exact repository registration state,
+  suspends the idle listener process group, rechecks remote activity and local
+  worker presence while no new assignment can start, then removes the launch
+  agent. Every failure and EXIT path resumes a suspended listener.
 - `Makefile` makes the full parity target build and inject the release Compose executable.
 - `scripts/run-with-container-runtime.sh` inspects the two production launch-agent entry points and fails fast when either can compete with isolated validation.
 - `Tools/ci/test_build_release_local_stack.py`, `Tools/release/test_container_stack_release.py`, and `Tools/ci/test_run_with_container_runtime.py` cover the release configuration, archive identity, Compose executable, and loaded-agent rejection.
@@ -42,6 +67,31 @@ shellcheck scripts/run-with-container-runtime.sh scripts/CONTAINER_STACK_RELEASE
 git diff --check
 ```
 
+The pull request 339 follow-up additionally passes twenty-two focused release-policy
+tests covering lock/quiescence order, configurable restoration retries, direct
+quiescence/restoration, hosted-runner preservation, exact runner activity,
+atomic activity and process-snapshot rechecking while the listener is
+suspended, fail-closed stop behavior, hardware-virtualization preflight, and
+release-root isolation. Failed launchd inspection is distinct from proven
+absence. Restoration requires a live service, a responsive devcontainer public
+API socket, and an online exact Actions runner registration. A live but
+definitively unready service receives one bounded restart only after the
+configured grace period; a replacement that has not published its PID yet is
+not restarted repeatedly. The listener process group must be observably stopped
+before its second activity snapshots begin. Every external readiness probe and
+recovery action is supervised by the remaining elapsed recovery deadline. That
+original deadline and the already-issued startup/restart state remain attached
+to a failed service across EXIT retries. Signal-safe cleanup retains
+restoration authority through candidate cleanup and the complete worker
+recovery window. The
+existing independent-user regression proves a second runtime user cannot
+acquire the same lock before its holder releases it. A live production-path
+exercise acquired the runtime lock, atomically drained and unloaded all three
+installed cooperating agents, proved none remained during the controlled
+window, restored all three as healthy idle/online services, verified the
+devcontainer `/_ping` endpoint, and left Docker 29.2.1 available through
+Colima.
+
 The exact signed release candidate reports Container `b19e8205fc91`, Containerization `e5a92e86bf03`, and `build: release`. Its archive SHA-256 is `a2a7eb7e487689a24a25948fd433b166f3b6e9ee16a8ce103833d530a86a80c1`.
 
 With the competing production agents absent, three unchanged-artifact repetitions record:
@@ -57,6 +107,31 @@ Raw timing TSV, JUnit XML, the human matrix, and exact runtime fingerprints are 
 
 - Ordinary Container and Compose builds retain their existing debug defaults; only stable packaging and the full stable parity target force release configuration.
 - A loaded production agent now causes an immediate actionable failure instead of a contaminated benchmark or an unattended Keychain dialog.
+- A direct stable release now temporarily unloads only known Compose and
+  devcontainer workers with user-owned regular launch-agent plists. Missing,
+  unsafe, or unresponsive state fails closed, and restoration is retried.
+- A competing Actions runner is removed only after exact GitHub activity is
+  idle, its listener group is suspended, and both GitHub activity and local
+  worker presence are rechecked. Every visible process-group member must first
+  report a stopped state. Active or indeterminate runners are resumed and left
+  untouched.
+- Quiescence accepts absence only from a successful launchd snapshot.
+  Restoration authority is retained until every service has a live process and
+  each Actions runner is online again. The devcontainer engine must also answer
+  its public socket health endpoint. Recovery has a 60-second per-service
+  elapsed deadline by default, bounds every external probe and recovery action
+  by the remaining time, and restarts a live but definitively unready service
+  at most once after a 10-observation grace period. An EXIT retry reuses the
+  retained deadline and action state instead of granting a second recovery
+  window or issuing another restart.
+- Once recovery begins, follow-up termination signals cannot interrupt worker
+  restoration or release the host lock prematurely. The same protection starts
+  before candidate cleanup on the EXIT path.
+- The worker window is inside the same host-wide runtime lock used by every
+  cooperating validation path. Workers are restored before that lock is
+  released, so a waiting release must quiesce the newly restored set itself.
+- A hosted stable gate derives and preserves its own exact runner label so it
+  can report the job result; other cooperating workers remain quiesced.
 - The launch-agent check covers stable and current Homebrew service entry points plus the stock apiserver entry point. A non-launchd process that ignores the shared runtime lock remains outside this narrow guard.
 - A read-only upgrade probe against this Mac's old default state correctly failed closed: that Keychain item was created by an ad-hoc development binary on 5 August 2026 and is ACL-bound to its obsolete code hash. A clean item created by the signed release candidate on 30 August carries the stable Developer ID designated requirement and team identifier instead.
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -23,6 +23,8 @@ readonly SELF_DIRECTORY
 readonly COMPOSE_PROMOTION_REVIEW_TOOL="${SELF_DIRECTORY}/../Tools/release/compose_promotion_review.py"
 readonly OCI_IMAGE_LAYOUT_VALIDATOR="${SELF_DIRECTORY}/../Tools/release/validate-oci-image-layout.py"
 readonly RELEASE_COMMAND_DEADLINE_RUNNER="${SELF_DIRECTORY}/../Tools/ci/run-command-with-deadline.py"
+# shellcheck disable=SC1091
+source "${SELF_DIRECTORY}/../Tools/ci/container-runtime-lock.sh"
 SCRIPT_NAME="$(basename "${SELF_PATH}")"
 readonly SCRIPT_NAME
 readonly SCRIPT_USAGE="scripts/${SCRIPT_NAME}"
@@ -144,6 +146,37 @@ Environment:
       Override the default 30-second bound for stopping the exact candidate
       runtime namespace during local release-gate cleanup.
 
+  CONTAINER_STACK_RELEASE_LAUNCHCTL
+      Override the system launchctl executable used by focused release
+      quiescence tests. Production releases use /bin/launchctl.
+
+  CONTAINER_STACK_RELEASE_PS
+  CONTAINER_STACK_RELEASE_KILL
+      Override the system process inspection and signalling executables used
+      by focused atomic runner-drain tests. Production releases use /bin/ps
+      and /bin/kill.
+
+  CONTAINER_STACK_RELEASE_QUIESCE_WAIT_ATTEMPTS
+  CONTAINER_STACK_RELEASE_QUIESCE_POLL_SECONDS
+      Override the default 30 one-second observations used while stopped
+      workers leave the performance host.
+
+  CONTAINER_STACK_RELEASE_RESTORE_WAIT_ATTEMPTS
+  CONTAINER_STACK_RELEASE_RESTORE_TIMEOUT_SECONDS
+  CONTAINER_STACK_RELEASE_RESTORE_POLL_SECONDS
+  CONTAINER_STACK_RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS
+      Override the default 60-observation, 60-second elapsed restoration
+      deadline and the default 10-observation grace before one restart of a
+      live but definitively unready service.
+
+  CONTAINER_STACK_RELEASE_DEVCONTAINER_CLI
+  CONTAINER_STACK_RELEASE_CURL
+  CONTAINER_STACK_RELEASE_GITHUB_CLI
+      Override the installed devcontainer and curl executables used to verify
+      the restored compatibility socket, or the GitHub CLI used to verify an
+      Actions runner registration. Production defaults are the first
+      devcontainer and gh on PATH plus /usr/bin/curl.
+
   CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE
       Absolute path to the retained OCI init-image archive used by the local
       release gate. Execute mode requires this hermetic bootstrap input so
@@ -212,6 +245,22 @@ STABLE_RELEASE_GATE_WAIT_SECONDS="${CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS:-10
 PROMOTION_WAIT_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS:-3600}"
 PROMOTION_POLL_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS:-30}"
 CANDIDATE_STOP_TIMEOUT_SECONDS="${CONTAINER_STACK_RELEASE_CANDIDATE_STOP_TIMEOUT_SECONDS:-30}"
+RELEASE_LAUNCHCTL="${CONTAINER_STACK_RELEASE_LAUNCHCTL:-/bin/launchctl}"
+RELEASE_PS="${CONTAINER_STACK_RELEASE_PS:-/bin/ps}"
+RELEASE_KILL="${CONTAINER_STACK_RELEASE_KILL:-/bin/kill}"
+RELEASE_SUSPENDED_RUNNER_PGIDS=()
+RELEASE_QUIESCED_ACTION_STARTED=()
+RELEASE_QUIESCED_DEADLINES=()
+RELEASE_QUIESCED_RESTARTED_UNREADY=()
+RELEASE_QUIESCE_WAIT_ATTEMPTS="${CONTAINER_STACK_RELEASE_QUIESCE_WAIT_ATTEMPTS:-30}"
+RELEASE_QUIESCE_POLL_SECONDS="${CONTAINER_STACK_RELEASE_QUIESCE_POLL_SECONDS:-1}"
+RELEASE_RESTORE_WAIT_ATTEMPTS="${CONTAINER_STACK_RELEASE_RESTORE_WAIT_ATTEMPTS:-60}"
+RELEASE_RESTORE_TIMEOUT_SECONDS="${CONTAINER_STACK_RELEASE_RESTORE_TIMEOUT_SECONDS:-60}"
+RELEASE_RESTORE_POLL_SECONDS="${CONTAINER_STACK_RELEASE_RESTORE_POLL_SECONDS:-1}"
+RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS="${CONTAINER_STACK_RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS:-10}"
+RELEASE_DEVCONTAINER_CLI="${CONTAINER_STACK_RELEASE_DEVCONTAINER_CLI:-$(command -v devcontainer || true)}"
+RELEASE_CURL="${CONTAINER_STACK_RELEASE_CURL:-/usr/bin/curl}"
+RELEASE_GITHUB_CLI="${CONTAINER_STACK_RELEASE_GITHUB_CLI:-$(command -v gh || true)}"
 COMPOSE_MAIN_PROMOTION_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_PROMOTION_MODE:-pr}"
 COMPOSE_MAIN_MERGE_MODE="${CONTAINER_STACK_RELEASE_COMPOSE_MAIN_MERGE_MODE:-checked-admin}"
 RELEASE_INTENT="${CONTAINER_STACK_RELEASE_INTENT:-}"
@@ -979,6 +1028,799 @@ run_local_release_gate_command() {
   return "${child_status}"
 }
 
+# Identify the launch agent that owns the current hosted release job. Its
+# listener must remain alive long enough to report the job result; every other
+# cooperating Container-family worker is temporarily quiesced.
+current_release_runner_launch_agent_label() {
+  if [[ "${GITHUB_ACTIONS:-}" != "true" || -z "${GITHUB_REPOSITORY:-}" ||
+    -z "${RUNNER_NAME:-}" ]]; then
+    return 1
+  fi
+
+  printf 'actions.runner.%s.%s\n' \
+    "${GITHUB_REPOSITORY//\//-}" "${RUNNER_NAME}"
+}
+
+# Print loaded launch agents that can replace shared Container services or
+# start competing Container-family validation while timings are recorded.
+list_competing_release_launch_agents() {
+  local current_runner_label=""
+  local label=""
+  local services=""
+
+  if [[ ! -x "${RELEASE_LAUNCHCTL}" ]]; then
+    printf 'release launch-agent manager is not executable: %s\n' \
+      "${RELEASE_LAUNCHCTL}" >&2
+    return 2
+  fi
+  if ! services="$("${RELEASE_LAUNCHCTL}" list)"; then
+    printf 'failed to list launch agents with %s\n' "${RELEASE_LAUNCHCTL}" >&2
+    return 1
+  fi
+  current_runner_label="$(current_release_runner_launch_agent_label || true)"
+
+  while read -r _ _ label; do
+    case "${label}" in
+      homebrew.mxcl.devcontainer | \
+        actions.runner.*-devcontainer.* | \
+        actions.runner.*-container-compose.*)
+        if [[ "${label}" != "${current_runner_label}" ]]; then
+          printf '%s\n' "${label}"
+        fi
+        ;;
+    esac
+  done <<<"${services}"
+}
+
+# Return success when a competing Actions runner is already executing a job,
+# return one when it is idle, and fail closed for missing or ambiguous runner
+# registration. The release gate owns the runtime lock at this point, so
+# aborting for a busy runner lets that job finish without booting out its
+# launch agent; a second release gate waiting on the lock can then proceed.
+competing_release_runner_is_busy() {
+  local label="$1"
+  local owner=""
+  local repository=""
+  local repository_key=""
+  local runner_name=""
+  local runner_state=""
+
+  repository_key="${label#actions.runner.}"
+  runner_name="${repository_key#*.}"
+  repository_key="${repository_key%%.*}"
+  case "${repository_key}" in
+    *-container-compose)
+      owner="${repository_key%-container-compose}"
+      repository="container-compose"
+      ;;
+    *-devcontainer)
+      owner="${repository_key%-devcontainer}"
+      repository="devcontainer"
+      ;;
+    *)
+      printf 'cannot resolve competing release runner registration from launch-agent label: %s\n' \
+        "${label}" >&2
+      return 2
+      ;;
+  esac
+  if [[ -z "${owner}" || -z "${runner_name}" ||
+    ! "${owner}" =~ ^[A-Za-z0-9._-]+$ ||
+    ! "${runner_name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    printf 'cannot resolve competing release runner identity from launch-agent label: %s\n' \
+      "${label}" >&2
+    return 2
+  fi
+
+  runner_state="$(github_cli api \
+    "repos/${owner}/${repository}/actions/runners?per_page=100" \
+    --jq "[.runners[] | select(.name == \"${runner_name}\")] | if length == 1 then .[0].busy elif length == 0 then \"missing\" else \"ambiguous\" end" \
+    2>/dev/null || true)"
+  case "${runner_state}" in
+    true)
+      return 0
+      ;;
+    false)
+      return 1
+      ;;
+    *)
+      printf 'cannot safely establish idle state for competing release runner %s: %s\n' \
+        "${label}" "${runner_state:-query failed}" >&2
+      return 2
+      ;;
+  esac
+}
+
+# Return success only when the exact Actions runner registration is online.
+# A loaded launchd job is not sufficient recovery evidence: a crash-looping or
+# disconnected listener can remain registered locally while being unusable.
+competing_release_runner_is_online() {
+  local label="$1"
+  local deadline="${2:-}"
+  local owner=""
+  local query_status=0
+  local repository=""
+  local repository_key=""
+  local runner_name=""
+  local runner_state=""
+
+  repository_key="${label#actions.runner.}"
+  runner_name="${repository_key#*.}"
+  repository_key="${repository_key%%.*}"
+  case "${repository_key}" in
+    *-container-compose)
+      owner="${repository_key%-container-compose}"
+      repository="container-compose"
+      ;;
+    *-devcontainer)
+      owner="${repository_key%-devcontainer}"
+      repository="devcontainer"
+      ;;
+    *)
+      printf 'cannot resolve release runner registration from launch-agent label: %s\n' \
+        "${label}" >&2
+      return 2
+      ;;
+  esac
+  if [[ -z "${owner}" || -z "${runner_name}" ||
+    ! "${owner}" =~ ^[A-Za-z0-9._-]+$ ||
+    ! "${runner_name}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    printf 'cannot resolve release runner identity from launch-agent label: %s\n' \
+      "${label}" >&2
+    return 2
+  fi
+
+  if [[ -n "${deadline}" ]]; then
+    if [[ -z "${RELEASE_GITHUB_CLI}" || ! -x "${RELEASE_GITHUB_CLI}" ]]; then
+      printf 'release GitHub CLI is not executable: %s\n' \
+        "${RELEASE_GITHUB_CLI:-missing}" >&2
+      return 2
+    fi
+    runner_state="$(release_command_with_restore_deadline "${deadline}" \
+      "${RELEASE_GITHUB_CLI}" api \
+      "repos/${owner}/${repository}/actions/runners?per_page=100" \
+      --jq "[.runners[] | select(.name == \"${runner_name}\")] | if length == 1 then .[0].status elif length == 0 then \"missing\" else \"ambiguous\" end" \
+      2>/dev/null)" || query_status=$?
+  else
+    runner_state="$(github_cli api \
+      "repos/${owner}/${repository}/actions/runners?per_page=100" \
+      --jq "[.runners[] | select(.name == \"${runner_name}\")] | if length == 1 then .[0].status elif length == 0 then \"missing\" else \"ambiguous\" end" \
+      2>/dev/null)" || query_status=$?
+  fi
+  if ((query_status != 0)); then
+    runner_state=""
+  fi
+  case "${runner_state}" in
+    online)
+      return 0
+      ;;
+    offline)
+      return 1
+      ;;
+    *)
+      printf 'cannot safely establish online state for restored release runner %s: %s\n' \
+        "${label}" "${runner_state:-query failed}" >&2
+      return 2
+      ;;
+  esac
+}
+
+# Print the process group that launchd owns for one runner service. Keeping the
+# complete group together lets the gate suspend the listener and any
+# just-spawned worker across the second activity observation.
+release_runner_service_process_group() {
+  local label="$1"
+  local launch_state=""
+  local pid=""
+  local process_group=""
+  local process_uid=""
+
+  if [[ ! -x "${RELEASE_PS}" || ! -x "${RELEASE_KILL}" ]]; then
+    printf 'release runner process tools are not executable: %s %s\n' \
+      "${RELEASE_PS}" "${RELEASE_KILL}" >&2
+    return 2
+  fi
+  launch_state="$("${RELEASE_LAUNCHCTL}" print "gui/$(id -u)/${label}" \
+    2>/dev/null || true)"
+  pid="$(awk '$1 == "pid" && $2 == "=" { print $3; exit }' \
+    <<<"${launch_state}")"
+  if ! [[ "${pid}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'cannot resolve launchd process for competing release runner: %s\n' \
+      "${label}" >&2
+    return 2
+  fi
+  process_uid="$("${RELEASE_PS}" -o uid= -p "${pid}" \
+    | awk '{$1=$1; print; exit}')"
+  process_group="$("${RELEASE_PS}" -o pgid= -p "${pid}" \
+    | awk '{$1=$1; print; exit}')"
+  if [[ "${process_uid}" != "$(id -u)" ||
+    ! "${process_group}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'cannot safely own competing release runner process group: %s pid=%s uid=%s pgid=%s\n' \
+      "${label}" "${pid}" "${process_uid:-missing}" \
+      "${process_group:-missing}" >&2
+    return 2
+  fi
+  printf '%s\n' "${process_group}"
+}
+
+# Return success when a Runner.Worker exists in the selected service process
+# group. This closes the local observation side of an assignment racing the
+# remote busy-state query.
+release_runner_process_group_has_worker() {
+  local process_group="$1"
+  local process_snapshot=""
+
+  if ! process_snapshot="$("${RELEASE_PS}" -axo pgid=,command=)"; then
+    printf 'cannot inspect competing release runner process group: %s\n' \
+      "${process_group}" >&2
+    return 2
+  fi
+  awk -v expected="${process_group}" '
+    $1 == expected && $2 ~ /\/bin\/Runner[.]Worker$/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' <<<"${process_snapshot}"
+}
+
+# Require every visible member of the selected runner process group to have
+# entered a stopped state. Sending SIGSTOP is asynchronous across CPUs; the
+# second remote/local activity observations are atomic only after this proof.
+# Return one while any member is still running and two when the snapshot is
+# unavailable or the process group has disappeared.
+release_runner_process_group_is_stopped() {
+  local process_group="$1"
+  local process_snapshot=""
+
+  if ! process_snapshot="$("${RELEASE_PS}" -axo pgid=,state=,command=)"; then
+    printf 'cannot inspect stopped competing release runner process group: %s\n' \
+      "${process_group}" >&2
+    return 2
+  fi
+  awk -v expected="${process_group}" '
+    $1 == expected {
+      found = 1
+      if ($2 !~ /^T/) running = 1
+    }
+    END {
+      if (!found) exit 2
+      exit(running ? 1 : 0)
+    }
+  ' <<<"${process_snapshot}"
+}
+
+# Print the whole seconds remaining before one restoration deadline. Each
+# external readiness probe is separately supervised with this remaining wall
+# clock so a stalled CLI cannot strand quiesced workers behind the runtime
+# lock. Return one after the deadline has elapsed.
+release_restore_remaining_seconds() {
+  local deadline="$1"
+  local remaining=$((deadline - SECONDS))
+
+  if ((remaining <= 0)); then
+    return 1
+  fi
+  printf '%s\n' "${remaining}"
+}
+
+# Run one external restoration probe under the process-group deadline helper.
+# Its detached cleanup also remains immune to repeated parent termination.
+release_command_with_restore_deadline() {
+  local deadline="$1"
+  local remaining=""
+  shift
+
+  remaining="$(release_restore_remaining_seconds "${deadline}")" || return 124
+  "${RELEASE_COMMAND_DEADLINE_RUNNER}" \
+    --seconds "${remaining}" --grace-seconds 0 --ignore-parent-signals -- "$@"
+}
+
+# Print one launch-agent row from a separately successful launchd snapshot.
+# Return one only when that successful snapshot proves absence, and two when
+# launchd state itself could not be inspected.
+release_launch_agent_snapshot_line() {
+  local label="$1"
+  local deadline="${2:-}"
+  local services=""
+  local service_line=""
+
+  if [[ -n "${deadline}" ]]; then
+    if ! services="$(release_command_with_restore_deadline "${deadline}" \
+      "${RELEASE_LAUNCHCTL}" list)"; then
+      printf 'cannot inspect release launch-agent state: %s\n' "${label}" >&2
+      return 2
+    fi
+  elif ! services="$("${RELEASE_LAUNCHCTL}" list)"; then
+    printf 'cannot inspect release launch-agent state: %s\n' "${label}" >&2
+    return 2
+  fi
+  service_line="$(awk -v expected="${label}" '$3 == expected { print; exit }' \
+    <<<"${services}")"
+  if [[ -z "${service_line}" ]]; then
+    return 1
+  fi
+  printf '%s\n' "${service_line}"
+}
+
+# Return success when a separately successful snapshot contains the service.
+release_launch_agent_is_loaded() {
+  release_launch_agent_snapshot_line "$1" "${2:-}" >/dev/null
+}
+
+# Require a live process from a successful launchd snapshot.
+release_launch_agent_has_live_process() {
+  local label="$1"
+  local deadline="${2:-}"
+  local service_line=""
+  local service_status=0
+  local service_pid=""
+
+  service_line="$(release_launch_agent_snapshot_line "${label}" "${deadline}")" || \
+    service_status=$?
+  if ((service_status != 0)); then
+    return "${service_status}"
+  fi
+  service_pid="$(awk '{ print $1; exit }' <<<"${service_line}")"
+  if ! [[ "${service_pid}" =~ ^[1-9][0-9]*$ ]]; then
+    return 1
+  fi
+  return 0
+}
+
+# Verify that the restored devcontainer engine serves its public Docker API.
+# The CLI owns configuration resolution and returns the exact endpoint without
+# requiring this release helper to parse user configuration or evaluate shell.
+release_devcontainer_engine_is_ready() {
+  local deadline="${1:-$((SECONDS + RELEASE_RESTORE_TIMEOUT_SECONDS))}"
+  local endpoint=""
+  local probe_status=0
+  local remaining=""
+  local response=""
+  local response_body=""
+  local response_status=""
+  local socket_path=""
+
+  if [[ -z "${RELEASE_DEVCONTAINER_CLI}" ||
+    ! -x "${RELEASE_DEVCONTAINER_CLI}" || ! -x "${RELEASE_CURL}" ]]; then
+    printf 'devcontainer readiness tools are not executable: %s %s\n' \
+      "${RELEASE_DEVCONTAINER_CLI:-missing}" "${RELEASE_CURL}" >&2
+    return 2
+  fi
+  endpoint="$(release_command_with_restore_deadline "${deadline}" \
+    "${RELEASE_DEVCONTAINER_CLI}" context --format value \
+    2>/dev/null)" || probe_status=$?
+  if ((probe_status != 0)); then
+    printf 'cannot resolve restored devcontainer endpoint\n' >&2
+    return 2
+  fi
+  socket_path="${endpoint#unix://}"
+  if [[ "${socket_path}" == "${endpoint}" || "${socket_path}" != /* ||
+    "${socket_path}" == *$'\n'* ]]; then
+    printf 'invalid restored devcontainer Unix endpoint: %s\n' \
+      "${endpoint}" >&2
+    return 2
+  fi
+  remaining="$(release_restore_remaining_seconds "${deadline}")" || return 2
+  probe_status=0
+  response="$(release_command_with_restore_deadline "${deadline}" \
+    "${RELEASE_CURL}" --unix-socket "${socket_path}" \
+    --max-time "${remaining}" --silent --show-error \
+    --write-out $'\n%{http_code}' http://localhost/_ping \
+    2>/dev/null)" || probe_status=$?
+  if ((probe_status == 124 || probe_status == 125)); then
+    return 2
+  fi
+  if ((probe_status != 0)); then
+    return 1
+  fi
+  response_status="${response##*$'\n'}"
+  response_body="${response%$'\n'*}"
+  [[ "${response_status}" == "200" && "${response_body}" == "OK" ]]
+}
+
+# Require a live launchd process and, for Actions services, an online exact
+# runner registration before restoration authority can be discarded.
+release_launch_agent_is_healthy() {
+  local label="$1"
+  local deadline="${2:-}"
+  local process_status=0
+
+  release_launch_agent_has_live_process "${label}" "${deadline}" || \
+    process_status=$?
+  if ((process_status != 0)); then
+    return "${process_status}"
+  fi
+  case "${label}" in
+    actions.runner.*)
+      competing_release_runner_is_online "${label}" "${deadline}"
+      ;;
+    homebrew.mxcl.devcontainer)
+      release_devcontainer_engine_is_ready "${deadline}"
+      ;;
+    *)
+      return 0
+      ;;
+  esac
+}
+
+# Resume runner groups recorded before SIGSTOP. A signal or failed activity
+# recheck must never strand an otherwise healthy listener in the stopped state.
+resume_suspended_release_runner_groups() {
+  local index=""
+  local process_group=""
+  local resume_status=0
+  local -a failed_groups=()
+
+  for ((index = ${#RELEASE_SUSPENDED_RUNNER_PGIDS[@]} - 1; index >= 0; index--)); do
+    process_group="${RELEASE_SUSPENDED_RUNNER_PGIDS[index]}"
+    if ! "${RELEASE_KILL}" -CONT "-${process_group}" 2>/dev/null; then
+      if "${RELEASE_KILL}" -0 "-${process_group}" 2>/dev/null; then
+        printf 'failed to resume competing release runner process group: %s\n' \
+          "${process_group}" >&2
+        failed_groups+=("${process_group}")
+        resume_status=1
+      fi
+    fi
+  done
+  RELEASE_SUSPENDED_RUNNER_PGIDS=("${failed_groups[@]}")
+  return "${resume_status}"
+}
+
+# Atomically drain an idle runner before launchctl removal. The first query
+# avoids suspending known active work. SIGSTOP then prevents the listener from
+# accepting a new assignment while both GitHub state and the local process
+# group are checked again. Return three for observed activity and two for an
+# indeterminate state.
+prepare_competing_release_runner_for_bootout() {
+  local attempt=0
+  local label="$1"
+  local process_group=""
+  local runner_status=0
+  local stopped_status=1
+  local worker_status=0
+
+  competing_release_runner_is_busy "${label}" || runner_status=$?
+  case "${runner_status}" in
+    0)
+      return 3
+      ;;
+    1)
+      ;;
+    *)
+      return 2
+      ;;
+  esac
+
+  process_group="$(release_runner_service_process_group "${label}")" || return 2
+  RELEASE_SUSPENDED_RUNNER_PGIDS+=("${process_group}")
+  if ! "${RELEASE_KILL}" -STOP "-${process_group}"; then
+    printf 'failed to suspend competing release runner process group: %s\n' \
+      "${process_group}" >&2
+    resume_suspended_release_runner_groups || true
+    return 2
+  fi
+
+  for ((attempt = 1; attempt <= RELEASE_QUIESCE_WAIT_ATTEMPTS; attempt++)); do
+    stopped_status=0
+    release_runner_process_group_is_stopped "${process_group}" || \
+      stopped_status=$?
+    if ((stopped_status == 0)); then
+      break
+    fi
+    if ((stopped_status == 2)); then
+      break
+    fi
+    if ((attempt < RELEASE_QUIESCE_WAIT_ATTEMPTS)); then
+      sleep "${RELEASE_QUIESCE_POLL_SECONDS}"
+    fi
+  done
+  if ((stopped_status != 0)); then
+    printf 'competing release runner process group did not stop: %s\n' \
+      "${process_group}" >&2
+    resume_suspended_release_runner_groups || true
+    return 2
+  fi
+
+  runner_status=0
+  competing_release_runner_is_busy "${label}" || runner_status=$?
+  worker_status=0
+  release_runner_process_group_has_worker "${process_group}" || worker_status=$?
+  if ((runner_status == 0 || worker_status == 0)); then
+    resume_suspended_release_runner_groups || true
+    return 3
+  fi
+  if ((runner_status != 1 || worker_status != 1)); then
+    resume_suspended_release_runner_groups || true
+    return 2
+  fi
+  return 0
+}
+
+# Restore only the launch agents this release invocation successfully stopped.
+restore_quiesced_release_launch_agents() {
+  local attempt=0
+  local deadline=0
+  local index=""
+  local label=""
+  local plist=""
+  local restore_status=0
+  local health_status=0
+  local loaded_status=0
+  local process_status=0
+  local restore_action_started=0
+  local restored=0
+  local restarted_unready_service=0
+  local sleep_seconds=0
+  local unready_live_attempts=0
+  local user_domain=""
+  local -a failed_action_started=()
+  local -a failed_deadlines=()
+  local -a failed_labels=()
+  local -a failed_plists=()
+  local -a failed_restarted_unready=()
+  user_domain="gui/$(id -u)"
+
+  if ! resume_suspended_release_runner_groups; then
+    restore_status=1
+  fi
+
+  for ((index = ${#RELEASE_QUIESCED_LABELS[@]} - 1; index >= 0; index--)); do
+    label="${RELEASE_QUIESCED_LABELS[index]}"
+    plist="${RELEASE_QUIESCED_PLISTS[index]}"
+    deadline="${RELEASE_QUIESCED_DEADLINES[index]:-}"
+    if ! [[ "${deadline}" =~ ^[1-9][0-9]*$ ]]; then
+      deadline=$((SECONDS + RELEASE_RESTORE_TIMEOUT_SECONDS))
+      RELEASE_QUIESCED_DEADLINES[index]="${deadline}"
+    fi
+    restore_action_started="${RELEASE_QUIESCED_ACTION_STARTED[index]:-0}"
+    if [[ "${restore_action_started}" != 0 && \
+      "${restore_action_started}" != 1 ]]; then
+      restore_action_started=0
+    fi
+    restored=0
+    restarted_unready_service="${RELEASE_QUIESCED_RESTARTED_UNREADY[index]:-0}"
+    if [[ "${restarted_unready_service}" != 0 && \
+      "${restarted_unready_service}" != 1 ]]; then
+      restarted_unready_service=0
+    fi
+    unready_live_attempts=0
+    for ((attempt = 1; attempt <= RELEASE_RESTORE_WAIT_ATTEMPTS; attempt++)); do
+      health_status=0
+      release_launch_agent_is_healthy "${label}" "${deadline}" || \
+        health_status=$?
+      if ((health_status == 0)); then
+        restored=1
+        break
+      fi
+      if ((health_status == 1)); then
+        process_status=0
+        release_launch_agent_has_live_process "${label}" "${deadline}" || \
+          process_status=$?
+        if ((process_status == 1 && restore_action_started == 0)); then
+          loaded_status=0
+          release_launch_agent_is_loaded "${label}" "${deadline}" || \
+            loaded_status=$?
+          case "${loaded_status}" in
+            0)
+              restore_action_started=1
+              RELEASE_QUIESCED_ACTION_STARTED[index]=1
+              release_command_with_restore_deadline "${deadline}" \
+                "${RELEASE_LAUNCHCTL}" kickstart -k \
+                "${user_domain}/${label}" >/dev/null 2>&1 || true
+              ;;
+            1)
+              restore_action_started=1
+              RELEASE_QUIESCED_ACTION_STARTED[index]=1
+              release_command_with_restore_deadline "${deadline}" \
+                "${RELEASE_LAUNCHCTL}" bootstrap "${user_domain}" "${plist}" \
+                >/dev/null 2>&1 || true
+              ;;
+            *)
+              ;;
+          esac
+        elif ((process_status == 0)); then
+          ((unready_live_attempts += 1))
+          if ((unready_live_attempts >= RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS &&
+            restarted_unready_service == 0)); then
+            restore_action_started=1
+            restarted_unready_service=1
+            RELEASE_QUIESCED_ACTION_STARTED[index]=1
+            RELEASE_QUIESCED_RESTARTED_UNREADY[index]=1
+            release_command_with_restore_deadline "${deadline}" \
+              "${RELEASE_LAUNCHCTL}" kickstart -k "${user_domain}/${label}" \
+              >/dev/null 2>&1 || true
+          fi
+        fi
+      fi
+      if ((attempt < RELEASE_RESTORE_WAIT_ATTEMPTS)); then
+        sleep_seconds="$(release_restore_remaining_seconds "${deadline}")" || \
+          break
+        if ((sleep_seconds > RELEASE_RESTORE_POLL_SECONDS)); then
+          sleep_seconds="${RELEASE_RESTORE_POLL_SECONDS}"
+        fi
+        sleep "${sleep_seconds}"
+      fi
+    done
+    if ((restored == 0)); then
+      printf 'failed to restore release launch agent %s from %s\n' \
+        "${label}" "${plist}" >&2
+      failed_labels+=("${label}")
+      failed_plists+=("${plist}")
+      failed_action_started+=("${restore_action_started}")
+      failed_deadlines+=("${deadline}")
+      failed_restarted_unready+=("${restarted_unready_service}")
+      restore_status=1
+    fi
+  done
+
+  RELEASE_QUIESCED_LABELS=("${failed_labels[@]}")
+  RELEASE_QUIESCED_PLISTS=("${failed_plists[@]}")
+  RELEASE_QUIESCED_ACTION_STARTED=("${failed_action_started[@]}")
+  RELEASE_QUIESCED_DEADLINES=("${failed_deadlines[@]}")
+  RELEASE_QUIESCED_RESTARTED_UNREADY=("${failed_restarted_unready[@]}")
+  return "${restore_status}"
+}
+
+# Restore the workers before releasing the host-wide runtime lock. A waiting
+# release gate must acquire the lock first and then quiesce the freshly restored
+# set for its own complete validation window.
+release_local_release_gate_host_state() {
+  # Cleanup owns the recovery authority and host-wide lock. Follow-up signals
+  # must not interrupt restoration and strand workers after that lock closes.
+  trap '' HUP INT QUIT TERM
+  if ! restore_quiesced_release_launch_agents; then
+    # Keep the lock while the EXIT trap retains restoration authority. A
+    # waiting gate must not enter its validation window between a failed
+    # explicit restore and the trap's final retry.
+    return 1
+  fi
+  release_container_runtime_lock
+}
+
+# Stop cooperating Container-family workers before an authoritative runtime or
+# parity gate. A hosted job retains only its own runner listener. The original
+# loaded set is restored by the caller's EXIT path even when validation fails.
+quiesce_local_release_workers() {
+  local attempt=0
+  local label=""
+  local listed_labels=""
+  local plist=""
+  local runner_status=0
+  local loaded_status=0
+  local user_domain=""
+  local -a labels=()
+  user_domain="gui/$(id -u)"
+
+  if ! [[ "${RELEASE_QUIESCE_WAIT_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'release quiescence wait attempts must be a positive integer: %s\n' \
+      "${RELEASE_QUIESCE_WAIT_ATTEMPTS}" >&2
+    return 2
+  fi
+  if ! [[ "${RELEASE_QUIESCE_POLL_SECONDS}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    printf 'release quiescence poll seconds must be non-negative: %s\n' \
+      "${RELEASE_QUIESCE_POLL_SECONDS}" >&2
+    return 2
+  fi
+  if ! [[ "${RELEASE_RESTORE_WAIT_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'release restoration wait attempts must be a positive integer: %s\n' \
+      "${RELEASE_RESTORE_WAIT_ATTEMPTS}" >&2
+    return 2
+  fi
+  if ! [[ "${RELEASE_RESTORE_TIMEOUT_SECONDS}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'release restoration timeout seconds must be a positive integer: %s\n' \
+      "${RELEASE_RESTORE_TIMEOUT_SECONDS}" >&2
+    return 2
+  fi
+  if ! [[ "${RELEASE_RESTORE_POLL_SECONDS}" =~ ^[0-9]+$ ]]; then
+    printf 'release restoration poll seconds must be a non-negative integer: %s\n' \
+      "${RELEASE_RESTORE_POLL_SECONDS}" >&2
+    return 2
+  fi
+  if ! [[ "${RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS}" =~ ^[1-9][0-9]*$ ]] ||
+    ((RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS > RELEASE_RESTORE_WAIT_ATTEMPTS)); then
+    printf 'release restoration restart grace must be a positive integer no greater than the wait attempts: %s\n' \
+      "${RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS}" >&2
+    return 2
+  fi
+  if ! listed_labels="$(list_competing_release_launch_agents)"; then
+    return 1
+  fi
+  while IFS= read -r label; do
+    [[ -n "${label}" ]] && labels+=("${label}")
+  done <<<"${listed_labels}"
+
+  for label in "${labels[@]}"; do
+    if ! [[ "${label}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+      printf 'refusing unsafe release launch-agent label: %s\n' "${label}" >&2
+      restore_quiesced_release_launch_agents || true
+      return 1
+    fi
+    plist="${HOME}/Library/LaunchAgents/${label}.plist"
+    if [[ ! -f "${plist}" || -L "${plist}" || ! -O "${plist}" ]]; then
+      printf 'cannot recoverably quiesce %s; launch-agent plist is not a user-owned regular file: %s\n' \
+        "${label}" "${plist}" >&2
+      restore_quiesced_release_launch_agents || true
+      return 1
+    fi
+    case "${label}" in
+      actions.runner.*)
+        runner_status=0
+        prepare_competing_release_runner_for_bootout "${label}" || runner_status=$?
+        case "${runner_status}" in
+          0)
+            ;;
+          3)
+            printf 'refusing to interrupt active competing release runner: %s\n' \
+              "${label}" >&2
+            restore_quiesced_release_launch_agents || true
+            return 1
+            ;;
+          *)
+            restore_quiesced_release_launch_agents || true
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+    # Record recovery authority before mutation so an asynchronous exit cannot
+    # strand a successfully booted-out worker in the instruction boundary.
+    RELEASE_QUIESCED_LABELS+=("${label}")
+    RELEASE_QUIESCED_PLISTS+=("${plist}")
+    RELEASE_QUIESCED_ACTION_STARTED+=(0)
+    RELEASE_QUIESCED_DEADLINES+=("")
+    RELEASE_QUIESCED_RESTARTED_UNREADY+=(0)
+    if ! "${RELEASE_LAUNCHCTL}" bootout "${user_domain}/${label}"; then
+      resume_suspended_release_runner_groups || true
+      loaded_status=0
+      release_launch_agent_is_loaded "${label}" || loaded_status=$?
+      if ((loaded_status != 1)); then
+        printf 'failed to quiesce or prove absence of competing release launch agent: %s\n' \
+          "${label}" >&2
+        restore_quiesced_release_launch_agents || true
+        return 1
+      fi
+    fi
+    if ! resume_suspended_release_runner_groups; then
+      restore_quiesced_release_launch_agents || true
+      return 1
+    fi
+  done
+
+  for ((attempt = 1; attempt <= RELEASE_QUIESCE_WAIT_ATTEMPTS; attempt++)); do
+    local workers_stopped=1
+    for label in "${RELEASE_QUIESCED_LABELS[@]}"; do
+      loaded_status=0
+      release_launch_agent_is_loaded "${label}" || loaded_status=$?
+      case "${loaded_status}" in
+        0)
+          workers_stopped=0
+          break
+          ;;
+        1)
+          ;;
+        *)
+          printf 'cannot safely verify release worker quiescence: %s\n' \
+            "${label}" >&2
+          restore_quiesced_release_launch_agents || true
+          return 1
+          ;;
+      esac
+    done
+    if ((workers_stopped)); then
+      if ((${#RELEASE_QUIESCED_LABELS[@]})); then
+        printf 'quiesced competing release workers: %s\n' \
+          "${RELEASE_QUIESCED_LABELS[*]}"
+      fi
+      return 0
+    fi
+    if ((attempt < RELEASE_QUIESCE_WAIT_ATTEMPTS)); then
+      sleep "${RELEASE_QUIESCE_POLL_SECONDS}"
+    fi
+  done
+
+  printf '%s\n' \
+    'competing Container-family workers did not quiesce' >&2
+  restore_quiesced_release_launch_agents || true
+  return 1
+}
+
 # Resolve retained evidence before it is also used as an absolute build/log
 # scratch root. Relative values are Compose-checkout-relative, matching the
 # documented .build/... form, and symlinks cannot smuggle the root directory
@@ -1004,6 +1846,12 @@ run_local_release_gate() {
   (
   local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive
   local containerization_reference required_init_references status runtime_run_id runtime_service_namespace runtime_namespace_digest
+  local -a RELEASE_QUIESCED_LABELS=()
+  local -a RELEASE_QUIESCED_PLISTS=()
+  local -a RELEASE_QUIESCED_ACTION_STARTED=()
+  local -a RELEASE_QUIESCED_DEADLINES=()
+  local -a RELEASE_QUIESCED_RESTARTED_UNREADY=()
+  local -a RELEASE_SUSPENDED_RUNNER_PGIDS=()
   path="$(repo_path "${COMPOSE_REPO}")"
   container_path="$(repo_path "${CONTAINER_REPO}")"
   containerization_path="$(repo_path "containerization")"
@@ -1014,6 +1862,14 @@ run_local_release_gate() {
 
   print_header "run local release gate"
   require_local_virtualization
+  if [[ "${EXECUTE}" == "1" ]]; then
+    trap release_local_release_gate_host_state EXIT
+    acquire_container_runtime_lock
+    quiesce_local_release_workers
+  else
+    printf '%s\n' \
+      'would quiesce and restore competing Container-family release workers'
+  fi
   for repository in "${path}" \
     "$(repo_path "container-builder-shim")" \
     "$(repo_path "containerization")" \
@@ -1066,12 +1922,20 @@ PY
   # shellcheck disable=SC2329
   cleanup_local_release_gate_roots() {
     local trapped_status=$?
+    # This EXIT handler owns candidate cleanup, worker restoration, and the
+    # host lock. Follow-up signals must not split that recovery sequence before
+    # worker restoration begins.
+    trap '' HUP INT QUIT TERM
+    local cleanup_status="${trapped_status}"
     if ! cleanup_local_release_gate_resources "${container_binary:-}" \
       "${runtime_parent:-}" "${runtime_app_root:-}" \
       "${runtime_service_namespace:-}"; then
-      return 1
+      cleanup_status=1
     fi
-    return "${trapped_status}"
+    if ! release_local_release_gate_host_state; then
+      cleanup_status=1
+    fi
+    return "${cleanup_status}"
   }
   trap cleanup_local_release_gate_roots EXIT
   container_binary="${CONTAINER_RUNTIME_CANDIDATE_ROOT}/bin/container"
@@ -1136,7 +2000,11 @@ PY
   runtime_app_root=""
   runtime_service_namespace=""
   CONTAINER_RUNTIME_CANDIDATE_ROOT=""
-  trap - EXIT
+  if release_local_release_gate_host_state; then
+    trap - EXIT
+  else
+    status=1
+  fi
   return "${status}"
   )
 }


### PR DESCRIPTION
## Summary

- stop and later restore cooperating Compose/devcontainer launch agents around the local stable release gate
- preserve the runner that owns a hosted release job
- atomically drain an idle competing runner before removing its launch agent
- refuse to interrupt a competing runner that is already executing a job
- fail closed when worker activity, stop state, or launch-agent recovery cannot be established
- retain the host-wide runtime lock through every restoration retry

## Evidence

- focused release and runtime-lock tests: 23 passed
- live production-path proof acquired the runtime lock, suspended/rechecked/unloaded all three cooperating agents, verified absence, then restored both runners healthy and online plus the devcontainer public `/_ping` socket
- live GitHub activity queries resolve both installed runner registrations as idle
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- Docker 29.2.1 remained available through Colima
- exact signed head: `360ab817762835ab86609cfa4fd9591d76b025cb`

The [issue handoff](https://github.com/stephenlclarke/container-compose/blob/360ab817762835ab86609cfa4fd9591d76b025cb/docs/upstream/container-compose/ISSUE-278.md) and [PR handoff](https://github.com/stephenlclarke/container-compose/blob/360ab817762835ab86609cfa4fd9591d76b025cb/docs/upstream/container-compose/PR-278-release-runtime-candidate.md) retain the failed sample and controlled proof.

Part of #278. The strict 10x gate is unchanged; this corrects measurement integrity rather than waiving the failed sample.
