### PR TITLE
fix(benchmarks): retain historical log corpus

### DIFF
--- a/Tools/parity/check-compose-performance-matrix.sh
+++ b/Tools/parity/check-compose-performance-matrix.sh
@@ -1100,7 +1100,10 @@ prepare_logging_history() {
     down_project "$lane" "$project" "$file"
     env LOG_WORKLOAD=history LOG_MAX_SIZE=64m \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up \
-        --abort-on-container-exit --exit-code-from logger --pull never >/dev/null
+        -d --pull never >/dev/null
+    env LOG_WORKLOAD=history LOG_MAX_SIZE=64m \
+        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" \
+        wait logger >/dev/null
 }
 
 # Time one canonical historical logging query against a prepared corpus.

--- a/Tools/parity/test_compose_performance_matrix.py
+++ b/Tools/parity/test_compose_performance_matrix.py
@@ -723,6 +723,56 @@ run_file_logging_lane container-compose 1 2 logging-write-json-compression "$FIX
         self.assertEqual(assertion[2], "1")
         self.assertEqual(Path(assertion[3]), fixtures / "completions")
 
+    def test_logging_read_corpus_retains_stopped_container(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-read-corpus-test-") as directory:
+            root = Path(directory)
+            invocations = root / "invocations.txt"
+            fake_compose = root / "compose"
+            fixture = root / "logging.yml"
+            fixture.touch()
+            fake_compose.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >>"$INVOCATIONS"
+""",
+                encoding="utf-8",
+            )
+            fake_compose.chmod(0o755)
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "FAKE_COMPOSE": str(fake_compose),
+                    "INVOCATIONS": str(invocations),
+                }
+            )
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    """
+source "$1"
+select_lane() { LANE_PREFIX=c; ACTIVE_COMPOSE=("$FAKE_COMPOSE"); }
+down_project() { :; }
+prepare_logging_history container-compose "$2"
+""",
+                    "_",
+                    HARNESS,
+                    fixture,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            invocation_lines = invocations.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(len(invocation_lines), 2)
+        self.assertIn(" up -d --pull never", invocation_lines[0])
+        self.assertNotIn("--abort-on-container-exit", invocation_lines[0])
+        self.assertTrue(invocation_lines[1].endswith(" wait logger"))
+
 
 class PerformanceMatrixEvidenceTests(unittest.TestCase):
     def test_finalizer_reports_comparable_median_and_p95(self) -> None:


### PR DESCRIPTION
## Summary

- prepare historical log-read corpora with detached `up`
- wait explicitly for the logger to finish while retaining the stopped container
- cover the invocation contract with a focused regression

## Cause

The full 0.13.0-vs-0.14.0 benchmark reached the checkpointed log-read phase in run #33447438607. Docker retained the foreground workload container, but the historical 0.13.0 Container lifecycle removed it after `--abort-on-container-exit`, so the following `logs` command could not resolve `cc-perf-c-logging-logger-1`.

## Proof

- `python3 -m unittest Tools.parity.test_compose_performance_matrix.PerformanceMatrixCompletionMarkerTests.test_logging_read_corpus_retains_stopped_container`
- `bash -n Tools/parity/check-compose-performance-matrix.sh`
- `shellcheck Tools/parity/check-compose-performance-matrix.sh`
- retained raw benchmark evidence: workflow run #33447438607, artifact #9779488452

After merge, the benchmark will resume from the retained 0.13.0 lifecycle/stream and file-log checkpoints instead of rerunning them.