### PR TITLE
docs(benchmarks): compare 0.14.0 with 0.13.0

### DIFF
--- a/docs/benchmarks/0.14.0-vs-0.13.0.md
+++ b/docs/benchmarks/0.14.0-vs-0.13.0.md
@@ -1,0 +1,82 @@
+# Historical reconstruction benchmark: 0.14.0 versus 0.13.0
+
+This report compares the immutable, Developer ID-signed host archives from each release. Each missing guest OCI archive was reconstructed from the exact retained Containerization CI initfs artifact with a release-mode `cctl` built from the release's exact Containerization revision. Both releases ran on the same host against the same Docker installation; Docker-normalized change is included to expose host drift.
+
+## Result
+
+Across 16 scored fixed-work fixtures, the Docker-normalized geometric-mean median changed -23.2% and the Docker-normalized geometric-mean P95 changed -12.0%. With a ±5% noise band applied to the normalized median, 5 fixtures improved, 6 stayed within noise, and 5 regressed. 7 additional fixtures were unscored because of recorded execution failures.
+
+Lower durations and negative changes are better.
+
+## Reconstructed historical inputs
+
+### Target 0.14.0
+
+Release: [https://github.com/stephenlclarke/container-compose/releases/tag/0.14.0](https://github.com/stephenlclarke/container-compose/releases/tag/0.14.0)
+Artifact source: [https://github.com/stephenlclarke/container-compose/actions/runs/33356908149](https://github.com/stephenlclarke/container-compose/actions/runs/33356908149).
+Release tag commit: `c09d017e775e7eec9a75eaccdfe597188c0a00c8`.
+Container: `stephenlclarke/container@f87481688f25bbc9d311ae09c4fcf33f121ba9ae`.
+Containerization: `stephenlclarke/containerization@e5a92e86bf03eb2cc244b3b47b0413b3935abfe4`.
+Guest init image: `container-vminit-arm64.oci.tar` at `9979480cdcad68bf70df85a8b1dc06182c76eb5d491a3561174fd7576fff4957`.
+
+- Guest initfs authority: [https://github.com/stephenlclarke/containerization/actions/runs/33272343831](https://github.com/stephenlclarke/containerization/actions/runs/33272343831); artifact `9720557307` at `sha256:d7e8a76ebab6e3b4df30917310cd6a9de81d244b5a5e3137adc43b9b4106b18b`.
+- Guest packager: `containerization@e5a92e86bf03eb2cc244b3b47b0413b3935abfe4`; recoverable receipt `11c04e5a208b5ade557e4904de84e5dc213ac64592dfa5d5e71939c3df1091b5`; stage artifact `6abb3a4ce8f24cbc63fc5204b00f4e69bb0e6fb6093e648a8cef0dafdfb757bd`; extracted `cctl` `912410cf0d33eae7497a0ba22eab3bc999c6d0c6c091af79455f35c73852bcff`.
+- Guest packager inputs: source `e4ca2ab880a7c300c7fb24a6e8def7136e7a7e51741c40ebdcc363054fff6d98`; source metadata `409f9811acb7dce2ffb612dec18fdb162439fd544468b47e0bf3bb542a5163fc`; command `04a28752a8aba9f64c04d69e4dfa3ca16634224a08ae4dcf206278527da83a97`; tools `10438e43b9d2536349fca50b350b8b9350e1f82223c291c1ae4d5b8905e9163f`.
+- `container-release-arm64.tar.gz`: SHA-256 `91e1ea7e48f6512cf8cd0254f75314b51d61f2faef11221f7bb9d771d4d12a0f`; Homebrew formula history `1a3a17d0a941cb31f718ec395aaec2849cd50014`.
+- `container-compose-plugin-release-arm64.tar.gz`: SHA-256 `f450d7fda9592a3a852d94ba1ef27ace7c2b5ae5a6ec18286d06b9555af426ae`; Homebrew formula history `1a3a17d0a941cb31f718ec395aaec2849cd50014`.
+
+### Comparison 0.13.0
+
+Release: [https://github.com/stephenlclarke/container-compose/releases/tag/0.13.0](https://github.com/stephenlclarke/container-compose/releases/tag/0.13.0)
+Artifact source: [https://github.com/stephenlclarke/container-compose/actions/runs/32784434403](https://github.com/stephenlclarke/container-compose/actions/runs/32784434403).
+Release tag commit: `52805d9539834ab375163d941bada6c4677a187a`.
+Container: `stephenlclarke/container@94bb6c4bd1ad00deffb68fc40e931ee143c43c65`.
+Containerization: `stephenlclarke/containerization@fefced145304666076d646609f21397f32909fcf`.
+Guest init image: `container-vminit-arm64.oci.tar` at `d20c920c60f7b3c8cf4c34e94d0e716a45d6822fb02c375090a356eac3ac3c44`.
+
+- Guest initfs authority: [https://github.com/stephenlclarke/containerization/actions/runs/32739306887](https://github.com/stephenlclarke/containerization/actions/runs/32739306887); artifact `9524710977` at `sha256:e73b213a24ad0f3cd30c93595120edd31f9d99d85e227f70d23e82eb856ce66d`.
+- Guest packager: `containerization@fefced145304666076d646609f21397f32909fcf`; recoverable receipt `637e62f5461c8709f84f1db912d02ebabf278fdea07b9410c81d3f48cd40902f`; stage artifact `c4c85a21b3f3b60fa7554474d546915995c437fb66eafe62dfd1d90b094cb66d`; extracted `cctl` `816eb3c759edc7877d196836ec3188b141aa6efad70ea78163914f28ed484dc0`.
+- Guest packager inputs: source `ac2ac5b49db428ab397122d13b048e5e405b5722766965bea322f82fbcb2b214`; source metadata `cf42d1ccd3cdb8a9b24b6de7ad39676b2b5db13cbd642228a1e517e88f1236fd`; command `04a28752a8aba9f64c04d69e4dfa3ca16634224a08ae4dcf206278527da83a97`; tools `10438e43b9d2536349fca50b350b8b9350e1f82223c291c1ae4d5b8905e9163f`.
+- `container-release-arm64.tar.gz`: SHA-256 `cd191d501bb3e9e60ccf4552460c71b8046c8937b15b2a2ed73e1fefde226e56`; Homebrew formula history `0d01024f40c604c28e59955e5016068dfb8572a8`.
+- `container-compose-plugin-release-arm64.tar.gz`: SHA-256 `39143c05a653c42e71da2132b9fe4172cc429e8c5e55b87e8733b86b29e18cc9`; Homebrew formula history `0d01024f40c604c28e59955e5016068dfb8572a8`.
+
+## Host and method
+
+- Host: `Mac17,9`, `arm64`, 25769803776 bytes memory, macOS `26.6.2`.
+- Docker Compose: `5.4.0`.
+- Repetitions: 5 per lane, counterbalanced Docker-first/candidate-first order.
+- Cross-VM remote-sink logging lanes: excluded to keep the unattended run free of macOS Local Network approval.
+- Workflow evidence: [https://github.com/stephenlclarke/container-compose/actions/runs/33468711244](https://github.com/stephenlclarke/container-compose/actions/runs/33468711244).
+- Raw TSV, JUnit, timing matrices, distribution manifests, and exact fingerprints are retained as the workflow artifact.
+
+## Fixture evidence
+
+| Fixture | Comparison median (s) | Target median (s) | Raw median change | Comparison P95 (s) | Target P95 (s) | Raw P95 change | Docker-normalized median change | Docker-normalized P95 change | Verdict |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| logging-aggregate-1-services | 0.828 | 1.021 | +23.4% | 0.911 | 1.085 | +19.1% | +19.9% | +20.1% | Regressed |
+| logging-aggregate-10-services | 6.390 | 2.036 | -68.1% | 6.736 | 2.167 | -67.8% | -64.7% | -67.0% | Improved |
+| logging-aggregate-50-services | 31.957 | n/a | n/a | 32.964 | n/a | n/a | n/a | n/a | Target container-compose failed (exit-1, exit-1, exit-1, exit-1, exit-1) |
+| logging-follow-rotation | 1.123 | 1.119 | -0.4% | 1.132 | 1.139 | +0.6% | -1.0% | -0.5% | Within noise |
+| logging-read-all | 0.393 | 0.394 | +0.2% | 0.400 | 0.412 | +3.1% | -9.9% | +5.5% | Improved |
+| logging-read-since-until | 0.172 | 0.172 | -0.3% | 0.174 | 0.184 | +5.9% | +5.4% | +9.4% | Regressed |
+| logging-read-tail-10 | 0.187 | 0.187 | +0.4% | 0.192 | 0.201 | +4.5% | -1.8% | +3.8% | Within noise |
+| logging-read-tail-1000 | 0.205 | 0.202 | -1.4% | 0.218 | 0.218 | +0.2% | +3.4% | -8.0% | Within noise |
+| logging-startup-first-output | 1.126 | 0.374 | -66.8% | 1.240 | 1.143 | -7.8% | -66.1% | -7.5% | Improved |
+| logging-startup-first-output-attached | 0.825 | n/a | n/a | 0.995 | n/a | n/a | n/a | n/a | Target container-compose failed (exit-1, exit-1, exit-1, exit-1) |
+| logging-throughput-mixed-small | 1.182 | n/a | n/a | 1.213 | n/a | n/a | n/a | n/a | Target container-compose failed (exit-1, exit-1, exit-1, exit-1, exit-1) |
+| logging-throughput-stderr-small | 1.178 | n/a | n/a | 1.234 | n/a | n/a | n/a | n/a | Target container-compose failed (exit-1, exit-1, exit-1, exit-1, exit-1) |
+| logging-throughput-stdout-16k | 1.104 | n/a | n/a | 1.564 | n/a | n/a | n/a | n/a | Target container-compose failed (exit-1, exit-1, exit-1, exit-1, exit-1) |
+| logging-throughput-stdout-1m | 1.343 | n/a | n/a | 1.424 | n/a | n/a | n/a | n/a | Target container-compose failed (exit-1, exit-1, exit-1, exit-1, exit-1) |
+| logging-throughput-stdout-small | 1.213 | n/a | n/a | 1.347 | n/a | n/a | n/a | n/a | Target container-compose failed (exit-1, exit-1, exit-1, exit-1, exit-1) |
+| logging-write-json-compression | 1.489 | 1.643 | +10.4% | 1.596 | 1.780 | +11.5% | +13.3% | +11.4% | Regressed |
+| logging-write-local-rotation | 1.141 | 1.284 | +12.5% | 1.252 | 1.388 | +10.9% | +13.4% | +11.7% | Regressed |
+| startup-1-services | 0.896 | 1.034 | +15.4% | 1.004 | 1.110 | +10.5% | +18.8% | +41.3% | Regressed |
+| startup-10-services | 6.684 | 1.821 | -72.8% | 6.755 | 2.010 | -70.2% | -72.2% | -70.0% | Improved |
+| startup-50-services | 33.517 | 8.946 | -73.3% | 34.530 | 13.134 | -62.0% | -72.3% | -62.1% | Improved |
+| teardown-1-services | 1.458 | 1.436 | -1.4% | 1.559 | 1.452 | -6.9% | -1.3% | -7.2% | Within noise |
+| teardown-10-services | 2.507 | 2.443 | -2.6% | 2.621 | 4.653 | +77.5% | -3.5% | +75.9% | Within noise |
+| teardown-50-services | 7.167 | 6.922 | -3.4% | 7.234 | 7.191 | -0.6% | -3.9% | -1.1% | Within noise |
+
+## Interpretation boundary
+
+The report supports claims only for the listed warm-image lifecycle and logging fixtures. It does not replace functional, Docker parity, security, quality, packaging, or release gates, and it is not authority for workloads absent from the matrix.


### PR DESCRIPTION
Historical reconstruction benchmark for 0.14.0 versus 0.13.0. Host executables are the immutable signed release packages; each missing guest archive is reconstructed from its exact retained CI initfs and Containerization source revision. Raw evidence is retained by workflow run 33468711244.\n\nThe benchmark and report generation completed successfully. The workflow could not create this PR because the repository currently disallows pull-request creation by GitHub Actions; this PR preserves the exact signed report commit already pushed by the run.