### PR TITLE
fix(benchmarks): avoid completed workload wait race

### DIFF
--- a/Tools/parity/check-compose-performance-matrix.sh
+++ b/Tools/parity/check-compose-performance-matrix.sh
@@ -1155,8 +1155,6 @@ run_logging_since_until_lane() {
         history-after "$project" "$file" "${ACTIVE_COMPOSE[@]}")"
     since="$(midpoint_log_timestamp "$before" "$first")"
     until="$(midpoint_log_timestamp "$last" "$after")"
-    env LOG_WORKLOAD=history-window LOG_MAX_SIZE=64m \
-        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" wait logger >/dev/null
     run_timed logging-read-since-until "$lane" "$repetition" "$schedule_position" \
         env LOG_WORKLOAD=history-window LOG_MAX_SIZE=64m \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" logs \

--- a/Tools/parity/test_compose_performance_matrix.py
+++ b/Tools/parity/test_compose_performance_matrix.py
@@ -777,17 +777,31 @@ prepare_logging_history container-compose "$2"
         with tempfile.TemporaryDirectory(prefix="compose-read-window-test-") as directory:
             root = Path(directory)
             invocations = root / "invocations.txt"
+            fake_compose = root / "compose"
             fixture = root / "logging.yml"
             fixture.touch()
+            fake_compose.write_text(
+                """#!/usr/bin/env bash
+set -euo pipefail
+printf 'compose %s\n' "$*" >>"$INVOCATIONS"
+""",
+                encoding="utf-8",
+            )
+            fake_compose.chmod(0o755)
             environment = dict(os.environ)
-            environment["INVOCATIONS"] = str(invocations)
+            environment.update(
+                {
+                    "FAKE_COMPOSE": str(fake_compose),
+                    "INVOCATIONS": str(invocations),
+                }
+            )
             result = subprocess.run(
                 [
                     "bash",
                     "-c",
                     """
 source "$1"
-select_lane() { LANE_PREFIX=c; ACTIVE_COMPOSE=(/usr/bin/true); }
+select_lane() { LANE_PREFIX=c; ACTIVE_COMPOSE=("$FAKE_COMPOSE"); }
 down_project() { :; }
 wait_for_log_text() { :; }
 wait_for_log_timestamp() {
@@ -817,10 +831,15 @@ run_logging_since_until_lane container-compose 2 1 "$2"
             invocation_lines = invocations.read_text(encoding="utf-8").splitlines()
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("--since 2026-08-31T12:00:00.500000Z", invocation_lines[0])
-        self.assertIn("--until 2026-08-31T12:00:02.500000Z", invocation_lines[0])
+        self.assertIn(" up -d --pull never", invocation_lines[0])
+        self.assertFalse(
+            any(line.endswith(" wait logger") for line in invocation_lines),
+            invocation_lines,
+        )
+        self.assertIn("--since 2026-08-31T12:00:00.500000Z", invocation_lines[1])
+        self.assertIn("--until 2026-08-31T12:00:02.500000Z", invocation_lines[1])
         self.assertEqual(
-            invocation_lines[1],
+            invocation_lines[2],
             "asserted 2026-08-31T12:00:00.500000Z 2026-08-31T12:00:02.500000Z",
         )
 


### PR DESCRIPTION
## Summary

- remove the redundant `compose wait logger` after the final `history-after` marker has already proved the one-shot workload completed
- prevent Docker Compose from racing a stopped one-shot container and returning `no containers for project`
- retain a focused regression that rejects reintroducing the post-completion wait

## Evidence

- Reproduction: historical benchmark run [33453757018](https://github.com/stephenlclarke/container-compose/actions/runs/33453757018), raw artifact [9781098185](https://github.com/stephenlclarke/container-compose/actions/runs/33453757018/artifacts/9781098185)
- Failure occurred after all four timestamp markers were readable, when the redundant Docker `wait` ran after the one-shot workload had exited
- Focused real-Docker history-window lifecycle passed after removing that wait, returning exactly `history-window-000` through `history-window-099`
- `python3 Tools/parity/test_compose_performance_matrix.py`: 26 tests passed
- `bash -n`, `shellcheck`, and `git diff --check`: passed

## Scope

Benchmark harness only. Runtime, release artifacts, and user-facing Compose behavior are unchanged.
