### PR TITLE
fix(release): verify Homebrew-derived stable versions

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -602,6 +602,17 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('if [[ "${RELEASE_TAG}" != "current" ]]', renderer)
         self.assertEqual(renderer.count('"${version_policy_args[@]}"'), 2)
 
+    def test_stable_package_verifier_requires_homebrew_derived_version(self) -> None:
+        verifier = self.script[
+            self.script.index("verify_compose_stable_package() {") : self.script.index(
+                "# Dispatch and verify one stable package workflow mode"
+            )
+        ]
+
+        self.assertIn('if [[ -n "${formula_version}" ]]', verifier)
+        self.assertIn("stable Homebrew formula must derive version", verifier)
+        self.assertNotIn('if [[ "${formula_version}" != "${version}" ]]', verifier)
+
     def test_homebrew_tap_pushes_authenticate_with_the_tap_token(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertEqual(

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -3561,8 +3561,9 @@ verify_compose_stable_package() {
     printf 'Homebrew formula URL mismatch: expected %s, got %s\n' "${expected_url}" "${formula_url}" >&2
     exit 1
   fi
-  if [[ "${formula_version}" != "${version}" ]]; then
-    printf 'Homebrew formula version mismatch: expected %s, got %s\n' "${version}" "${formula_version}" >&2
+  if [[ -n "${formula_version}" ]]; then
+    printf 'stable Homebrew formula must derive version %s from its release URL; found explicit version %s\n' \
+      "${version}" "${formula_version}" >&2
     exit 1
   fi
   if [[ "${formula_sha}" != "${asset_sha}" ]]; then


### PR DESCRIPTION
## Summary
- require stable Homebrew formulae to omit redundant explicit versions
- continue verifying the exact release version through the immutable asset URL
- add a focused release-policy regression

## Validation
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- 9 focused release formula/verifier tests