### PR TITLE
fix(benchmarks): export importable OCI fixture

### DIFF
--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -66,7 +66,8 @@ jobs:
       FIXTURE_GROUPS: ${{ inputs.fixture_groups }}
       FIXTURE_IMAGE: alpine:3.20
       FIXTURE_IMAGE_INDEX_DIGEST: sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
-      FIXTURE_IMAGE_MANIFEST_DIGEST: sha256:3bc2f9693214618ce31d85a9379aa48097d55524d02d0a8c8b4ebd27842f3c94
+      FIXTURE_IMAGE_MANIFEST_DIGEST: sha256:5c2987750228f21fa5e602dbc36c4535b34deed426b8f13806c0e2dfbf9b1fba
+      FIXTURE_IMAGE_MANIFEST_MEDIA_TYPE: application/vnd.oci.image.manifest.v1+json
       RUNTIME_ROOT_PREFIX: /private/tmp/cchr-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Select local benchmark root
@@ -202,12 +203,15 @@ jobs:
             '{{(index .Endpoints "docker").Host}}')"
           [[ "${docker_host}" == unix:///* ]]
           [[ -S "${docker_host#unix://}" ]]
-          /opt/homebrew/bin/skopeo copy --preserve-digests \
+          /opt/homebrew/bin/skopeo copy --format oci \
             --src-daemon-host "${docker_host}" \
             "docker-daemon:${FIXTURE_IMAGE}" "oci-archive:${archive}:3.20"
           archive_digest="$(/opt/homebrew/bin/skopeo inspect \
             "oci-archive:${archive}:3.20" | jq -r '.Digest')"
           [[ "${archive_digest}" == "${FIXTURE_IMAGE_MANIFEST_DIGEST}" ]]
+          archive_media_type="$(tar -xOf "${archive}" index.json | \
+            jq -er '.manifests | if length == 1 then .[0].mediaType else error("expected exactly one manifest") end')"
+          [[ "${archive_media_type}" == "${FIXTURE_IMAGE_MANIFEST_MEDIA_TYPE}" ]]
           /usr/bin/python3 Tools/release/validate-oci-image-layout.py \
             "${archive}" 3.20
           shasum -a 256 "${archive}" \

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -261,7 +261,16 @@ class HistoricalWorkflowTests(unittest.TestCase):
 
         self.assertLess(prepare, quiet_host)
         self.assertIn("FIXTURE_IMAGE_INDEX_DIGEST: sha256:", workflow)
-        self.assertIn("FIXTURE_IMAGE_MANIFEST_DIGEST: sha256:", workflow)
+        self.assertIn(
+            "FIXTURE_IMAGE_MANIFEST_DIGEST: "
+            "sha256:5c2987750228f21fa5e602dbc36c4535b34deed426b8f13806c0e2dfbf9b1fba",
+            workflow,
+        )
+        self.assertIn(
+            "FIXTURE_IMAGE_MANIFEST_MEDIA_TYPE: "
+            "application/vnd.oci.image.manifest.v1+json",
+            workflow,
+        )
         self.assertIn("docker-daemon:${FIXTURE_IMAGE}", workflow)
         self.assertIn(
             'if ! docker image inspect "${FIXTURE_IMAGE}" > "${docker_metadata}"; then',
@@ -274,9 +283,15 @@ class HistoricalWorkflowTests(unittest.TestCase):
         self.assertNotIn(
             "recover before retrying with: docker pull %s", workflow
         )
-        self.assertIn("--preserve-digests", workflow)
+        self.assertIn("skopeo copy --format oci", workflow)
+        self.assertNotIn("--preserve-digests", workflow)
         self.assertIn("--src-daemon-host", workflow)
         self.assertIn("docker context inspect", workflow)
+        self.assertIn("expected exactly one manifest", workflow)
+        self.assertIn(
+            '[[ "${archive_media_type}" == "${FIXTURE_IMAGE_MANIFEST_MEDIA_TYPE}" ]]',
+            workflow,
+        )
         self.assertIn("validate-oci-image-layout.py", workflow)
         self.assertIn("PARITY_FIXTURE_IMAGE_ARCHIVE=", workflow)
         self.assertIn("PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE=3.20", workflow)


### PR DESCRIPTION
## Summary

- convert the cached digest-verified Alpine fixture to a native OCI manifest
- pin the converted manifest digest and require the OCI image media type
- retain offline per-phase loading and fail before timing if conversion drifts

## Validation

- `actionlint .github/workflows/historical-benchmark.yml`
- `python3 -m unittest Tools.parity.test_historical_reconstruction_benchmark Tools.parity.test_compose_performance_matrix` (50 tests)
- exact 0.13.0 released runtime and Compose client lifecycle proof: 517 filesystem entries unpacked, `sh` executed, clean teardown
- exact-head critical review: no blocking issues

Closes #374