### PR TITLE
fix(parity): enforce release timing boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ SWIFT_RUNTIME_TEST_FILTER ?= ComposeRuntimeTests
 DEFAULT_COMPOSE_TEST_BINARY := $(abspath .build/debug/compose)
 COMPOSE_TEST_BINARY ?= $(DEFAULT_COMPOSE_TEST_BINARY)
 RELEASE_PARITY_COMPOSE_BINARY := $(abspath .build/release/compose)
+RELEASE_PARITY_BUILD_INFO := $(abspath .build/release-parity-build-info.json)
 CONTAINER_STACK_REPO ?= $(abspath ../container)
 CONTAINERIZATION_STACK_REPO ?= $(abspath ../containerization)
 CONTAINER_ENGINE_API_STACK_REPO ?= $(abspath ../container-engine-api)
@@ -455,7 +456,6 @@ RELEASE_GATE_PARITY_INPUT_FINGERPRINT = $(shell { printf '%s\n' \
 	'repetitions=$(PARITY_REPETITIONS)' \
 	'timeout=$(PARITY_TIMEOUT_SECONDS)' \
 	'timing-max-ratio=$(PARITY_TIMING_MAX_RATIO)' \
-	'timing-min-delta-seconds=$(PARITY_TIMING_MIN_DELTA_SECONDS)' \
 	'timing-policy=$(PARITY_TIMING_POLICY)' \
 	'comparable-noise-pct=$(PARITY_COMPARABLE_NOISE_PCT)' \
 	'include-remote-logging=$(PARITY_INCLUDE_REMOTE_LOGGING)' \
@@ -1122,6 +1122,22 @@ build-release:
 	else \
 		$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) -c release --product compose $(SWIFT_RELEASE_FLAGS); \
 	fi
+
+.PHONY: release-parity-build-info
+release-parity-build-info:
+	$(PYTHON) Tools/release/write-build-info.py \
+		--output "$(RELEASE_PARITY_BUILD_INFO)" \
+		--version "$(COMPOSE_VERSION)" \
+		--source "$(CONTAINER_COMPOSE_SOURCE)" \
+		--branch "$(CONTAINER_COMPOSE_BRANCH)" \
+		--lane "$(CONTAINER_COMPOSE_LANE)" \
+		--commit "$(CONTAINER_COMPOSE_COMMIT)" \
+		--build-type release \
+		--container-source "$(CONTAINER_SOURCE)" \
+		--container-ref "$(PARITY_CONTAINER_REF)" \
+		--containerization-source "$(CONTAINERIZATION_SOURCE)" \
+		--containerization-ref "$(PARITY_CONTAINERIZATION_REF)" \
+		--compose-go-version "$(COMPOSE_GO_VERSION)"
 
 run:
 	$(SWIFT) run $(SWIFT_RESOLVED_FLAGS) compose version
@@ -2257,7 +2273,7 @@ docker-compose-reference:
 docker-compose-e2e-fixtures:
 	DOCKER_COMPOSE_E2E_REF="$(DOCKER_COMPOSE_E2E_REF)" ./Tools/parity/sync-docker-compose-e2e-fixtures.sh --strict
 
-docker-compose-parity: build-release container-stack-build-if-needed docker-compose-reference
+docker-compose-parity: build-release release-parity-build-info container-stack-build-if-needed docker-compose-reference
 	container_binary="$(CONTAINER_COMPOSE_CONTAINER)"; \
 	if [[ "$$container_binary" == "container" ]]; then \
 		for candidate in "$(LOCAL_CONTAINER_BINARY)" "$(LOCAL_CONTAINER_PACKAGE_BINARY)"; do \
@@ -2265,6 +2281,7 @@ docker-compose-parity: build-release container-stack-build-if-needed docker-comp
 		done; \
 	fi; \
 	CONTAINER_COMPOSE="$(RELEASE_PARITY_COMPOSE_BINARY)" \
+	CONTAINER_COMPOSE_BUILD_INFO="$(RELEASE_PARITY_BUILD_INFO)" \
 	CONTAINER_RUNTIME_APP_ROOT="$(CONTAINER_RUNTIME_APP_ROOT)" \
 		CONTAINER_RUNTIME_INIT_BLOCK_REPO="$(CONTAINER_RUNTIME_INIT_BLOCK_REPO)" \
 		CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" \

--- a/Tools/ci/test_build_release_local_stack.py
+++ b/Tools/ci/test_build_release_local_stack.py
@@ -107,13 +107,27 @@ class BuildReleaseLocalStackTests(unittest.TestCase):
 
         self.assertTrue(
             parity.startswith(
-                "docker-compose-parity: build-release "
+                "docker-compose-parity: build-release release-parity-build-info "
                 "container-stack-build-if-needed docker-compose-reference"
             ),
             parity,
         )
         self.assertIn(
             'CONTAINER_COMPOSE="$(RELEASE_PARITY_COMPOSE_BINARY)"', parity
+        )
+        self.assertIn(
+            'CONTAINER_COMPOSE_BUILD_INFO="$(RELEASE_PARITY_BUILD_INFO)"', parity
+        )
+
+        build_info = makefile[
+            makefile.index("release-parity-build-info:") : makefile.index(
+                "\nrun:", makefile.index("release-parity-build-info:")
+            )
+        ]
+        self.assertIn('--commit "$(CONTAINER_COMPOSE_COMMIT)"', build_info)
+        self.assertIn('--container-ref "$(PARITY_CONTAINER_REF)"', build_info)
+        self.assertIn(
+            '--containerization-ref "$(PARITY_CONTAINERIZATION_REF)"', build_info
         )
 
 

--- a/Tools/parity/check-compose-cp-stdio-archive-streams.sh
+++ b/Tools/parity/check-compose-cp-stdio-archive-streams.sh
@@ -39,9 +39,6 @@
 #                      Per-copy hang timeout. Defaults to 120 seconds.
 #   PARITY_TIMING_MAX_RATIO
 #                      Material slowdown ratio. Defaults to 10.
-#   PARITY_TIMING_MIN_DELTA_SECONDS
-#                      Minimum absolute slowdown before ratio enforcement.
-#                      Defaults to 5 seconds.
 #
 # This script is intentionally local-only and is not part of CI. It verifies
 # Docker Compose V2 and container-compose `cp -` archive stream behavior for
@@ -63,7 +60,6 @@ TAR_BINARY="${TAR:-tar}"
 PARITY_TIMING_OUTPUT="${PARITY_TIMING_OUTPUT:-}"
 PARITY_TIMEOUT_SECONDS="${PARITY_TIMEOUT_SECONDS:-120}"
 PARITY_TIMING_MAX_RATIO="${PARITY_TIMING_MAX_RATIO:-10}"
-PARITY_TIMING_MIN_DELTA_SECONDS="${PARITY_TIMING_MIN_DELTA_SECONDS:-5}"
 DOCKER_COMPOSE_COMMAND=()
 FIXTURE_DIR=""
 LONG_ARCHIVE_PATH=""
@@ -258,13 +254,16 @@ print(f"{sys.argv[1]}\t{sys.argv[2]}\t{(int(sys.argv[4]) - int(sys.argv[3])) / 1
 }
 
 report_timing_metrics() {
-    python3 - "$TIMING_FILE" "$PARITY_TIMING_MAX_RATIO" "$PARITY_TIMING_MIN_DELTA_SECONDS" <<'PY'
+    python3 - "$TIMING_FILE" "$PARITY_TIMING_MAX_RATIO" "$REPO_ROOT" <<'PY'
 import pathlib
 import sys
 
+sys.path.insert(0, sys.argv[3])
+
+from Tools.parity.timing_policy import exceeds_slowdown_boundary, slowdown_ratio
+
 path = pathlib.Path(sys.argv[1])
 max_ratio = float(sys.argv[2])
-min_delta = float(sys.argv[3])
 measurements = {}
 for line in path.read_text(encoding="utf-8").splitlines():
     implementation, operation, raw_seconds = line.split("\t")
@@ -276,16 +275,16 @@ for operation in sorted(measurements):
     values = measurements[operation]
     docker = values["docker"]
     container = values["container-compose"]
-    ratio = container / docker if docker > 0 else float("inf")
+    ratio = slowdown_ratio(docker, container)
     delta = container - docker
     print(
         f"  {operation}: docker={docker:.6f} "
         f"container-compose={container:.6f} ratio={ratio:.2f}x delta={delta:+.6f}"
     )
-    if ratio > max_ratio and delta > min_delta:
+    if exceeds_slowdown_boundary(docker, container, max_ratio):
         print(
             f"error: {operation} exceeds the material slowdown boundary: "
-            f"{ratio:.2f}x and {delta:.3f}s slower",
+            f"{ratio:.2f}x (threshold is <{max_ratio:g}x)",
             file=sys.stderr,
         )
         failed = True

--- a/Tools/parity/check-compose-links.sh
+++ b/Tools/parity/check-compose-links.sh
@@ -38,10 +38,7 @@
 #   PARITY_TIMING_OUTPUT
 #                      Timing report path. Defaults below .build/parity.
 #   PARITY_TIMING_MAX_RATIO
-#                      Material slowdown ratio. Defaults to 30.
-#   PARITY_TIMING_MIN_DELTA_SECONDS
-#                      Minimum absolute slowdown before ratio enforcement.
-#                      Defaults to 60 seconds.
+#                      Material slowdown ratio. Defaults to 10.
 #
 # This local-only check records Docker and container-compose timings while
 # validating source-scoped link aliases, scaled targets, dynamic external
@@ -63,8 +60,7 @@ CONTAINER_COMPOSE_LIVE="${CONTAINER_COMPOSE_LIVE:-0}"
 PARITY_REPETITIONS="${PARITY_REPETITIONS:-3}"
 PARITY_TIMEOUT_SECONDS="${PARITY_TIMEOUT_SECONDS:-300}"
 PARITY_TIMING_OUTPUT="${PARITY_TIMING_OUTPUT:-$REPO_ROOT/.build/parity/compose-links-timings.tsv}"
-PARITY_TIMING_MAX_RATIO="${PARITY_TIMING_MAX_RATIO:-30}"
-PARITY_TIMING_MIN_DELTA_SECONDS="${PARITY_TIMING_MIN_DELTA_SECONDS:-60}"
+PARITY_TIMING_MAX_RATIO="${PARITY_TIMING_MAX_RATIO:-10}"
 DOCKER_COMPOSE_COMMAND=()
 ACTIVE_COMPOSE=()
 FIXTURE_DIR=""
@@ -243,8 +239,7 @@ create_fixtures() {
         printf '# repetitions=%s\n' "$PARITY_REPETITIONS"
         printf '# comparison=median elapsed monotonic seconds by matching operation\n'
         printf '# timeout_seconds=%s\n' "$PARITY_TIMEOUT_SECONDS"
-        printf '# material_slowdown=max_ratio:%s,min_delta_seconds:%s\n' \
-            "$PARITY_TIMING_MAX_RATIO" "$PARITY_TIMING_MIN_DELTA_SECONDS"
+        printf '# material_slowdown=max_ratio:%s\n' "$PARITY_TIMING_MAX_RATIO"
         printf '# fixture_image=%s\n' "$FIXTURE_IMAGE"
         printf '# image_preparation=pulled outside the timed startup workload\n'
         printf 'implementation\toperation\trepetition\tseconds\n'
@@ -682,14 +677,17 @@ prepare_fixture_images() {
 report_timings() {
     mkdir -p "$(dirname "$PARITY_TIMING_OUTPUT")"
     cp "$TIMING_FILE" "$PARITY_TIMING_OUTPUT"
-    python3 - "$TIMING_FILE" "$PARITY_TIMING_MAX_RATIO" "$PARITY_TIMING_MIN_DELTA_SECONDS" <<'PY'
+    python3 - "$TIMING_FILE" "$PARITY_TIMING_MAX_RATIO" "$REPO_ROOT" <<'PY'
 import pathlib
 import statistics
 import sys
 
+sys.path.insert(0, sys.argv[3])
+
+from Tools.parity.timing_policy import exceeds_slowdown_boundary, slowdown_ratio
+
 path = pathlib.Path(sys.argv[1])
 max_ratio = float(sys.argv[2])
-min_delta = float(sys.argv[3])
 measurements = {}
 for line in path.read_text(encoding="utf-8").splitlines():
     if not line or line.startswith("#") or line.startswith("implementation\t"):
@@ -708,13 +706,13 @@ for operation in sorted(measurements):
     if "docker" in medians and "container-compose" in medians:
         reference = medians["docker"]
         implementation = medians["container-compose"]
-        ratio = implementation / reference if reference > 0 else float("inf")
+        ratio = slowdown_ratio(reference, implementation)
         delta = implementation - reference
         line += f" ratio={ratio:.2f}x delta={delta:+.6f}"
-        if ratio > max_ratio and delta > min_delta:
+        if exceeds_slowdown_boundary(reference, implementation, max_ratio):
             print(
                 f"error: {operation} exceeds the material slowdown boundary: "
-                f"{ratio:.2f}x and {delta:.3f}s slower",
+                f"{ratio:.2f}x (threshold is <{max_ratio:g}x)",
                 file=sys.stderr,
             )
             failed = True

--- a/Tools/parity/check-compose-network-service-discovery.sh
+++ b/Tools/parity/check-compose-network-service-discovery.sh
@@ -38,10 +38,7 @@
 #   PARITY_TIMING_OUTPUT
 #                      Timing report path. Defaults below .build/parity.
 #   PARITY_TIMING_MAX_RATIO
-#                      Material slowdown ratio. Defaults to 30.
-#   PARITY_TIMING_MIN_DELTA_SECONDS
-#                      Minimum absolute slowdown before ratio enforcement.
-#                      Defaults to 60 seconds.
+#                      Material slowdown ratio. Defaults to 10.
 #
 # This local-only check records Docker and container-compose timings while
 # validating network-scoped container names, service names, explicit aliases,
@@ -64,8 +61,7 @@ CONTAINER_COMPOSE_LIVE="${CONTAINER_COMPOSE_LIVE:-0}"
 PARITY_REPETITIONS="${PARITY_REPETITIONS:-3}"
 PARITY_TIMEOUT_SECONDS="${PARITY_TIMEOUT_SECONDS:-300}"
 PARITY_TIMING_OUTPUT="${PARITY_TIMING_OUTPUT:-$REPO_ROOT/.build/parity/network-service-discovery-timings.tsv}"
-PARITY_TIMING_MAX_RATIO="${PARITY_TIMING_MAX_RATIO:-30}"
-PARITY_TIMING_MIN_DELTA_SECONDS="${PARITY_TIMING_MIN_DELTA_SECONDS:-60}"
+PARITY_TIMING_MAX_RATIO="${PARITY_TIMING_MAX_RATIO:-10}"
 DOCKER_COMPOSE_COMMAND=()
 ACTIVE_COMPOSE=()
 FIXTURE_DIR=""
@@ -231,8 +227,7 @@ create_fixtures() {
         printf '# repetitions=%s\n' "$PARITY_REPETITIONS"
         printf '# comparison=median elapsed monotonic seconds by matching operation\n'
         printf '# timeout_seconds=%s\n' "$PARITY_TIMEOUT_SECONDS"
-        printf '# material_slowdown=max_ratio:%s,min_delta_seconds:%s\n' \
-            "$PARITY_TIMING_MAX_RATIO" "$PARITY_TIMING_MIN_DELTA_SECONDS"
+        printf '# material_slowdown=max_ratio:%s\n' "$PARITY_TIMING_MAX_RATIO"
         printf '# fixture_image=%s\n' "$FIXTURE_IMAGE"
         printf '# image_preparation=pulled outside the timed startup workload\n'
         printf 'implementation\toperation\trepetition\tseconds\n'
@@ -487,14 +482,17 @@ prepare_fixture_images() {
 report_timings() {
     mkdir -p "$(dirname "$PARITY_TIMING_OUTPUT")"
     cp "$TIMING_FILE" "$PARITY_TIMING_OUTPUT"
-    python3 - "$TIMING_FILE" "$PARITY_TIMING_MAX_RATIO" "$PARITY_TIMING_MIN_DELTA_SECONDS" <<'PY'
+    python3 - "$TIMING_FILE" "$PARITY_TIMING_MAX_RATIO" "$REPO_ROOT" <<'PY'
 import pathlib
 import statistics
 import sys
 
+sys.path.insert(0, sys.argv[3])
+
+from Tools.parity.timing_policy import exceeds_slowdown_boundary, slowdown_ratio
+
 path = pathlib.Path(sys.argv[1])
 max_ratio = float(sys.argv[2])
-min_delta = float(sys.argv[3])
 measurements = {}
 for line in path.read_text(encoding="utf-8").splitlines():
     if not line or line.startswith("#") or line.startswith("implementation\t"):
@@ -513,13 +511,13 @@ for operation in sorted(measurements):
     if "docker" in medians and "container-compose" in medians:
         reference = medians["docker"]
         implementation = medians["container-compose"]
-        ratio = implementation / reference if reference > 0 else float("inf")
+        ratio = slowdown_ratio(reference, implementation)
         delta = implementation - reference
         line += f" ratio={ratio:.2f}x delta={delta:+.6f}"
-        if ratio > max_ratio and delta > min_delta:
+        if exceeds_slowdown_boundary(reference, implementation, max_ratio):
             print(
                 f"error: {operation} exceeds the material slowdown boundary: "
-                f"{ratio:.2f}x and {delta:.3f}s slower",
+                f"{ratio:.2f}x (threshold is <{max_ratio:g}x)",
                 file=sys.stderr,
             )
             failed = True

--- a/Tools/parity/test_timing_policy.py
+++ b/Tools/parity/test_timing_policy.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import math
+import pathlib
+import unittest
+
+from Tools.parity.timing_policy import (
+    exceeds_slowdown_boundary,
+    slowdown_ratio,
+)
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+class TimingPolicyTests(unittest.TestCase):
+    def test_ratio_below_boundary_passes(self) -> None:
+        self.assertFalse(exceeds_slowdown_boundary(1.0, 9.999, 10.0))
+
+    def test_ratio_at_boundary_fails(self) -> None:
+        self.assertTrue(exceeds_slowdown_boundary(0.075, 0.75, 10.0))
+
+    def test_ratio_above_boundary_fails_without_absolute_delta_escape(self) -> None:
+        self.assertTrue(exceeds_slowdown_boundary(0.05, 0.51, 10.0))
+
+    def test_zero_reference_is_infinite_and_fails(self) -> None:
+        self.assertTrue(math.isinf(slowdown_ratio(0.0, 0.1)))
+        self.assertTrue(exceeds_slowdown_boundary(0.0, 0.1, 10.0))
+
+    def test_invalid_inputs_are_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            slowdown_ratio(-1.0, 1.0)
+        with self.assertRaises(ValueError):
+            slowdown_ratio(1.0, -1.0)
+        with self.assertRaises(ValueError):
+            slowdown_ratio(math.nan, 1.0)
+        with self.assertRaises(ValueError):
+            slowdown_ratio(1.0, math.inf)
+        with self.assertRaises(ValueError):
+            exceeds_slowdown_boundary(1.0, 1.0, 0.0)
+        with self.assertRaises(ValueError):
+            exceeds_slowdown_boundary(1.0, 1.0, math.nan)
+
+    def test_all_direct_timing_checks_use_the_shared_inclusive_policy(self) -> None:
+        scripts = (
+            "check-compose-cp-stdio-archive-streams.sh",
+            "check-compose-links.sh",
+            "check-compose-network-service-discovery.sh",
+        )
+        for name in scripts:
+            with self.subTest(script=name):
+                source = (ROOT / "Tools" / "parity" / name).read_text(
+                    encoding="utf-8"
+                )
+                self.assertIn("exceeds_slowdown_boundary", source)
+                self.assertIn(
+                    'PARITY_TIMING_MAX_RATIO="${PARITY_TIMING_MAX_RATIO:-10}"',
+                    source,
+                )
+                self.assertNotIn("PARITY_TIMING_MIN_DELTA_SECONDS", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/parity/timing_policy.py
+++ b/Tools/parity/timing_policy.py
@@ -1,0 +1,27 @@
+"""Shared timing policy for Docker Compose parity checks."""
+
+from __future__ import annotations
+
+import math
+
+
+def slowdown_ratio(reference_seconds: float, candidate_seconds: float) -> float:
+    """Return the candidate/reference duration ratio."""
+    if not math.isfinite(reference_seconds) or not math.isfinite(candidate_seconds):
+        raise ValueError("timing durations must be finite")
+    if reference_seconds < 0 or candidate_seconds < 0:
+        raise ValueError("timing durations must be non-negative")
+    if reference_seconds == 0:
+        return math.inf
+    return candidate_seconds / reference_seconds
+
+
+def exceeds_slowdown_boundary(
+    reference_seconds: float,
+    candidate_seconds: float,
+    max_ratio: float,
+) -> bool:
+    """Return whether the candidate reaches the inclusive slowdown boundary."""
+    if not math.isfinite(max_ratio) or max_ratio <= 0:
+        raise ValueError("maximum slowdown ratio must be finite and positive")
+    return slowdown_ratio(reference_seconds, candidate_seconds) >= max_ratio

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1444,7 +1444,6 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             for name, value in {
                 "DOCKER_COMPOSE_PARITY_TARGETS": "docker-compose-links-parity",
                 "PARITY_TIMING_MAX_RATIO": "9",
-                "PARITY_TIMING_MIN_DELTA_SECONDS": "4",
                 "PARITY_COMPARABLE_NOISE_PCT": "4",
                 "PARITY_SINK_STALL_SECONDS": "3",
                 "PARITY_PRESSURE_RECORDS": "32768",


### PR DESCRIPTION
## Summary
- enforce the inclusive 10x Docker slowdown boundary without an absolute-delta escape
- share one validated timing policy across direct parity checks
- benchmark the release Compose binary with exact packaged provenance instead of its development Git-probing fallback

## Evidence
- corrected gate rejected the unpackaged path at 10.35x and 10.57x before any release tag was created
- exact release-provenance rerun passed all cp content, metadata, sparse, and hard-link checks at 2.47x to 4.08x Docker
- release provenance reduced Compose process startup median from about 305 ms to 10 ms, matching the shipped package path

## Validation
- python3 -m unittest Tools.ci.test_build_release_local_stack Tools.parity.test_timing_policy
- two focused release-fingerprint policy tests
- bash -n for the three timing scripts
- shellcheck for the three timing scripts
- git diff --check
- focused matched-runtime Docker cp parity contract