### PR TITLE
fix(release): refresh demo init authority

### DIFF
--- a/.github/workflows/current-demo.yml
+++ b/.github/workflows/current-demo.yml
@@ -191,7 +191,7 @@ jobs:
         env:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 2db57c055840d04574d81a51817c16b5c3880b958c9264a451ef95a99970f8db
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: fe3354c60bf0f1eb509bcee36956fda2ce14bf5d40aa001003567067b55ac82f
         shell: bash
         run: |
           set -euo pipefail
@@ -225,7 +225,7 @@ jobs:
         env:
           DEMO_ASSET: container-compose-demo-current.gif
           DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: 2db57c055840d04574d81a51817c16b5c3880b958c9264a451ef95a99970f8db
+          DEMO_INIT_IMAGE_ARCHIVE_SHA256: fe3354c60bf0f1eb509bcee36956fda2ce14bf5d40aa001003567067b55ac82f
         shell: bash
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- refresh the Current-demo init-image digest to the exact archive for containerization `e5a92e86bf03eb2cc244b3b47b0413b3935abfe4`
- retain the same pinned digest in both authority validation and runtime staging

## Evidence

- failed Current Demo run 33306855686 rejected the stale `59ce…` archive because it did not contain the pinned `e5a92…` reference
- replacement archive SHA-256: `fe3354c60bf0f1eb509bcee36956fda2ce14bf5d40aa001003567067b55ac82f`
- `validate-oci-image-layout.py` accepts the replacement for both `vminit:container-compose` and `ghcr.io/stephenlclarke/containerization/vminit:e5a92e86bf03eb2cc244b3b47b0413b3935abfe4`
- `actionlint .github/workflows/current-demo.yml`
- `git diff --check`

## Scope

This changes no runtime or package source. It restores the optional Current VHS documentation lane before the 0.14.0 stable promotion.
