### PR TITLE
fix(benchmarks): avoid log timestamp equality boundaries

### DIFF
--- a/Tools/parity/check-compose-performance-matrix.sh
+++ b/Tools/parity/check-compose-performance-matrix.sh
@@ -828,6 +828,24 @@ raise SystemExit(f"timed out waiting for timestamped log marker {expected!r}")
 PY
 }
 
+# Return an RFC 3339 timestamp strictly between two persisted log records.
+midpoint_log_timestamp() {
+    python3 - "$1" "$2" <<'PY'
+from datetime import datetime, timezone
+import sys
+
+start_text, end_text = sys.argv[1:]
+start = datetime.fromisoformat(start_text.replace("Z", "+00:00"))
+end = datetime.fromisoformat(end_text.replace("Z", "+00:00"))
+if end <= start:
+    raise SystemExit(
+        f"log timestamp gap is not positive: {start_text!r} .. {end_text!r}"
+    )
+midpoint = start + (end - start) / 2
+print(midpoint.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z"))
+PY
+}
+
 # Assert that one since/until query returns exactly the bounded history window.
 assert_since_until_window() {
     local label="$1" since="$2" until="$3" project="$4" file="$5"
@@ -1118,7 +1136,8 @@ run_logging_read_lane() {
 
 # Time and prove one absolute since/until query around a deterministic window.
 run_logging_since_until_lane() {
-    local lane="$1" repetition="$2" schedule_position="$3" file="$4" project since until
+    local lane="$1" repetition="$2" schedule_position="$3" file="$4"
+    local project before first last after since until
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-logging"
     down_project "$lane" "$project" "$file"
@@ -1126,10 +1145,16 @@ run_logging_since_until_lane() {
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up -d --pull never >/dev/null
     LOG_WORKLOAD=history-window wait_for_log_text \
         history-before "$project" "$file" "${ACTIVE_COMPOSE[@]}"
-    since="$(LOG_WORKLOAD=history-window wait_for_log_timestamp \
+    before="$(LOG_WORKLOAD=history-window wait_for_log_timestamp \
+        history-before "$project" "$file" "${ACTIVE_COMPOSE[@]}")"
+    first="$(LOG_WORKLOAD=history-window wait_for_log_timestamp \
         history-window-000 "$project" "$file" "${ACTIVE_COMPOSE[@]}")"
-    until="$(LOG_WORKLOAD=history-window wait_for_log_timestamp \
+    last="$(LOG_WORKLOAD=history-window wait_for_log_timestamp \
         history-window-099 "$project" "$file" "${ACTIVE_COMPOSE[@]}")"
+    after="$(LOG_WORKLOAD=history-window wait_for_log_timestamp \
+        history-after "$project" "$file" "${ACTIVE_COMPOSE[@]}")"
+    since="$(midpoint_log_timestamp "$before" "$first")"
+    until="$(midpoint_log_timestamp "$last" "$after")"
     env LOG_WORKLOAD=history-window LOG_MAX_SIZE=64m \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" wait logger >/dev/null
     run_timed logging-read-since-until "$lane" "$repetition" "$schedule_position" \

--- a/Tools/parity/test_compose_performance_matrix.py
+++ b/Tools/parity/test_compose_performance_matrix.py
@@ -773,6 +773,57 @@ prepare_logging_history container-compose "$2"
         self.assertNotIn("--abort-on-container-exit", invocation_lines[0])
         self.assertTrue(invocation_lines[1].endswith(" wait logger"))
 
+    def test_logging_window_uses_quiet_gap_boundaries(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-read-window-test-") as directory:
+            root = Path(directory)
+            invocations = root / "invocations.txt"
+            fixture = root / "logging.yml"
+            fixture.touch()
+            environment = dict(os.environ)
+            environment["INVOCATIONS"] = str(invocations)
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    """
+source "$1"
+select_lane() { LANE_PREFIX=c; ACTIVE_COMPOSE=(/usr/bin/true); }
+down_project() { :; }
+wait_for_log_text() { :; }
+wait_for_log_timestamp() {
+    case "$1" in
+        history-before) printf '2026-08-31T12:00:00.000000Z\n' ;;
+        history-window-000) printf '2026-08-31T12:00:01.000000Z\n' ;;
+        history-window-099) printf '2026-08-31T12:00:02.000000Z\n' ;;
+        history-after) printf '2026-08-31T12:00:03.000000Z\n' ;;
+    esac
+}
+run_timed() { printf 'timed %s\n' "$*" >>"$INVOCATIONS"; }
+assert_since_until_window() {
+    printf 'asserted %s %s\n' "$2" "$3" >>"$INVOCATIONS"
+}
+run_logging_since_until_lane container-compose 2 1 "$2"
+""",
+                    "_",
+                    HARNESS,
+                    fixture,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            invocation_lines = invocations.read_text(encoding="utf-8").splitlines()
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("--since 2026-08-31T12:00:00.500000Z", invocation_lines[0])
+        self.assertIn("--until 2026-08-31T12:00:02.500000Z", invocation_lines[0])
+        self.assertEqual(
+            invocation_lines[1],
+            "asserted 2026-08-31T12:00:00.500000Z 2026-08-31T12:00:02.500000Z",
+        )
+
 
 class PerformanceMatrixEvidenceTests(unittest.TestCase):
     def test_finalizer_reports_comparable_median_and_p95(self) -> None:


### PR DESCRIPTION
## Summary

- derive `--since` and `--until` from the midpoint of the fixture’s deliberate quiet gaps
- avoid equality semantics when a persisted log batch shares the final marker timestamp
- add a focused regression proving both boundaries fall strictly between sentinel and corpus timestamps

## Evidence

Historical reconstruction run [#33451287399](https://github.com/stephenlclarke/container-compose/actions/runs/33451287399) proved the stopped-container retention fix, then exposed this boundary defect on exact 0.13.0 repetition 2: marker `099` shared its timestamp with the final batch, and the exclusive `--until` returned records 0 through 80.

- `python3 Tools/parity/test_compose_performance_matrix.py` — 26 tests pass
- `bash -n Tools/parity/check-compose-performance-matrix.sh`
- `shellcheck Tools/parity/check-compose-performance-matrix.sh`
- `git diff --check`

Raw failed-run evidence is retained as artifact `historical-benchmark-33451287399-1` (ID `9780289802`, digest `sha256:71fc346cf61dc89ff30879687840c7523e94bdb659d1ecc1e60962a358cddbba`).