### PR TITLE
fix(benchmarks): report published execution failures

### DIFF
--- a/Tools/parity/check-compose-performance-matrix.sh
+++ b/Tools/parity/check-compose-performance-matrix.sh
@@ -41,9 +41,9 @@
 #   PARITY_TIMEOUT_SECONDS       Per-operation timeout (default: 300).
 #   PARITY_TIMING_MAX_RATIO      Candidate median/P95 limit (default: 10).
 #   PARITY_TIMING_POLICY         `enforce` fails the ratio guard; `record`
-#                                records regressions without making a
-#                                published-version comparison a release gate.
-#                                Default: enforce.
+#                                records timing and execution failures without
+#                                making a published-version comparison a
+#                                release gate. Default: enforce.
 #   PARITY_COMPARABLE_NOISE_PCT  Comparable-performance noise band (default: 5).
 #   PARITY_SINK_STALL_SECONDS    Host slow-sink pause (default: 2).
 #   PARITY_PRESSURE_RECORDS      Records in pressure workloads (default: 65536).
@@ -620,6 +620,7 @@ run_timed() {
     python3 - "$TIMING_TSV" "$fixture" "$lane" "$repetition" "$schedule_position" "$PARITY_TIMEOUT_SECONDS" "$@" <<'PY'
 import csv, os, shlex, signal, subprocess, sys, time
 timing, fixture, lane, repetition, schedule_position, timeout, *command = sys.argv[1:]
+def failed_outcome(returncode): return f"exit-{returncode if returncode > 0 else 128 - returncode if returncode < 0 else 1}"
 started = time.monotonic()
 process = subprocess.Popen(command, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE, text=True, start_new_session=True)
 outcome = "success"
@@ -627,14 +628,78 @@ try: _, stderr = process.communicate(timeout=float(timeout))
 except subprocess.TimeoutExpired:
     os.killpg(process.pid, signal.SIGKILL); _, stderr = process.communicate(); outcome = "timeout"
 else:
-    if process.returncode: outcome = f"exit-{process.returncode}"
+    if process.returncode: outcome = failed_outcome(process.returncode)
 duration = time.monotonic() - started
 with open(timing, "a", encoding="utf-8", newline="") as handle:
     csv.writer(handle, delimiter="\t", lineterminator="\n").writerow([fixture, lane, repetition, schedule_position, "lower-is-better", f"{duration:.9f}", outcome, shlex.join(command)])
 print(f"{fixture} {lane} repetition {repetition}: {duration:.3f}s ({outcome})")
 if outcome != "success":
     if stderr: print(stderr, file=sys.stderr, end="" if stderr.endswith("\n") else "\n")
-    raise SystemExit(124 if outcome == "timeout" else process.returncode or 1)
+    raise SystemExit(124 if outcome == "timeout" else int(outcome.removeprefix("exit-")))
+PY
+}
+
+# Preserve timed failures in published comparisons while keeping strict runs fail-fast.
+run_recordable_timing() {
+    local fixture="$1" lane="$2" status=0
+    shift 2
+    RECORDED_TIMING_FAILED=0
+    "$@" || status=$?
+    if ((status == 0)); then
+        return 0
+    fi
+    if [[ "$PARITY_TIMING_POLICY" == record ]]; then
+        RECORDED_TIMING_FAILED=1
+        warning "recorded $fixture $lane execution failure (exit $status)"
+        return 0
+    fi
+    return "$status"
+}
+
+# Retain one required sample that could not run after a prerequisite failed.
+record_unexecuted_timing() {
+    local fixture="$1" lane="$2" repetition="$3" schedule_position="$4" reason="$5"
+    python3 - "$TIMING_TSV" "$fixture" "$lane" "$repetition" \
+        "$schedule_position" "$reason" <<'PY'
+import csv, sys
+timing, fixture, lane, repetition, schedule_position, reason = sys.argv[1:]
+with open(timing, "a", encoding="utf-8", newline="") as handle:
+    csv.writer(handle, delimiter="\t", lineterminator="\n").writerow([
+        fixture, lane, repetition, schedule_position, "lower-is-better", "0.000000000",
+        "skipped-dependency", f"not-run: {reason}",
+    ])
+PY
+}
+
+# Invalidate a successful paired sample when its required peer validation was skipped.
+invalidate_successful_timing() {
+    local fixture="$1" lane="$2" repetition="$3" reason="$4"
+    python3 - "$TIMING_TSV" "$fixture" "$lane" "$repetition" "$reason" <<'PY'
+import csv, os, pathlib, sys, tempfile
+path = pathlib.Path(sys.argv[1]); fixture, lane, repetition, reason = sys.argv[2:]
+with path.open(encoding="utf-8", newline="") as handle:
+    reader = csv.DictReader(handle, delimiter="\t")
+    fieldnames = reader.fieldnames
+    rows = list(reader)
+if not fieldnames:
+    raise SystemExit(f"timing evidence has no header: {path}")
+matches = [
+    row for row in rows
+    if row["fixture"] == fixture and row["lane"] == lane and row["repetition"] == repetition
+]
+if len(matches) != 1:
+    raise SystemExit(f"expected one timing sample for {fixture}/{lane}/{repetition}, found {len(matches)}")
+row = matches[0]
+if row["outcome"] == "success":
+    row["outcome"] = "invalidated-dependency"
+    row["command"] += f"; invalidated: {reason}"
+with tempfile.NamedTemporaryFile(
+    mode="w", encoding="utf-8", newline="", dir=path.parent, delete=False
+) as handle:
+    temporary = pathlib.Path(handle.name)
+    writer = csv.DictWriter(handle, fieldnames=fieldnames, delimiter="\t", lineterminator="\n")
+    writer.writeheader(); writer.writerows(rows)
+os.replace(temporary, path)
 PY
 }
 
@@ -646,10 +711,11 @@ run_to_completion_marker() {
         "$schedule_position" "$PARITY_TIMEOUT_SECONDS" "$marker" "$@" <<'PY'
 import csv, pathlib, shlex, subprocess, sys, time
 timing, fixture, lane, repetition, schedule_position, timeout, marker, *command = sys.argv[1:]
+def failed_outcome(returncode): return f"exit-{returncode if returncode > 0 else 128 - returncode if returncode < 0 else 1}"
 marker_path = pathlib.Path(marker); marker_path.unlink(missing_ok=True); started = time.monotonic(); outcome = "success"; diagnostic = ""
 try:
     result = subprocess.run(command, capture_output=True, check=False, text=True, timeout=float(timeout))
-    if result.returncode: outcome = f"exit-{result.returncode}"; diagnostic = result.stderr
+    if result.returncode: outcome = failed_outcome(result.returncode); diagnostic = result.stderr
     else:
         deadline = started + float(timeout)
         while time.monotonic() < deadline:
@@ -873,6 +939,7 @@ run_attached_startup_to_first_output() {
         "$PARITY_TIMEOUT_SECONDS" "$project" "$file" "$@" <<'PY'
 import csv, os, selectors, shlex, signal, subprocess, sys, time
 timing, lane, repetition, schedule_position, timeout, project, file, *compose = sys.argv[1:]
+def failed_outcome(returncode): return f"exit-{returncode if returncode > 0 else 128 - returncode if returncode < 0 else 1}"
 environment = dict(os.environ); environment["LOG_WORKLOAD"] = "startup"; environment["LOG_MAX_SIZE"] = "64m"
 command = [*compose, "-p", project, "-f", file, "up", "--pull", "never", "--no-log-prefix"]
 started = time.monotonic(); outcome = "success"; diagnostic = bytearray(); process = None; duration = None
@@ -882,7 +949,7 @@ try:
     selector = selectors.DefaultSelector(); selector.register(process.stdout, selectors.EVENT_READ)
     deadline = started + float(timeout)
     while time.monotonic() < deadline:
-        if process.poll() is not None: outcome = f"exit-{process.returncode}"; break
+        if process.poll() is not None: outcome = failed_outcome(process.returncode); break
         events = selector.select(timeout=min(0.1, deadline - time.monotonic()))
         for key, _ in events:
             chunk = os.read(key.fileobj.fileno(), 65536)
@@ -914,6 +981,7 @@ run_startup_to_first_output() {
         "$PARITY_TIMEOUT_SECONDS" "$project" "$file" "$@" <<'PY'
 import csv, os, shlex, subprocess, sys, time
 timing, lane, repetition, schedule_position, timeout, project, file, *compose = sys.argv[1:]
+def failed_outcome(returncode): return f"exit-{returncode if returncode > 0 else 128 - returncode if returncode < 0 else 1}"
 environment = dict(os.environ)
 environment["LOG_WORKLOAD"] = "startup"
 environment["LOG_MAX_SIZE"] = "64m"
@@ -931,7 +999,7 @@ try:
         env=environment,
     )
     if up.returncode:
-        outcome = f"exit-{up.returncode}"
+        outcome = failed_outcome(up.returncode)
         diagnostic = up.stderr
     else:
         deadline = started + float(timeout)
@@ -945,7 +1013,7 @@ try:
                 env=environment,
             )
             if logs.returncode:
-                outcome = f"exit-{logs.returncode}"
+                outcome = failed_outcome(logs.returncode)
                 diagnostic = logs.stderr
                 break
             if "logging-ready" in logs.stdout:
@@ -1002,13 +1070,29 @@ down_project() {
 
 # Run one lifecycle startup/teardown pair for a lane.
 run_lifecycle_lane() {
-    local lane="$1" repetition="$2" schedule_position="$3" count="$4" file="$5" project
+    local lane="$1" repetition="$2" schedule_position="$3" count="$4" file="$5" project status=0
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-$count"
-    run_timed "startup-$count-services" "$lane" "$repetition" "$schedule_position" \
-        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up -d --pull never
-    run_timed "teardown-$count-services" "$lane" "$repetition" "$schedule_position" \
-        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" down --volumes --remove-orphans
+    run_recordable_timing "startup-$count-services" "$lane" run_timed \
+        "startup-$count-services" "$lane" "$repetition" "$schedule_position" \
+        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up -d --pull never || status=$?
+    if ((status != 0)); then
+        down_project "$lane" "$project" "$file"
+        return "$status"
+    fi
+    if ((RECORDED_TIMING_FAILED)); then
+        record_unexecuted_timing "teardown-$count-services" "$lane" \
+            "$repetition" "$schedule_position" "startup-$count-services failed"
+        down_project "$lane" "$project" "$file"
+        return 0
+    fi
+    run_recordable_timing "teardown-$count-services" "$lane" run_timed \
+        "teardown-$count-services" "$lane" "$repetition" "$schedule_position" \
+        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" down --volumes --remove-orphans || status=$?
+    if ((status != 0 || RECORDED_TIMING_FAILED)); then
+        down_project "$lane" "$project" "$file"
+    fi
+    return "$status"
 }
 
 # Run startup-to-first-output for one logging lane.
@@ -1017,7 +1101,8 @@ run_logging_startup_lane() {
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-logging"
     down_project "$lane" "$project" "$file"
-    run_startup_to_first_output "$lane" "$repetition" "$schedule_position" \
+    run_recordable_timing logging-startup-first-output "$lane" \
+        run_startup_to_first_output "$lane" "$repetition" "$schedule_position" \
         "$project" "$file" "${ACTIVE_COMPOSE[@]}"
     down_project "$lane" "$project" "$file"
 }
@@ -1028,7 +1113,8 @@ run_logging_attached_startup_lane() {
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-logging"
     down_project "$lane" "$project" "$file"
-    run_attached_startup_to_first_output "$lane" "$repetition" "$schedule_position" \
+    run_recordable_timing logging-startup-first-output-attached "$lane" \
+        run_attached_startup_to_first_output "$lane" "$repetition" "$schedule_position" \
         "$project" "$file" "${ACTIVE_COMPOSE[@]}"
     down_project "$lane" "$project" "$file"
 }
@@ -1039,7 +1125,8 @@ run_logging_throughput_lane() {
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-logging"
     down_project "$lane" "$project" "$file"
-    run_timed "$fixture" "$lane" "$repetition" "$schedule_position" \
+    run_recordable_timing "$fixture" "$lane" run_timed \
+        "$fixture" "$lane" "$repetition" "$schedule_position" \
         env LOG_WORKLOAD="$workload" LOG_MAX_SIZE=64m \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up \
         --abort-on-container-exit --exit-code-from logger --pull never
@@ -1065,12 +1152,18 @@ run_remote_sink_lane() {
     completion_file="$label.done"
     completion_path="$completion_dir/$completion_file"
     mkdir -p "$completion_dir"
-    run_to_completion_marker "$fixture" "$lane" "$repetition" \
+    run_recordable_timing "$fixture" "$lane" run_to_completion_marker \
+        "$fixture" "$lane" "$repetition" \
         "$schedule_position" "$completion_path" \
         env LOG_WORKLOAD=pressure LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
         LOG_COMPLETION_FILE="$completion_file" PERF_COMPLETION_DIR="$completion_dir" \
         LOG_BUFFER_SIZE="$buffer_size" PERF_SYSLOG_ADDRESS="$address" \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up -d --pull never
+    if ((RECORDED_TIMING_FAILED)); then
+        stop_sink
+        down_project "$lane" "$project" "$FIXTURE_DIR/logging.yml"
+        return 0
+    fi
     env LOG_WORKLOAD=pressure LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
         LOG_COMPLETION_FILE="$completion_file" PERF_COMPLETION_DIR="$completion_dir" \
         LOG_BUFFER_SIZE="$buffer_size" PERF_SYSLOG_ADDRESS="$address" \
@@ -1094,13 +1187,18 @@ run_file_logging_lane() {
     completion_path="$completion_dir/$completion_file"
     mkdir -p "$completion_dir"
     down_project "$lane" "$project" "$FIXTURE_DIR/logging.yml"
-    run_to_completion_marker "$fixture" "$lane" "$repetition" \
+    run_recordable_timing "$fixture" "$lane" run_to_completion_marker \
+        "$fixture" "$lane" "$repetition" \
         "$schedule_position" "$completion_path" \
         env LOG_WORKLOAD=pressure LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
         LOG_COMPLETION_FILE="$completion_file" \
         LOG_RETAIN_AFTER_COMPLETION=1 PERF_COMPLETION_DIR="$completion_dir" \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up \
         -d --pull never
+    if ((RECORDED_TIMING_FAILED)); then
+        down_project "$lane" "$project" "$FIXTURE_DIR/logging.yml"
+        return 0
+    fi
     LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
         LOG_COMPLETION_FILE="$completion_file" \
         LOG_RETAIN_AFTER_COMPLETION=1 PERF_COMPLETION_DIR="$completion_dir" \
@@ -1129,7 +1227,8 @@ run_logging_read_lane() {
     local lane="$1" repetition="$2" schedule_position="$3" fixture="$4" tail="$5" file="$6" project
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-logging"
-    run_timed "$fixture" "$lane" "$repetition" "$schedule_position" \
+    run_recordable_timing "$fixture" "$lane" run_timed \
+        "$fixture" "$lane" "$repetition" "$schedule_position" \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" logs \
         --no-color --no-log-prefix --tail "$tail" logger
 }
@@ -1155,10 +1254,15 @@ run_logging_since_until_lane() {
         history-after "$project" "$file" "${ACTIVE_COMPOSE[@]}")"
     since="$(midpoint_log_timestamp "$before" "$first")"
     until="$(midpoint_log_timestamp "$last" "$after")"
-    run_timed logging-read-since-until "$lane" "$repetition" "$schedule_position" \
+    run_recordable_timing logging-read-since-until "$lane" run_timed \
+        logging-read-since-until "$lane" "$repetition" "$schedule_position" \
         env LOG_WORKLOAD=history-window LOG_MAX_SIZE=64m \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" logs \
         --no-color --no-log-prefix --since "$since" --until "$until" logger
+    if ((RECORDED_TIMING_FAILED)); then
+        down_project "$lane" "$project" "$file"
+        return 0
+    fi
     LOG_WORKLOAD=history-window LOG_MAX_SIZE=64m assert_since_until_window \
         "logging-read-since-until-$lane-$repetition" "$since" "$until" \
         "$project" "$file" "${ACTIVE_COMPOSE[@]}"
@@ -1173,7 +1277,8 @@ run_logging_follow_lane() {
     down_project "$lane" "$project" "$file"
     env LOG_WORKLOAD=follow-rotation LOG_MAX_SIZE=8k \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up -d --pull never >/dev/null
-    run_timed logging-follow-rotation "$lane" "$repetition" "$schedule_position" \
+    run_recordable_timing logging-follow-rotation "$lane" run_timed \
+        logging-follow-rotation "$lane" "$repetition" "$schedule_position" \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" logs \
         --follow --no-color --no-log-prefix logger
     down_project "$lane" "$project" "$file"
@@ -1182,23 +1287,36 @@ run_logging_follow_lane() {
 # Time remote delivery and its canonical dual-cache read for one lane.
 run_dual_cache_lane() {
     local lane="$1" repetition="$2" schedule_position="$3" file="$4"
-    local project label address
+    local project label address timing_failed=0
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-logging"
     label="logging-dual-cache-$lane-$repetition"
     down_project "$lane" "$project" "$FIXTURE_DIR/logging.yml"
     start_sink "$label" 0
     address="$(syslog_address "$lane")"
-    run_timed logging-dual-cache-delivery "$lane" "$repetition" "$schedule_position" \
+    run_recordable_timing logging-dual-cache-delivery "$lane" run_timed \
+        logging-dual-cache-delivery "$lane" "$repetition" "$schedule_position" \
         env LOG_WORKLOAD=pressure LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
         PERF_SYSLOG_ADDRESS="$address" \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up \
         --abort-on-container-exit --exit-code-from logger --pull never
-    run_timed logging-dual-cache-read "$lane" "$repetition" "$schedule_position" \
+    ((RECORDED_TIMING_FAILED == 0)) || timing_failed=1
+    run_recordable_timing logging-dual-cache-read "$lane" run_timed \
+        logging-dual-cache-read "$lane" "$repetition" "$schedule_position" \
         env LOG_WORKLOAD=pressure LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
         PERF_SYSLOG_ADDRESS="$address" \
         "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" logs \
         --no-color --no-log-prefix --tail all logger
+    ((RECORDED_TIMING_FAILED == 0)) || timing_failed=1
+    if ((timing_failed)); then
+        invalidate_successful_timing logging-dual-cache-delivery "$lane" \
+            "$repetition" "paired delivery/read validation was skipped"
+        invalidate_successful_timing logging-dual-cache-read "$lane" \
+            "$repetition" "paired delivery/read validation was skipped"
+        stop_sink
+        down_project "$lane" "$project" "$FIXTURE_DIR/logging.yml"
+        return 0
+    fi
     LOG_WORKLOAD=pressure LOG_RECORD_COUNT="$PARITY_PRESSURE_RECORDS" \
         PERF_SYSLOG_ADDRESS="$address" assert_logging_record_count \
         "logging-dual-cache-read-$lane-$repetition" "$PARITY_PRESSURE_RECORDS" \
@@ -1209,13 +1327,15 @@ run_dual_cache_lane() {
 
 # Time foreground aggregation for one service count.
 run_logging_aggregate_lane() {
-    local lane="$1" repetition="$2" schedule_position="$3" count="$4" file="$5" project
+    local lane="$1" repetition="$2" schedule_position="$3" count="$4" file="$5" project status=0
     select_lane "$lane"
     project="cc-perf-$LANE_PREFIX-aggregate-$count"
     down_project "$lane" "$project" "$file"
-    run_timed "logging-aggregate-$count-services" "$lane" "$repetition" "$schedule_position" \
-        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up --pull never
+    run_recordable_timing "logging-aggregate-$count-services" "$lane" run_timed \
+        "logging-aggregate-$count-services" "$lane" "$repetition" "$schedule_position" \
+        "${ACTIVE_COMPOSE[@]}" -p "$project" -f "$file" up --pull never || status=$?
     down_project "$lane" "$project" "$file"
+    return "$status"
 }
 
 # Require finalization to use the render controls retained with raw evidence.
@@ -1314,8 +1434,21 @@ for fixture in expected:
         for repetition in range(1, repetitions + 1)
         for lane in ("docker", "container-compose")
     )
-    if not valid_counts or not valid_direction or not valid_schedule or any(r["outcome"] != "success" for r in docker + candidate):
-        reason = "fixture did not retain the required successful lower-is-better samples in both lanes"; ET.SubElement(testcase, "failure", message=reason).text = reason; failures.append(f"{fixture}: {reason}"); table.append((fixture, "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "NOT MET", "FAIL")); continue
+    if not valid_counts or not valid_direction or not valid_schedule:
+        reason = "fixture did not retain the required counterbalanced lower-is-better sample structure"
+        ET.SubElement(testcase, "failure", message=reason).text = reason
+        failures.append(f"{fixture}: {reason}")
+        table.append((fixture, "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "NOT MET", "FAIL")); continue
+    if any(r["outcome"] != "success" for r in docker + candidate):
+        reason = "fixture retained a timed execution failure"
+        if policy == "enforce":
+            ET.SubElement(testcase, "failure", message=reason).text = reason
+            failures.append(f"{fixture}: {reason}")
+            result = "FAIL"
+        else:
+            ET.SubElement(testcase, "system-err").text = reason
+            result = "RECORDED FAILURE"
+        table.append((fixture, "n/a", "n/a", "n/a", "n/a", "n/a", "n/a", "NOT MET", result)); continue
     d = [float(r["duration_seconds"]) for r in docker]; c = [float(r["duration_seconds"]) for r in candidate]
     dm = statistics.median(d); dp = p95(d); cm = statistics.median(c); cp = p95(c)
     median_ratio = cm / dm if dm else float("inf"); p95_ratio = cp / dp if dp else float("inf"); result = "PASS"
@@ -1331,7 +1464,7 @@ suite.set("failures", str(len(failures))); ET.ElementTree(suite).write(junit, en
 policy_text = (
     f"Timeout, incomplete execution, or a candidate median/P95 at least {threshold:g}x Docker fails the regression guard."
     if policy == "enforce"
-    else f"Timeout or incomplete execution fails; the {threshold:g}x timing threshold is recorded but not enforced for this published-version comparison."
+    else f"Execution failures and the {threshold:g}x timing threshold are recorded but not enforced for this published-version comparison."
 )
 lines = ["# Compose Performance Matrix", "", f"Warm-image same-host fixed-work samples. {policy_text} Comparable-or-better requires both candidate statistics to be within {(noise_ratio - 1) * 100:g}% of Docker.", "", "| Fixture | Docker median (s) | Docker P95 (s) | container-compose median (s) | container-compose P95 (s) | Median ratio | P95 ratio | Comparable or better | Guard |", "| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |"]
 lines += [f"| {' | '.join(row)} |" for row in table]; lines += ["", "Raw repetitions are in `timings.tsv`; exact host and runtime fingerprints are in `fingerprints.json`.", ""]

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -465,25 +465,41 @@ def nearest_rank_p95(values: list[float]) -> float:
     return sorted(values)[math.ceil(len(values) * 0.95) - 1]
 
 
-def load_samples(evidence: Path) -> dict[str, dict[str, list[float]]]:
+def load_samples(
+    evidence: Path,
+) -> dict[str, dict[str, list[dict[str, float | str]]]]:
     path = evidence / "timings.tsv"
     with path.open(encoding="utf-8", newline="") as handle:
         rows = list(csv.DictReader(handle, delimiter="\t"))
     if not rows:
         raise BenchmarkInputError(f"benchmark has no samples: {path}")
-    grouped: dict[str, dict[str, list[float]]] = defaultdict(
+    grouped: dict[str, dict[str, list[dict[str, float | str]]]] = defaultdict(
         lambda: defaultdict(list)
     )
     for row in rows:
-        if row.get("outcome") != "success" or row.get("direction") != "lower-is-better":
+        if row.get("direction") != "lower-is-better":
             raise BenchmarkInputError(
-                f"benchmark contains an unsuccessful or unsupported sample: {path}"
+                f"benchmark contains an unsupported sample: {path}"
             )
         lane = row.get("lane")
         fixture = row.get("fixture")
         if lane not in {"docker", "container-compose"} or not fixture:
             raise BenchmarkInputError(f"benchmark contains an invalid lane: {path}")
-        grouped[fixture][lane].append(float(row["duration_seconds"]))
+        outcome = row.get("outcome")
+        if not isinstance(outcome, str) or (
+            outcome
+            not in {
+                "success",
+                "timeout",
+                "skipped-dependency",
+                "invalidated-dependency",
+            }
+            and re.fullmatch(r"exit-[1-9][0-9]*", outcome) is None
+        ):
+            raise BenchmarkInputError(f"benchmark contains an invalid outcome: {path}")
+        grouped[fixture][lane].append(
+            {"duration": float(row["duration_seconds"]), "outcome": outcome}
+        )
     result = {fixture: dict(lanes) for fixture, lanes in grouped.items()}
     for fixture, lanes in result.items():
         if set(lanes) != {"docker", "container-compose"}:
@@ -704,18 +720,79 @@ def render_report(
     rows: list[tuple[object, ...]] = []
     normalized_median_ratios: list[float] = []
     normalized_p95_ratios: list[float] = []
-    improved = unchanged = regressed = 0
+    improved = unchanged = regressed = unscored = 0
     for fixture in sorted(target_samples):
         target = target_samples[fixture]
         baseline = baseline_samples[fixture]
-        target_median = statistics.median(target["container-compose"])
-        baseline_median = statistics.median(baseline["container-compose"])
-        target_p95 = nearest_rank_p95(target["container-compose"])
-        baseline_p95 = nearest_rank_p95(baseline["container-compose"])
-        target_docker_median = statistics.median(target["docker"])
-        baseline_docker_median = statistics.median(baseline["docker"])
-        target_docker_p95 = nearest_rank_p95(target["docker"])
-        baseline_docker_p95 = nearest_rank_p95(baseline["docker"])
+        failed: list[str] = []
+        for label, samples in (("Comparison", baseline), ("Target", target)):
+            for lane in ("docker", "container-compose"):
+                outcomes = [
+                    str(sample["outcome"])
+                    for sample in samples[lane]
+                    if sample["outcome"] != "success"
+                ]
+                if outcomes:
+                    failed.append(f"{label} {lane} failed ({', '.join(outcomes)})")
+        baseline_candidate = [
+            float(sample["duration"])
+            for sample in baseline["container-compose"]
+            if sample["outcome"] == "success"
+        ]
+        target_candidate = [
+            float(sample["duration"])
+            for sample in target["container-compose"]
+            if sample["outcome"] == "success"
+        ]
+        if failed:
+            baseline_median = (
+                statistics.median(baseline_candidate)
+                if len(baseline_candidate) == repetitions
+                else None
+            )
+            baseline_p95 = (
+                nearest_rank_p95(baseline_candidate)
+                if len(baseline_candidate) == repetitions
+                else None
+            )
+            target_median = (
+                statistics.median(target_candidate)
+                if len(target_candidate) == repetitions
+                else None
+            )
+            target_p95 = (
+                nearest_rank_p95(target_candidate)
+                if len(target_candidate) == repetitions
+                else None
+            )
+            rows.append(
+                (
+                    fixture,
+                    baseline_median,
+                    target_median,
+                    None,
+                    baseline_p95,
+                    target_p95,
+                    None,
+                    None,
+                    None,
+                    "; ".join(failed),
+                )
+            )
+            unscored += 1
+            continue
+        target_values = target_candidate
+        baseline_values = baseline_candidate
+        target_docker = [float(sample["duration"]) for sample in target["docker"]]
+        baseline_docker = [float(sample["duration"]) for sample in baseline["docker"]]
+        target_median = statistics.median(target_values)
+        baseline_median = statistics.median(baseline_values)
+        target_p95 = nearest_rank_p95(target_values)
+        baseline_p95 = nearest_rank_p95(baseline_values)
+        target_docker_median = statistics.median(target_docker)
+        baseline_docker_median = statistics.median(baseline_docker)
+        target_docker_p95 = nearest_rank_p95(target_docker)
+        baseline_docker_p95 = nearest_rank_p95(baseline_docker)
         median_ratio = target_median / baseline_median
         p95_ratio = target_p95 / baseline_p95
         normalized_median_ratio = (
@@ -750,13 +827,21 @@ def render_report(
             )
         )
 
-    geometric_median = math.exp(
-        sum(math.log(value) for value in normalized_median_ratios)
-        / len(normalized_median_ratios)
+    geometric_median = (
+        math.exp(
+            sum(math.log(value) for value in normalized_median_ratios)
+            / len(normalized_median_ratios)
+        )
+        if normalized_median_ratios
+        else None
     )
-    geometric_p95 = math.exp(
-        sum(math.log(value) for value in normalized_p95_ratios)
-        / len(normalized_p95_ratios)
+    geometric_p95 = (
+        math.exp(
+            sum(math.log(value) for value in normalized_p95_ratios)
+            / len(normalized_p95_ratios)
+        )
+        if normalized_p95_ratios
+        else None
     )
     host = target_fingerprints["host"]
     docker = target_fingerprints["docker"]
@@ -785,6 +870,28 @@ def render_report(
             "change is included to expose host drift."
         )
         inputs_heading = "## Published inputs"
+    if geometric_median is None or geometric_p95 is None:
+        result_summary = (
+            f"No fixture retained complete successful samples in both releases; "
+            f"{unscored} fixture{' was' if unscored == 1 else 's were'} "
+            "unscored because of recorded execution failures."
+        )
+    else:
+        result_summary = (
+            f"Across {len(normalized_median_ratios)} scored fixed-work fixtures, "
+            f"the Docker-normalized geometric-mean median changed "
+            f"{percentage(geometric_median)} and the Docker-normalized "
+            f"geometric-mean P95 changed {percentage(geometric_p95)}. With a "
+            f"±{noise:g}% noise band applied to the normalized median, "
+            f"{improved} fixtures improved, {unchanged} stayed within noise, and "
+            f"{regressed} regressed."
+        )
+        if unscored:
+            result_summary += (
+                f" {unscored} additional fixture"
+                f"{' was' if unscored == 1 else 's were'} unscored because of "
+                "recorded execution failures."
+            )
     lines = [
         report_title,
         "",
@@ -792,7 +899,7 @@ def render_report(
         "",
         "## Result",
         "",
-        f"Across {len(rows)} fixed-work fixtures, the Docker-normalized geometric-mean median changed {percentage(geometric_median)} and the Docker-normalized geometric-mean P95 changed {percentage(geometric_p95)}. With a ±{noise:g}% noise band applied to the normalized median, {improved} fixtures improved, {unchanged} stayed within noise, and {regressed} regressed.",
+        result_summary,
         "",
         "Lower durations and negative changes are better.",
         "",
@@ -845,10 +952,16 @@ def render_report(
             "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |",
         ]
     )
+    def duration(value: object) -> str:
+        return f"{float(value):.3f}" if value is not None else "n/a"
+
+    def change(value: object) -> str:
+        return percentage(float(value)) if value is not None else "n/a"
+
     for row in rows:
         fixture, baseline_median, target_median, median_ratio, baseline_p95, target_p95, p95_ratio, normalized_median_ratio, normalized_p95_ratio, verdict = row
         lines.append(
-            f"| {fixture} | {baseline_median:.3f} | {target_median:.3f} | {percentage(median_ratio)} | {baseline_p95:.3f} | {target_p95:.3f} | {percentage(p95_ratio)} | {percentage(normalized_median_ratio)} | {percentage(normalized_p95_ratio)} | {verdict} |"
+            f"| {fixture} | {duration(baseline_median)} | {duration(target_median)} | {change(median_ratio)} | {duration(baseline_p95)} | {duration(target_p95)} | {change(p95_ratio)} | {change(normalized_median_ratio)} | {change(normalized_p95_ratio)} | {verdict} |"
         )
     lines.extend(
         [

--- a/Tools/parity/test_compose_performance_matrix.py
+++ b/Tools/parity/test_compose_performance_matrix.py
@@ -590,6 +590,178 @@ class PerformanceMatrixSinkSafetyTests(unittest.TestCase):
 
 
 class PerformanceMatrixCompletionMarkerTests(unittest.TestCase):
+    def test_timed_signal_exit_is_normalized_to_shell_status(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-signal-test-") as directory:
+            evidence = Path(directory)
+            timing = evidence / "timings.tsv"
+            self.write_timing_header(timing)
+            environment = dict(os.environ)
+            environment["PARITY_EVIDENCE_DIR"] = str(evidence)
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        'source "$1"; run_timed signal-test docker 1 1 '
+                        "python3 -c 'import os, signal; "
+                        "os.kill(os.getpid(), signal.SIGTERM)'"
+                    ),
+                    "_",
+                    HARNESS,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            with timing.open(encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle, delimiter="\t"))
+
+        self.assertEqual(result.returncode, 143)
+        self.assertEqual(rows[0]["outcome"], "exit-143")
+
+    def test_attached_early_clean_exit_is_recorded_as_failure(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-attached-test-") as directory:
+            evidence = Path(directory)
+            timing = evidence / "timings.tsv"
+            fake_compose = evidence / "compose"
+            fake_compose.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+            fake_compose.chmod(0o755)
+            self.write_timing_header(timing)
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "PARITY_EVIDENCE_DIR": str(evidence),
+                    "PARITY_TIMEOUT_SECONDS": "2",
+                }
+            )
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        'source "$1"; run_attached_startup_to_first_output '
+                        'docker 1 1 project fixture.yml "$2"'
+                    ),
+                    "_",
+                    HARNESS,
+                    fake_compose,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            with timing.open(encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle, delimiter="\t"))
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertEqual(rows[0]["outcome"], "exit-1")
+
+    def test_recorded_startup_failure_skips_and_invalidates_teardown(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-lifecycle-test-") as directory:
+            evidence = Path(directory)
+            timing = evidence / "timings.tsv"
+            self.write_timing_header(timing)
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "PARITY_EVIDENCE_DIR": str(evidence),
+                    "PARITY_TIMING_POLICY": "record",
+                }
+            )
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    r'''
+source "$1"
+select_lane() { ACTIVE_COMPOSE=(/usr/bin/false); LANE_PREFIX=c; }
+down_project() { printf 'cleanup\n'; }
+run_lifecycle_lane container-compose 1 1 1 services.yml
+''',
+                    "_",
+                    HARNESS,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            with timing.open(encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle, delimiter="\t"))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            [row["fixture"] for row in rows],
+            ["startup-1-services", "teardown-1-services"],
+        )
+        self.assertEqual(rows[0]["outcome"], "exit-1")
+        self.assertEqual(rows[1]["outcome"], "skipped-dependency")
+        self.assertIn("startup-1-services failed", rows[1]["command"])
+        self.assertIn("cleanup", result.stdout)
+
+    def test_dual_cache_invalidation_preserves_failure_and_invalidates_peer(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-dual-cache-test-") as directory:
+            evidence = Path(directory)
+            timing = evidence / "timings.tsv"
+            self.write_timing_header(timing)
+            with timing.open("a", encoding="utf-8", newline="") as handle:
+                writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
+                writer.writerow(
+                    [
+                        "logging-dual-cache-delivery",
+                        "docker",
+                        1,
+                        1,
+                        "lower-is-better",
+                        1,
+                        "exit-7",
+                        "delivery",
+                    ]
+                )
+                writer.writerow(
+                    [
+                        "logging-dual-cache-read",
+                        "docker",
+                        1,
+                        1,
+                        "lower-is-better",
+                        1,
+                        "success",
+                        "read",
+                    ]
+                )
+            environment = dict(os.environ)
+            environment["PARITY_EVIDENCE_DIR"] = str(evidence)
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        'source "$1"; invalidate_successful_timing '
+                        'logging-dual-cache-delivery docker 1 pair; '
+                        'invalidate_successful_timing logging-dual-cache-read docker 1 pair'
+                    ),
+                    "_",
+                    HARNESS,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            with timing.open(encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle, delimiter="\t"))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(rows[0]["outcome"], "exit-7")
+        self.assertEqual(rows[1]["outcome"], "invalidated-dependency")
+
     def test_completion_marker_times_workload_enqueue_not_process_teardown(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-marker-test-") as directory:
             evidence = Path(directory)
@@ -645,6 +817,22 @@ class PerformanceMatrixCompletionMarkerTests(unittest.TestCase):
         self.assertEqual(rows[0]["outcome"], "success")
         self.assertGreaterEqual(float(rows[0]["duration_seconds"]), 0.04)
         self.assertIn(f"until-file:{marker}", rows[0]["command"])
+
+    @staticmethod
+    def write_timing_header(path: Path) -> None:
+        with path.open("w", encoding="utf-8", newline="") as handle:
+            csv.writer(handle, delimiter="\t", lineterminator="\n").writerow(
+                [
+                    "fixture",
+                    "lane",
+                    "repetition",
+                    "schedule_position",
+                    "direction",
+                    "duration_seconds",
+                    "outcome",
+                    "command",
+                ]
+            )
 
     def test_file_logging_keeps_container_available_for_log_assertion(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-file-logging-test-") as directory:
@@ -893,6 +1081,74 @@ class PerformanceMatrixEvidenceTests(unittest.TestCase):
         self.assertIn("recorded but not enforced", matrix)
         self.assertIn("| NOT MET | RECORDED |", matrix)
 
+    def test_finalizer_records_published_execution_failure_without_gating(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-performance-test-") as directory:
+            evidence = Path(directory)
+            self.write_samples(
+                evidence,
+                outcome_override={
+                    (
+                        "logging-aggregate-50-services",
+                        "container-compose",
+                        1,
+                    ): "exit-1",
+                },
+            )
+
+            result = self.finalize(evidence, timing_policy="record")
+            matrix = (evidence / "timing-matrix.md").read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Execution failures", matrix)
+        self.assertIn(
+            "| logging-aggregate-50-services | n/a | n/a | n/a | n/a | "
+            "n/a | n/a | NOT MET | RECORDED FAILURE |",
+            matrix,
+        )
+
+    def test_finalizer_rejects_execution_failure_in_strict_mode(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-performance-test-") as directory:
+            evidence = Path(directory)
+            self.write_samples(
+                evidence,
+                outcome_override={
+                    (
+                        "logging-aggregate-50-services",
+                        "container-compose",
+                        1,
+                    ): "exit-1",
+                },
+            )
+
+            result = self.finalize(evidence)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("logging-aggregate-50-services", result.stderr)
+
+    def test_aggregate_execution_failure_remains_strict_by_default(self) -> None:
+        result = self.run_failed_aggregate("enforce")
+
+        self.assertEqual(result.returncode, 42)
+        self.assertIn("down container-compose", result.stdout)
+
+    def test_aggregate_execution_failure_is_recorded_for_published_run(self) -> None:
+        result = self.run_failed_aggregate("record")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("down container-compose", result.stdout)
+        self.assertIn("recorded logging-aggregate-50-services", result.stderr)
+
+    def test_nonaggregate_execution_failure_is_recorded_for_published_run(self) -> None:
+        result = self.run_failed_read("record")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("recorded logging-read-tail-10", result.stderr)
+
+    def test_nonaggregate_execution_failure_remains_strict_by_default(self) -> None:
+        result = self.run_failed_read("enforce")
+
+        self.assertEqual(result.returncode, 42)
+
     def test_finalizer_rejects_missing_declared_fixture_samples(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-performance-test-") as directory:
             evidence = Path(directory)
@@ -918,16 +1174,33 @@ class PerformanceMatrixEvidenceTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("logging-startup-first-output", result.stderr)
 
+    def test_record_finalizer_rejects_non_counterbalanced_schedule(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-performance-test-") as directory:
+            evidence = Path(directory)
+            self.write_samples(
+                evidence,
+                schedule_override={
+                    ("logging-startup-first-output", "container-compose", 2): 2,
+                },
+            )
+
+            result = self.finalize(evidence, timing_policy="record")
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("logging-startup-first-output", result.stderr)
+
     def write_samples(
         self,
         evidence: Path,
         omitted_fixture: str | None = None,
         override: dict[tuple[str, str, int], float] | None = None,
         schedule_override: dict[tuple[str, str, int], int] | None = None,
+        outcome_override: dict[tuple[str, str, int], str] | None = None,
     ) -> None:
         evidence.mkdir(parents=True, exist_ok=True)
         override = override or {}
         schedule_override = schedule_override or {}
+        outcome_override = outcome_override or {}
         with (evidence / "timings.tsv").open(
             "w", encoding="utf-8", newline=""
         ) as handle:
@@ -968,10 +1241,61 @@ class PerformanceMatrixEvidenceTests(unittest.TestCase):
                                 position,
                                 "lower-is-better",
                                 f"{duration:.9f}",
-                                "success",
+                                outcome_override.get(
+                                    (fixture, lane, repetition), "success"
+                                ),
                                 "fixture-command",
                             ]
                         )
+
+    def run_failed_aggregate(
+        self, timing_policy: str
+    ) -> subprocess.CompletedProcess[str]:
+        environment = dict(os.environ)
+        environment["PARITY_TIMING_POLICY"] = timing_policy
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                r'''
+source "$1"
+select_lane() { ACTIVE_COMPOSE=(compose); LANE_PREFIX=c; }
+down_project() { printf 'down %s\n' "$1"; }
+run_timed() { return 42; }
+run_logging_aggregate_lane container-compose 1 1 50 aggregate-50.yml
+''',
+                "_",
+                HARNESS,
+            ],
+            cwd=REPOSITORY,
+            env=environment,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+
+    def run_failed_read(self, timing_policy: str) -> subprocess.CompletedProcess[str]:
+        environment = dict(os.environ)
+        environment["PARITY_TIMING_POLICY"] = timing_policy
+        return subprocess.run(
+            [
+                "bash",
+                "-c",
+                r'''
+source "$1"
+select_lane() { ACTIVE_COMPOSE=(compose); LANE_PREFIX=c; }
+run_timed() { return 42; }
+run_logging_read_lane container-compose 1 1 logging-read-tail-10 10 logging.yml
+''',
+                "_",
+                HARNESS,
+            ],
+            cwd=REPOSITORY,
+            env=environment,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
 
     def finalize(
         self, evidence: Path, timing_policy: str = "enforce"

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -325,6 +325,64 @@ class PublishedReportTests(unittest.TestCase):
         self.assertIn("excluded to keep the unattended run free", report)
         self.assertIn("Artifact source:", report)
 
+    def test_report_records_released_target_execution_failure(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="published-benchmark-") as directory:
+            root = Path(directory)
+            baseline = root / "baseline"
+            target = root / "target"
+            baseline.mkdir()
+            target.mkdir()
+            self.write_evidence(baseline, 1.0, 1.0)
+            self.write_evidence(
+                target,
+                0.8,
+                1.0,
+                candidate_outcome="exit-1",
+            )
+            baseline_manifest = self.write_manifest(root, "0.13.0")
+            target_manifest = self.write_manifest(root, "0.14.0")
+            output = root / "report.md"
+
+            MODULE.render_report(
+                target,
+                baseline,
+                target_manifest,
+                baseline_manifest,
+                output,
+                "https://github.example/actions/runs/1",
+            )
+            report = output.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "1 fixture was unscored because of recorded execution failures",
+            report,
+        )
+        self.assertIn("Target container-compose failed (exit-1, exit-1)", report)
+        self.assertIn(
+            "| startup-1-services | 1.000 | n/a | n/a | 1.000 | n/a |",
+            report,
+        )
+
+    def test_loader_accepts_dependency_failure_outcomes(self) -> None:
+        for outcome in ("skipped-dependency", "invalidated-dependency"):
+            with self.subTest(outcome=outcome), tempfile.TemporaryDirectory(
+                prefix="published-benchmark-"
+            ) as directory:
+                evidence = Path(directory)
+                self.write_evidence(
+                    evidence,
+                    0.8,
+                    1.0,
+                    candidate_outcome=outcome,
+                )
+
+                samples = MODULE.load_samples(evidence)
+
+            self.assertEqual(
+                samples["startup-1-services"]["container-compose"][0]["outcome"],
+                outcome,
+            )
+
     def test_report_labels_historical_guest_reconstruction(self) -> None:
         with tempfile.TemporaryDirectory(prefix="published-benchmark-") as directory:
             root = Path(directory)
@@ -607,6 +665,7 @@ class PublishedReportTests(unittest.TestCase):
         candidate: float,
         docker: float,
         version: str | None = None,
+        candidate_outcome: str = "success",
     ) -> None:
         with (root / "timings.tsv").open("w", encoding="utf-8", newline="") as handle:
             writer = csv.writer(handle, delimiter="\t", lineterminator="\n")
@@ -627,7 +686,16 @@ class PublishedReportTests(unittest.TestCase):
                     ["startup-1-services", "docker", repetition, 1, "lower-is-better", docker, "success", "docker"]
                 )
                 writer.writerow(
-                    ["startup-1-services", "container-compose", repetition, 2, "lower-is-better", candidate, "success", "compose"]
+                    [
+                        "startup-1-services",
+                        "container-compose",
+                        repetition,
+                        2,
+                        "lower-is-better",
+                        candidate,
+                        candidate_outcome,
+                        "compose",
+                    ]
                 )
         release_version = version or ("0.13.0" if "baseline" in root.name else "0.14.0")
         container_ref = ("1" if release_version == "0.13.0" else "2") * 40


### PR DESCRIPTION
## Summary

- preserve every timed execution failure in published-comparison `record` mode while keeping strict/release mode fail-fast
- keep malformed sample structure fatal, isolate teardown evidence after failed startup, and invalidate both dual-cache samples when paired validation cannot complete
- normalize early and signal exits, retain dependency-skipped outcomes, and render failed released fixtures as explicit unscored functional failures instead of aborting before the report

## Evidence

- `python3 -m unittest Tools.parity.test_compose_performance_matrix Tools.parity.test_published_release_benchmark` — 68 passed
- `bash -n Tools/parity/check-compose-performance-matrix.sh`
- `shellcheck Tools/parity/check-compose-performance-matrix.sh`
- `python3 -m py_compile Tools/parity/published_release_benchmark.py Tools/parity/test_compose_performance_matrix.py Tools/parity/test_published_release_benchmark.py`
- exact released 0.14.0 offline aggregate proof continued after the reproducible 50-service `VZErrorDomain` failure and rendered `RECORDED FAILURE`; 1-service and 10-service rows remained valid
- strict-mode unit proofs preserve non-zero execution and finalization exits

Closes #370
