### PR TITLE
fix(release): pin demo stat implementation

### DIFF
--- a/.github/workflows/current-demo.yml
+++ b/.github/workflows/current-demo.yml
@@ -238,8 +238,8 @@ jobs:
             if [[ ! -d "${demo_session_root}" || -L "${demo_session_root}" ||
                   ! -f "${marker}" || -L "${marker}" ||
                   "$(cat "${marker}")" != "container-compose-current-demo-v1" ||
-                  "$(stat -f %u "${demo_session_root}")" != "$(id -u)" ||
-                  "$(stat -f %Lp "${demo_session_root}")" != "700" ]]; then
+                  "$(/usr/bin/stat -f %u "${demo_session_root}")" != "$(id -u)" ||
+                  "$(/usr/bin/stat -f %Lp "${demo_session_root}")" != "700" ]]; then
               printf 'refusing unsafe stable Current demo root: %s\n' \
                 "${demo_session_root}" >&2
               exit 1

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -702,8 +702,14 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('demo_session_root="/private/tmp/container-compose-current-demo"', workflow)
         self.assertIn(".container-compose-current-demo-root", workflow)
         self.assertIn("container-compose-current-demo-v1", workflow)
-        self.assertIn('"$(stat -f %u "${demo_session_root}")" != "$(id -u)"', workflow)
-        self.assertIn('"$(stat -f %Lp "${demo_session_root}")" != "700"', workflow)
+        self.assertIn(
+            '"$(/usr/bin/stat -f %u "${demo_session_root}")" != "$(id -u)"',
+            workflow,
+        )
+        self.assertIn(
+            '"$(/usr/bin/stat -f %Lp "${demo_session_root}")" != "700"',
+            workflow,
+        )
         self.assertNotIn("/tmp/cc-current-${GITHUB_RUN_ID}", workflow)
         self.assertIn(
             "python3 Tools/ci/run-command-with-deadline.py \\\n"


### PR DESCRIPTION
## Summary

- use macOS `/usr/bin/stat` explicitly for the Current-demo root ownership and mode checks
- avoid Homebrew GNU coreutils changing the semantics of BSD `stat -f`

## Evidence

- Current Demo run 33308099372 passed exact package and init-image authority validation, then failed because PATH resolved `stat` to GNU stat: `cannot read file system information for '%u'`
- `/usr/bin/stat -f %u /private/tmp/container-compose-current-demo` matches the runner UID
- `/usr/bin/stat -f %Lp /private/tmp/container-compose-current-demo` reports the required `700` mode
- focused `test_current_demo_is_recoverable_and_not_release_critical`
- `actionlint .github/workflows/current-demo.yml`
- `git diff --check`

## Scope

This changes only the safety-check tool authority. It does not weaken the ownership/mode checks or change package/runtime source.
