### PR TITLE
fix(benchmarks): preload historical fixture image

### DIFF
--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -64,6 +64,9 @@ jobs:
       PIPELINE_STATE_ROOT: /Volumes/SSD/github/.container-compose-pipeline
       REPETITIONS: ${{ inputs.repetitions }}
       FIXTURE_GROUPS: ${{ inputs.fixture_groups }}
+      FIXTURE_IMAGE: alpine:3.20
+      FIXTURE_IMAGE_INDEX_DIGEST: sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
+      FIXTURE_IMAGE_MANIFEST_DIGEST: sha256:3bc2f9693214618ce31d85a9379aa48097d55524d02d0a8c8b4ebd27842f3c94
       RUNTIME_ROOT_PREFIX: /private/tmp/cchr-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Select local benchmark root
@@ -166,7 +169,53 @@ jobs:
             "${BENCHMARK_ROOT}/downloads" \
             "${BENCHMARK_ROOT}/prepared" \
             "${BENCHMARK_ROOT}/evidence" \
+            "${BENCHMARK_ROOT}/fixtures" \
             "${BENCHMARK_ROOT}/work"
+
+      - name: Prepare pinned offline fixture image
+        shell: bash
+        run: |
+          set -euo pipefail
+          command -v /opt/homebrew/bin/skopeo >/dev/null
+          docker_metadata="${BENCHMARK_ROOT}/evidence/fixture-docker-image.json"
+          expected_reference="alpine@${FIXTURE_IMAGE_INDEX_DIGEST}"
+          recovery_command="docker pull ${expected_reference} && docker image tag ${expected_reference} ${FIXTURE_IMAGE}"
+          if ! docker image inspect "${FIXTURE_IMAGE}" > "${docker_metadata}"; then
+            printf 'the pinned local fixture is unavailable: expected %s, found []\n' \
+              "${expected_reference}" >&2
+            printf 'recover before retrying with: %s\n' \
+              "${recovery_command}" >&2
+            exit 1
+          fi
+          jq -e --arg expected "${expected_reference}" \
+            '.[0].RepoDigests | index($expected) != null' \
+            "${docker_metadata}" >/dev/null || {
+            printf 'the pinned local fixture is unavailable: expected %s, found %s\n' \
+              "${expected_reference}" \
+              "$(jq -c '.[0].RepoDigests // []' "${docker_metadata}")" >&2
+            printf 'recover before retrying with: %s\n' \
+              "${recovery_command}" >&2
+            exit 1
+          }
+          archive="${BENCHMARK_ROOT}/fixtures/alpine-3.20-arm64.oci.tar"
+          docker_host="$(docker context inspect --format \
+            '{{(index .Endpoints "docker").Host}}')"
+          [[ "${docker_host}" == unix:///* ]]
+          [[ -S "${docker_host#unix://}" ]]
+          /opt/homebrew/bin/skopeo copy --preserve-digests \
+            --src-daemon-host "${docker_host}" \
+            "docker-daemon:${FIXTURE_IMAGE}" "oci-archive:${archive}:3.20"
+          archive_digest="$(/opt/homebrew/bin/skopeo inspect \
+            "oci-archive:${archive}:3.20" | jq -r '.Digest')"
+          [[ "${archive_digest}" == "${FIXTURE_IMAGE_MANIFEST_DIGEST}" ]]
+          /usr/bin/python3 Tools/release/validate-oci-image-layout.py \
+            "${archive}" 3.20
+          shasum -a 256 "${archive}" \
+            > "${BENCHMARK_ROOT}/evidence/fixture-image.sha256"
+          printf 'PARITY_FIXTURE_IMAGE_ARCHIVE=%s\n' "${archive}" \
+            >> "${GITHUB_ENV}"
+          printf 'PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE=3.20\n' \
+            >> "${GITHUB_ENV}"
 
       - name: Recover host packages and exact historical guest closure
         env:
@@ -434,6 +483,8 @@ jobs:
                 CONTAINER_COMPOSE_CONTAINER="${runtime}" \
                 PARITY_INIT_IMAGE_ARCHIVE="${init_archive}" \
                 PARITY_INIT_IMAGE_REFERENCES="${init_references}" \
+                PARITY_FIXTURE_IMAGE_ARCHIVE="${PARITY_FIXTURE_IMAGE_ARCHIVE}" \
+                PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE="${PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE}" \
                 PARITY_WORK_ROOT="${run_root}/fixtures" \
                 PARITY_EVIDENCE_DIR="${BENCHMARK_ROOT}/evidence/${version}" \
                 PARITY_EVIDENCE_MODE="${evidence_mode}" \

--- a/Makefile
+++ b/Makefile
@@ -478,6 +478,8 @@ RELEASE_GATE_PARITY_INPUT_FINGERPRINT = $(shell { printf '%s\n' \
 	'container-host-address=$(PARITY_CONTAINER_HOST_ADDRESS)' \
 	'init-image-archive=$(shell if [[ -z "$(PARITY_INIT_IMAGE_ARCHIVE)" ]]; then printf unset; elif [[ -f "$(PARITY_INIT_IMAGE_ARCHIVE)" ]]; then shasum -a 256 "$(PARITY_INIT_IMAGE_ARCHIVE)" | awk '{print $$1}'; else printf missing; fi)' \
 	'init-image-references='$(call PIPELINE_SHELL_QUOTE,$(PARITY_INIT_IMAGE_REFERENCES)) \
+	'fixture-image-archive=$(shell if [[ -z "$(PARITY_FIXTURE_IMAGE_ARCHIVE)" ]]; then printf unset; elif [[ -f "$(PARITY_FIXTURE_IMAGE_ARCHIVE)" ]]; then shasum -a 256 "$(PARITY_FIXTURE_IMAGE_ARCHIVE)" | awk '{print $$1}'; else printf missing; fi)' \
+	'fixture-image-reference='$(call PIPELINE_SHELL_QUOTE,$(PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE)) \
 	'work-root='$(call PIPELINE_SHELL_QUOTE,$(PARITY_WORK_ROOT)); \
 	} | shasum -a 256 | awk '{print $$1}')
 override RELEASE_GATE_STATIC_FINGERPRINT = compose=$(shell /usr/bin/git rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):builder=$(shell /usr/bin/git -C "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):containerization=$(shell /usr/bin/git -C "$(CONTAINERIZATION_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):container=$(shell /usr/bin/git -C "$(CONTAINER_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):homebrew=$(shell if [[ -f "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" ]]; then shasum -a 256 "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" | awk '{print $$1}'; else printf missing; fi):candidate=$(CONTAINER_RUNTIME_CANDIDATE_SHA256):init=$(RELEASE_GATE_INIT_ARCHIVE_FINGERPRINT):compose-test=$(RELEASE_GATE_COMPOSE_TEST_BINARY_FINGERPRINT):tools=$(RELEASE_GATE_TOOL_FINGERPRINT):engine=$(PARITY_CONTAINER_ENGINE_API_REF):container-source=$(CONTAINER_SOURCE):container-ref=$(PARITY_CONTAINER_REF):containerization-source=$(CONTAINERIZATION_SOURCE):containerization-ref=$(PARITY_CONTAINERIZATION_REF):swift=$(shell $(SWIFT) --version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):swift-resolved-flags=$(SWIFT_RESOLVED_FLAGS):swift-test-flags=$(SWIFT_TEST_FLAGS):swift-test-run-flags=$(SWIFT_TEST_RUN_FLAGS):swift-test-attempts=$(SWIFT_TEST_ATTEMPTS):swift-coverage-attempts=$(SWIFT_COVERAGE_TEST_ATTEMPTS):swift-runtime-filter=$(SWIFT_RUNTIME_TEST_FILTER):go=$(shell $(GO) version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):go-release-env=$(GO_RELEASE_ENV):go-release-build-flags=$(GO_RELEASE_BUILD_FLAGS):go-release-ldflags=$(GO_RELEASE_LDFLAGS):docker=$(shell $(DOCKER_COMPOSE_REFERENCE) version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):reference=$(DOCKER_COMPOSE_REFERENCE_VERSION):fixtures=$(DOCKER_COMPOSE_E2E_REF):parity-inputs=$(RELEASE_GATE_PARITY_INPUT_FINGERPRINT):release-stack-timeout=$(RELEASE_GATE_STACK_TIMEOUT_SECONDS):release-parity-timeout=$(RELEASE_GATE_PARITY_TIMEOUT_SECONDS):parity-stage-timeout=$(PARITY_STAGE_TIMEOUT_SECONDS):runtime-start-deadline=$(CONTAINER_RUNTIME_START_DEADLINE_SECONDS):parity-live=1:build-check-live=1:swift-core-min=$(SWIFT_CORE_COVERAGE_MIN):swift-runtime-spi-min=$(SWIFT_RUNTIME_SPI_COVERAGE_MIN):swift-provider-min=$(SWIFT_PROVIDER_COVERAGE_MIN):swift-plugin-min=$(SWIFT_PLUGIN_COVERAGE_MIN):swift-aggregate-min=$(SWIFT_AGGREGATE_COVERAGE_MIN):go-min=$(GO_COVERAGE_MIN)
@@ -498,6 +500,8 @@ PARITY_ENV = \
 	DOCKER_COMPOSE="$(DOCKER_COMPOSE_REFERENCE)" \
 	DOCKER_COMPOSE_E2E_REF="$(DOCKER_COMPOSE_E2E_REF)" \
 	PARITY_EVIDENCE_DIR="$(PARITY_EVIDENCE_DIR)" \
+	PARITY_FIXTURE_IMAGE_ARCHIVE="$(PARITY_FIXTURE_IMAGE_ARCHIVE)" \
+	PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE="$(PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE)" \
 	PARITY_REPETITIONS="$(PARITY_REPETITIONS)" \
 	PARITY_TIMEOUT_SECONDS="$(PARITY_TIMEOUT_SECONDS)" \
 	PARITY_SINK_BIND_ADDRESS="$${PARITY_SINK_BIND_ADDRESS}"
@@ -2529,9 +2533,11 @@ docker-compose-performance-matrix: build docker-compose-reference
 		CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" \
 		CONTAINER_RUNTIME_START_DEADLINE_SECONDS="$(CONTAINER_RUNTIME_START_DEADLINE_SECONDS)" \
 		CONTAINERIZATION_INIT_SOURCE_PATH="$(CONTAINERIZATION_INIT_SOURCE_PATH)" \
-		./scripts/run-with-container-runtime.sh "$$container_binary" \
-			env \
-			PARITY_SINK_BIND_ADDRESS="$${PARITY_SINK_BIND_ADDRESS}" \
+			./scripts/run-with-container-runtime.sh "$$container_binary" \
+				env \
+				PARITY_FIXTURE_IMAGE_ARCHIVE="$(PARITY_FIXTURE_IMAGE_ARCHIVE)" \
+				PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE="$(PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE)" \
+				PARITY_SINK_BIND_ADDRESS="$${PARITY_SINK_BIND_ADDRESS}" \
 			PARITY_REPETITIONS="$${PARITY_REPETITIONS:-5}" \
 			PARITY_TIMEOUT_SECONDS="$${PARITY_TIMEOUT_SECONDS:-300}" \
 			PARITY_TIMING_MAX_RATIO="$${PARITY_TIMING_MAX_RATIO:-10}" \

--- a/Tools/parity/check-compose-performance-matrix.sh
+++ b/Tools/parity/check-compose-performance-matrix.sh
@@ -30,6 +30,10 @@
 #   PARITY_WORK_ROOT             Local fixture root (default: .build/parity).
 #   PARITY_INIT_IMAGE_ARCHIVE    Exact guest OCI archive used by the runtime.
 #   PARITY_INIT_IMAGE_REFERENCES Space-separated immutable guest references.
+#   PARITY_FIXTURE_IMAGE_ARCHIVE Offline OCI archive for the warm fixture.
+#   PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE
+#                                Source reference imported from that archive.
+#                                When both are set, registry pulls are disabled.
 #   PARITY_REPETITIONS           Timed repetitions per lane (default: 5).
 #   PARITY_FIXTURE_GROUPS        Comma-separated fixture groups or `all`.
 #                                Groups: lifecycle, logging-stream,
@@ -88,6 +92,8 @@ PARITY_EVIDENCE_DIR="${PARITY_EVIDENCE_DIR:-$REPO_ROOT/.build/parity/performance
 PARITY_WORK_ROOT="${PARITY_WORK_ROOT:-$REPO_ROOT/.build/parity}"
 PARITY_INIT_IMAGE_ARCHIVE="${PARITY_INIT_IMAGE_ARCHIVE:-}"
 PARITY_INIT_IMAGE_REFERENCES="${PARITY_INIT_IMAGE_REFERENCES:-}"
+PARITY_FIXTURE_IMAGE_ARCHIVE="${PARITY_FIXTURE_IMAGE_ARCHIVE:-}"
+PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE="${PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE:-}"
 PARITY_REPETITIONS="${PARITY_REPETITIONS:-5}"
 PARITY_FIXTURE_GROUPS="${PARITY_FIXTURE_GROUPS-all}"
 PARITY_EVIDENCE_MODE="${PARITY_EVIDENCE_MODE:-reset}"
@@ -280,8 +286,51 @@ check_tools() {
         error "PARITY_INIT_IMAGE_ARCHIVE does not exist: $PARITY_INIT_IMAGE_ARCHIVE"
         return 2
     fi
+    if { [[ -n "$PARITY_FIXTURE_IMAGE_ARCHIVE" ]] && [[ -z "$PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE" ]]; } || \
+        { [[ -z "$PARITY_FIXTURE_IMAGE_ARCHIVE" ]] && [[ -n "$PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE" ]]; }; then
+        error "PARITY_FIXTURE_IMAGE_ARCHIVE and PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE must be set together"
+        return 2
+    fi
+    if [[ -n "$PARITY_FIXTURE_IMAGE_ARCHIVE" && ! -f "$PARITY_FIXTURE_IMAGE_ARCHIVE" ]]; then
+        error "PARITY_FIXTURE_IMAGE_ARCHIVE does not exist: $PARITY_FIXTURE_IMAGE_ARCHIVE"
+        return 2
+    fi
     if [[ "$PARITY_INCLUDE_REMOTE_LOGGING" == 1 && "$PARITY_SINK_BIND_ADDRESS" == "127.0.0.1" && "$PARITY_DOCKER_HOST_ADDRESS" != "127.0.0.1" ]]; then
         skip_or_fail 'Docker remote-logging probes require an explicit host-reachable PARITY_SINK_BIND_ADDRESS (for example 0.0.0.0); refusing to request local-network access implicitly'
+    fi
+}
+
+# Warm the fixture outside timed work. Published comparisons import one pinned
+# local archive into every fresh runtime and never contact a registry.
+prepare_fixture_image() {
+    local count file
+    if [[ -n "$PARITY_FIXTURE_IMAGE_ARCHIVE" ]]; then
+        docker image inspect "$FIXTURE_IMAGE" >/dev/null 2>&1 || {
+            error "preloaded Docker fixture is unavailable: $FIXTURE_IMAGE"
+            return 1
+        }
+        "$CONTAINER_BINARY" image load --input "$PARITY_FIXTURE_IMAGE_ARCHIVE" >/dev/null
+        "$CONTAINER_BINARY" image tag \
+            "$PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE" "$FIXTURE_IMAGE"
+        "$CONTAINER_BINARY" image inspect "$FIXTURE_IMAGE" >/dev/null
+        return
+    fi
+
+    file="$FIXTURE_DIR/services-1.yml"
+    "$CONTAINER_COMPOSE" --ansi never -p cc-perf-c-1 -f "$file" pull --quiet >/dev/null
+    if group_enabled lifecycle; then
+        for count in 1 10 50; do
+            file="$FIXTURE_DIR/services-$count.yml"
+            "${DOCKER_COMPOSE_COMMAND[@]}" -p "cc-perf-d-$count" -f "$file" pull --quiet >/dev/null
+            if ((count != 1)); then
+                "$CONTAINER_COMPOSE" --ansi never -p "cc-perf-c-$count" -f "$file" pull --quiet >/dev/null
+            fi
+        done
+    fi
+    if group_enabled logging-stream || group_enabled logging-file ||
+        group_enabled logging-read || group_enabled logging-aggregate; then
+        "${DOCKER_COMPOSE_COMMAND[@]}" -p cc-perf-d-logging -f "$FIXTURE_DIR/logging.yml" pull --quiet >/dev/null
+        "$CONTAINER_COMPOSE" --ansi never -p cc-perf-c-logging -f "$FIXTURE_DIR/logging.yml" pull --quiet >/dev/null
     fi
 }
 
@@ -507,9 +556,13 @@ create_fixtures() {
 
 # Initialize raw samples and exact run fingerprints.
 initialize_evidence() {
-    local init_image_sha=
+    local fixture_image_sha=""
+    local init_image_sha=""
     if [[ -n "$PARITY_INIT_IMAGE_ARCHIVE" ]]; then
         init_image_sha="$(shasum -a 256 "$PARITY_INIT_IMAGE_ARCHIVE" | awk '{print $1}')"
+    fi
+    if [[ -n "$PARITY_FIXTURE_IMAGE_ARCHIVE" ]]; then
+        fixture_image_sha="$(shasum -a 256 "$PARITY_FIXTURE_IMAGE_ARCHIVE" | awk '{print $1}')"
     fi
     mkdir -p "$PARITY_EVIDENCE_DIR"
     PARITY_REPETITIONS="$PARITY_REPETITIONS" python3 - \
@@ -526,10 +579,11 @@ initialize_evidence() {
         "$PARITY_SINK_STALL_SECONDS" "$PARITY_INCLUDE_REMOTE_LOGGING" \
         "$PARITY_SINK_BIND_ADDRESS" "$PARITY_DOCKER_HOST_ADDRESS" \
         "$PARITY_CONTAINER_HOST_ADDRESS" "$init_image_sha" \
-        "$PARITY_INIT_IMAGE_REFERENCES" <<'PY'
+        "$PARITY_INIT_IMAGE_REFERENCES" "$fixture_image_sha" \
+        "$PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE" <<'PY'
 import json, os, pathlib, sys
 from datetime import datetime, timezone
-(mode, timing, fingerprints, timing_junit, timing_matrix, docker_compose, docker_engine, compose_version, runtime_version, commit, model, memory, macos, architecture, compose_sha, runtime_sha, noise, timeout, maximum_ratio, timing_policy, pressure_records, sink_stall, include_remote_logging, sink_bind, docker_host, container_host, init_sha, init_references) = sys.argv[1:]
+(mode, timing, fingerprints, timing_junit, timing_matrix, docker_compose, docker_engine, compose_version, runtime_version, commit, model, memory, macos, architecture, compose_sha, runtime_sha, noise, timeout, maximum_ratio, timing_policy, pressure_records, sink_stall, include_remote_logging, sink_bind, docker_host, container_host, init_sha, init_references, fixture_sha, fixture_reference) = sys.argv[1:]
 def decode(value):
     try: return json.loads(value)
     except json.JSONDecodeError: return value
@@ -562,6 +616,11 @@ current = {
     "docker": {"composeVersion": docker_compose, "engine": decode(docker_engine)},
     "host": {"architecture": architecture, "hardwareMemoryBytes": int(memory), "hardwareModel": model, "macOSVersion": macos},
 }
+if fixture_sha:
+    current["conditions"]["fixtureImageArchive"] = {
+        "sha256": fixture_sha,
+        "sourceReference": fixture_reference,
+    }
 timing_path = pathlib.Path(timing)
 fingerprint_path = pathlib.Path(fingerprints)
 header = "fixture\tlane\trepetition\tschedule_position\tdirection\tduration_seconds\toutcome\tcommand\n"
@@ -1476,24 +1535,9 @@ PY
 # Warm each image and run counterbalanced lifecycle and logging samples.
 run_matrix() {
     local count repetition file lane position fixture workload tail buffer_size
-    file="$FIXTURE_DIR/services-1.yml"
-    "$CONTAINER_COMPOSE" --ansi never -p cc-perf-c-1 -f "$file" pull --quiet >/dev/null
+    prepare_fixture_image
     initialize_evidence
     preflight_candidate_lifecycle
-    if group_enabled lifecycle; then
-        for count in 1 10 50; do
-            file="$FIXTURE_DIR/services-$count.yml"
-            "${DOCKER_COMPOSE_COMMAND[@]}" -p "cc-perf-d-$count" -f "$file" pull --quiet >/dev/null
-            if ((count != 1)); then
-                "$CONTAINER_COMPOSE" --ansi never -p "cc-perf-c-$count" -f "$file" pull --quiet >/dev/null
-            fi
-        done
-    fi
-    if group_enabled logging-stream || group_enabled logging-file ||
-        group_enabled logging-read || group_enabled logging-aggregate; then
-        "${DOCKER_COMPOSE_COMMAND[@]}" -p cc-perf-d-logging -f "$FIXTURE_DIR/logging.yml" pull --quiet >/dev/null
-        "$CONTAINER_COMPOSE" --ansi never -p cc-perf-c-logging -f "$FIXTURE_DIR/logging.yml" pull --quiet >/dev/null
-    fi
     for ((repetition = 1; repetition <= PARITY_REPETITIONS; repetition++)); do
         select_lane_order "$repetition"
         if group_enabled lifecycle; then

--- a/Tools/parity/test_compose_performance_matrix.py
+++ b/Tools/parity/test_compose_performance_matrix.py
@@ -226,6 +226,102 @@ class PerformanceMatrixInventoryTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("PARITY_FIXTURE_GROUPS must not be empty", result.stderr)
 
+    def test_offline_fixture_archive_suppresses_registry_pulls(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-performance-fixture-") as directory:
+            root = Path(directory)
+            archive = root / "alpine.oci.tar"
+            archive.write_bytes(b"pinned fixture")
+            calls = root / "calls.log"
+            fixture_dir = root / "fixtures"
+            fixture_dir.mkdir()
+            runtime = root / "container"
+            runtime.write_text(
+                '#!/bin/sh\nprintf "container %s\\n" "$*" >>"$CALL_LOG"\n',
+                encoding="utf-8",
+            )
+            runtime.chmod(0o755)
+            compose = root / "compose"
+            compose.write_text(
+                '#!/bin/sh\nprintf "compose %s\\n" "$*" >>"$CALL_LOG"\n',
+                encoding="utf-8",
+            )
+            compose.chmod(0o755)
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "CALL_LOG": str(calls),
+                    "CONTAINER_COMPOSE_CONTAINER": str(runtime),
+                    "PARITY_FIXTURE_IMAGE_ARCHIVE": str(archive),
+                    "PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE": "3.20",
+                }
+            )
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    r'''
+source "$1"
+docker() { printf 'docker %s\n' "$*" >>"$CALL_LOG"; }
+FIXTURE_DIR="$2"
+CONTAINER_COMPOSE="$3"
+DOCKER_COMPOSE_COMMAND=("$3")
+prepare_fixture_image
+''',
+                    "_",
+                    HARNESS,
+                    fixture_dir,
+                    compose,
+                ],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            invocations = calls.read_text(encoding="utf-8")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("docker image inspect alpine:3.20", invocations)
+        self.assertIn(f"container image load --input {archive}", invocations)
+        self.assertIn("container image tag 3.20 alpine:3.20", invocations)
+        self.assertIn("container image inspect alpine:3.20", invocations)
+        self.assertNotIn(" pull ", invocations)
+
+    def test_offline_fixture_archive_is_retained_in_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-performance-fixture-") as directory:
+            root = Path(directory)
+            archive = root / "alpine.oci.tar"
+            archive.write_bytes(b"pinned fixture")
+            evidence = root / "evidence"
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "PARITY_EVIDENCE_DIR": str(evidence),
+                    "PARITY_FIXTURE_IMAGE_ARCHIVE": str(archive),
+                    "PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE": "3.20",
+                }
+            )
+            result = subprocess.run(
+                ["bash", "-c", INITIALIZE_EVIDENCE_SCRIPT, "_", HARNESS],
+                cwd=REPOSITORY,
+                env=environment,
+                capture_output=True,
+                check=False,
+                text=True,
+            )
+            fingerprint = json.loads(
+                (evidence / "fingerprints.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            fingerprint["conditions"]["fixtureImageArchive"],
+            {
+                "sha256": "20899fac2e03608f209e7a72eb3fc133b543111a21b15a4bd98ceee8701cd8e5",
+                "sourceReference": "3.20",
+            },
+        )
+
     def test_append_mode_preserves_existing_samples(self) -> None:
         with tempfile.TemporaryDirectory(prefix="compose-performance-append-") as directory:
             evidence = Path(directory)

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -253,6 +253,46 @@ class HistoricalWorkflowTests(unittest.TestCase):
         self.assertNotIn("security import", workflow)
         self.assertNotIn("crane auth", workflow)
 
+    def test_workflow_preloads_a_pinned_fixture_without_registry_access(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        makefile = MAKEFILE.read_text(encoding="utf-8")
+        prepare = workflow.index("Prepare pinned offline fixture image")
+        quiet_host = workflow.index("Require a quiet benchmark host")
+
+        self.assertLess(prepare, quiet_host)
+        self.assertIn("FIXTURE_IMAGE_INDEX_DIGEST: sha256:", workflow)
+        self.assertIn("FIXTURE_IMAGE_MANIFEST_DIGEST: sha256:", workflow)
+        self.assertIn("docker-daemon:${FIXTURE_IMAGE}", workflow)
+        self.assertIn(
+            'if ! docker image inspect "${FIXTURE_IMAGE}" > "${docker_metadata}"; then',
+            workflow,
+        )
+        self.assertIn("docker pull ${expected_reference}", workflow)
+        self.assertIn(
+            "docker image tag ${expected_reference} ${FIXTURE_IMAGE}", workflow
+        )
+        self.assertNotIn(
+            "recover before retrying with: docker pull %s", workflow
+        )
+        self.assertIn("--preserve-digests", workflow)
+        self.assertIn("--src-daemon-host", workflow)
+        self.assertIn("docker context inspect", workflow)
+        self.assertIn("validate-oci-image-layout.py", workflow)
+        self.assertIn("PARITY_FIXTURE_IMAGE_ARCHIVE=", workflow)
+        self.assertIn("PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE=3.20", workflow)
+        self.assertIn(
+            'PARITY_FIXTURE_IMAGE_ARCHIVE="${PARITY_FIXTURE_IMAGE_ARCHIVE}"',
+            workflow,
+        )
+        self.assertIn(
+            'PARITY_FIXTURE_IMAGE_ARCHIVE="$(PARITY_FIXTURE_IMAGE_ARCHIVE)"',
+            makefile,
+        )
+        self.assertIn(
+            "PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE=\"$(PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE)\"",
+            makefile,
+        )
+
     def test_workflow_checkpoints_fixture_groups_before_finalizing(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         self.assertIn('"lifecycle,logging-stream"', workflow)


### PR DESCRIPTION
## Summary

- export the exact cached `alpine:3.20` Docker fixture once as a pinned OCI archive before long reconstruction work
- import and tag that same archive in every fresh Container runtime phase
- suppress all registry pulls in archive-backed runs while retaining ordinary developer pull behavior
- retain the fixture archive checksum and reference in benchmark fingerprints and release-gate inputs

## Proof

- `actionlint .github/workflows/historical-benchmark.yml`
- `bash -n Tools/parity/check-compose-performance-matrix.sh`
- `shellcheck Tools/parity/check-compose-performance-matrix.sh`
- 82 focused benchmark/reconstruction/release-policy tests passed
- dry-run Make target proves the archive controls reach the harness
- local offline export proved canonical Alpine index `sha256:d9e853...` becomes arm64 OCI manifest `sha256:3bc2f9...` and passes OCI layout validation

Closes #372