### PR TITLE
fix(benchmarks): retain historical logging containers

### DIFF
--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -56,11 +56,18 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, container-compose-release]
     timeout-minutes: 240
     env:
-      BENCHMARK_ROOT: /private/tmp/container-compose-historical-benchmark-${{ github.run_id }}-${{ github.run_attempt }}
       PIPELINE_STATE_ROOT: /Volumes/SSD/github/.container-compose-pipeline
       REPETITIONS: ${{ inputs.repetitions }}
       RUNTIME_ROOT_PREFIX: /private/tmp/cchr-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
+      - name: Select local benchmark root
+        shell: bash
+        run: |
+          set -euo pipefail
+          printf 'BENCHMARK_ROOT=%s/container-compose-historical-benchmark-%s-%s\n' \
+            "${RUNNER_TEMP}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}" \
+            >> "${GITHUB_ENV}"
+
       - name: Checkout benchmark controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/Tools/parity/check-compose-performance-matrix.sh
+++ b/Tools/parity/check-compose-performance-matrix.sh
@@ -320,6 +320,7 @@ create_fixtures() {
             '          pressure)' \
             '            index=0; while [ "$$index" -lt "$${LOG_RECORD_COUNT}" ]; do printf '\''perf-record-%06d %s\n'\'' "$$index" "$$small_payload"; index=$$((index + 1)); done' \
             '            if [ -n "$${LOG_COMPLETION_FILE:-}" ]; then printf complete >"/completion/$${LOG_COMPLETION_FILE}"; fi' \
+            '            if [ "$${LOG_RETAIN_AFTER_COMPLETION:-0}" = 1 ]; then sleep 600; fi' \
             '            ;;' \
             '          history-window)' \
             '            printf '\''history-before\n'\''' \
@@ -354,6 +355,14 @@ create_fixtures() {
             '    extends:' \
             '      file: logging-workload.yml' \
             '      service: logger' \
+            '    environment:' \
+            '      LOG_COMPLETION_FILE: ${LOG_COMPLETION_FILE:?LOG_COMPLETION_FILE is required}' \
+            '      LOG_RETAIN_AFTER_COMPLETION: "${LOG_RETAIN_AFTER_COMPLETION:-0}"' \
+            '    volumes:' \
+            '      - type: bind' \
+            '        source: ${PERF_COMPLETION_DIR:?PERF_COMPLETION_DIR is required}' \
+            '        target: /completion' \
+            '    stop_grace_period: 1s' \
             '    logging:' \
             '      driver: json-file' \
             '      options:' \
@@ -368,6 +377,14 @@ create_fixtures() {
             '    extends:' \
             '      file: logging-workload.yml' \
             '      service: logger' \
+            '    environment:' \
+            '      LOG_COMPLETION_FILE: ${LOG_COMPLETION_FILE:?LOG_COMPLETION_FILE is required}' \
+            '      LOG_RETAIN_AFTER_COMPLETION: "${LOG_RETAIN_AFTER_COMPLETION:-0}"' \
+            '    volumes:' \
+            '      - type: bind' \
+            '        source: ${PERF_COMPLETION_DIR:?PERF_COMPLETION_DIR is required}' \
+            '        target: /completion' \
+            '    stop_grace_period: 1s' \
             '    logging:' \
             '      driver: local' \
             '      options:' \
@@ -960,15 +977,26 @@ run_remote_sink_lane() {
 
 # Time one retained built-in rotation/compression writer and prove exact reads.
 run_file_logging_lane() {
-    local lane="$1" repetition="$2" schedule_position="$3" fixture="$4" file="$5" project
+    local lane="$1" repetition="$2" schedule_position="$3" fixture="$4" file="$5"
+    local project completion_dir completion_file completion_path
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-logging"
+    completion_dir="$FIXTURE_DIR/completions"
+    completion_file="$fixture-$lane-$repetition.done"
+    completion_path="$completion_dir/$completion_file"
+    mkdir -p "$completion_dir"
     down_project "$lane" "$project" "$FIXTURE_DIR/logging.yml"
-    run_timed "$fixture" "$lane" "$repetition" "$schedule_position" \
+    run_to_completion_marker "$fixture" "$lane" "$repetition" \
+        "$schedule_position" "$completion_path" \
         env LOG_WORKLOAD=pressure LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
+        LOG_COMPLETION_FILE="$completion_file" \
+        LOG_RETAIN_AFTER_COMPLETION=1 PERF_COMPLETION_DIR="$completion_dir" \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up \
-        --abort-on-container-exit --exit-code-from logger --pull never
-    LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" assert_logging_record_count \
+        -d --pull never
+    LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
+        LOG_COMPLETION_FILE="$completion_file" \
+        LOG_RETAIN_AFTER_COMPLETION=1 PERF_COMPLETION_DIR="$completion_dir" \
+        assert_logging_record_count \
         "$fixture-$lane-$repetition" "$PARITY_PRESSURE_RECORDS" \
         "$project" "$file" "${ACTIVE_COMPOSE[@]}"
     down_project "$lane" "$project" "$FIXTURE_DIR/logging.yml"

--- a/Tools/parity/test_compose_performance_matrix.py
+++ b/Tools/parity/test_compose_performance_matrix.py
@@ -172,6 +172,46 @@ class PerformanceMatrixInventoryTests(unittest.TestCase):
             fixture_root = Path(result.stdout.strip())
             self.assertEqual(fixture_root.parent, work_root)
 
+    def test_file_logging_fixtures_retain_completed_writer_for_assertion(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-performance-work-") as directory:
+            work_root = Path(directory) / "fixtures"
+            environment = dict(os.environ)
+            environment["PARITY_WORK_ROOT"] = str(work_root)
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    'source "$1"; create_fixtures; printf "%s\\n" "$FIXTURE_DIR"',
+                    "_",
+                    HARNESS,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+            fixture_root = Path(result.stdout.strip())
+            workload = (fixture_root / "logging-workload.yml").read_text(
+                encoding="utf-8"
+            )
+            regular = (fixture_root / "logging.yml").read_text(encoding="utf-8")
+            retained = [
+                (fixture_root / filename).read_text(encoding="utf-8")
+                for filename in (
+                    "logging-json-compress.yml",
+                    "logging-local.yml",
+                )
+            ]
+
+        self.assertIn("LOG_RETAIN_AFTER_COMPLETION", workload)
+        self.assertNotIn("LOG_COMPLETION_FILE", regular)
+        for fixture in retained:
+            self.assertIn("LOG_COMPLETION_FILE", fixture)
+            self.assertIn("LOG_RETAIN_AFTER_COMPLETION", fixture)
+            self.assertIn("target: /completion", fixture)
+            self.assertIn("stop_grace_period: 1s", fixture)
+
 
 class PerformanceMatrixSinkSafetyTests(unittest.TestCase):
     def test_non_loopback_sink_requires_explicit_opt_in(self) -> None:
@@ -287,6 +327,83 @@ class PerformanceMatrixCompletionMarkerTests(unittest.TestCase):
         self.assertEqual(rows[0]["outcome"], "success")
         self.assertGreaterEqual(float(rows[0]["duration_seconds"]), 0.04)
         self.assertIn(f"until-file:{marker}", rows[0]["command"])
+
+    def test_file_logging_keeps_container_available_for_log_assertion(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-file-logging-test-") as directory:
+            root = Path(directory)
+            evidence = root / "evidence"
+            fixtures = root / "fixtures"
+            invocations = root / "invocations.tsv"
+            fake_compose = root / "compose"
+            fake_compose.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\t%s\\t%s\\n' "$LOG_WORKLOAD" "$LOG_RETAIN_AFTER_COMPLETION" "$*" >>"$INVOCATIONS"
+mkdir -p "$PERF_COMPLETION_DIR"
+touch "$PERF_COMPLETION_DIR/$LOG_COMPLETION_FILE"
+""",
+                encoding="utf-8",
+            )
+            fake_compose.chmod(0o755)
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "FAKE_COMPOSE": str(fake_compose),
+                    "INVOCATIONS": str(invocations),
+                    "PARITY_EVIDENCE_DIR": str(evidence),
+                    "PARITY_PRESSURE_RECORDS": "3",
+                    "PARITY_TIMEOUT_SECONDS": "2",
+                    "PARITY_WORK_ROOT": str(root),
+                }
+            )
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    """
+source "$1"
+mkdir -p "$PARITY_EVIDENCE_DIR" "$PARITY_WORK_ROOT/fixtures"
+FIXTURE_DIR="$PARITY_WORK_ROOT/fixtures"
+printf 'fixture\\tlane\\trepetition\\tschedule_position\\tdirection\\tduration_seconds\\toutcome\\tcommand\\n' >"$TIMING_TSV"
+touch "$FIXTURE_DIR/logging.yml" "$FIXTURE_DIR/logging-json-compress.yml"
+select_lane() { LANE_PREFIX=c; ACTIVE_COMPOSE=("$FAKE_COMPOSE"); }
+down_project() { :; }
+assert_logging_record_count() {
+    printf 'asserted\\t%s\\t%s\\t%s\\n' \
+        "$LOG_COMPLETION_FILE" "$LOG_RETAIN_AFTER_COMPLETION" \
+        "$PERF_COMPLETION_DIR" >>"$INVOCATIONS"
+}
+run_file_logging_lane container-compose 1 2 logging-write-json-compression "$FIXTURE_DIR/logging-json-compress.yml"
+""",
+                    "_",
+                    HARNESS,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            with (evidence / "timings.tsv").open(
+                encoding="utf-8", newline=""
+            ) as handle:
+                rows = list(csv.DictReader(handle, delimiter="\t"))
+            invocation_lines = invocations.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["outcome"], "success")
+        self.assertIn("until-file:", rows[0]["command"])
+        self.assertIn("pressure\t1\t", invocation_lines[0])
+        self.assertIn(" up -d --pull never", invocation_lines[0])
+        assertion = invocation_lines[1].split("\t")
+        self.assertEqual(assertion[0], "asserted")
+        self.assertEqual(
+            assertion[1],
+            "logging-write-json-compression-container-compose-1.done",
+        )
+        self.assertEqual(assertion[2], "1")
+        self.assertEqual(Path(assertion[3]), fixtures / "completions")
 
 
 class PerformanceMatrixEvidenceTests(unittest.TestCase):

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -244,7 +244,7 @@ class HistoricalWorkflowTests(unittest.TestCase):
 
     def test_workflow_keeps_runtime_inputs_local_and_noninteractive(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("BENCHMARK_ROOT: /private/tmp/", workflow)
+        self.assertIn('"${RUNNER_TEMP}" "${GITHUB_RUN_ID}"', workflow)
         self.assertIn("PIPELINE_STATE_ROOT: /Volumes/SSD/github/", workflow)
         self.assertIn("PARITY_INCLUDE_REMOTE_LOGGING=0", workflow)
         self.assertIn("CONTAINER_RUNTIME_LOCAL_EXECUTION_ROOT=/private/tmp", workflow)


### PR DESCRIPTION
Advances #362.

## Outcome

Makes retained local logging benchmarks compatible with the exact 0.13.0 runtime. The writer now publishes an explicit host completion marker and remains alive while the harness proves the full canonical log sequence, avoiding the 0.13.0 stopped-container retention assumption that failed run 33430018409.

The ephemeral benchmark root moves from `/private/tmp` to the self-hosted runner's local, home-backed temp directory so Colima and the Container VM can both mount completion evidence. Runtime app state remains in `/private/tmp`; recoverable build/cache evidence remains on `/Volumes/SSD`.

## Focused proof

- 52 impacted performance, published-release, and historical-reconstruction tests pass.
- `bash -n` and ShellCheck pass.
- actionlint passes the historical workflow.
- `git diff --check` passes.

The failed run retained raw evidence and cleaned its marker-protected temporary/runtime roots successfully.