### PR TITLE
feat(build): reconstruct historical benchmark inputs

### DIFF
--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -248,20 +248,41 @@ jobs:
               }]' "${version_root}/containerization-run-pages.json" \
               > "${version_root}/containerization-runs.json"
             /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py \
-              resolve-run \
+              run-candidates \
               --runs "${version_root}/containerization-runs.json" \
               --revision "${containerization_ref}" \
-              > "${version_root}/containerization-run.json"
-            containerization_run_id="$(jq -r \
-              '.runId' "${version_root}/containerization-run.json")"
-            gh api \
-              "repos/stephenlclarke/containerization/actions/runs/${containerization_run_id}/artifacts" \
-              > "${version_root}/containerization-artifacts.json"
-            /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py \
-              validate-initfs \
-              --run "${version_root}/containerization-run.json" \
-              --artifacts "${version_root}/containerization-artifacts.json" \
-              > "${version_root}/guest-provenance.json"
+              > "${version_root}/containerization-run-candidates.json"
+            containerization_run_id=
+            while IFS= read -r candidate_id; do
+              [[ "${candidate_id}" =~ ^[1-9][0-9]*$ ]]
+              candidate_run="${version_root}/containerization-run-${candidate_id}.json"
+              candidate_artifacts="${version_root}/containerization-artifacts-${candidate_id}.json"
+              candidate_provenance="${version_root}/guest-provenance-${candidate_id}.json"
+              jq --argjson id "${candidate_id}" \
+                '.[] | select(.runId == $id)' \
+                "${version_root}/containerization-run-candidates.json" \
+                > "${candidate_run}"
+              gh api \
+                "repos/stephenlclarke/containerization/actions/runs/${candidate_id}/artifacts" \
+                > "${candidate_artifacts}"
+              if /usr/bin/python3 \
+                Tools/parity/historical_reconstruction_benchmark.py \
+                validate-initfs --run "${candidate_run}" \
+                --artifacts "${candidate_artifacts}" \
+                > "${candidate_provenance}" 2> \
+                "${version_root}/containerization-artifacts-${candidate_id}.error.log"; then
+                containerization_run_id="${candidate_id}"
+                /bin/cp "${candidate_provenance}" \
+                  "${version_root}/guest-provenance.json"
+                break
+              fi
+            done < <(jq -r '.[].runId' \
+              "${version_root}/containerization-run-candidates.json")
+            if [[ -z "${containerization_run_id}" ]]; then
+              printf 'no retained initfs run exists for containerization@%s\n' \
+                "${containerization_ref}" >&2
+              exit 1
+            fi
             initfs_artifact_id="$(jq -r \
               '.artifactId' "${version_root}/guest-provenance.json")"
             initfs_artifact_digest="$(jq -r \

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -158,9 +158,18 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN}" ]]
-          gh run list --repo "${GITHUB_REPOSITORY}" \
-            --workflow prebuilt-binaries.yml --limit 100 \
-            --json databaseId,displayTitle,status,conclusion,event,createdAt,url \
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/prebuilt-binaries.yml/runs?event=workflow_dispatch&per_page=100" \
+            > "${BENCHMARK_ROOT}/downloads/package-run-pages.json"
+          jq '[.[].workflow_runs[] | {
+              databaseId: .id,
+              displayTitle: .display_title,
+              status,
+              conclusion,
+              event,
+              createdAt: .created_at,
+              url: .html_url
+            }]' "${BENCHMARK_ROOT}/downloads/package-run-pages.json" \
             > "${BENCHMARK_ROOT}/downloads/package-runs.json"
 
           for version in "${BASELINE_VERSION}" "${TARGET_VERSION}"; do

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -39,7 +39,7 @@ on:
           - "7"
 
 permissions:
-  actions: read
+  actions: write
   contents: write
   pull-requests: write
 
@@ -390,9 +390,14 @@ jobs:
           git commit -S -m \
             "docs(benchmarks): compare ${TARGET_VERSION} with ${BASELINE_VERSION}"
           git push --set-upstream origin "${branch}"
-          gh pr create --base main --head "${branch}" \
+          pr_url="$(gh pr create --base main --head "${branch}" \
             --title "docs(benchmarks): compare ${TARGET_VERSION} with ${BASELINE_VERSION}" \
-            --body "Historical reconstruction benchmark for ${TARGET_VERSION} versus ${BASELINE_VERSION}. Host executables are the immutable signed release packages; each missing guest archive is reconstructed from its exact retained CI initfs and Containerization source revision. Raw evidence is retained by workflow run ${GITHUB_RUN_ID}."
+            --body "Historical reconstruction benchmark for ${TARGET_VERSION} versus ${BASELINE_VERSION}. Host executables are the immutable signed release packages; each missing guest archive is reconstructed from its exact retained CI initfs and Containerization source revision. Raw evidence is retained by workflow run ${GITHUB_RUN_ID}.")"
+          pr_number="${pr_url##*/}"
+          gh workflow run ci.yml --repo "${GITHUB_REPOSITORY}" \
+            --ref "${branch}" -f documentation_pr="${pr_number}"
+          printf 'Documentation report pull request: %s\n' "${pr_url}" \
+            >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Clean marker-protected benchmark root
         if: always()

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -1,0 +1,421 @@
+#===----------------------------------------------------------------------===#
+# Copyright © 2026 container-compose project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===----------------------------------------------------------------------===#
+
+name: Historical Reconstruction Benchmark
+run-name: Reconstruct and benchmark ${{ inputs.version }} vs ${{ inputs.compare_to || 'previous stable' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Stable version to benchmark"
+        required: true
+        type: string
+      compare_to:
+        description: "Optional comparison version; defaults to the previous stable"
+        required: false
+        type: string
+      repetitions:
+        description: "Timed repetitions per fixture and lane"
+        required: true
+        default: "5"
+        type: choice
+        options:
+          - "3"
+          - "5"
+          - "7"
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: container-compose-performance-benchmark
+  cancel-in-progress: false
+
+jobs:
+  benchmark:
+    name: Reconstruct Missing Guest Closure And Compare
+    if: >
+      github.repository == 'stephenlclarke/container-compose' &&
+      github.ref == 'refs/heads/main'
+    runs-on: [self-hosted, macOS, ARM64, container-compose-release]
+    timeout-minutes: 240
+    env:
+      BENCHMARK_ROOT: /private/tmp/container-compose-historical-benchmark-${{ github.run_id }}-${{ github.run_attempt }}
+      PIPELINE_STATE_ROOT: /Volumes/SSD/github/.container-compose-pipeline
+      REPETITIONS: ${{ inputs.repetitions }}
+      RUNTIME_ROOT_PREFIX: /private/tmp/cchr-${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout benchmark controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          ref: main
+
+      - name: Checkout complete Homebrew distribution history
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: stephenlclarke/homebrew-tap
+          path: homebrew-tap
+          fetch-depth: 0
+
+      - name: Checkout Containerization source authority
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: stephenlclarke/containerization
+          path: containerization-source
+          fetch-depth: 0
+
+      - name: Verify unattended documentation signing
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git config --global --get gpg.format)" == "ssh" ]]
+          [[ "$(git config --global --get commit.gpgsign)" == "true" ]]
+          signing_key="$(git config --global --get user.signingkey)"
+          [[ -n "${signing_key}" && -r "${signing_key}" ]]
+          signing_private_key="${signing_key%.pub}"
+          [[ -r "${signing_private_key}" ]]
+          ssh-keygen -y -P '' -f "${signing_private_key}" >/dev/null 2>&1
+          git config gpg.format ssh
+          git config commit.gpgsign true
+          git config user.signingkey "${signing_key}"
+
+      - name: Resolve exact stable versions
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_INPUT: ${{ inputs.version }}
+          BASELINE_INPUT: ${{ inputs.compare_to }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
+            --json tagName,isDraft,isPrerelease,publishedAt \
+            > "${RUNNER_TEMP}/published-releases.json"
+          arguments=(
+            resolve
+            --releases "${RUNNER_TEMP}/published-releases.json"
+            --target "${TARGET_INPUT}"
+          )
+          if [[ -n "${BASELINE_INPUT}" ]]; then
+            arguments+=(--baseline "${BASELINE_INPUT}")
+          fi
+          /usr/bin/python3 Tools/parity/published_release_benchmark.py \
+            "${arguments[@]}" \
+            > "${RUNNER_TEMP}/comparison.json"
+          target="$(jq -r '.target' "${RUNNER_TEMP}/comparison.json")"
+          baseline="$(jq -r '.baseline' "${RUNNER_TEMP}/comparison.json")"
+          printf 'TARGET_VERSION=%s\nBASELINE_VERSION=%s\n' \
+            "${target}" "${baseline}" >> "${GITHUB_ENV}"
+          printf 'Reconstructing %s and %s from exact retained authorities.\n' \
+            "${target}" "${baseline}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Require unattended local build authority
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -d /Volumes/SSD/github ]]
+          [[ -d "${PIPELINE_STATE_ROOT}" ]]
+          [[ -f "${PIPELINE_STATE_ROOT}/.container-compose-pipeline-root" ]]
+          [[ "$(<"${PIPELINE_STATE_ROOT}/.container-compose-pipeline-root")" == \
+            'container-compose recoverable pipeline v1' ]]
+          [[ -x "${PIPELINE_STATE_ROOT}/tools/nextflow/26.04.6/nextflow" ]]
+          if [[ -e "${BENCHMARK_ROOT}" ]]; then
+            printf 'benchmark root already exists: %s\n' "${BENCHMARK_ROOT}" >&2
+            exit 1
+          fi
+          install -d -m 0700 "${BENCHMARK_ROOT}"
+          printf 'container-compose historical benchmark v1\n' \
+            > "${BENCHMARK_ROOT}/.historical-benchmark-root"
+          install -d -m 0700 \
+            "${BENCHMARK_ROOT}/downloads" \
+            "${BENCHMARK_ROOT}/prepared" \
+            "${BENCHMARK_ROOT}/evidence" \
+            "${BENCHMARK_ROOT}/work"
+
+      - name: Recover host packages and exact historical guest closure
+        env:
+          # The workflow token is scoped to this repository. This existing
+          # cross-repository token is required only to read retained Actions
+          # artifacts from the sibling Containerization repository.
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -n "${GH_TOKEN}" ]]
+          gh run list --repo "${GITHUB_REPOSITORY}" \
+            --workflow prebuilt-binaries.yml --limit 100 \
+            --json databaseId,displayTitle,status,conclusion,event,createdAt,url \
+            > "${BENCHMARK_ROOT}/downloads/package-runs.json"
+
+          for version in "${BASELINE_VERSION}" "${TARGET_VERSION}"; do
+            version_root="${BENCHMARK_ROOT}/downloads/${version}"
+            distribution="${version_root}/distribution"
+            initfs_root="${version_root}/initfs"
+            guest_root="${version_root}/guest"
+            install -d -m 0700 "${distribution}" "${guest_root}"
+
+            /usr/bin/python3 Tools/parity/published_release_benchmark.py \
+              resolve-package-run \
+              --runs "${BENCHMARK_ROOT}/downloads/package-runs.json" \
+              --version "${version}" > "${version_root}/package-run.json"
+            package_run_id="$(jq -r '.runId' "${version_root}/package-run.json")"
+            package_run_url="$(jq -r '.url' "${version_root}/package-run.json")"
+            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${package_run_id}/artifacts" \
+              > "${version_root}/package-artifacts.json"
+            /usr/bin/python3 Tools/parity/published_release_benchmark.py \
+              validate-package-artifacts \
+              --artifacts "${version_root}/package-artifacts.json" \
+              > "${version_root}/validated-package-artifacts.json"
+            gh run download "${package_run_id}" --repo "${GITHUB_REPOSITORY}" \
+              --dir "${distribution}" --name 'container-release-arm64.tar.gz'
+            gh run download "${package_run_id}" --repo "${GITHUB_REPOSITORY}" \
+              --dir "${distribution}" \
+              --name 'container-compose-plugin-release-arm64.tar.gz'
+            Tools/release/verify-developer-id-archive.sh \
+              "${distribution}/container-release-arm64.tar.gz"
+            Tools/release/verify-developer-id-archive.sh \
+              "${distribution}/container-compose-plugin-release-arm64.tar.gz"
+
+            source_commit="$(git rev-parse --verify "refs/tags/${version}^{commit}")"
+            git show "${source_commit}:Tools/release/stack-refs.json" \
+              > "${version_root}/stack-refs.json"
+            containerization_ref="$(jq -r \
+              '.components.containerization.ref' "${version_root}/stack-refs.json")"
+            [[ "${containerization_ref}" =~ ^[0-9a-f]{40}$ ]]
+
+            gh run list --repo stephenlclarke/containerization \
+              --commit "${containerization_ref}" --limit 30 \
+              --json databaseId,workflowName,headSha,status,conclusion,event,createdAt,url \
+              > "${version_root}/containerization-runs.json"
+            /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py \
+              resolve-run \
+              --runs "${version_root}/containerization-runs.json" \
+              --revision "${containerization_ref}" \
+              > "${version_root}/containerization-run.json"
+            containerization_run_id="$(jq -r \
+              '.runId' "${version_root}/containerization-run.json")"
+            gh api \
+              "repos/stephenlclarke/containerization/actions/runs/${containerization_run_id}/artifacts" \
+              > "${version_root}/containerization-artifacts.json"
+            /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py \
+              validate-initfs \
+              --run "${version_root}/containerization-run.json" \
+              --artifacts "${version_root}/containerization-artifacts.json" \
+              > "${version_root}/guest-provenance.json"
+            initfs_artifact_id="$(jq -r \
+              '.artifactId' "${version_root}/guest-provenance.json")"
+            initfs_artifact_digest="$(jq -r \
+              '.artifactDigest' "${version_root}/guest-provenance.json")"
+            gh api -H 'Accept: application/vnd.github+json' \
+              "repos/stephenlclarke/containerization/actions/artifacts/${initfs_artifact_id}/zip" \
+              > "${version_root}/initfs.zip"
+            /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py \
+              extract-initfs --archive "${version_root}/initfs.zip" \
+              --digest "${initfs_artifact_digest}" --output "${initfs_root}"
+
+            attempt_id="historical-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${version//./-}"
+            PIPELINE_PROFILE=benchmark-reconstruction \
+              PIPELINE_STAGE_SELECTOR=containerization-benchmark-cctl \
+              PIPELINE_ATTEMPT_ID="${attempt_id}" \
+              PIPELINE_CONTAINERIZATION_REPO="${GITHUB_WORKSPACE}/containerization-source" \
+              PIPELINE_CONTAINERIZATION_REF="${containerization_ref}" \
+              /opt/homebrew/opt/make/libexec/gnubin/make \
+                --no-print-directory pipeline
+            pipeline_evidence="${PIPELINE_STATE_ROOT}/evidence/${attempt_id}"
+            cctl_result="${version_root}/cctl-result.json"
+            /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py \
+              extract-cctl \
+              --archive "${pipeline_evidence}/receipts/containerization-benchmark-cctl.artifacts.tar" \
+              --manifest "${pipeline_evidence}/receipts/containerization-benchmark-cctl.artifacts.tsv" \
+              --output "${version_root}/cctl" > "${cctl_result}"
+
+            cctl_home="${version_root}/cctl-home"
+            install -d -m 0700 "${cctl_home}/Library/Application Support" \
+              "${version_root}/tmp"
+            cctl_environment=(env -i \
+              PATH=/usr/bin:/bin HOME="${cctl_home}" \
+              TMPDIR="${version_root}/tmp" LC_ALL=C LANG=C TERM=dumb TZ=UTC)
+            "${cctl_environment[@]}" "${version_root}/cctl" rootfs create \
+              --image vminit:latest \
+              --label org.opencontainers.image.source=https://github.com/stephenlclarke/containerization \
+              "${initfs_root}/init.rootfs.tar.gz"
+            exact_reference="ghcr.io/stephenlclarke/containerization/vminit:${containerization_ref}"
+            "${cctl_environment[@]}" "${version_root}/cctl" images tag \
+              vminit:latest vminit:container-compose
+            "${cctl_environment[@]}" "${version_root}/cctl" images tag \
+              vminit:latest "${exact_reference}"
+            guest_archive="${guest_root}/container-vminit-arm64.oci.tar"
+            "${cctl_environment[@]}" "${version_root}/cctl" images save \
+              --output "${guest_archive}" \
+              vminit:container-compose "${exact_reference}"
+            guest_digest="$(shasum -a 256 "${guest_archive}" | awk '{print $1}')"
+            printf '%s  %s\n' "${guest_digest}" \
+              container-vminit-arm64.oci.tar \
+              > "${guest_archive}.sha256"
+            jq -s '.[0] + .[1]' \
+              "${version_root}/guest-provenance.json" "${cctl_result}" \
+              > "${version_root}/guest-provenance.complete.json"
+
+            /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py prepare \
+              --version "${version}" --distribution "${distribution}" \
+              --init-distribution "${guest_root}" \
+              --tap-repository homebrew-tap --source-repository . \
+              --artifact-source "${package_run_url}" \
+              --guest-provenance "${version_root}/guest-provenance.complete.json" \
+              --output "${BENCHMARK_ROOT}/prepared/${version}"
+            /usr/bin/python3 Tools/release/validate-oci-image-layout.py \
+              "${BENCHMARK_ROOT}/prepared/${version}/init/container-vminit-arm64.oci.tar" \
+              vminit:container-compose "${exact_reference}"
+          done
+
+      - name: Require a quiet benchmark host
+        shell: bash
+        run: |
+          set -euo pipefail
+          competing=0
+          for process_name in swift-frontend swiftc clang xcodebuild nextflow; do
+            if pgrep -x "${process_name}" > \
+              "${BENCHMARK_ROOT}/work/competing-${process_name}.txt" 2>/dev/null; then
+              printf 'competing build process is still active: %s\n' \
+                "${process_name}" >&2
+              competing=1
+            fi
+          done
+          pmset -g therm > "${BENCHMARK_ROOT}/evidence/thermal-before.txt"
+          sysctl -n vm.loadavg > "${BENCHMARK_ROOT}/evidence/load-before.txt"
+          ps -Ao pid,ppid,%cpu,comm -r \
+            > "${BENCHMARK_ROOT}/evidence/processes-before.txt"
+          load_one="$(awk '{ print $2 }' \
+            "${BENCHMARK_ROOT}/evidence/load-before.txt")"
+          cpu_count="$(sysctl -n hw.ncpu)"
+          awk -v load="${load_one}" -v cpus="${cpu_count}" \
+            'BEGIN { exit !(load <= cpus / 2) }'
+          ((competing == 0))
+
+      - name: Run same-host reconstructed comparisons
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_version() {
+            local version="$1"
+            local prepared="${BENCHMARK_ROOT}/prepared/${version}"
+            local runtime="${prepared}/runtime/bin/container"
+            local compose="${prepared}/compose/compose/bin/compose"
+            local init_archive="${prepared}/init/container-vminit-arm64.oci.tar"
+            local init_references
+            init_references="$(jq -r '.assets.guest.references | join(" ")' \
+              "${prepared}/published-distribution.json")"
+            local run_root="${BENCHMARK_ROOT}/work/${version}"
+            local runtime_root="${RUNTIME_ROOT_PREFIX}-${version}"
+            install -d -m 0700 "${run_root}/fixtures"
+            CONTAINER_RUNTIME_APP_ROOT="${runtime_root}" \
+              CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS=ghcr.io,docker.io,registry-1.docker.io,index.docker.io \
+              CONTAINER_RUNTIME_LOCAL_EXECUTION_ROOT=/private/tmp \
+              CONTAINER_RUNTIME_LOCALIZE_APP_ROOT=never \
+              CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="${init_archive}" \
+              CONTAINER_RUNTIME_REQUIRED_INIT_IMAGE_REFERENCES="${init_references}" \
+              CONTAINER_COMPOSE_INIT_IMAGE=vminit:container-compose \
+              CONTAINER_COMPOSE="${compose}" \
+              CONTAINER_COMPOSE_CONTAINER="${runtime}" \
+              PARITY_INIT_IMAGE_ARCHIVE="${init_archive}" \
+              PARITY_INIT_IMAGE_REFERENCES="${init_references}" \
+              PARITY_WORK_ROOT="${run_root}/fixtures" \
+              PARITY_EVIDENCE_DIR="${BENCHMARK_ROOT}/evidence/${version}" \
+              PARITY_REPETITIONS="${REPETITIONS}" \
+              PARITY_INCLUDE_REMOTE_LOGGING=0 \
+              PARITY_TIMING_POLICY=record \
+              scripts/run-with-container-runtime.sh "${runtime}" \
+                Tools/parity/check-compose-performance-matrix.sh --strict
+          }
+          run_version "${BASELINE_VERSION}"
+          run_version "${TARGET_VERSION}"
+          pmset -g therm > "${BENCHMARK_ROOT}/evidence/thermal-after.txt"
+          sysctl -n vm.loadavg > "${BENCHMARK_ROOT}/evidence/load-after.txt"
+
+      - name: Render reconstruction evidence report
+        env:
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          report="docs/benchmarks/${TARGET_VERSION}-vs-${BASELINE_VERSION}.md"
+          /usr/bin/python3 Tools/parity/published_release_benchmark.py render \
+            --target-evidence "${BENCHMARK_ROOT}/evidence/${TARGET_VERSION}" \
+            --baseline-evidence "${BENCHMARK_ROOT}/evidence/${BASELINE_VERSION}" \
+            --target-distribution "${BENCHMARK_ROOT}/prepared/${TARGET_VERSION}/published-distribution.json" \
+            --baseline-distribution "${BENCHMARK_ROOT}/prepared/${BASELINE_VERSION}/published-distribution.json" \
+            --output "${report}" --workflow-url "${WORKFLOW_URL}"
+          printf 'REPORT_PATH=%s\n' "${report}" >> "${GITHUB_ENV}"
+
+      - name: Retain raw reconstruction evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: historical-benchmark-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.BENCHMARK_ROOT }}/evidence
+            ${{ env.BENCHMARK_ROOT }}/prepared/*/published-distribution.json
+            ${{ env.BENCHMARK_ROOT }}/downloads/*/guest-provenance.complete.json
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Open documentation pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          branch="docs/historical-benchmark-${TARGET_VERSION}-vs-${BASELINE_VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git switch -c "${branch}"
+          git add -- "${REPORT_PATH}"
+          git diff --cached --check
+          git commit -S -m \
+            "docs(benchmarks): compare ${TARGET_VERSION} with ${BASELINE_VERSION}"
+          git push --set-upstream origin "${branch}"
+          gh pr create --base main --head "${branch}" \
+            --title "docs(benchmarks): compare ${TARGET_VERSION} with ${BASELINE_VERSION}" \
+            --body "Historical reconstruction benchmark for ${TARGET_VERSION} versus ${BASELINE_VERSION}. Host executables are the immutable signed release packages; each missing guest archive is reconstructed from its exact retained CI initfs and Containerization source revision. Raw evidence is retained by workflow run ${GITHUB_RUN_ID}."
+
+      - name: Clean marker-protected benchmark root
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          marker="${BENCHMARK_ROOT}/.historical-benchmark-root"
+          if [[ -f "${marker}" ]] && \
+            [[ "$(<"${marker}")" == 'container-compose historical benchmark v1' ]]; then
+            find "${BENCHMARK_ROOT}" -depth -delete
+          elif [[ -e "${BENCHMARK_ROOT}" ]]; then
+            printf 'refusing to clean unmarked benchmark root: %s\n' \
+              "${BENCHMARK_ROOT}" >&2
+            exit 1
+          fi
+          for version in "${BASELINE_VERSION:-}" "${TARGET_VERSION:-}"; do
+            [[ -n "${version}" ]] || continue
+            runtime_root="${RUNTIME_ROOT_PREFIX}-${version}"
+            runtime_marker="${runtime_root}/.container-compose-runtime-root"
+            if [[ -f "${runtime_marker}" ]] && \
+              [[ "$(<"${runtime_marker}")" == 'container-compose isolated runtime state v1' ]]; then
+              find "${runtime_root}" -depth -delete
+            elif [[ -e "${runtime_root}" ]]; then
+              printf 'refusing to clean unmarked runtime root: %s\n' \
+                "${runtime_root}" >&2
+              exit 1
+            fi
+          done

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -187,17 +187,35 @@ jobs:
             install -d -m 0700 "${distribution}" "${guest_root}"
 
             /usr/bin/python3 Tools/parity/published_release_benchmark.py \
-              resolve-package-run \
+              package-run-candidates \
               --runs "${BENCHMARK_ROOT}/downloads/package-runs.json" \
-              --version "${version}" > "${version_root}/package-run.json"
-            package_run_id="$(jq -r '.runId' "${version_root}/package-run.json")"
-            package_run_url="$(jq -r '.url' "${version_root}/package-run.json")"
-            gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${package_run_id}/artifacts" \
-              > "${version_root}/package-artifacts.json"
-            /usr/bin/python3 Tools/parity/published_release_benchmark.py \
-              validate-package-artifacts \
-              --artifacts "${version_root}/package-artifacts.json" \
-              > "${version_root}/validated-package-artifacts.json"
+              --version "${version}" \
+              > "${version_root}/package-run-candidates.json"
+            package_run_id=
+            package_run_url=
+            while IFS=$'\t' read -r candidate_id candidate_url; do
+              candidate_artifacts="${version_root}/package-artifacts-${candidate_id}.json"
+              candidate_validation="${version_root}/validated-package-artifacts-${candidate_id}.json"
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/actions/runs/${candidate_id}/artifacts" \
+                > "${candidate_artifacts}"
+              if /usr/bin/python3 \
+                Tools/parity/published_release_benchmark.py \
+                validate-package-artifacts \
+                --artifacts "${candidate_artifacts}" \
+                > "${candidate_validation}" 2> \
+                "${version_root}/package-artifacts-${candidate_id}.error.log"; then
+                package_run_id="${candidate_id}"
+                package_run_url="${candidate_url}"
+                break
+              fi
+            done < <(jq -r '.[] | [.runId, .url] | @tsv' \
+              "${version_root}/package-run-candidates.json")
+            if [[ -z "${package_run_id}" || -z "${package_run_url}" ]]; then
+              printf 'no retained complete package run exists for %s\n' \
+                "${version}" >&2
+              exit 1
+            fi
             gh run download "${package_run_id}" --repo "${GITHUB_REPOSITORY}" \
               --dir "${distribution}" --name 'container-release-arm64.tar.gz'
             gh run download "${package_run_id}" --repo "${GITHUB_REPOSITORY}" \

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -243,6 +243,8 @@ jobs:
               extract-cctl \
               --archive "${pipeline_evidence}/receipts/containerization-benchmark-cctl.artifacts.tar" \
               --manifest "${pipeline_evidence}/receipts/containerization-benchmark-cctl.artifacts.tsv" \
+              --receipt "${pipeline_evidence}/receipts/containerization-benchmark-cctl.receipt.tsv" \
+              --summary "${pipeline_evidence}/pipeline-summary.tsv" \
               --output "${version_root}/cctl" > "${cctl_result}"
 
             cctl_home="${version_root}/cctl-home"

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -104,8 +104,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh release list --repo "${GITHUB_REPOSITORY}" --limit 100 \
-            --json tagName,isDraft,isPrerelease,publishedAt \
+          gh api --paginate --slurp \
+            "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
+            > "${RUNNER_TEMP}/published-release-pages.json"
+          jq '[.[][] | {
+              tagName: .tag_name,
+              isDraft: .draft,
+              isPrerelease: .prerelease,
+              publishedAt: .published_at
+            }]' "${RUNNER_TEMP}/published-release-pages.json" \
             > "${RUNNER_TEMP}/published-releases.json"
           arguments=(
             resolve
@@ -208,9 +215,19 @@ jobs:
               '.components.containerization.ref' "${version_root}/stack-refs.json")"
             [[ "${containerization_ref}" =~ ^[0-9a-f]{40}$ ]]
 
-            gh run list --repo stephenlclarke/containerization \
-              --commit "${containerization_ref}" --limit 30 \
-              --json databaseId,workflowName,headSha,status,conclusion,event,createdAt,url \
+            gh api --paginate --slurp \
+              "repos/stephenlclarke/containerization/actions/workflows/containerization-build.yml/runs?head_sha=${containerization_ref}&per_page=100" \
+              > "${version_root}/containerization-run-pages.json"
+            jq '[.[].workflow_runs[] | {
+                databaseId: .id,
+                workflowName: .name,
+                headSha: .head_sha,
+                status,
+                conclusion,
+                event,
+                createdAt: .created_at,
+                url: .html_url
+              }]' "${version_root}/containerization-run-pages.json" \
               > "${version_root}/containerization-runs.json"
             /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py \
               resolve-run \

--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -44,7 +44,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: published-release-benchmark
+  group: container-compose-performance-benchmark
   cancel-in-progress: false
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,9 @@ endif
 ifneq ($(origin PIPELINE_STAGE_SELECTOR),undefined)
 override PIPELINE_STAGE_SELECTOR := $(value PIPELINE_STAGE_SELECTOR)
 endif
+ifneq ($(origin PIPELINE_ATTEMPT_ID),undefined)
+override PIPELINE_ATTEMPT_ID := $(value PIPELINE_ATTEMPT_ID)
+endif
 ifneq ($(origin PIPELINE_SESSION),undefined)
 override PIPELINE_SESSION := $(value PIPELINE_SESSION)
 endif
@@ -321,6 +324,11 @@ PIPELINE_STAGE_SELECTOR :=
 else
 override PIPELINE_STAGE_SELECTOR := $(value PIPELINE_STAGE_SELECTOR)
 endif
+ifeq ($(origin PIPELINE_ATTEMPT_ID),undefined)
+PIPELINE_ATTEMPT_ID :=
+else
+override PIPELINE_ATTEMPT_ID := $(value PIPELINE_ATTEMPT_ID)
+endif
 ifeq ($(origin PIPELINE_SESSION),undefined)
 PIPELINE_SESSION :=
 else
@@ -432,7 +440,8 @@ export NEXTFLOW_JAVA_SHA256 NEXTFLOW_JAVA_MODULES_SHA256
 export NEXTFLOW_JAVA_LIBJVM_SHA256 NEXTFLOW_JAVA_RELEASE_SHA256
 export CONTAINER_FAMILY_SOURCE_ROOT
 export PIPELINE_STATE_ROOT PIPELINE_MARKER_VALUE PIPELINE_EXECUTION_PATH
-export PIPELINE_PROFILE PIPELINE_ACTION PIPELINE_STAGE_SELECTOR PIPELINE_SESSION
+export PIPELINE_PROFILE PIPELINE_ACTION PIPELINE_STAGE_SELECTOR PIPELINE_ATTEMPT_ID
+export PIPELINE_SESSION
 export PIPELINE_RESUME_SESSION PIPELINE_ORCHESTRATOR_TIMEOUT_SECONDS
 export PIPELINE_SOURCE_TIMEOUT_SECONDS PIPELINE_FUNCTIONAL_TIMEOUT_SECONDS
 export PIPELINE_COMPOSE_REPO PIPELINE_COMPOSE_REF PIPELINE_BUILDER_REPO
@@ -590,8 +599,9 @@ pipeline-help:
 		'  pipeline-self-test  Prove exact-session recovery without rerunning upstream work.' \
 		'' \
 		'Important selectors:' \
-		'  PIPELINE_PROFILE=focused|repository|stack|hosted-safe|release-hosted' \
+		'  PIPELINE_PROFILE=focused|repository|stack|hosted-safe|release-hosted|benchmark-reconstruction' \
 		'  PIPELINE_STAGE_SELECTOR=compose-source,compose-swift-test,compose-go-test,compose-cli-smoke' \
+		'  PIPELINE_ATTEMPT_ID=<safe-unique-id-for-a-known-evidence-directory>' \
 		'  PIPELINE_SESSION=<failed-session-uuid>' \
 		'  CONTAINER_FAMILY_SOURCE_ROOT=<directory-containing-sibling-repositories>' \
 		'  PIPELINE_STATE_ROOT=<absolute-durable-state-directory>'
@@ -909,7 +919,11 @@ pipeline-execute: pipeline-runtime-check
 		JAVA_CMD="$${NEXTFLOW_JAVA_BIN}" NXF_JAVA_HOME="$${NEXTFLOW_JAVA_HOME}" \
 		NXF_HOME="$$state_root/nextflow-home" NXF_TEMP="$$state_root/tmp" \
 		NXF_ANSI_LOG=false NXF_DISABLE_CHECK_LATEST=true); \
-	attempt_id="$$(/bin/date -u +%Y%m%dT%H%M%SZ)-$$$$"; \
+	attempt_id="$${PIPELINE_ATTEMPT_ID:-$$(/bin/date -u +%Y%m%dT%H%M%SZ)-$$$$}"; \
+	if ! [[ "$$attempt_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$$ ]]; then \
+		printf 'PIPELINE_ATTEMPT_ID is unsafe: %s\n' "$$attempt_id" >&2; \
+		exit 2; \
+	fi; \
 	attempt_dir="$$state_root/evidence/$$attempt_id"; \
 	/bin/mkdir "$$attempt_dir"; \
 	printf 'schema\t1\naction\t%s\nprofile\t%s\nstage-selector\t%s\nresume-session\t%s\nsource\t%s\njava-home\t%s\njava-version\t%s\njava-sha256\t%s\njava-modules-sha256\t%s\njava-libjvm-sha256\t%s\njava-release-sha256\t%s\nstarted-utc\t%s\n' \
@@ -940,7 +954,7 @@ pipeline-execute: pipeline-runtime-check
 				"$$@" \
 				--pipelineAction "$$action" \
 				--pipelineProfile "$${PIPELINE_PROFILE}" \
-				--stageSelector "$${PIPELINE_STAGE_SELECTOR}" \
+				"--stageSelector=$${PIPELINE_STAGE_SELECTOR}" \
 				--stateRoot "$$state_root" \
 				--evidenceDir "$$attempt_dir" \
 				--stateMarkerValue "$${PIPELINE_MARKER_VALUE}" \

--- a/Tools/parity/historical_reconstruction_benchmark.py
+++ b/Tools/parity/historical_reconstruction_benchmark.py
@@ -185,10 +185,32 @@ def read_tsv(path: Path) -> list[list[str]]:
         return list(csv.reader(handle, delimiter="\t"))
 
 
-def extract_cctl(archive: Path, manifest: Path, output: Path) -> dict[str, object]:
+def extract_cctl(
+    archive: Path,
+    manifest: Path,
+    receipt: Path,
+    summary: Path,
+    output: Path,
+) -> dict[str, object]:
     rows = read_tsv(manifest)
     records = {row[0]: row[1:] for row in rows if len(row) >= 2}
     artifact_rows = [row for row in rows if row[:2] == ["artifact", "bin/cctl"]]
+    receipt_rows = read_tsv(receipt)
+    receipt_records = {
+        row[0]: row[1:] for row in receipt_rows if len(row) >= 2
+    }
+    summary_rows = read_tsv(summary)
+    archive_digest = file_sha256(archive)
+    manifest_digest = file_sha256(manifest)
+    receipt_digest = file_sha256(receipt)
+    expected_summary_rows = {
+        ("stage-receipt", receipt.name, receipt_digest),
+        ("stage-artifact", archive.name, archive_digest),
+        ("stage-artifact", manifest.name, manifest_digest),
+    }
+    observed_summary_rows = {
+        tuple(row) for row in summary_rows if row and row[0].startswith("stage-")
+    }
     if (
         records.get("schema") != ["1"]
         or records.get("stage") != ["containerization-benchmark-cctl"]
@@ -197,9 +219,33 @@ def extract_cctl(archive: Path, manifest: Path, output: Path) -> dict[str, objec
         or len(artifact_rows) != 1
         or len(artifact_rows[0]) != 4
         or SHA256.fullmatch(artifact_rows[0][2]) is None
-        or records.get("archive-sha256") != [file_sha256(archive)]
+        or records.get("archive-sha256") != [archive_digest]
+        or receipt_records.get("schema") != ["3"]
+        or receipt_records.get("stage") != ["containerization-benchmark-cctl"]
+        or receipt_records.get("repository") != ["containerization"]
+        or receipt_records.get("artifact-archive-sha256") != [archive_digest]
+        or receipt_records.get("artifact-manifest-sha256") != [manifest_digest]
+        or receipt_records.get("artifact-count") != ["1"]
+        or receipt_records.get("exit") != ["0"]
+        or not expected_summary_rows.issubset(observed_summary_rows)
     ):
-        raise ReconstructionInputError("recoverable cctl artifact manifest is invalid")
+        raise ReconstructionInputError(
+            "recoverable cctl artifact evidence is invalid"
+        )
+    evidence_keys = (
+        "source-payload-sha256",
+        "source-metadata-sha256",
+        "command-sha256",
+        "stage-tools-sha256",
+    )
+    if any(
+        len(receipt_records.get(key, [])) != 1
+        or SHA256.fullmatch(receipt_records[key][0]) is None
+        for key in evidence_keys
+    ):
+        raise ReconstructionInputError(
+            "recoverable cctl build identity is incomplete"
+        )
     with tarfile.open(archive) as bundle:
         members = bundle.getmembers()
         if len(members) != 1 or members[0].name != "bin/cctl":
@@ -217,7 +263,14 @@ def extract_cctl(archive: Path, manifest: Path, output: Path) -> dict[str, objec
         raise ReconstructionInputError("extracted cctl digest mismatch")
     output.chmod(0o500)
     return {
-        "cctlArtifactSha256": file_sha256(archive),
+        "cctlArtifactSha256": archive_digest,
+        "cctlBuildCommandSha256": receipt_records["command-sha256"][0],
+        "cctlBuildSourceMetadataSha256": receipt_records[
+            "source-metadata-sha256"
+        ][0],
+        "cctlBuildSourceSha256": receipt_records["source-payload-sha256"][0],
+        "cctlBuildToolsSha256": receipt_records["stage-tools-sha256"][0],
+        "cctlReceiptSha256": receipt_digest,
         "cctlSha256": artifact_rows[0][2],
     }
 
@@ -237,6 +290,11 @@ def prepare_reconstruction(
         "artifactDigest",
         "artifactId",
         "cctlArtifactSha256",
+        "cctlBuildCommandSha256",
+        "cctlBuildSourceMetadataSha256",
+        "cctlBuildSourceSha256",
+        "cctlBuildToolsSha256",
+        "cctlReceiptSha256",
         "cctlSha256",
         "containerizationRef",
         "runUrl",
@@ -246,7 +304,11 @@ def prepare_reconstruction(
     if (
         COMMIT.fullmatch(str(provenance["containerizationRef"])) is None
         or SHA256.fullmatch(str(provenance["cctlArtifactSha256"])) is None
-        or SHA256.fullmatch(str(provenance["cctlSha256"])) is None
+        or any(
+            SHA256.fullmatch(str(provenance[key])) is None
+            for key in required
+            if key.endswith("Sha256")
+        )
         or re.fullmatch(r"sha256:[0-9a-f]{64}", str(provenance["artifactDigest"]))
         is None
         or not isinstance(provenance["artifactId"], int)
@@ -304,6 +366,8 @@ def main() -> None:
     cctl = subparsers.add_parser("extract-cctl")
     cctl.add_argument("--archive", type=Path, required=True)
     cctl.add_argument("--manifest", type=Path, required=True)
+    cctl.add_argument("--receipt", type=Path, required=True)
+    cctl.add_argument("--summary", type=Path, required=True)
     cctl.add_argument("--output", type=Path, required=True)
 
     prepare = subparsers.add_parser("prepare")
@@ -339,7 +403,13 @@ def main() -> None:
         elif arguments.command == "extract-cctl":
             print(
                 json.dumps(
-                    extract_cctl(arguments.archive, arguments.manifest, arguments.output),
+                    extract_cctl(
+                        arguments.archive,
+                        arguments.manifest,
+                        arguments.receipt,
+                        arguments.summary,
+                        arguments.output,
+                    ),
                     sort_keys=True,
                 )
             )

--- a/Tools/parity/historical_reconstruction_benchmark.py
+++ b/Tools/parity/historical_reconstruction_benchmark.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Recover exact historical guest inputs omitted from stable release assets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import re
+import shutil
+import stat
+import tarfile
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+import published_release_benchmark as published
+
+
+CONTAINERIZATION_REPOSITORY = "stephenlclarke/containerization"
+COMMIT = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+
+class ReconstructionInputError(ValueError):
+    """Raised when historical reconstruction authority is incomplete."""
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def resolve_containerization_run(
+    runs: Iterable[dict[str, object]], revision: str
+) -> dict[str, object]:
+    if COMMIT.fullmatch(revision) is None:
+        raise ReconstructionInputError(
+            f"Containerization revision must be an exact commit: {revision}"
+        )
+    candidates: list[tuple[str, int, str]] = []
+    for run in runs:
+        if (
+            run.get("workflowName") != "Build containerization"
+            or run.get("headSha") != revision
+            or run.get("status") != "completed"
+            or run.get("conclusion") != "success"
+            or run.get("event") not in {"push", "workflow_dispatch"}
+        ):
+            continue
+        run_id = run.get("databaseId")
+        created_at = run.get("createdAt")
+        url = run.get("url")
+        if (
+            not isinstance(run_id, int)
+            or run_id <= 0
+            or not isinstance(created_at, str)
+            or not created_at
+            or url
+            != f"https://github.com/{CONTAINERIZATION_REPOSITORY}/actions/runs/{run_id}"
+        ):
+            continue
+        candidates.append((created_at, run_id, url))
+    if not candidates:
+        raise ReconstructionInputError(
+            f"no successful Containerization build run exists at {revision}"
+        )
+    created_at, run_id, url = max(candidates)
+    return {
+        "containerizationRef": revision,
+        "createdAt": created_at,
+        "runId": run_id,
+        "runUrl": url,
+    }
+
+
+def validate_initfs_artifact(
+    payload: dict[str, object], run: dict[str, object]
+) -> dict[str, object]:
+    artifacts = payload.get("artifacts")
+    if not isinstance(artifacts, list):
+        raise ReconstructionInputError("artifact metadata is not an array")
+    matches = [
+        artifact
+        for artifact in artifacts
+        if isinstance(artifact, dict) and artifact.get("name") == "initfs"
+    ]
+    if len(matches) != 1:
+        raise ReconstructionInputError(
+            "Containerization run must retain exactly one initfs artifact"
+        )
+    artifact = matches[0]
+    artifact_id = artifact.get("id")
+    digest = artifact.get("digest")
+    archive_url = artifact.get("archive_download_url")
+    workflow_run = artifact.get("workflow_run")
+    if (
+        not isinstance(artifact_id, int)
+        or artifact_id <= 0
+        or artifact.get("expired") is not False
+        or not isinstance(digest, str)
+        or not digest.startswith("sha256:")
+        or SHA256.fullmatch(digest.removeprefix("sha256:")) is None
+        or archive_url
+        != (
+            "https://api.github.com/repos/"
+            f"{CONTAINERIZATION_REPOSITORY}/actions/artifacts/{artifact_id}/zip"
+        )
+        or not isinstance(workflow_run, dict)
+        or workflow_run.get("id") != run.get("runId")
+        or workflow_run.get("head_sha") != run.get("containerizationRef")
+    ):
+        raise ReconstructionInputError(
+            "initfs artifact is expired or does not match the exact build run"
+        )
+    return {
+        **run,
+        "artifactId": artifact_id,
+        "artifactDigest": digest,
+        "archiveDownloadUrl": archive_url,
+    }
+
+
+def extract_initfs(archive: Path, expected_digest: str, output: Path) -> None:
+    digest = expected_digest.removeprefix("sha256:")
+    if SHA256.fullmatch(digest) is None or file_sha256(archive) != digest:
+        raise ReconstructionInputError("downloaded initfs artifact digest mismatch")
+    required = {"initfs.ext4", "init.rootfs.tar.gz"}
+    members: dict[str, zipfile.ZipInfo] = {}
+    with zipfile.ZipFile(archive) as bundle:
+        for member in bundle.infolist():
+            member_path = PurePosixPath(member.filename)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise ReconstructionInputError(
+                    f"unsafe initfs artifact path: {member.filename}"
+                )
+            mode = member.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise ReconstructionInputError(
+                    f"initfs artifact contains a symbolic link: {member.filename}"
+                )
+            if member.is_dir():
+                continue
+            basename = member_path.name
+            if basename not in required or basename in members:
+                raise ReconstructionInputError(
+                    f"unexpected initfs artifact member: {member.filename}"
+                )
+            members[basename] = member
+        if set(members) != required:
+            missing = ", ".join(sorted(required - set(members)))
+            raise ReconstructionInputError(
+                f"initfs artifact is missing required members: {missing}"
+            )
+        output.mkdir(parents=True, exist_ok=False)
+        for basename, member in members.items():
+            destination = output / basename
+            with bundle.open(member) as source, destination.open("wb") as target:
+                shutil.copyfileobj(source, target)
+            destination.chmod(0o444)
+
+
+def read_tsv(path: Path) -> list[list[str]]:
+    with path.open(encoding="utf-8", newline="") as handle:
+        return list(csv.reader(handle, delimiter="\t"))
+
+
+def extract_cctl(archive: Path, manifest: Path, output: Path) -> dict[str, object]:
+    rows = read_tsv(manifest)
+    records = {row[0]: row[1:] for row in rows if len(row) >= 2}
+    artifact_rows = [row for row in rows if row[:2] == ["artifact", "bin/cctl"]]
+    if (
+        records.get("schema") != ["1"]
+        or records.get("stage") != ["containerization-benchmark-cctl"]
+        or records.get("repository") != ["containerization"]
+        or records.get("artifact-count") != ["1"]
+        or len(artifact_rows) != 1
+        or len(artifact_rows[0]) != 4
+        or SHA256.fullmatch(artifact_rows[0][2]) is None
+        or records.get("archive-sha256") != [file_sha256(archive)]
+    ):
+        raise ReconstructionInputError("recoverable cctl artifact manifest is invalid")
+    with tarfile.open(archive) as bundle:
+        members = bundle.getmembers()
+        if len(members) != 1 or members[0].name != "bin/cctl":
+            raise ReconstructionInputError("recoverable artifact is not exactly bin/cctl")
+        member = members[0]
+        if not member.isfile() or member.issym() or member.islnk():
+            raise ReconstructionInputError("recoverable cctl artifact is not regular")
+        source = bundle.extractfile(member)
+        if source is None:
+            raise ReconstructionInputError("recoverable cctl artifact cannot be read")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        with source, output.open("wb") as target:
+            shutil.copyfileobj(source, target)
+    if file_sha256(output) != artifact_rows[0][2]:
+        raise ReconstructionInputError("extracted cctl digest mismatch")
+    output.chmod(0o500)
+    return {
+        "cctlArtifactSha256": file_sha256(archive),
+        "cctlSha256": artifact_rows[0][2],
+    }
+
+
+def prepare_reconstruction(
+    version: str,
+    distribution: Path,
+    init_distribution: Path,
+    tap_repository: Path,
+    source_repository: Path,
+    artifact_source: str,
+    guest_provenance_path: Path,
+    output: Path,
+) -> dict[str, object]:
+    provenance = json.loads(guest_provenance_path.read_text(encoding="utf-8"))
+    required = {
+        "artifactDigest",
+        "artifactId",
+        "cctlArtifactSha256",
+        "cctlSha256",
+        "containerizationRef",
+        "runUrl",
+    }
+    if not isinstance(provenance, dict) or not required.issubset(provenance):
+        raise ReconstructionInputError("guest reconstruction provenance is incomplete")
+    if (
+        COMMIT.fullmatch(str(provenance["containerizationRef"])) is None
+        or SHA256.fullmatch(str(provenance["cctlArtifactSha256"])) is None
+        or SHA256.fullmatch(str(provenance["cctlSha256"])) is None
+        or re.fullmatch(r"sha256:[0-9a-f]{64}", str(provenance["artifactDigest"]))
+        is None
+        or not isinstance(provenance["artifactId"], int)
+        or provenance["artifactId"] <= 0
+        or provenance["runUrl"]
+        != f"https://github.com/{CONTAINERIZATION_REPOSITORY}/actions/runs/{provenance.get('runId')}"
+    ):
+        raise ReconstructionInputError("guest reconstruction provenance is invalid")
+    manifest = published.prepare_distribution(
+        version,
+        distribution,
+        init_distribution,
+        tap_repository,
+        source_repository,
+        artifact_source,
+        output,
+    )
+    stack_ref = manifest["stack"]["containerization"]["ref"]  # type: ignore[index]
+    if provenance["containerizationRef"] != stack_ref:
+        raise ReconstructionInputError(
+            "guest reconstruction does not match the release stack"
+        )
+    manifest["comparisonMode"] = "historical-source-reconstruction"
+    guest = manifest["assets"]["guest"]  # type: ignore[index]
+    guest["source"] = provenance["runUrl"]  # type: ignore[index]
+    guest["reconstruction"] = provenance  # type: ignore[index]
+    (output / "published-distribution.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    resolve = subparsers.add_parser("resolve-run")
+    resolve.add_argument("--runs", type=Path, required=True)
+    resolve.add_argument("--revision", required=True)
+
+    validate = subparsers.add_parser("validate-initfs")
+    validate.add_argument("--run", type=Path, required=True)
+    validate.add_argument("--artifacts", type=Path, required=True)
+
+    initfs = subparsers.add_parser("extract-initfs")
+    initfs.add_argument("--archive", type=Path, required=True)
+    initfs.add_argument("--digest", required=True)
+    initfs.add_argument("--output", type=Path, required=True)
+
+    cctl = subparsers.add_parser("extract-cctl")
+    cctl.add_argument("--archive", type=Path, required=True)
+    cctl.add_argument("--manifest", type=Path, required=True)
+    cctl.add_argument("--output", type=Path, required=True)
+
+    prepare = subparsers.add_parser("prepare")
+    prepare.add_argument("--version", required=True)
+    prepare.add_argument("--distribution", type=Path, required=True)
+    prepare.add_argument("--init-distribution", type=Path, required=True)
+    prepare.add_argument("--tap-repository", type=Path, required=True)
+    prepare.add_argument("--source-repository", type=Path, required=True)
+    prepare.add_argument("--artifact-source", required=True)
+    prepare.add_argument("--guest-provenance", type=Path, required=True)
+    prepare.add_argument("--output", type=Path, required=True)
+
+    arguments = parser.parse_args()
+    try:
+        if arguments.command == "resolve-run":
+            runs = load_json(arguments.runs)
+            if not isinstance(runs, list):
+                raise ReconstructionInputError("run metadata has an invalid shape")
+            print(
+                json.dumps(
+                    resolve_containerization_run(runs, arguments.revision),
+                    sort_keys=True,
+                )
+            )
+        elif arguments.command == "validate-initfs":
+            run = load_json(arguments.run)
+            artifacts = load_json(arguments.artifacts)
+            if not isinstance(run, dict) or not isinstance(artifacts, dict):
+                raise ReconstructionInputError("artifact metadata has an invalid shape")
+            print(json.dumps(validate_initfs_artifact(artifacts, run), sort_keys=True))
+        elif arguments.command == "extract-initfs":
+            extract_initfs(arguments.archive, arguments.digest, arguments.output)
+        elif arguments.command == "extract-cctl":
+            print(
+                json.dumps(
+                    extract_cctl(arguments.archive, arguments.manifest, arguments.output),
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(
+                json.dumps(
+                    prepare_reconstruction(
+                        arguments.version,
+                        arguments.distribution,
+                        arguments.init_distribution,
+                        arguments.tap_repository,
+                        arguments.source_repository,
+                        arguments.artifact_source,
+                        arguments.guest_provenance,
+                        arguments.output,
+                    ),
+                    sort_keys=True,
+                )
+            )
+    except (ReconstructionInputError, published.BenchmarkInputError) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/parity/historical_reconstruction_benchmark.py
+++ b/Tools/parity/historical_reconstruction_benchmark.py
@@ -51,9 +51,9 @@ def file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def resolve_containerization_run(
+def containerization_run_candidates(
     runs: Iterable[dict[str, object]], revision: str
-) -> dict[str, object]:
+) -> list[dict[str, object]]:
     if COMMIT.fullmatch(revision) is None:
         raise ReconstructionInputError(
             f"Containerization revision must be an exact commit: {revision}"
@@ -85,13 +85,21 @@ def resolve_containerization_run(
         raise ReconstructionInputError(
             f"no successful Containerization build run exists at {revision}"
         )
-    created_at, run_id, url = max(candidates)
-    return {
-        "containerizationRef": revision,
-        "createdAt": created_at,
-        "runId": run_id,
-        "runUrl": url,
-    }
+    return [
+        {
+            "containerizationRef": revision,
+            "createdAt": created_at,
+            "runId": run_id,
+            "runUrl": url,
+        }
+        for created_at, run_id, url in sorted(candidates, reverse=True)
+    ]
+
+
+def resolve_containerization_run(
+    runs: Iterable[dict[str, object]], revision: str
+) -> dict[str, object]:
+    return containerization_run_candidates(runs, revision)[0]
 
 
 def validate_initfs_artifact(
@@ -354,6 +362,10 @@ def main() -> None:
     resolve.add_argument("--runs", type=Path, required=True)
     resolve.add_argument("--revision", required=True)
 
+    candidates = subparsers.add_parser("run-candidates")
+    candidates.add_argument("--runs", type=Path, required=True)
+    candidates.add_argument("--revision", required=True)
+
     validate = subparsers.add_parser("validate-initfs")
     validate.add_argument("--run", type=Path, required=True)
     validate.add_argument("--artifacts", type=Path, required=True)
@@ -382,15 +394,17 @@ def main() -> None:
 
     arguments = parser.parse_args()
     try:
-        if arguments.command == "resolve-run":
+        if arguments.command in {"resolve-run", "run-candidates"}:
             runs = load_json(arguments.runs)
             if not isinstance(runs, list):
                 raise ReconstructionInputError("run metadata has an invalid shape")
+            result = (
+                containerization_run_candidates(runs, arguments.revision)
+                if arguments.command == "run-candidates"
+                else resolve_containerization_run(runs, arguments.revision)
+            )
             print(
-                json.dumps(
-                    resolve_containerization_run(runs, arguments.revision),
-                    sort_keys=True,
-                )
+                json.dumps(result, sort_keys=True)
             )
         elif arguments.command == "validate-initfs":
             run = load_json(arguments.run)

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -118,9 +118,9 @@ def canonical_artifact_source(version: str, source: str) -> str:
     return source
 
 
-def resolve_packaging_run(
+def packaging_run_candidates(
     runs: Iterable[dict[str, object]], version: str
-) -> dict[str, object]:
+) -> list[dict[str, object]]:
     version_tuple(version)
     title = f"Prebuilt Binaries · {version}"
     candidates: list[tuple[str, int, str]] = []
@@ -150,8 +150,16 @@ def resolve_packaging_run(
         raise BenchmarkInputError(
             f"no successful immutable package run retained for {version}"
         )
-    created_at, run_id, url = max(candidates)
-    return {"runId": run_id, "url": url, "createdAt": created_at}
+    return [
+        {"runId": run_id, "url": url, "createdAt": created_at}
+        for created_at, run_id, url in sorted(candidates, reverse=True)
+    ]
+
+
+def resolve_packaging_run(
+    runs: Iterable[dict[str, object]], version: str
+) -> dict[str, object]:
+    return packaging_run_candidates(runs, version)[0]
 
 
 def validate_packaging_artifacts(payload: dict[str, object]) -> dict[str, int]:
@@ -872,6 +880,10 @@ def main() -> None:
     package_run.add_argument("--runs", type=Path, required=True)
     package_run.add_argument("--version", required=True)
 
+    package_candidates = subparsers.add_parser("package-run-candidates")
+    package_candidates.add_argument("--runs", type=Path, required=True)
+    package_candidates.add_argument("--version", required=True)
+
     package_artifacts = subparsers.add_parser("validate-package-artifacts")
     package_artifacts.add_argument("--artifacts", type=Path, required=True)
 
@@ -900,11 +912,17 @@ def main() -> None:
                 raise BenchmarkInputError("release metadata must be a JSON array")
             result = resolve_versions(releases, arguments.target, arguments.baseline)
             print(json.dumps(result, sort_keys=True))
-        elif arguments.command == "resolve-package-run":
+        elif arguments.command in {
+            "resolve-package-run",
+            "package-run-candidates",
+        }:
             runs = load_json(arguments.runs)
             if not isinstance(runs, list):
                 raise BenchmarkInputError("package run metadata must be a JSON array")
-            result = resolve_packaging_run(runs, arguments.version)
+            if arguments.command == "package-run-candidates":
+                result = packaging_run_candidates(runs, arguments.version)
+            else:
+                result = resolve_packaging_run(runs, arguments.version)
             print(json.dumps(result, sort_keys=True))
         elif arguments.command == "validate-package-artifacts":
             artifacts = load_json(arguments.artifacts)

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -643,6 +643,15 @@ def render_report(
 ) -> None:
     target_manifest = json.loads(target_distribution.read_text(encoding="utf-8"))
     baseline_manifest = json.loads(baseline_distribution.read_text(encoding="utf-8"))
+    target_mode = target_manifest.get("comparisonMode", "published-artifacts")
+    baseline_mode = baseline_manifest.get("comparisonMode", "published-artifacts")
+    if target_mode != baseline_mode:
+        raise BenchmarkInputError("target and comparison authority modes differ")
+    if target_mode not in {
+        "published-artifacts",
+        "historical-source-reconstruction",
+    }:
+        raise BenchmarkInputError(f"unsupported benchmark authority mode: {target_mode}")
     target_version = target_manifest["version"]
     baseline_version = baseline_manifest["version"]
     target_samples = load_samples(target_evidence)
@@ -743,10 +752,35 @@ def render_report(
     )
     host = target_fingerprints["host"]
     docker = target_fingerprints["docker"]
+    if target_mode == "historical-source-reconstruction":
+        report_title = (
+            f"# Historical reconstruction benchmark: {target_version} "
+            f"versus {baseline_version}"
+        )
+        authority_summary = (
+            "This report compares the immutable, Developer ID-signed host archives "
+            "from each release. Each missing guest OCI archive was reconstructed from "
+            "the exact retained Containerization CI initfs artifact with a release-mode "
+            "`cctl` built from the release's exact Containerization revision. Both "
+            "releases ran on the same host against the same Docker installation; "
+            "Docker-normalized change is included to expose host drift."
+        )
+        inputs_heading = "## Reconstructed historical inputs"
+    else:
+        report_title = (
+            f"# Published release benchmark: {target_version} versus {baseline_version}"
+        )
+        authority_summary = (
+            "This report compares immutable, Developer ID-signed release archives. "
+            "No source product was built by the benchmark workflow. Both releases ran "
+            "on the same host against the same Docker installation; Docker-normalized "
+            "change is included to expose host drift."
+        )
+        inputs_heading = "## Published inputs"
     lines = [
-        f"# Published release benchmark: {target_version} versus {baseline_version}",
+        report_title,
         "",
-        "This report compares immutable, Developer ID-signed release archives. No source product was built by the benchmark workflow. Both releases ran on the same host against the same Docker installation; Docker-normalized change is included to expose host drift.",
+        authority_summary,
         "",
         "## Result",
         "",
@@ -754,7 +788,7 @@ def render_report(
         "",
         "Lower durations and negative changes are better.",
         "",
-        "## Published inputs",
+        inputs_heading,
         "",
     ]
     for label, manifest in (("Target", target_manifest), ("Comparison", baseline_manifest)):
@@ -771,6 +805,14 @@ def render_report(
                 "",
             ]
         )
+        reconstruction = manifest["assets"]["guest"].get("reconstruction")
+        if reconstruction:
+            lines.extend(
+                [
+                    f"- Guest initfs authority: [{reconstruction['runUrl']}]({reconstruction['runUrl']}); artifact `{reconstruction['artifactId']}` at `{reconstruction['artifactDigest']}`.",
+                    f"- Guest packager: `containerization@{reconstruction['containerizationRef']}`; recoverable stage artifact `{reconstruction['cctlArtifactSha256']}`; extracted `cctl` `{reconstruction['cctlSha256']}`.",
+                ]
+            )
         for component in ("runtime", "compose"):
             asset = manifest["assets"][component]
             lines.append(

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -810,7 +810,8 @@ def render_report(
             lines.extend(
                 [
                     f"- Guest initfs authority: [{reconstruction['runUrl']}]({reconstruction['runUrl']}); artifact `{reconstruction['artifactId']}` at `{reconstruction['artifactDigest']}`.",
-                    f"- Guest packager: `containerization@{reconstruction['containerizationRef']}`; recoverable stage artifact `{reconstruction['cctlArtifactSha256']}`; extracted `cctl` `{reconstruction['cctlSha256']}`.",
+                    f"- Guest packager: `containerization@{reconstruction['containerizationRef']}`; recoverable receipt `{reconstruction['cctlReceiptSha256']}`; stage artifact `{reconstruction['cctlArtifactSha256']}`; extracted `cctl` `{reconstruction['cctlSha256']}`.",
+                    f"- Guest packager inputs: source `{reconstruction['cctlBuildSourceSha256']}`; source metadata `{reconstruction['cctlBuildSourceMetadataSha256']}`; command `{reconstruction['cctlBuildCommandSha256']}`; tools `{reconstruction['cctlBuildToolsSha256']}`.",
                 ]
             )
         for component in ("runtime", "compose"):

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -208,6 +208,8 @@ class HistoricalWorkflowTests(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("runs-on: [self-hosted, macOS, ARM64", workflow)
         self.assertIn("validate-package-artifacts", workflow)
+        self.assertIn("package-run-candidates", workflow)
+        self.assertIn("no retained complete package run exists", workflow)
         self.assertIn("gh api --paginate --slurp", workflow)
         self.assertNotIn("--workflow prebuilt-binaries.yml --limit", workflow)
         self.assertNotIn("--limit ", workflow)

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -214,6 +214,8 @@ class HistoricalWorkflowTests(unittest.TestCase):
         self.assertIn("PIPELINE_PROFILE=benchmark-reconstruction", workflow)
         self.assertIn("containerization-benchmark-cctl", workflow)
         self.assertIn("validate-oci-image-layout.py", workflow)
+        self.assertIn("actions: write", workflow)
+        self.assertIn('-f documentation_pr="${pr_number}"', workflow)
 
     def test_workflow_keeps_runtime_inputs_local_and_noninteractive(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -63,11 +63,29 @@ class HistoricalReconstructionTests(unittest.TestCase):
         return record
 
     def test_resolves_only_an_exact_successful_source_run(self) -> None:
+        older = self.run_record(
+            databaseId=self.run_id - 1,
+            createdAt="2026-08-23T14:32:14Z",
+            url=(
+                "https://github.com/stephenlclarke/containerization/"
+                f"actions/runs/{self.run_id - 1}"
+            ),
+        )
         resolved = MODULE.resolve_containerization_run(
-            [self.run_record(), self.run_record(headSha="b" * 40)], self.revision
+            [older, self.run_record(), self.run_record(headSha="b" * 40)],
+            self.revision,
         )
         self.assertEqual(resolved["runId"], self.run_id)
         self.assertEqual(resolved["containerizationRef"], self.revision)
+        self.assertEqual(
+            [
+                candidate["runId"]
+                for candidate in MODULE.containerization_run_candidates(
+                    [older, self.run_record()], self.revision
+                )
+            ],
+            [self.run_id, self.run_id - 1],
+        )
 
         with self.assertRaisesRegex(
             MODULE.ReconstructionInputError, "no successful"
@@ -215,6 +233,8 @@ class HistoricalWorkflowTests(unittest.TestCase):
         self.assertNotIn("--limit ", workflow)
         self.assertIn("verify-developer-id-archive.sh", workflow)
         self.assertIn("validate-initfs", workflow)
+        self.assertIn("run-candidates", workflow)
+        self.assertIn("no retained initfs run exists", workflow)
         self.assertIn("artifactDigest", workflow)
         self.assertIn("PIPELINE_PROFILE=benchmark-reconstruction", workflow)
         self.assertIn("containerization-benchmark-cctl", workflow)

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+import sys
+import tarfile
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("historical_reconstruction_benchmark.py")
+WORKFLOW = SCRIPT.parents[2] / ".github/workflows/historical-benchmark.yml"
+MAKEFILE = SCRIPT.parents[2] / "Makefile"
+PIPELINE = SCRIPT.parents[2] / "main.nf"
+STAGE_MODULE = SCRIPT.parents[2] / "build-pipeline/modules/repository-stage.nf"
+spec = importlib.util.spec_from_file_location("historical_reconstruction_benchmark", SCRIPT)
+assert spec and spec.loader
+MODULE = importlib.util.module_from_spec(spec)
+sys.path.insert(0, str(SCRIPT.parent))
+spec.loader.exec_module(MODULE)
+
+
+class HistoricalReconstructionTests(unittest.TestCase):
+    revision = "a" * 40
+    run_id = 12345
+
+    def run_record(self, **overrides: object) -> dict[str, object]:
+        record: dict[str, object] = {
+            "databaseId": self.run_id,
+            "workflowName": "Build containerization",
+            "headSha": self.revision,
+            "status": "completed",
+            "conclusion": "success",
+            "event": "push",
+            "createdAt": "2026-08-24T14:32:14Z",
+            "url": (
+                "https://github.com/stephenlclarke/containerization/"
+                f"actions/runs/{self.run_id}"
+            ),
+        }
+        record.update(overrides)
+        return record
+
+    def test_resolves_only_an_exact_successful_source_run(self) -> None:
+        resolved = MODULE.resolve_containerization_run(
+            [self.run_record(), self.run_record(headSha="b" * 40)], self.revision
+        )
+        self.assertEqual(resolved["runId"], self.run_id)
+        self.assertEqual(resolved["containerizationRef"], self.revision)
+
+        with self.assertRaisesRegex(
+            MODULE.ReconstructionInputError, "no successful"
+        ):
+            MODULE.resolve_containerization_run(
+                [self.run_record(conclusion="failure")], self.revision
+            )
+
+    def test_requires_one_unexpired_initfs_artifact_bound_to_the_run(self) -> None:
+        run = MODULE.resolve_containerization_run([self.run_record()], self.revision)
+        payload = {
+            "artifacts": [
+                {
+                    "id": 99,
+                    "name": "initfs",
+                    "expired": False,
+                    "digest": "sha256:" + "c" * 64,
+                    "archive_download_url": (
+                        "https://api.github.com/repos/stephenlclarke/"
+                        "containerization/actions/artifacts/99/zip"
+                    ),
+                    "workflow_run": {
+                        "id": self.run_id,
+                        "head_sha": self.revision,
+                    },
+                }
+            ]
+        }
+        resolved = MODULE.validate_initfs_artifact(payload, run)
+        self.assertEqual(resolved["artifactId"], 99)
+
+        payload["artifacts"][0]["expired"] = True
+        with self.assertRaisesRegex(
+            MODULE.ReconstructionInputError, "expired or does not match"
+        ):
+            MODULE.validate_initfs_artifact(payload, run)
+
+    def test_extracts_only_the_two_digest_bound_initfs_members(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="historical-initfs-") as directory:
+            root = Path(directory)
+            archive = root / "initfs.zip"
+            with zipfile.ZipFile(archive, "w") as bundle:
+                bundle.writestr("initfs.ext4", b"ext4")
+                bundle.writestr("init.rootfs.tar.gz", b"rootfs")
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            output = root / "output"
+            MODULE.extract_initfs(archive, f"sha256:{digest}", output)
+            self.assertEqual((output / "initfs.ext4").read_bytes(), b"ext4")
+            self.assertEqual(
+                (output / "init.rootfs.tar.gz").read_bytes(), b"rootfs"
+            )
+
+            with self.assertRaisesRegex(
+                MODULE.ReconstructionInputError, "digest mismatch"
+            ):
+                MODULE.extract_initfs(archive, "sha256:" + "0" * 64, root / "bad")
+
+    def test_extracts_a_manifest_authenticated_cctl(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="historical-cctl-") as directory:
+            root = Path(directory)
+            archive = root / "cctl.tar"
+            payload = b"exact-cctl"
+            with tarfile.open(archive, "w") as bundle:
+                member = tarfile.TarInfo("bin/cctl")
+                member.size = len(payload)
+                member.mode = 0o755
+                bundle.addfile(member, io.BytesIO(payload))
+            payload_digest = hashlib.sha256(payload).hexdigest()
+            archive_digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            manifest = root / "cctl.tsv"
+            manifest.write_text(
+                "schema\t1\n"
+                "stage\tcontainerization-benchmark-cctl\n"
+                "repository\tcontainerization\n"
+                f"artifact\tbin/cctl\t{payload_digest}\t{len(payload)}\n"
+                "artifact-count\t1\n"
+                f"archive-sha256\t{archive_digest}\n",
+                encoding="utf-8",
+            )
+            output = root / "prepared/cctl"
+            result = MODULE.extract_cctl(archive, manifest, output)
+            self.assertEqual(output.read_bytes(), payload)
+            self.assertEqual(result["cctlArtifactSha256"], archive_digest)
+
+    def test_prepare_reconstruction_requires_complete_provenance(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="historical-provenance-") as directory:
+            provenance = Path(directory) / "provenance.json"
+            provenance.write_text(json.dumps({"runId": 1}), encoding="utf-8")
+            with self.assertRaisesRegex(
+                MODULE.ReconstructionInputError, "incomplete"
+            ):
+                MODULE.prepare_reconstruction(
+                    "0.13.0",
+                    Path(directory),
+                    Path(directory),
+                    Path(directory),
+                    Path(directory),
+                    "https://github.test",
+                    provenance,
+                    Path(directory) / "output",
+                )
+
+
+class HistoricalWorkflowTests(unittest.TestCase):
+    def test_workflow_uses_exact_recoverable_authorities(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("runs-on: [self-hosted, macOS, ARM64", workflow)
+        self.assertIn("validate-package-artifacts", workflow)
+        self.assertIn("verify-developer-id-archive.sh", workflow)
+        self.assertIn("validate-initfs", workflow)
+        self.assertIn("artifactDigest", workflow)
+        self.assertIn("PIPELINE_PROFILE=benchmark-reconstruction", workflow)
+        self.assertIn("containerization-benchmark-cctl", workflow)
+        self.assertIn("validate-oci-image-layout.py", workflow)
+
+    def test_workflow_keeps_runtime_inputs_local_and_noninteractive(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("BENCHMARK_ROOT: /private/tmp/", workflow)
+        self.assertIn("PIPELINE_STATE_ROOT: /Volumes/SSD/github/", workflow)
+        self.assertIn("PARITY_INCLUDE_REMOTE_LOGGING=0", workflow)
+        self.assertIn("CONTAINER_RUNTIME_LOCAL_EXECUTION_ROOT=/private/tmp", workflow)
+        self.assertIn("/opt/homebrew/opt/make/libexec/gnubin/make", workflow)
+        self.assertIn("ssh-keygen -y -P ''", workflow)
+        self.assertNotIn("security import", workflow)
+        self.assertNotIn("crane auth", workflow)
+
+    def test_workflow_does_not_create_a_patch_release_or_run_release_only_work(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertNotIn("gh release create", workflow)
+        self.assertNotIn("CodeQL", workflow)
+        self.assertNotIn("make docs", workflow)
+        self.assertNotIn("package-release", workflow)
+
+    def test_recoverable_pipeline_exports_authenticated_stage_artifacts(self) -> None:
+        pipeline = PIPELINE.read_text(encoding="utf-8")
+        stage_module = STAGE_MODULE.read_text(encoding="utf-8")
+        makefile = MAKEFILE.read_text(encoding="utf-8")
+        self.assertIn("'benchmark-reconstruction'", pipeline)
+        self.assertIn("'containerization-benchmark-cctl': 'bin/cctl'", pipeline)
+        self.assertIn("artifact-archive-sha256", stage_module)
+        self.assertIn("artifact-manifest-sha256", stage_module)
+        self.assertIn('"--stageSelector=$${PIPELINE_STAGE_SELECTOR}"', makefile)
+        self.assertIn("PIPELINE_ATTEMPT_ID is unsafe", makefile)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -210,6 +210,7 @@ class HistoricalWorkflowTests(unittest.TestCase):
         self.assertIn("validate-package-artifacts", workflow)
         self.assertIn("gh api --paginate --slurp", workflow)
         self.assertNotIn("--workflow prebuilt-binaries.yml --limit", workflow)
+        self.assertNotIn("--limit ", workflow)
         self.assertIn("verify-developer-id-archive.sh", workflow)
         self.assertIn("validate-initfs", workflow)
         self.assertIn("artifactDigest", workflow)

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -208,6 +208,8 @@ class HistoricalWorkflowTests(unittest.TestCase):
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("runs-on: [self-hosted, macOS, ARM64", workflow)
         self.assertIn("validate-package-artifacts", workflow)
+        self.assertIn("gh api --paginate --slurp", workflow)
+        self.assertNotIn("--workflow prebuilt-binaries.yml --limit", workflow)
         self.assertIn("verify-developer-id-archive.sh", workflow)
         self.assertIn("validate-initfs", workflow)
         self.assertIn("artifactDigest", workflow)

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -147,10 +147,42 @@ class HistoricalReconstructionTests(unittest.TestCase):
                 f"archive-sha256\t{archive_digest}\n",
                 encoding="utf-8",
             )
+            manifest_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
+            receipt = root / "containerization-benchmark-cctl.receipt.tsv"
+            receipt.write_text(
+                "schema\t3\n"
+                "stage\tcontainerization-benchmark-cctl\n"
+                "repository\tcontainerization\n"
+                f"source-payload-sha256\t{'1' * 64}\n"
+                f"source-metadata-sha256\t{'2' * 64}\n"
+                f"command-sha256\t{'3' * 64}\n"
+                f"stage-tools-sha256\t{'4' * 64}\n"
+                f"artifact-archive-sha256\t{archive_digest}\n"
+                f"artifact-manifest-sha256\t{manifest_digest}\n"
+                "artifact-count\t1\n"
+                "exit\t0\n",
+                encoding="utf-8",
+            )
+            receipt_digest = hashlib.sha256(receipt.read_bytes()).hexdigest()
+            summary = root / "pipeline-summary.tsv"
+            summary.write_text(
+                "schema\t1\n"
+                "stage-receipt\t"
+                f"{receipt.name}\t{receipt_digest}\n"
+                "stage-artifact\t"
+                f"{archive.name}\t{archive_digest}\n"
+                "stage-artifact\t"
+                f"{manifest.name}\t{manifest_digest}\n"
+                "complete\ttrue\n",
+                encoding="utf-8",
+            )
             output = root / "prepared/cctl"
-            result = MODULE.extract_cctl(archive, manifest, output)
+            result = MODULE.extract_cctl(
+                archive, manifest, receipt, summary, output
+            )
             self.assertEqual(output.read_bytes(), payload)
             self.assertEqual(result["cctlArtifactSha256"], archive_digest)
+            self.assertEqual(result["cctlReceiptSha256"], receipt_digest)
 
     def test_prepare_reconstruction_requires_complete_provenance(self) -> None:
         with tempfile.TemporaryDirectory(prefix="historical-provenance-") as directory:

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -319,6 +319,54 @@ class PublishedReportTests(unittest.TestCase):
         self.assertIn("excluded to keep the unattended run free", report)
         self.assertIn("Artifact source:", report)
 
+    def test_report_labels_historical_guest_reconstruction(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="published-benchmark-") as directory:
+            root = Path(directory)
+            baseline = root / "baseline"
+            target = root / "target"
+            baseline.mkdir()
+            target.mkdir()
+            self.write_evidence(baseline, 1.0, 1.0, "0.13.0")
+            self.write_evidence(target, 0.8, 1.0, "0.14.0")
+            manifests = [
+                self.write_manifest(root, "0.13.0"),
+                self.write_manifest(root, "0.14.0"),
+            ]
+            for manifest_path in manifests:
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+                manifest["comparisonMode"] = "historical-source-reconstruction"
+                manifest["assets"]["guest"]["reconstruction"] = {
+                    "artifactDigest": "sha256:" + "d" * 64,
+                    "artifactId": 123,
+                    "cctlArtifactSha256": "e" * 64,
+                    "cctlSha256": "f" * 64,
+                    "containerizationRef": manifest["stack"]["containerization"][
+                        "ref"
+                    ],
+                    "runId": 456,
+                    "runUrl": (
+                        "https://github.com/stephenlclarke/containerization/"
+                        "actions/runs/456"
+                    ),
+                }
+                manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+            output = root / "report.md"
+
+            MODULE.render_report(
+                target,
+                baseline,
+                manifests[1],
+                manifests[0],
+                output,
+                "https://github.example/actions/runs/1",
+            )
+            report = output.read_text(encoding="utf-8")
+
+        self.assertIn("# Historical reconstruction benchmark", report)
+        self.assertIn("exact retained Containerization CI initfs artifact", report)
+        self.assertIn("Guest initfs authority:", report)
+        self.assertNotIn("No source product was built", report)
+
     def test_report_rejects_mismatched_benchmark_conditions(self) -> None:
         with tempfile.TemporaryDirectory(prefix="published-benchmark-") as directory:
             root = Path(directory)

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -339,6 +339,11 @@ class PublishedReportTests(unittest.TestCase):
                     "artifactDigest": "sha256:" + "d" * 64,
                     "artifactId": 123,
                     "cctlArtifactSha256": "e" * 64,
+                    "cctlBuildCommandSha256": "1" * 64,
+                    "cctlBuildSourceMetadataSha256": "2" * 64,
+                    "cctlBuildSourceSha256": "3" * 64,
+                    "cctlBuildToolsSha256": "4" * 64,
+                    "cctlReceiptSha256": "5" * 64,
                     "cctlSha256": "f" * 64,
                     "containerizationRef": manifest["stack"]["containerization"][
                         "ref"

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -118,6 +118,12 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
                 "createdAt": "2026-08-24T11:00:00Z",
             },
         )
+        self.assertEqual(
+            [candidate["runId"] for candidate in MODULE.packaging_run_candidates(
+                runs, "0.13.0"
+            )],
+            [12, 10],
+        )
 
     def test_missing_successful_package_run_is_rejected(self) -> None:
         with self.assertRaisesRegex(

--- a/build-pipeline/modules/repository-stage.nf
+++ b/build-pipeline/modules/repository-stage.nf
@@ -8,9 +8,9 @@ process RUN_REPOSITORY_STAGE {
 
     input:
     tuple val(stageName), val(repositoryName), val(failureClass),
-        val(deadlineSeconds), val(stageCommandBase64), val(sourcePaths),
-        path(sourcePayload), path(sourceMetadata), path(stageTools),
-        val(gateReady)
+        val(deadlineSeconds), val(stageCommandBase64), val(artifactPaths),
+        val(sourcePaths), path(sourcePayload), path(sourceMetadata),
+        path(stageTools), val(gateReady)
     path deadlineRunner
     val stateRootBase64
     val sessionIdentifier
@@ -18,7 +18,9 @@ process RUN_REPOSITORY_STAGE {
     output:
     tuple val(repositoryName), val(stageName),
         path("${stageName}.receipt.tsv"), path("${stageName}.stdout.log"),
-        path("${stageName}.stderr.log"), emit: receipt
+        path("${stageName}.stderr.log"),
+        path("${stageName}.artifacts.tar"),
+        path("${stageName}.artifacts.tsv"), emit: receipt
 
     shell:
     '''
@@ -38,6 +40,7 @@ process RUN_REPOSITORY_STAGE {
     repository_name="!{repositoryName}"
     failure_class="!{failureClass}"
     deadline_seconds="!{deadlineSeconds}"
+    artifact_paths="!{artifactPaths}"
     source_paths="!{sourcePaths}"
     source_payload="$task_root/!{sourcePayload}"
     source_metadata="$task_root/!{sourceMetadata}"
@@ -49,6 +52,8 @@ process RUN_REPOSITORY_STAGE {
     failure_receipt="$task_root/!{stageName}.failure.tsv"
     stdout_log="$task_root/!{stageName}.stdout.log"
     stderr_log="$task_root/!{stageName}.stderr.log"
+    artifact_archive="$task_root/!{stageName}.artifacts.tar"
+    artifact_manifest="$task_root/!{stageName}.artifacts.tsv"
     execution_root=
     stage_command=
     failure_session_root=
@@ -150,7 +155,8 @@ process RUN_REPOSITORY_STAGE {
     esac
     if ! [[ "$stage_name" =~ ^[a-z0-9][a-z0-9-]*$ ]] ||
         ! [[ "$failure_class" =~ ^(source|test|build)$ ]] ||
-        ! [[ "$deadline_seconds" =~ ^[1-9][0-9]*$ ]]; then
+        ! [[ "$deadline_seconds" =~ ^[1-9][0-9]*$ ]] ||
+        ! [[ "$artifact_paths" =~ ^(none|[A-Za-z0-9._/+ -]+)$ ]]; then
         printf 'invalid stage declaration: %s/%s/%s\n' \
             "$stage_name" "$failure_class" "$deadline_seconds" >&2
         exit 2
@@ -618,6 +624,56 @@ process RUN_REPOSITORY_STAGE {
     fi
     verify_tool_closure
 
+    artifact_count=0
+    artifact_arguments=()
+    {
+        printf 'schema\t1\n'
+        printf 'stage\t%s\n' "$stage_name"
+        printf 'repository\t%s\n' "$repository_name"
+    } >"$artifact_manifest"
+    if [[ "$artifact_paths" != none ]]; then
+        read -r -a requested_artifacts <<<"$artifact_paths"
+        for requested_artifact in "${requested_artifacts[@]}"; do
+            if [[ "$requested_artifact" == /* ]] ||
+                [[ "$requested_artifact" == -* ]] ||
+                [[ "$requested_artifact" == '..' ]] ||
+                [[ "$requested_artifact" == ../* ]] ||
+                [[ "$requested_artifact" == */../* ]] ||
+                [[ "$requested_artifact" == */.. ]]; then
+                printf 'unsafe stage artifact path: %s\n' \
+                    "$requested_artifact" >&2
+                exit 2
+            fi
+            artifact_source="$execution_root/source/$requested_artifact"
+            if [[ -L "$artifact_source" ]] || [[ ! -f "$artifact_source" ]]; then
+                printf 'declared stage artifact is not a regular file: %s\n' \
+                    "$requested_artifact" >&2
+                exit 2
+            fi
+            artifact_sha256="$(/usr/bin/shasum -a 256 "$artifact_source" | \
+                /usr/bin/awk '{ print $1 }')"
+            artifact_size="$(/usr/bin/stat -f '%z' "$artifact_source")"
+            printf 'artifact\t%s\t%s\t%s\n' "$requested_artifact" \
+                "$artifact_sha256" "$artifact_size" >>"$artifact_manifest"
+            artifact_arguments+=("$requested_artifact")
+            ((artifact_count += 1))
+        done
+        (
+            cd "$execution_root/source"
+            COPYFILE_DISABLE=1 /usr/bin/tar -cf "$artifact_archive" \
+                "${artifact_arguments[@]}"
+        )
+    else
+        COPYFILE_DISABLE=1 /usr/bin/tar -cf "$artifact_archive" \
+            --files-from /dev/null
+    fi
+    test -s "$artifact_archive"
+    artifact_archive_sha256="$(/usr/bin/shasum -a 256 "$artifact_archive" | \
+        /usr/bin/awk '{ print $1 }')"
+    printf 'artifact-count\t%s\n' "$artifact_count" >>"$artifact_manifest"
+    printf 'archive-sha256\t%s\n' "$artifact_archive_sha256" \
+        >>"$artifact_manifest"
+
     command_sha256="$(/usr/bin/shasum -a 256 "$stage_command" | \
         /usr/bin/awk '{ print $1 }')"
     tools_sha256="$(/usr/bin/shasum -a 256 "$stage_tools" | \
@@ -628,8 +684,10 @@ process RUN_REPOSITORY_STAGE {
         /usr/bin/awk '{ print $1 }')"
     stderr_sha256="$(/usr/bin/shasum -a 256 "$stderr_log" | \
         /usr/bin/awk '{ print $1 }')"
+    artifact_manifest_sha256="$(/usr/bin/shasum -a 256 \
+        "$artifact_manifest" | /usr/bin/awk '{ print $1 }')"
     {
-        printf 'schema\t2\n'
+        printf 'schema\t3\n'
         printf 'stage\t%s\n' "$stage_name"
         printf 'repository\t%s\n' "$repository_name"
         printf 'source-format\t%s\n' "$source_format"
@@ -641,6 +699,11 @@ process RUN_REPOSITORY_STAGE {
         printf 'stage-tools-sha256\t%s\n' "$tools_sha256"
         printf 'stdout-sha256\t%s\n' "$stdout_sha256"
         printf 'stderr-sha256\t%s\n' "$stderr_sha256"
+        printf 'artifact-archive-sha256\t%s\n' \
+            "$artifact_archive_sha256"
+        printf 'artifact-manifest-sha256\t%s\n' \
+            "$artifact_manifest_sha256"
+        printf 'artifact-count\t%s\n' "$artifact_count"
         printf 'stdin-closed\ttrue\n'
         printf 'environment\tallowlisted\n'
         printf 'timezone\tUTC\n'

--- a/main.nf
+++ b/main.nf
@@ -42,7 +42,8 @@ params.stateMarkerValue = 'container-compose recoverable pipeline v1'
 params.executionPath = '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin'
 
 def supportedProfiles() {
-    ['focused', 'repository', 'stack', 'hosted-safe', 'release-hosted']
+    ['focused', 'repository', 'stack', 'hosted-safe', 'release-hosted',
+        'benchmark-reconstruction']
 }
 
 def encodeParameter(value) {
@@ -216,15 +217,46 @@ def releaseHostedFunctionalStageSpecs() {
     ]
 }
 
+def benchmarkReconstructionSourceStageSpecs() {
+    [
+        ['containerization', 'containerization-benchmark-source', 'source',
+            params.sourceTimeoutSeconds as Integer,
+            'test -f Makefile && test -f Package.resolved && test -f vminitd/Makefile',
+            'make,apple-swift', '.', 'commit'],
+    ]
+}
+
+def benchmarkReconstructionFunctionalStageSpecs() {
+    [
+        ['containerization', 'containerization-benchmark-cctl', 'build',
+            params.functionalTimeoutSeconds as Integer,
+            'CI=1 make --no-print-directory ROOT_DIR="$PWD" SWIFT=/usr/bin/swift BUILD_CONFIGURATION=release containerization',
+            'make,apple-swift,codesign',
+            'Package.swift Package.resolved Sources Tests vminitd/Sources vminitd/Makefile Makefile Protobuf.Makefile .swift-version signing',
+            'commit'],
+    ]
+}
+
+def stageArtifactPaths(stageName) {
+    [
+        'containerization-benchmark-cctl': 'bin/cctl',
+    ].get(stageName.toString(), 'none')
+}
+
 def pipelineSelection() {
     def repositories = allRepositorySpecs()
     def sourceStages = params.pipelineProfile == 'release-hosted' ?
-        releaseHostedSourceStageSpecs() : sourceStageSpecs()
+        releaseHostedSourceStageSpecs() :
+        params.pipelineProfile == 'benchmark-reconstruction' ?
+            benchmarkReconstructionSourceStageSpecs() : sourceStageSpecs()
     def functionalStages = params.pipelineProfile == 'release-hosted' ?
-        releaseHostedFunctionalStageSpecs() : functionalStageSpecs()
-    def profileRepositoryNames = params.pipelineProfile in
-        ['stack', 'hosted-safe', 'release-hosted'] ?
-        repositories.collect { repository -> repository[0] } : ['container-compose']
+        releaseHostedFunctionalStageSpecs() :
+        params.pipelineProfile == 'benchmark-reconstruction' ?
+            benchmarkReconstructionFunctionalStageSpecs() : functionalStageSpecs()
+    def profileRepositoryNames = params.pipelineProfile ==
+        'benchmark-reconstruction' ? ['containerization'] :
+        params.pipelineProfile in ['stack', 'hosted-safe', 'release-hosted'] ?
+            repositories.collect { repository -> repository[0] } : ['container-compose']
     def selectedSources = sourceStages.findAll { stage ->
         profileRepositoryNames.contains(stage[0])
     }
@@ -297,7 +329,7 @@ def encodedStageInputSpecs(selection) {
         [
             stage[0], stage[1], stage[2], stage[3],
             encodeParameter(stage[4]),
-            stage[5], stage[6], stage[7],
+            stage[5], stage[6], stage[7], stageArtifactPaths(stage[1]),
         ]
     }
 }
@@ -741,15 +773,15 @@ process CAPTURE_STAGE_SOURCE {
     input:
     tuple val(repositoryName), val(stageName), val(failureClass),
         val(deadlineSeconds), val(stageCommandBase64), val(requiredTools),
-        val(sourcePaths), val(metadataRequirements), path(repositoryIdentity),
-        path(repositoryProvenance)
+        val(sourcePaths), val(metadataRequirements), val(artifactPaths),
+        path(repositoryIdentity), path(repositoryProvenance)
     path deadlineRunner
 
     output:
     tuple val(stageName), val(repositoryName), val(failureClass),
-        val(deadlineSeconds), val(stageCommandBase64), val(sourcePaths),
-        path("${stageName}.payload.*"), path("${stageName}.source.tsv"),
-        emit: prepared
+        val(deadlineSeconds), val(stageCommandBase64), val(artifactPaths),
+        val(sourcePaths), path("${stageName}.payload.*"),
+        path("${stageName}.source.tsv"), emit: prepared
 
     shell:
     '''
@@ -972,7 +1004,8 @@ process PREFLIGHT_STAGE_TOOLS {
     input:
     tuple val(repositoryName), val(stageName), val(failureClass),
         val(deadlineSeconds), val(stageCommandBase64), val(requiredTools),
-        val(sourcePaths), val(metadataRequirements), path(hostReady)
+        val(sourcePaths), val(metadataRequirements), val(artifactPaths),
+        path(hostReady)
     val executionPathBase64
     path deadlineRunner
 
@@ -1033,6 +1066,7 @@ process PREFLIGHT_STAGE_TOOLS {
         system-ln:/bin/ln \
         system-base64:/usr/bin/base64 system-head:/usr/bin/head \
         system-file:/usr/bin/file system-tr:/usr/bin/tr \
+        system-stat:/usr/bin/stat \
         system-ps:/bin/ps system-readlink:/usr/bin/readlink \
         system-xcode-select:/usr/bin/xcode-select system-xcrun:/usr/bin/xcrun)
     IFS=',' read -r -a requested_tools <<<"$required_tools"
@@ -1367,7 +1401,9 @@ process PIPELINE_SUMMARY {
         evidence_name="$(/usr/bin/basename "$evidence")"
         case "$evidence_name" in
             *.receipt.tsv) ;;
-            *.stdout.log|*.stderr.log) test -f "$evidence" ;;
+            *.stdout.log|*.stderr.log|*.artifacts.tar|*.artifacts.tsv)
+                test -f "$evidence"
+                ;;
             *) exit 2 ;;
         esac
     done
@@ -1386,18 +1422,36 @@ process PIPELINE_SUMMARY {
         ((observed_stage_count += 1))
         stdout_log="${receipt_stage}.stdout.log"
         stderr_log="${receipt_stage}.stderr.log"
+        artifact_archive="${receipt_stage}.artifacts.tar"
+        artifact_manifest="${receipt_stage}.artifacts.tsv"
         test -f "$stdout_log"
         test -f "$stderr_log"
+        test -s "$artifact_archive"
+        test -s "$artifact_manifest"
         expected_stdout_sha256="$(/usr/bin/awk -F '\t' \
             '$1 == "stdout-sha256" { print $2 }' "$receipt")"
         expected_stderr_sha256="$(/usr/bin/awk -F '\t' \
             '$1 == "stderr-sha256" { print $2 }' "$receipt")"
+        expected_artifact_archive_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-archive-sha256" { print $2 }' "$receipt")"
+        expected_artifact_manifest_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-manifest-sha256" { print $2 }' "$receipt")"
         [[ "$expected_stdout_sha256" =~ ^[0-9a-f]{64}$ ]]
         [[ "$expected_stderr_sha256" =~ ^[0-9a-f]{64}$ ]]
+        [[ "$expected_artifact_archive_sha256" =~ ^[0-9a-f]{64}$ ]]
+        [[ "$expected_artifact_manifest_sha256" =~ ^[0-9a-f]{64}$ ]]
         [[ "$(/usr/bin/shasum -a 256 "$stdout_log" | \
             /usr/bin/awk '{ print $1 }')" == "$expected_stdout_sha256" ]]
         [[ "$(/usr/bin/shasum -a 256 "$stderr_log" | \
             /usr/bin/awk '{ print $1 }')" == "$expected_stderr_sha256" ]]
+        [[ "$(/usr/bin/shasum -a 256 "$artifact_archive" | \
+            /usr/bin/awk '{ print $1 }')" == \
+            "$expected_artifact_archive_sha256" ]]
+        [[ "$(/usr/bin/shasum -a 256 "$artifact_manifest" | \
+            /usr/bin/awk '{ print $1 }')" == \
+            "$expected_artifact_manifest_sha256" ]]
+        [[ "$(/usr/bin/awk -F '\t' '$1 == "archive-sha256" { print $2 }' \
+            "$artifact_manifest")" == "$expected_artifact_archive_sha256" ]]
         printf 'stage-receipt\t%s\t%s\n' "$(/usr/bin/basename "$receipt")" \
             "$(/usr/bin/shasum -a 256 "$receipt" | /usr/bin/awk '{ print $1 }')" \
             >>pipeline-summary.tsv
@@ -1405,6 +1459,10 @@ process PIPELINE_SUMMARY {
             "$expected_stdout_sha256" >>pipeline-summary.tsv
         printf 'stage-output\t%s\t%s\n' "$stderr_log" \
             "$expected_stderr_sha256" >>pipeline-summary.tsv
+        printf 'stage-artifact\t%s\t%s\n' "$artifact_archive" \
+            "$expected_artifact_archive_sha256" >>pipeline-summary.tsv
+        printf 'stage-artifact\t%s\t%s\n' "$artifact_manifest" \
+            "$expected_artifact_manifest_sha256" >>pipeline-summary.tsv
     done
     IFS=',' read -r -a expected_stages <<<"$expected_stage_names"
     [[ "$observed_stage_count" -eq "${#expected_stages[@]}" ]]
@@ -1494,7 +1552,7 @@ workflow PREFLIGHT_ONLY {
         "repository preflight passed: ${item[0]} (${item[1]})"
     }
     PREPARE_STAGE_GRAPH.out.prepared.view { item ->
-        "stage preflight passed: ${item[0]} (${item[8]})"
+        "stage preflight passed: ${item[0]} (${item[9]})"
     }
 }
 
@@ -1535,10 +1593,10 @@ workflow PIPELINE {
     functionalInputs = PREPARE_STAGE_GRAPH.out.prepared
         .filter { item -> functionalStageNames.contains(item[0]) }
         .map { item -> tuple(item[1], item[0], item[2], item[3], item[4],
-            item[5], item[6], item[7], item[8]) }
+            item[5], item[6], item[7], item[8], item[9]) }
         .combine(repositorySourceGates, by: 0)
         .map { item -> tuple(item[1], item[0], item[2], item[3], item[4],
-            item[5], item[6], item[7], item[8], item[9]) }
+            item[5], item[6], item[7], item[8], item[9], item[10]) }
     swiftRepositoryNames = [
         'container-compose', 'containerization', 'container',
         'container-engine-api', 'devcontainer', 'container-k8s',
@@ -1563,11 +1621,11 @@ workflow PIPELINE {
     )
 
     allStageEvidence = RUN_SOURCE_STAGE.out.receipt
-        .flatMap { item -> [item[2], item[3], item[4]] }
+        .flatMap { item -> [item[2], item[3], item[4], item[5], item[6]] }
         .concat(RUN_SWIFT_STAGE.out.receipt
-            .flatMap { item -> [item[2], item[3], item[4]] })
+            .flatMap { item -> [item[2], item[3], item[4], item[5], item[6]] })
         .concat(RUN_LIGHTWEIGHT_STAGE.out.receipt
-            .flatMap { item -> [item[2], item[3], item[4]] })
+            .flatMap { item -> [item[2], item[3], item[4], item[5], item[6]] })
         .collect()
     allRepositoryReceipts = repositoryReceipts
         .flatMap { item -> [item[1], item[2]] }


### PR DESCRIPTION
Advances #362.

## Outcome

Adds a deterministic, recoverable historical benchmark path for stable releases whose original host packages remain available but whose guest OCI closure was not published. This makes the exact 0.13.0 versus 0.14.0 comparison possible without publishing a misleading 0.13.1 release.

The workflow uses the immutable Developer ID-signed host archives from each successful package run, the exact retained Containerization initfs artifact for each release stack revision, and a release-mode cctl built from that exact Containerization revision through the recoverable Nextflow graph. Runtime fixtures and evidence remain on the internal volume; durable build/cache state remains under /Volumes/SSD.

## Reliability boundaries

- authenticated declared build artifacts are now recoverable Nextflow stage outputs;
- every retained initfs download is bound to one successful exact-head CI run and API SHA-256;
- cctl and initfs packaging use isolated HOME/TMPDIR state with no registry authentication or keychain access;
- remote logging, CodeQL, DocC, release publication, and broad regression work are excluded;
- published and reconstructed benchmarks share one concurrency lock and require a quiet host before timing;
- documentation commits fail fast unless passphrase-free SSH signing is available.

## Focused proof

- 38 Python benchmark/reconstruction tests pass;
- actionlint passes both benchmark workflows;
- Nextflow pipeline lint passes with only the existing shell-deprecation warnings;
- exact 0.13.0 and 0.14.0 Containerization revisions each built and exported authenticated cctl artifacts;
- the retained 0.13.0 initfs artifact was digest-verified, reconstructed into an OCI archive, and passed exact-reference OCI layout validation;
- git diff --check passes.