### PR TITLE
test(release): track parity provenance input

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1271,8 +1271,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             self.assertIn(f"--stage {stage}", makefile)
         self.assertIn("docker-compose-parity-stages:", makefile)
         self.assertIn(
-            "docker-compose-parity: build-release container-stack-build-if-needed "
-            "docker-compose-reference",
+            "docker-compose-parity: build-release release-parity-build-info "
+            "container-stack-build-if-needed docker-compose-reference",
             makefile,
         )
         self.assertIn(


### PR DESCRIPTION
## Summary
- update the remaining release policy assertion for the new exact provenance prerequisite

## Validation
- reproduced the exact main Source Checks failure locally
- exact failing release-policy test now passes
- build-release wiring and shared timing-policy tests pass (10 focused tests total)
- git diff --check