### PR TITLE
chore(parity): add policy license headers

### DIFF
--- a/Tools/parity/test_timing_policy.py
+++ b/Tools/parity/test_timing_policy.py
@@ -1,3 +1,19 @@
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
 from __future__ import annotations
 
 import math

--- a/Tools/parity/timing_policy.py
+++ b/Tools/parity/timing_policy.py
@@ -1,3 +1,19 @@
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
 """Shared timing policy for Docker Compose parity checks."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add the required Apache headers to the two new timing-policy Python files

## Validation
- reproduced the exact main Hawkeye failure
- make check-licenses passes
- shared timing-policy tests pass
- git diff --check