### PR TITLE
fix(docs): isolate manual build concurrency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,7 +47,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: documentation-${{ github.workflow }}-${{ github.ref }}
+  group: documentation-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -924,6 +924,15 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def test_documentation_sites_build_in_parallel_before_pages_assembly(self) -> None:
         workflow = DOCS_WORKFLOW.read_text(encoding="utf-8")
 
+        concurrency = workflow[
+            workflow.index("concurrency:") : workflow.index("\njobs:")
+        ]
+        self.assertIn(
+            "group: documentation-${{ github.workflow }}-${{ github.ref }}-"
+            "${{ github.event_name }}",
+            concurrency,
+        )
+        self.assertIn("cancel-in-progress: true", concurrency)
         self.assertIn("strategy:", workflow)
         self.assertIn("fail-fast: true", workflow)
         self.assertEqual(workflow.count("- site:"), 4)


### PR DESCRIPTION
## Summary

- isolate Documentation concurrency by event authority
- keep stale-run cancellation within the same event/ref class
- add a focused policy regression for the concurrency contract

## Why

The final manual four-site DocC run was canceled after 51 minutes by a later main push whose classifier then skipped all DocC work. A no-op push must not have authority to discard a manual release documentation build.

## Validation

- focused documentation policy unit test
- `actionlint .github/workflows/docs.yml`
- `git diff --check`

Fixes #359