### PR TITLE
fix(benchmarks): recover retained release artifacts

### DIFF
--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -150,8 +150,10 @@ jobs:
           printf 'container-compose published benchmark v1\n' \
             > "${BENCHMARK_ROOT}/.published-benchmark-root"
           install -d -m 0700 \
-            "${BENCHMARK_ROOT}/downloads/${TARGET_VERSION}" \
-            "${BENCHMARK_ROOT}/downloads/${BASELINE_VERSION}" \
+            "${BENCHMARK_ROOT}/downloads/${TARGET_VERSION}/release" \
+            "${BENCHMARK_ROOT}/downloads/${TARGET_VERSION}/actions" \
+            "${BENCHMARK_ROOT}/downloads/${BASELINE_VERSION}/release" \
+            "${BENCHMARK_ROOT}/downloads/${BASELINE_VERSION}/actions" \
             "${BENCHMARK_ROOT}/prepared" \
             "${BENCHMARK_ROOT}/evidence" \
             "${BENCHMARK_ROOT}/work"
@@ -163,25 +165,78 @@ jobs:
         run: |
           set -euo pipefail
           # No source products are built. Both complete runtime/plugin pairs
-          # come from published GitHub assets and must match a historical
-          # Homebrew formula URL and SHA-256 before execution.
+          # come from immutable published GitHub assets and must match a
+          # historical Homebrew formula URL and SHA-256 before execution.
+          # A successful retained package run is the recovery authority when
+          # an older stable release omitted its attached release assets.
           for version in "${BASELINE_VERSION}" "${TARGET_VERSION}"; do
-            gh release download "${version}" \
+            release_dir="${BENCHMARK_ROOT}/downloads/${version}/release"
+            actions_dir="${BENCHMARK_ROOT}/downloads/${version}/actions"
+            distribution="${release_dir}"
+            artifact_source="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${version}"
+            release_complete=true
+            if ! gh release download "${version}" \
               --repo "${GITHUB_REPOSITORY}" \
-              --dir "${BENCHMARK_ROOT}/downloads/${version}" \
+              --dir "${release_dir}" \
               --pattern 'container-release-arm64.tar.gz' \
               --pattern 'container-release-arm64.tar.gz.sha256' \
               --pattern 'container-compose-plugin-release-arm64.tar.gz' \
-              --pattern 'container-compose-plugin-release-arm64.tar.gz.sha256'
+              --pattern 'container-compose-plugin-release-arm64.tar.gz.sha256'; then
+              release_complete=false
+            fi
+            for asset in \
+              container-release-arm64.tar.gz \
+              container-release-arm64.tar.gz.sha256 \
+              container-compose-plugin-release-arm64.tar.gz \
+              container-compose-plugin-release-arm64.tar.gz.sha256; do
+              if [[ ! -f "${release_dir}/${asset}" ]]; then
+                release_complete=false
+              fi
+            done
+            if [[ "${release_complete}" != true ]]; then
+              runs="${BENCHMARK_ROOT}/downloads/${version}/package-runs.json"
+              resolved="${BENCHMARK_ROOT}/downloads/${version}/package-run.json"
+              artifacts="${BENCHMARK_ROOT}/downloads/${version}/package-artifacts.json"
+              gh run list \
+                --repo "${GITHUB_REPOSITORY}" \
+                --workflow prebuilt-binaries.yml \
+                --limit 500 \
+                --json databaseId,displayTitle,status,conclusion,event,createdAt,url \
+                > "${runs}"
+              python3 Tools/parity/published_release_benchmark.py \
+                resolve-package-run \
+                --runs "${runs}" \
+                --version "${version}" \
+                > "${resolved}"
+              package_run_id="$(jq -r '.runId' "${resolved}")"
+              artifact_source="$(jq -r '.url' "${resolved}")"
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${package_run_id}/artifacts" \
+                > "${artifacts}"
+              python3 Tools/parity/published_release_benchmark.py \
+                validate-package-artifacts \
+                --artifacts "${artifacts}" \
+                > "${BENCHMARK_ROOT}/downloads/${version}/validated-artifacts.json"
+              gh run download "${package_run_id}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --dir "${actions_dir}" \
+                --name 'container-release-arm64.tar.gz'
+              gh run download "${package_run_id}" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --dir "${actions_dir}" \
+                --name 'container-compose-plugin-release-arm64.tar.gz'
+              distribution="${actions_dir}"
+            fi
             Tools/release/verify-developer-id-archive.sh \
-              "${BENCHMARK_ROOT}/downloads/${version}/container-release-arm64.tar.gz"
+              "${distribution}/container-release-arm64.tar.gz"
             Tools/release/verify-developer-id-archive.sh \
-              "${BENCHMARK_ROOT}/downloads/${version}/container-compose-plugin-release-arm64.tar.gz"
+              "${distribution}/container-compose-plugin-release-arm64.tar.gz"
             python3 Tools/parity/published_release_benchmark.py prepare \
               --version "${version}" \
-              --distribution "${BENCHMARK_ROOT}/downloads/${version}" \
+              --distribution "${distribution}" \
               --tap-repository homebrew-tap \
               --source-repository . \
+              --artifact-source "${artifact_source}" \
               --output "${BENCHMARK_ROOT}/prepared/${version}"
           done
 
@@ -237,7 +292,7 @@ jobs:
           path: |
             ${{ env.BENCHMARK_ROOT }}/evidence
             ${{ env.BENCHMARK_ROOT }}/prepared/*/published-distribution.json
-            ${{ env.BENCHMARK_ROOT }}/downloads/*/*.sha256
+            ${{ env.BENCHMARK_ROOT }}/downloads/*/*/*.sha256
           if-no-files-found: error
           retention-days: 90
 

--- a/Tools/ci/classify-documentation-changes.py
+++ b/Tools/ci/classify-documentation-changes.py
@@ -39,12 +39,9 @@ DOCUMENTATION_INPUTS = (
     ".swift-version",
     "Package.resolved",
     "Package.swift",
-    "README.md",
-    "Tools/ci/classify-documentation-changes.py",
     "scripts/make-docs.sh",
 )
-DOCUMENTATION_PREFIXES = ("docs/",)
-BENCHMARK_REPORT = re.compile(r"^docs/benchmarks/[^/]+[.]md$")
+REPOSITORY_DOCUMENTATION = re.compile(r"^docs/")
 SWIFT_SOURCE = re.compile(r"^Sources/.+[.]swift$")
 NON_SWIFT_API_SOURCE = re.compile(r"^Sources/.+[.](?:h|hpp|modulemap)$")
 ATTRIBUTE_PREFIX = r"(?:(?:@\w+(?:\([^\n]*\))?)\s+)*"
@@ -279,12 +276,11 @@ def classify(repository: Path, base: str, head: str) -> Classification:
     changes = changed_files(repository, base, head)
     if not changes:
         return Classification(False, "no changed files", changes)
-    if all(BENCHMARK_REPORT.match(path) for path in changes):
-        return Classification(False, "published benchmark report only", changes)
-    if any(
-        path in DOCUMENTATION_INPUTS or path.startswith(DOCUMENTATION_PREFIXES)
-        for path in changes
-    ):
+    if all(REPOSITORY_DOCUMENTATION.match(path) for path in changes):
+        return Classification(
+            False, "repository documentation does not feed DocC", changes
+        )
+    if any(path in DOCUMENTATION_INPUTS for path in changes):
         return Classification(True, "documentation input changed", changes)
     if any(NON_SWIFT_API_SOURCE.match(path) for path in changes):
         return Classification(True, "non-Swift API source changed", changes)

--- a/Tools/ci/test_classify_documentation_changes.py
+++ b/Tools/ci/test_classify_documentation_changes.py
@@ -257,17 +257,66 @@ public protocol Feature {
         self.assertTrue(result.build_docc)
         self.assertIn("ambiguous Swift API", result.reason)
 
-    def test_benchmark_report_only_skips_docc(self) -> None:
+    def test_repository_documentation_only_skips_docc(self) -> None:
         base = self.commit({"README.md": "root\n"}, "base")
         head = self.commit(
-            {"docs/benchmarks/0.14.0-vs-0.13.0.md": "evidence\n"},
-            "benchmark",
+            {
+                "docs/benchmarks/0.14.0-vs-0.13.0.md": "evidence\n",
+                "docs/upstream/container-compose/ISSUE-353.md": "handoff\n",
+            },
+            "documentation",
         )
 
         result = CLASSIFIER.classify(self.repository, base, head)
 
         self.assertFalse(result.build_docc)
-        self.assertEqual(result.reason, "published benchmark report only")
+        self.assertEqual(
+            result.reason, "repository documentation does not feed DocC"
+        )
+
+    def test_repository_documentation_does_not_hide_api_change(self) -> None:
+        base = self.commit(
+            {
+                "Sources/App/Feature.swift": "public func value() -> Int { 1 }\n",
+                "docs/STATUS.md": "old\n",
+            },
+            "base",
+        )
+        head = self.commit(
+            {
+                "Sources/App/Feature.swift": (
+                    "public func value(options: Int) -> Int { options }\n"
+                ),
+                "docs/STATUS.md": "new\n",
+            },
+            "api",
+        )
+
+        result = CLASSIFIER.classify(self.repository, base, head)
+
+        self.assertTrue(result.build_docc)
+        self.assertEqual(result.reason, "documented Swift API changed")
+
+    def test_readme_and_classifier_changes_skip_docc(self) -> None:
+        base = self.commit(
+            {
+                "README.md": "old\n",
+                "Tools/ci/classify-documentation-changes.py": "old\n",
+            },
+            "base",
+        )
+        head = self.commit(
+            {
+                "README.md": "new\n",
+                "Tools/ci/classify-documentation-changes.py": "new\n",
+            },
+            "controls",
+        )
+
+        result = CLASSIFIER.classify(self.repository, base, head)
+
+        self.assertFalse(result.build_docc)
+        self.assertEqual(result.reason, "no documentation or source input changed")
 
     def test_package_or_documentation_control_change_builds_docc(self) -> None:
         base = self.commit({"Package.swift": "// old\n"}, "base")

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -103,6 +103,86 @@ def resolve_versions(
     return {"target": target, "baseline": baseline}
 
 
+def canonical_artifact_source(version: str, source: str) -> str:
+    version_tuple(version)
+    release = f"https://github.com/{REPOSITORY}/releases/tag/{version}"
+    run_pattern = re.compile(
+        rf"https://github[.]com/{re.escape(REPOSITORY)}/actions/runs/[1-9][0-9]*"
+    )
+    if source != release and run_pattern.fullmatch(source) is None:
+        raise BenchmarkInputError(
+            f"artifact source is not a canonical release or package run: {source}"
+        )
+    return source
+
+
+def resolve_packaging_run(
+    runs: Iterable[dict[str, object]], version: str
+) -> dict[str, object]:
+    version_tuple(version)
+    title = f"Prebuilt Binaries · {version}"
+    candidates: list[tuple[str, int, str]] = []
+    for run in runs:
+        if (
+            run.get("displayTitle") != title
+            or run.get("event") != "workflow_dispatch"
+            or run.get("status") != "completed"
+            or run.get("conclusion") != "success"
+        ):
+            continue
+        run_id = run.get("databaseId")
+        created_at = run.get("createdAt")
+        url = run.get("url")
+        if (
+            not isinstance(run_id, int)
+            or run_id <= 0
+            or not isinstance(created_at, str)
+            or not created_at
+            or not isinstance(url, str)
+            or url
+            != f"https://github.com/{REPOSITORY}/actions/runs/{run_id}"
+        ):
+            continue
+        candidates.append((created_at, run_id, url))
+    if not candidates:
+        raise BenchmarkInputError(
+            f"no successful immutable package run retained for {version}"
+        )
+    created_at, run_id, url = max(candidates)
+    return {"runId": run_id, "url": url, "createdAt": created_at}
+
+
+def validate_packaging_artifacts(payload: dict[str, object]) -> dict[str, int]:
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise BenchmarkInputError("package run artifact metadata is not an array")
+    required = {asset_name for asset_name, _ in ASSETS.values()}
+    matches: dict[str, list[dict[str, object]]] = {
+        name: [] for name in required
+    }
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            continue
+        name = artifact.get("name")
+        if isinstance(name, str) and name in matches:
+            matches[name].append(artifact)
+    validated: dict[str, int] = {}
+    for name in sorted(required):
+        candidates = matches[name]
+        if len(candidates) != 1:
+            raise BenchmarkInputError(
+                f"package run must retain exactly one {name} artifact"
+            )
+        artifact = candidates[0]
+        artifact_id = artifact.get("id")
+        if not isinstance(artifact_id, int) or artifact_id <= 0:
+            raise BenchmarkInputError(f"package run artifact has no valid id: {name}")
+        if artifact.get("expired") is not False:
+            raise BenchmarkInputError(f"package run artifact has expired: {name}")
+        validated[name] = artifact_id
+    return validated
+
+
 def sha256(path: Path) -> str:
     digest = hashlib.sha256()
     with path.open("rb") as handle:
@@ -279,9 +359,11 @@ def prepare_distribution(
     distribution: Path,
     tap_repository: Path,
     source_repository: Path,
+    artifact_source: str,
     output: Path,
 ) -> dict[str, object]:
     version_tuple(version)
+    artifact_source = canonical_artifact_source(version, artifact_source)
     source_commit = release_tag_commit(source_repository, version)
     source_stack = release_tag_stack(source_repository, source_commit)
     output.mkdir(parents=True, exist_ok=False)
@@ -326,6 +408,7 @@ def prepare_distribution(
         "sourceCommit": source_commit,
         "stack": source_stack,
         "release": f"https://github.com/{REPOSITORY}/releases/tag/{version}",
+        "artifactSource": artifact_source,
         "assets": asset_manifest,
     }
     (output / "published-distribution.json").write_text(
@@ -379,6 +462,7 @@ def validate_release_identity(
     version = manifest.get("version")
     source_commit = manifest.get("sourceCommit")
     source_stack = manifest.get("stack")
+    artifact_source = manifest.get("artifactSource")
     compose_record = fingerprints.get("containerCompose")
     runtime_record = fingerprints.get("containerRuntime")
     if (
@@ -386,9 +470,11 @@ def validate_release_identity(
         or not isinstance(source_commit, str)
         or re.fullmatch(r"[0-9a-f]{40}", source_commit) is None
         or not isinstance(source_stack, dict)
+        or not isinstance(artifact_source, str)
         or not isinstance(compose_record, dict)
     ):
         raise BenchmarkInputError(f"{label} release identity is incomplete")
+    canonical_artifact_source(version, artifact_source)
     if not isinstance(runtime_record, dict):
         raise BenchmarkInputError(f"{label} runtime identity is incomplete")
 
@@ -615,6 +701,7 @@ def render_report(
                 f"### {label} {manifest['version']}",
                 "",
                 f"Release: [{manifest['release']}]({manifest['release']})",
+                f"Artifact source: [{manifest['artifactSource']}]({manifest['artifactSource']}).",
                 f"Release tag commit: `{manifest['sourceCommit']}`.",
                 f"Container: `{manifest['stack']['container']['repository']}@{manifest['stack']['container']['ref']}`.",
                 f"Containerization: `{manifest['stack']['containerization']['repository']}@{manifest['stack']['containerization']['ref']}`.",
@@ -675,11 +762,19 @@ def main() -> None:
     resolve.add_argument("--target", required=True)
     resolve.add_argument("--baseline")
 
+    package_run = subparsers.add_parser("resolve-package-run")
+    package_run.add_argument("--runs", type=Path, required=True)
+    package_run.add_argument("--version", required=True)
+
+    package_artifacts = subparsers.add_parser("validate-package-artifacts")
+    package_artifacts.add_argument("--artifacts", type=Path, required=True)
+
     prepare = subparsers.add_parser("prepare")
     prepare.add_argument("--version", required=True)
     prepare.add_argument("--distribution", type=Path, required=True)
     prepare.add_argument("--tap-repository", type=Path, required=True)
     prepare.add_argument("--source-repository", type=Path, required=True)
+    prepare.add_argument("--artifact-source", required=True)
     prepare.add_argument("--output", type=Path, required=True)
 
     render = subparsers.add_parser("render")
@@ -698,12 +793,27 @@ def main() -> None:
                 raise BenchmarkInputError("release metadata must be a JSON array")
             result = resolve_versions(releases, arguments.target, arguments.baseline)
             print(json.dumps(result, sort_keys=True))
+        elif arguments.command == "resolve-package-run":
+            runs = load_json(arguments.runs)
+            if not isinstance(runs, list):
+                raise BenchmarkInputError("package run metadata must be a JSON array")
+            result = resolve_packaging_run(runs, arguments.version)
+            print(json.dumps(result, sort_keys=True))
+        elif arguments.command == "validate-package-artifacts":
+            artifacts = load_json(arguments.artifacts)
+            if not isinstance(artifacts, dict):
+                raise BenchmarkInputError(
+                    "package run artifact metadata must be a JSON object"
+                )
+            result = validate_packaging_artifacts(artifacts)
+            print(json.dumps(result, sort_keys=True))
         elif arguments.command == "prepare":
             result = prepare_distribution(
                 arguments.version,
                 arguments.distribution,
                 arguments.tap_repository,
                 arguments.source_repository,
+                arguments.artifact_source,
                 arguments.output,
             )
             print(json.dumps(result, sort_keys=True))

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -68,6 +68,113 @@ class ResolvePublishedVersionsTests(unittest.TestCase):
             MODULE.resolve_versions(self.releases, "0.15.0", None)
 
 
+class ResolvePublishedArtifactsTests(unittest.TestCase):
+    def test_newest_successful_immutable_package_run_is_selected(self) -> None:
+        repository = "https://github.com/stephenlclarke/container-compose"
+        runs = [
+            {
+                "databaseId": 10,
+                "displayTitle": "Prebuilt Binaries · 0.13.0",
+                "event": "workflow_dispatch",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-08-23T10:00:00Z",
+                "url": f"{repository}/actions/runs/10",
+            },
+            {
+                "databaseId": 11,
+                "displayTitle": "Prebuilt Binaries · 0.13.0",
+                "event": "workflow_dispatch",
+                "status": "completed",
+                "conclusion": "failure",
+                "createdAt": "2026-08-24T10:00:00Z",
+                "url": f"{repository}/actions/runs/11",
+            },
+            {
+                "databaseId": 12,
+                "displayTitle": "Prebuilt Binaries · 0.13.0",
+                "event": "workflow_dispatch",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-08-24T11:00:00Z",
+                "url": f"{repository}/actions/runs/12",
+            },
+            {
+                "databaseId": 13,
+                "displayTitle": "Prebuilt Binaries · 0.13.0",
+                "event": "push",
+                "status": "completed",
+                "conclusion": "success",
+                "createdAt": "2026-08-25T10:00:00Z",
+                "url": f"{repository}/actions/runs/13",
+            },
+        ]
+
+        self.assertEqual(
+            MODULE.resolve_packaging_run(runs, "0.13.0"),
+            {
+                "runId": 12,
+                "url": f"{repository}/actions/runs/12",
+                "createdAt": "2026-08-24T11:00:00Z",
+            },
+        )
+
+    def test_missing_successful_package_run_is_rejected(self) -> None:
+        with self.assertRaisesRegex(
+            MODULE.BenchmarkInputError, "no successful immutable package run"
+        ):
+            MODULE.resolve_packaging_run([], "0.13.0")
+
+    def test_required_unexpired_package_artifacts_are_validated(self) -> None:
+        payload = {
+            "artifacts": [
+                {
+                    "id": 1,
+                    "name": "container-release-arm64.tar.gz",
+                    "expired": False,
+                },
+                {
+                    "id": 2,
+                    "name": "container-compose-plugin-release-arm64.tar.gz",
+                    "expired": False,
+                },
+                {"id": 3, "name": "unrelated", "expired": False},
+            ]
+        }
+
+        self.assertEqual(
+            MODULE.validate_packaging_artifacts(payload),
+            {
+                "container-compose-plugin-release-arm64.tar.gz": 2,
+                "container-release-arm64.tar.gz": 1,
+            },
+        )
+
+    def test_expired_or_duplicate_package_artifact_is_rejected(self) -> None:
+        payload = {
+            "artifacts": [
+                {
+                    "id": 1,
+                    "name": "container-release-arm64.tar.gz",
+                    "expired": False,
+                },
+                {
+                    "id": 2,
+                    "name": "container-release-arm64.tar.gz",
+                    "expired": False,
+                },
+                {
+                    "id": 3,
+                    "name": "container-compose-plugin-release-arm64.tar.gz",
+                    "expired": True,
+                },
+            ]
+        }
+
+        with self.assertRaises(MODULE.BenchmarkInputError):
+            MODULE.validate_packaging_artifacts(payload)
+
+
 class HomebrewAuthorityTests(unittest.TestCase):
     def test_release_tag_resolves_to_peeled_commit(self) -> None:
         with tempfile.TemporaryDirectory(prefix="published-source-") as directory:
@@ -210,6 +317,7 @@ class PublishedReportTests(unittest.TestCase):
         self.assertIn("Improved", report)
         self.assertIn("No source product was built", report)
         self.assertIn("excluded to keep the unattended run free", report)
+        self.assertIn("Artifact source:", report)
 
     def test_report_rejects_mismatched_benchmark_conditions(self) -> None:
         with tempfile.TemporaryDirectory(prefix="published-benchmark-") as directory:
@@ -540,6 +648,10 @@ class PublishedReportTests(unittest.TestCase):
                         },
                     },
                     "release": f"https://github.example/{version}",
+                    "artifactSource": (
+                        "https://github.com/stephenlclarke/container-compose/"
+                        f"releases/tag/{version}"
+                    ),
                     "assets": {
                         "runtime": {
                             "asset": "container-release-arm64.tar.gz",
@@ -578,6 +690,10 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
     def test_workflow_downloads_published_assets_without_building_products(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("gh release download", workflow)
+        self.assertIn("resolve-package-run", workflow)
+        self.assertIn("validate-package-artifacts", workflow)
+        self.assertIn("gh run download", workflow)
+        self.assertIn("--artifact-source", workflow)
         self.assertIn("No source products are built", workflow)
         self.assertIn("PARITY_INCLUDE_REMOTE_LOGGING=0", workflow)
         self.assertNotIn("PARITY_SINK_BIND_ADDRESS=0.0.0.0", workflow)

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7188,6 +7188,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/352"
     },
     {
+      "id": "container-compose-354",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Recover retained release artifacts",
+      "state": "active-draft",
+      "lastVerified": "2026-08-31",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-353.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-354.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/354"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-08-31
 
-Entries: 391. Document snapshots: 682. Current supporting documents: 76.
+Entries: 392. Document snapshots: 684. Current supporting documents: 78.
 
-States: `active-draft` 6, `archived` 304, `closed` 17, `merged` 10, `submitted` 12, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 7, `archived` 304, `closed` 17, `merged` 10, `submitted` 12, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -221,6 +221,7 @@ States: `active-draft` 6, `archived` 304, `closed` 17, `merged` 10, `submitted` 
 | `stephenlclarke/container-compose` | [Reuse Container command context](https://github.com/stephenlclarke/container-compose/pull/342) | `submitted` | `0200d2759ee8` | [PR details](container-compose/PR-342.md) |
 | `stephenlclarke/container-compose` | [Pin the final 0.14.0 Container runtime](https://github.com/stephenlclarke/container-compose/pull/348) | `active-draft` | None recorded | [PR details](container-compose/PR-348.md) |
 | `stephenlclarke/container-compose` | [Fail fast before expensive release jobs](https://github.com/stephenlclarke/container-compose/pull/352) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-351.md); [PR details](container-compose/PR-352.md) |
+| `stephenlclarke/container-compose` | [Recover retained release artifacts](https://github.com/stephenlclarke/container-compose/pull/354) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-353.md); [PR details](container-compose/PR-354.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-353.md
+++ b/docs/upstream/container-compose/ISSUE-353.md
@@ -1,0 +1,24 @@
+# Issue 353: recover retained package artifacts for published benchmarks
+
+## Problem
+
+The first published-artifact benchmark for 0.14.0 versus 0.13.0 failed before timing began because the older stable GitHub release has no attached assets. The successful 0.13.0 package workflow still retains the exact signed runtime and Compose archives, their checksum sidecars, and immutable run metadata. Rebuilding those products would violate the benchmark's released-artifact contract and would make the comparison irreproducible.
+
+Tracking issue: [`#353`](https://github.com/stephenlclarke/container-compose/issues/353).
+
+## Required outcome
+
+- Prefer the complete asset set attached to the stable GitHub release.
+- When that set is absent or incomplete, select only an exact-version, successful, completed `workflow_dispatch` package run from this repository.
+- Require exactly one unexpired runtime artifact and one unexpired Compose artifact from the selected run.
+- Preserve the Developer ID, sidecar checksum, historical Homebrew formula, release-tag commit, and matched-stack verification performed for release assets.
+- Record the exact release or Actions run used as the artifact source in the durable benchmark manifest and report.
+- Never build a source product while recovering benchmark inputs.
+- Skip DocC for repository Markdown that is not consumed by the DocC generator while retaining forced manual and release documentation builds.
+
+## Acceptance evidence
+
+- Focused tests reject failed, incomplete, wrongly triggered, missing, duplicate, or expired package authorities.
+- The retained 0.13.0 package run and both required artifact IDs resolve through the same checked implementation used by the workflow.
+- Actionlint, Python compilation, focused benchmark and DocC-classifier tests, and `git diff --check` pass.
+- The implementation lands through a signed Conventional Commit and protected pull request before the benchmark is retried.

--- a/docs/upstream/container-compose/PR-354.md
+++ b/docs/upstream/container-compose/PR-354.md
@@ -1,0 +1,30 @@
+# Pull request 354: recover retained release artifacts
+
+## Summary
+
+Pull request [`#354`](https://github.com/stephenlclarke/container-compose/pull/354) closes tracking issue [`#353`](https://github.com/stephenlclarke/container-compose/issues/353).
+
+- Prefer complete stable-release assets and recover from the newest exact-version successful manual package run only when they are absent or incomplete.
+- Require exactly one unexpired runtime artifact and one unexpired Compose artifact from the retained run.
+- Apply the existing Developer ID, checksum, historical Homebrew formula, release-tag, and matched-stack authorities to either source.
+- Record the canonical release or Actions run URL in the benchmark manifest and evidence report.
+- Treat repository Markdown and classifier controls as non-DocC inputs because the site generator does not read them; manual and scheduled release documentation still rebuild every site.
+
+## Failure boundary
+
+The workflow does not rebuild a missing product. It stops unless an immutable successful package run for the exact stable version still retains both required artifacts. Missing, duplicate, expired, failed, incomplete, incorrectly triggered, or non-canonical package authorities are rejected before a benchmark process starts.
+
+## Validation
+
+- [x] 37 focused published-benchmark and documentation-classifier tests
+- [x] Production resolver selects retained 0.13.0 package run `32784434403`
+- [x] Production validator selects unexpired artifact IDs `9541233047` and `9541228336`
+- [x] Python compilation
+- [x] Actionlint on both affected workflow contracts
+- [x] Bash, Markdown, and Go static lint
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+
+## Compatibility and risk
+
+Runtime and Compose behavior are unchanged. Release assets remain the primary authority. The fallback only restores exact bytes that the successful release package workflow produced and Homebrew recorded; all downstream signature and identity checks remain mandatory. Repository Markdown no longer triggers product documentation builds because `scripts/make-docs.sh` consumes neither `docs/` nor `README.md`.


### PR DESCRIPTION
## Summary

- recover exact signed runtime and Compose archives from a successful retained package run when an older stable release omitted attached assets
- require the exact version, successful completed manual package authority, and exactly one unexpired artifact per product
- preserve Developer ID, checksum, historical Homebrew, release-tag, and matched-stack verification and record the exact artifact source
- skip DocC for repository Markdown and classifier controls that do not feed the generated sites

## Evidence

- the production resolver selects 0.13.0 package run `32784434403`
- the production artifact validator selects unexpired artifact IDs `9541233047` and `9541228336`
- 37 focused benchmark and documentation-classifier tests pass
- Python compilation, Actionlint, static lint, Markdownlint, and `git diff --check` pass
- no source product is built by the benchmark workflow

Closes #353
