### PR TITLE
fix(ci): skip packaging for documentation-only changes

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -245,8 +245,14 @@ jobs:
                 jq -c '[.[] | .jobs[] | select(.name == "Validate" or .name == "Validate Runtime") | .conclusion]' \
                   <<<"${workflow_jobs}"
               )"
+              runtime_validate_conclusions="$(
+                jq -c '[.[] | .jobs[] | select(.name == "Validate Runtime") | .conclusion]' \
+                  <<<"${workflow_jobs}"
+              )"
               if jq -e 'length > 0 and all(.[]; . != null)' \
-                <<<"${validate_conclusions}" >/dev/null; then
+                <<<"${validate_conclusions}" >/dev/null && \
+                jq -e 'length > 0 and all(.[]; . != null)' \
+                  <<<"${runtime_validate_conclusions}" >/dev/null; then
                 return 0
               fi
               if (( attempt >= max_attempts )); then
@@ -284,6 +290,10 @@ jobs:
                 <<<"${validate_conclusions}" >/dev/null; then
                 printf 'Skipping package publish because CI Validate results were %s.\n' \
                   "$(jq -r 'if length == 0 then "missing" else join(",") end' <<<"${validate_conclusions}")"
+              elif jq -e \
+                'length > 0 and all(.[]; . == "skipped")' \
+                <<<"${runtime_validate_conclusions}" >/dev/null; then
+                printf 'Skipping package publish because CI Validate Runtime was intentionally skipped.\n'
               elif [[ "${WORKFLOW_RUN_HEAD_BRANCH}" == "main" ]]; then
                 if wait_for_successful_main_sonarqube_scan "${WORKFLOW_RUN_HEAD_SHA}"; then
                   scan_authority_available=true

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1051,6 +1051,49 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 msg=f"unexpected settled classification for {payload}: {result.stderr}",
             )
 
+    def test_current_package_skips_documentation_only_ci_before_sonar_polling(
+        self,
+    ) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        runtime_query = (
+            '[.[] | .jobs[] | select(.name == "Validate Runtime") | .conclusion]'
+        )
+        runtime_skip_filter = 'length > 0 and all(.[]; . == "skipped")'
+        skip_message = (
+            "Skipping package publish because CI Validate Runtime was "
+            "intentionally skipped."
+        )
+
+        self.assertIn(runtime_query, workflow)
+        self.assertIn(runtime_skip_filter, workflow)
+        self.assertIn(skip_message, workflow)
+        self.assertLess(
+            workflow.index(skip_message),
+            workflow.index(
+                'wait_for_successful_main_sonarqube_scan '
+                '"${WORKFLOW_RUN_HEAD_SHA}"'
+            ),
+        )
+        for payload, expected in (
+            ('["skipped"]', True),
+            ('["skipped", "skipped"]', True),
+            ('["success"]', False),
+            ('["skipped", "success"]', False),
+            ("[]", False),
+        ):
+            result = subprocess.run(
+                ["jq", "-e", runtime_skip_filter],
+                input=payload,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            self.assertEqual(
+                result.returncode == 0,
+                expected,
+                msg=f"unexpected runtime classification for {payload}: {result.stderr}",
+            )
+
     def test_current_package_skips_only_when_the_pointer_already_matches_main(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("Skipping current package because current already points at", workflow)

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "archiveCommit": "3d77ec228c7f55a04f689d5e1453752fc0c27f72",
-  "generatedAt": "2026-08-31",
+  "generatedAt": "2026-09-01",
   "entries": [
     {
       "id": "apple-container-1459",
@@ -7273,6 +7273,27 @@
         }
       ],
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/363"
+    },
+    {
+      "id": "container-compose-380",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Skip packaging immediately for documentation-only CI",
+      "state": "submitted",
+      "lastVerified": "2026-09-01",
+      "commits": [
+        "502aae5a649e9f6f6451eb30a3e9e2f0bb085c8a"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-379.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-380.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/380"
     },
     {
       "id": "container-compose-333",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -6,11 +6,11 @@ This registry replaces the retired issue and pull-request handoff pairs.
 Current supporting records remain as ordinary Markdown files; every retired document
 links to an immutable Git snapshot.
 
-Last verified: 2026-08-31
+Last verified: 2026-09-01
 
-Entries: 395. Document snapshots: 691. Current supporting documents: 85.
+Entries: 396. Document snapshots: 693. Current supporting documents: 87.
 
-States: `active-draft` 9, `archived` 304, `closed` 17, `merged` 10, `submitted` 13, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 9, `archived` 304, `closed` 17, `merged` 10, `submitted` 14, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -225,6 +225,7 @@ States: `active-draft` 9, `archived` 304, `closed` 17, `merged` 10, `submitted` 
 | `stephenlclarke/container-compose` | [Require published guest authority](https://github.com/stephenlclarke/container-compose/pull/356) | `active-draft` | `465dc7e49b92` | [Issue details](container-compose/ISSUE-355.md); [PR details](container-compose/PR-356.md) |
 | `stephenlclarke/container-compose` | [Bound Current Demo engine readiness](https://github.com/stephenlclarke/container-compose/pull/361) | `active-draft` | `dec369f5d3f0`, `54ce64c52033` | [Issue details](container-compose/ISSUE-357.md); [PR details](container-compose/PR-358.md); [PR details](container-compose/PR-361.md) |
 | `stephenlclarke/container-compose` | [Make release validation deterministic](https://github.com/stephenlclarke/container-compose/pull/363) | `submitted` | `d4691370576e` | [Issue details](container-compose/ISSUE-362.md); [PR details](container-compose/PR-363.md) |
+| `stephenlclarke/container-compose` | [Skip packaging immediately for documentation-only CI](https://github.com/stephenlclarke/container-compose/pull/380) | `submitted` | `502aae5a649e` | [Issue details](container-compose/ISSUE-379.md); [PR details](container-compose/PR-380.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-379.md
+++ b/docs/upstream/container-compose/ISSUE-379.md
@@ -1,0 +1,21 @@
+# Issue 379: skip packaging immediately for documentation-only CI
+
+## Problem
+
+The first completed historical benchmark report merged as a documentation-only change. Its exact pull-request head passed the documentation validation path, but the successful main CI still triggered Prebuilt Binaries. The packaging resolver then entered the exact-main SonarQube polling path even though CI had intentionally skipped `Validate Runtime`, so no product input had changed and no SonarQube scan could exist for that commit.
+
+Tracking issue: [`#379`](https://github.com/stephenlclarke/container-compose/issues/379).
+
+## Required outcome
+
+- Treat an intentionally skipped `Validate Runtime` job as authoritative documentation-only classification.
+- Exit the package resolver immediately without SonarQube polling, package work, or downstream publication.
+- Preserve existing fail-closed behavior for missing, unsettled, failed, or unreadable CI authority.
+- Preserve normal packaging for exact-main CI whose `Validate Runtime` job succeeds.
+
+## Acceptance evidence
+
+- Focused workflow contract tests cover the runtime-classification guard and its position before SonarQube polling.
+- Actionlint and `git diff --check` pass.
+- The repository setting permits GitHub Actions to create the benchmark's documentation pull request.
+- Exact-head review finds no further issue.

--- a/docs/upstream/container-compose/PR-380.md
+++ b/docs/upstream/container-compose/PR-380.md
@@ -1,0 +1,26 @@
+# Pull request 380: skip packaging immediately for documentation-only CI
+
+## Summary
+
+Pull request [`#380`](https://github.com/stephenlclarke/container-compose/pull/380) closes tracking issue [`#379`](https://github.com/stephenlclarke/container-compose/issues/379).
+
+- Read the settled `Validate Runtime` conclusion from the exact successful CI run.
+- Stop the packaging resolver immediately when runtime validation was intentionally skipped.
+- Keep exact-main SonarQube authority and package publication unchanged for source-bearing CI runs.
+
+## Failure boundary
+
+Missing, pending, failed, or unreadable CI job evidence retains the existing fail-closed behavior. Only a settled successful CI run whose `Validate Runtime` job is present but intentionally skipped takes the new no-product-change exit.
+
+## Validation
+
+- [x] Three focused package workflow contract tests
+- [x] Production classification of docs-only CI run [`33472618656`](https://github.com/stephenlclarke/container-compose/actions/runs/33472618656) as `runtime=["skipped"]`
+- [x] Actionlint
+- [x] Markdown lint
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+
+## Compatibility and risk
+
+Runtime and package contents are unchanged. The change removes an impossible SonarQube wait and prevents downstream package work for documentation-only main commits. Manual stable packaging and source-bearing current packaging keep their existing authorities.


### PR DESCRIPTION
Closes #379.

Uses the exact successful CI run job conclusions to stop Prebuilt Binaries immediately when `Validate Runtime` was intentionally skipped. This removes the impossible exact-main SonarQube wait and prevents downstream package work for documentation-only commits while preserving fail-closed behavior and normal source-bearing packaging.

Validation:
- three focused workflow contract tests
- production classification proof from main CI run 33472618656
- actionlint
- markdownlint
- git diff --check
- signed Conventional Commit