### PR TITLE
fix(release): align 0.13.1 fixed runtime stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Classify changed files
         id: filter
         env:
+          GITHUB_REF_TYPE: ${{ github.ref_type }}
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
@@ -69,6 +70,10 @@ jobs:
                 --jq '.[].filename' > "$changed_files"
               ;;
             push)
+              if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+                printf 'heavy=true\n' >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
               before="${{ github.event.before }}"
               after="${GITHUB_SHA}"
               if [[ "$before" =~ ^0+$ ]] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,7 +348,7 @@ jobs:
           HAWKEYE_AUTO_INSTALL: "1"
 
       - name: Cache SonarQube packages
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: ~/.sonar/cache
@@ -357,7 +357,7 @@ jobs:
 
       - name: Check SonarQube TCP availability
         id: sonar_tcp
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         env:
           SONAR_HOST: sonarcloud.io
           SONAR_PORT: "443"
@@ -371,7 +371,9 @@ jobs:
 
       - name: Check SonarQube API availability
         id: sonar_api
-        if: github.ref == 'refs/heads/main' && steps.sonar_tcp.outputs.available == 'true'
+        if: >
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
+          steps.sonar_tcp.outputs.available == 'true'
         env:
           SONAR_STATUS_URL: https://sonarcloud.io/api/system/status
         run: |
@@ -390,7 +392,7 @@ jobs:
       - name: Install Sonar Scanner CLI
         id: sonar_install
         if: >
-          github.ref == 'refs/heads/main' &&
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
           steps.sonar_tcp.outputs.available == 'true' &&
           steps.sonar_api.outputs.available == 'true'
         continue-on-error: true
@@ -453,7 +455,7 @@ jobs:
       - name: SonarQube scan
         id: sonar_scan
         if: >
-          github.ref == 'refs/heads/main' &&
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
           steps.sonar_tcp.outputs.available == 'true' &&
           steps.sonar_api.outputs.available == 'true' &&
           steps.sonar_install.outcome == 'success'
@@ -469,7 +471,7 @@ jobs:
 
       - name: Enforce SonarQube failures when the service is available
         if: >
-          github.ref == 'refs/heads/main' &&
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
           (steps.sonar_tcp.outputs.available != 'true' || steps.sonar_api.outputs.available != 'true' || steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
         env:
           SONAR_TCP_AVAILABLE: ${{ steps.sonar_tcp.outputs.available }}

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -133,6 +133,14 @@ jobs:
             exit 1
           }
 
+          latest_semantic_source_tag() {
+            git ls-remote --tags --refs "${remote}" \
+              | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
+              | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
+              | sort -V \
+              | tail -n 1
+          }
+
           # Query GitHub Actions authority with bounded retries. A transient API
           # outage must never be interpreted as missing quality evidence: that
           # would leave Current stale while reporting a successful skipped run.
@@ -384,6 +392,12 @@ jobs:
                   printf 'Homebrew tap repair requires a stable semantic tag, got: %s\n' "${DISPATCH_REF}" >&2
                   exit 1
                 fi
+                latest_stable_tag="$(latest_semantic_source_tag)"
+                if [[ "${DISPATCH_REF}" != "${latest_stable_tag}" ]]; then
+                  printf 'Homebrew tap repair is limited to the global latest stable tag %s, got: %s\n' \
+                    "${latest_stable_tag:-missing}" "${DISPATCH_REF}" >&2
+                  exit 1
+                fi
                 repair_tap="true"
                 ;;
               *)
@@ -481,24 +495,51 @@ jobs:
                 printf 'COMPOSE_VERSION %s does not match stable tag %s\n' "${compose_version}" "${PUBLISH_REF_NAME}" >&2
                 exit 1
               fi
+              latest_stable_tag="$(
+                git ls-remote --tags --refs "https://github.com/${GITHUB_REPOSITORY}.git" \
+                  | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
+                  | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
+                  | sort -V \
+                  | tail -n 1
+              )"
+              if [[ -z "${latest_stable_tag}" ]]; then
+                printf 'could not resolve the global latest stable tag\n' >&2
+                exit 1
+              fi
               release_tag="${PUBLISH_REF_NAME}"
               release_title="${compose_version}"
-              release_label="stable release"
-              release_latest="true"
               release_prerelease="false"
-              update_tap="true"
               asset="container-compose-plugin-release-arm64.tar.gz"
               highlights_asset="release-highlights.json"
               demo_asset=""
               quality_snapshot_asset="quality-snapshot.svg"
-              formula="container-compose.rb"
-              formula_class="ContainerCompose"
-              runtime_formula="container"
-              container_formula="container.rb"
-              container_formula_class="Container"
-              container_compose_formula="container-compose"
               formula_version="${compose_version}"
-              package_lane="stable"
+              if [[ "${PUBLISH_REF_NAME}" == "${latest_stable_tag}" ]]; then
+                release_label="stable release"
+                release_latest="true"
+                update_tap="true"
+                formula="container-compose.rb"
+                formula_class="ContainerCompose"
+                runtime_formula="container"
+                container_formula="container.rb"
+                container_formula_class="Container"
+                container_compose_formula="container-compose"
+                package_lane="stable"
+              else
+                # Older supported lines remain immutable installable GitHub
+                # releases, but must never downgrade GitHub Latest or the
+                # unversioned Homebrew stable pair.
+                release_label="maintenance release"
+                release_latest="false"
+                update_tap="false"
+                formula=""
+                formula_class=""
+                runtime_formula=""
+                container_formula=""
+                container_formula_class=""
+                container_compose_formula=""
+                package_lane="maintenance"
+              fi
               ;;
             *)
               printf 'Unsupported release ref: %s %s\n' "${PUBLISH_REF_TYPE}" "${PUBLISH_REF_NAME}" >&2

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -15,6 +15,7 @@
 #===----------------------------------------------------------------------===#
 
 name: Stable Release Gate
+run-name: Stable Release Gate · ${{ inputs.ref }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -41,7 +41,7 @@ jobs:
       sha: ${{ steps.candidate.outputs.sha }}
       homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}
     steps:
-      - name: Require an immutable main tag and green main CI
+      - name: Require an immutable release-line tag and green tag CI
         id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
@@ -67,10 +67,37 @@ jobs:
                 | tail -n 1
             )"
           fi
-          main_sha="$(git ls-remote --heads "${remote}" refs/heads/main | awk '{ print $1 }' | tail -n 1)"
-          if [[ ! "${tag_sha}" =~ ^[0-9a-f]{40}$ ]] || [[ -z "${main_sha}" ]]; then
-            printf 'could not resolve stable tag %s or main\n' "${RELEASE_TAG}" >&2
+          release_line="${RELEASE_TAG%.*}"
+          release_branch="release-${release_line}"
+          release_branch_sha="$(
+            git ls-remote --heads "${remote}" "refs/heads/${release_branch}" \
+              | awk '{ print $1 }' \
+              | tail -n 1
+          )"
+          if [[ ! "${tag_sha}" =~ ^[0-9a-f]{40}$ ]] || \
+            [[ ! "${release_branch_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'could not resolve stable tag %s or release branch %s\n' \
+              "${RELEASE_TAG}" "${release_branch}" >&2
             exit 1
+          fi
+          if [[ "${GITHUB_REF}" != "refs/heads/${release_branch}" ]] || \
+            [[ "${GITHUB_SHA}" != "${release_branch_sha}" ]]; then
+            printf 'stable gate for %s must run from exact %s head %s\n' \
+              "${RELEASE_TAG}" "${release_branch}" "${release_branch_sha}" >&2
+            exit 1
+          fi
+          compare_status="$(
+            gh api "repos/${GITHUB_REPOSITORY}/compare/${tag_sha}...${release_branch_sha}" \
+              --jq '.status'
+          )"
+          if [[ "${compare_status}" != "identical" && "${compare_status}" != "ahead" ]]; then
+            printf 'stable tag %s is not on release branch %s (%s)\n' \
+              "${RELEASE_TAG}" "${release_branch}" "${compare_status:-missing}" >&2
+            exit 1
+          fi
+          if [[ "${compare_status}" == "ahead" ]]; then
+            printf 'stable tag %s is behind %s; accepting its GitHub-verified unpublished source for a release retry\n' \
+              "${RELEASE_TAG}" "${release_branch}"
           fi
           tag_object="$(
             gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}" --jq '.object.sha'
@@ -83,16 +110,18 @@ jobs:
             exit 1
           fi
 
-          latest_stable_tag="$(
+          release_line_regex="${release_line//./[.]}"
+          latest_release_line_tag="$(
             git ls-remote --tags --refs "${remote}" \
               | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
               | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
+              | awk -v line="${release_line_regex}" '$0 ~ ("^" line "[.][0-9]+$")' \
               | sort -V \
               | tail -n 1
           )"
-          if [[ "${latest_stable_tag}" != "${RELEASE_TAG}" ]]; then
-            printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
-              "${RELEASE_TAG}" "${latest_stable_tag:-missing}" >&2
+          if [[ "${latest_release_line_tag}" != "${RELEASE_TAG}" ]]; then
+            printf 'stable tag %s is not the latest %s source tag (%s)\n' \
+              "${RELEASE_TAG}" "${release_line}" "${latest_release_line_tag:-missing}" >&2
             exit 1
           fi
 
@@ -113,11 +142,6 @@ jobs:
             exit 1
           fi
 
-          if [[ "${tag_sha}" != "${main_sha}" ]]; then
-            printf 'stable tag %s no longer matches main; accepting its GitHub-verified unpublished source for a release retry\n' \
-              "${RELEASE_TAG}"
-          fi
-
           homebrew_tap_ref="$(
             git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git refs/heads/main \
               | awk '{ print $1 }' \
@@ -133,7 +157,8 @@ jobs:
             run="$(
               gh run list --repo "${GITHUB_REPOSITORY}" --workflow ci.yml --commit "${tag_sha}" \
                 --event push --limit 20 --json databaseId,status,conclusion,headBranch \
-                --jq 'map(select(.headBranch == "main") | select(.status == "completed" or .status == "in_progress" or .status == "queued")) | .[0] // empty'
+                | jq -c --arg tag "${RELEASE_TAG}" \
+                  'map(select(.headBranch == $tag) | select(.status == "completed" or .status == "in_progress" or .status == "queued")) | .[0] // empty'
             )"
             status="$(jq -r '.status // empty' <<<"${run}")"
             conclusion="$(jq -r '.conclusion // empty' <<<"${run}")"
@@ -141,14 +166,14 @@ jobs:
               break
             fi
             if [[ "${status}" == "completed" ]]; then
-              printf 'main CI for %s concluded %s\n' "${tag_sha}" "${conclusion:-missing}" >&2
+              printf 'tag CI for %s concluded %s\n' "${tag_sha}" "${conclusion:-missing}" >&2
               exit 1
             fi
             if (( SECONDS >= deadline )); then
-              printf 'timed out waiting for green main CI (including SonarQube) at %s\n' "${tag_sha}" >&2
+              printf 'timed out waiting for green tag CI (including SonarQube) at %s\n' "${tag_sha}" >&2
               exit 1
             fi
-            printf 'waiting for main CI (including SonarQube) at %s\n' "${tag_sha}"
+            printf 'waiting for tag CI (including SonarQube) at %s\n' "${tag_sha}"
             sleep 30
           done
 
@@ -309,7 +334,7 @@ jobs:
       # checkouts. Validate the Compose application against the candidate's
       # immutable remote pins before any such edit can hide the checked-in
       # release provenance. The resolver already requires the candidate's
-      # complete main CI, including the 390 tool-policy tests. Do not rerun its
+      # complete tag CI, including the 390 tool-policy tests. Do not rerun its
       # wall-clock deadline harnesses on a variably loaded macOS host; keep this
       # lane focused on the macOS application build, coverage, and CLI proof.
       - name: Run Compose application CI from immutable source lockfile

--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ DOCS_OUTPUT_DIR ?= _site
 DOCS_SERVER_DIR ?= _serve
 DOCS_HOSTING_BASE_PATH ?= container-compose
 DOCS_SCRATCH_PATH ?= .build/docc
-COMPOSE_VERSION ?= 0.13.0
+COMPOSE_VERSION ?= 0.13.1
 CONTAINER_COMPOSE_SOURCE ?= $(shell $(PYTHON) -c 'import subprocess; result = subprocess.run(["git", "remote", "get-url", "origin"], capture_output=True, text=True); url = result.stdout.strip() if result.returncode == 0 else ""; url = url[len("git@github.com:"):] if url.startswith("git@github.com:") else url; url = url[len("https://github.com/"):] if url.startswith("https://github.com/") else url; url = url[:-4] if url.endswith(".git") else url; print(url)')
 CONTAINER_COMPOSE_BRANCH ?= $(shell git branch --show-current 2>/dev/null || git rev-parse --short HEAD)
 CONTAINER_COMPOSE_LANE ?= $(shell $(PYTHON) -c 'branch = "$(CONTAINER_COMPOSE_BRANCH)"; print("main" if branch == "main" else "release" if branch == "release" or branch.startswith("release-") else "detached" if branch in ("", "HEAD") else "development")')

--- a/Makefile
+++ b/Makefile
@@ -1286,16 +1286,16 @@ cli-smoke-built:
 	.build/debug/compose --ansi never version >/dev/null
 	.build/debug/compose version --dry-run >/dev/null
 	version_short_output="$$(".build/debug/compose" version --short)"; \
-	[[ "$$version_short_output" == "0.13.0" ]]; \
+	[[ "$$version_short_output" == "0.13.1" ]]; \
 	version_pretty_output="$$(".build/debug/compose" version)"; \
-	[[ "$$version_pretty_output" == *"container-compose 0.13.0"* ]]; \
+	[[ "$$version_pretty_output" == *"container-compose 0.13.1"* ]]; \
 	[[ "$$version_pretty_output" == *"container:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"containerization:"*" (custom)"* ]]; \
 	[[ "$$version_pretty_output" == *"compose-go: $(COMPOSE_GO_VERSION)"* ]]; \
 	[[ "$$version_pretty_output" == *"runtime-capability-schema: 1"* ]]; \
 	[[ "$$version_pretty_output" == *"runtime-capability: io.github.stephenlclarke.container.compose.archive-copy.v1"* ]]; \
 	version_json_output="$$(".build/debug/compose" version --format json)"; \
-	[[ "$$version_json_output" == *'"version":"0.13.0"'* ]]; \
+	[[ "$$version_json_output" == *'"version":"0.13.1"'* ]]; \
 	[[ "$$version_json_output" == *'"containerSource":"stephenlclarke/container"'* ]]; \
 	[[ "$$version_json_output" == *'"containerRef":"$(CONTAINER_REF)"'* ]]; \
 	[[ "$$version_json_output" == *'"containerDistribution":"custom"'* ]]; \
@@ -1305,16 +1305,16 @@ cli-smoke-built:
 	[[ "$$version_json_output" == *'"runtimeCapabilitySchemaVersion":1'* ]]; \
 	[[ "$$version_json_output" == *'"runtimeCapabilities":["io.github.stephenlclarke.container.compose.archive-copy.v1"'* ]]; \
 	version_short_format_output="$$(".build/debug/compose" version -f json)"; \
-	[[ "$$version_short_format_output" == *'"version":"0.13.0"'* ]]; \
+	[[ "$$version_short_format_output" == *'"version":"0.13.1"'* ]]; \
 	version_compact_format_output="$$(".build/debug/compose" version -fjson)"; \
-	[[ "$$version_compact_format_output" == *'"version":"0.13.0"'* ]]; \
+	[[ "$$version_compact_format_output" == *'"version":"0.13.1"'* ]]; \
 	package_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$package_tmp"' EXIT; \
 	mkdir -p "$$package_tmp/compose/bin" "$$package_tmp/compose/resources" "$$package_tmp/bin"; \
 	cp .build/debug/compose "$$package_tmp/compose/bin/compose"; \
 	cp "$(PLUGIN_ICON)" "$$package_tmp/compose/resources/container-compose-icon.png"; \
 	test -f "$$package_tmp/compose/resources/container-compose-icon.png"; \
-	printf '%s\n' '{"version":"0.13.0","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
+	printf '%s\n' '{"version":"0.13.1","source":"stephenlclarke/container-compose","branch":"symlink-smoke","lane":"stable","commit":"packaged-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"container-smoke","containerizationSource":"stephenlclarke/containerization","containerizationRef":"containerization-smoke","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$package_tmp/compose/resources/build-info.json"; \
 	ln -s ../compose/bin/compose "$$package_tmp/bin/container-compose"; \
 	packaged_version_output="$$(cd /tmp && "$$package_tmp/bin/container-compose" version --format json)"; \
 	[[ "$$packaged_version_output" == *'"branch":"symlink-smoke"'* ]]; \
@@ -1338,7 +1338,7 @@ cli-smoke-built:
 	[[ "$$compat_output" == *"https://github.com/stephenlclarke/container-compose/blob/main/docs/guides/INSTALL.md"* ]]; \
 	service_tmp="$$(mktemp -d)"; \
 	trap 'rm -rf "$$service_tmp"' EXIT; \
-	printf '%s\n' '{"version":"0.13.0","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
+	printf '%s\n' '{"version":"0.13.1","source":"stephenlclarke/container-compose","branch":"service-smoke","lane":"stable","commit":"service-smoke","buildType":"release","containerSource":"stephenlclarke/container","containerRef":"matched-container","containerizationSource":"stephenlclarke/containerization","containerizationRef":"matched-containerization","composeGoVersion":"$(COMPOSE_GO_VERSION)"}' > "$$service_tmp/build-info.json"; \
 	printf '%s\n' '#!/usr/bin/env bash' 'if [[ "$$*" == "system version --format json" ]]; then' '  printf '\''[{"appName":"container","buildType":"release","commit":"matched-container","containerization":"stephenlclarke/containerization@matched-containerization","distribution":"custom","runtimeCapabilitySchemaVersion":1,"runtimeCapabilities":["io.github.stephenlclarke.container.compose.archive-copy.v1","io.github.stephenlclarke.container.compose.build-extensions.v1","io.github.stephenlclarke.container.compose.create-configuration.v1","io.github.stephenlclarke.container.compose.image-filesystem.v1","io.github.stephenlclarke.container.compose.lifecycle.v1","io.github.stephenlclarke.container.compose.observation.v1"],"source":"stephenlclarke/container","version":"homebrew-main"}]\n'\''' '  exit 0' 'fi' 'if [[ "$$*" == "system status" ]]; then' '  printf '\''apiserver is not running and not registered with launchd\n'\'' >&2' '  exit 1' 'fi' 'exit 2' > "$$service_tmp/container"; \
 	chmod +x "$$service_tmp/container"; \
 	set +e; \
@@ -1573,7 +1573,7 @@ cli-smoke-built:
 	printf 'services:\n  api:\n    image: alpine\n    build:\n      context: ./api\n    volumes:\n      - ./src:/src\n' > "$$tmpdir/relative-paths.yml"; \
 	printf 'services:\n  api:\n    image: alpine\n    depends_on:\n      - missing\n' > "$$tmpdir/missing-dependency.yml"; \
 	version_compact_global_output="$$(".build/debug/compose" -pcompact -f"$$tmpdir/compose.yml" version --short)"; \
-	[[ "$$version_compact_global_output" == "0.13.0" ]]; \
+	[[ "$$version_compact_global_output" == "0.13.1" ]]; \
 	config_output="$$(".build/debug/compose" -f "$$tmpdir/compose.yml" config)"; \
 	[[ "$$config_output" == *"name: \"demo\""* ]]; \
 	[[ "$$config_output" == *"services:"* ]]; \

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6936225c45e4f857a4dfef22a5400fb8af2fdfb7be5b7f004bfa338af4e8dbdc",
+  "originHash" : "442026fb7eef0304d3f538883f3bd21392586419cc9d67106c8edca3d3e893ef",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "94bb6c4bd1ad00deffb68fc40e931ee143c43c65"
+        "revision" : "d428123088728c6539c73ac48aa5ce65843f31aa"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "fefced145304666076d646609f21397f32909fcf"
+        "revision" : "e5a92e86bf03eb2cc244b3b47b0413b3935abfe4"
       }
     },
     {
@@ -59,6 +59,15 @@
       "state" : {
         "revision" : "176c5a434fd76f6f479848d1a8f7d44967534168",
         "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "punycodeswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/futamura/PunycodeSwift.git",
+      "state" : {
+        "revision" : "de703481cf48b859a04bac8ef1d98217b9c97aa9",
+        "version" : "4.0.3"
       }
     },
     {
@@ -246,7 +255,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/swift-nio-ssl.git",
       "state" : {
-        "revision" : "a9d648535c62e640d1df258a70c9117a8ddea43e"
+        "revision" : "09c5c9adcdd2a459187e45fe0143eb01063f244a"
       }
     },
     {
@@ -310,6 +319,15 @@
       "state" : {
         "revision" : "827506c90475e82d5a7f191f950fb3025cbdc0d6",
         "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "tldextractswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/futamura/TLDExtractSwift.git",
+      "state" : {
+        "revision" : "5fb29b13f99b24401cd93c6c0c83faf7c23e9918",
+        "version" : "4.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "94bb6c4bd1ad00deffb68fc40e931ee143c43c65",
+        revision: "d428123088728c6539c73ac48aa5ce65843f31aa",
     )
 }()
 
@@ -38,13 +38,13 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "fefced145304666076d646609f21397f32909fcf",
+        revision: "e5a92e86bf03eb2cc244b3b47b0413b3935abfe4",
     )
 }()
 
 let nioSSLDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/swift-nio-ssl.git",
-    revision: "a9d648535c62e640d1df258a70c9117a8ddea43e",
+    revision: "09c5c9adcdd2a459187e45fe0143eb01063f244a",
 )
 
 let package = Package(

--- a/Sources/ComposeCore/ComposeOrchestratorUp.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUp.swift
@@ -824,7 +824,7 @@ extension ComposeOrchestrator {
         _ = try watchPlans(project: project, services: watchServices)
     }
 
-    /// Waits for `up` exit-control conditions, tears the project down, and returns the CLI exit code.
+    /// Waits for `up` exit-control conditions, stops the project, and returns the CLI exit code.
     func waitForUpExitControl(project: ComposeProject, services: [ComposeService], options up: ComposeUpOptions) async throws -> Int32 {
         let allTargets = try await serviceContainerTargets(project: project, services: services)
         let exitCodeTargets: [ServiceContainerTarget]
@@ -850,25 +850,43 @@ extension ComposeOrchestrator {
             for target in allTargets {
                 emitComposeRuntimeOperation(["wait", target.name])
             }
-            try await down(project: project, options: ComposeDownOptions())
+            try await stopUpExitControlServices(
+                project: project,
+                services: services,
+                targets: allTargets,
+                timeout: up.timeout,
+            )
             return 0
         }
 
         if up.exitCodeFrom != nil {
-            return try await waitForExitCodeFromAndDown(project: project, targets: allTargets, exitCodeTargets: exitCodeTargets)
+            return try await waitForExitCodeFromAndStop(
+                project: project,
+                services: services,
+                targets: allTargets,
+                exitCodeTargets: exitCodeTargets,
+                timeout: up.timeout,
+            )
         }
         let result = try await up.abortOnContainerFailure && !up.abortOnContainerExit
             ? waitForFirstServiceContainerFailureOrCompletion(allTargets)
             : waitForFirstServiceContainerExit(allTargets)
-        try await down(project: project, options: ComposeDownOptions())
+        try await stopUpExitControlServices(
+            project: project,
+            services: services,
+            targets: allTargets,
+            timeout: up.timeout,
+        )
         return result.exitCode
     }
 
     /// Waits for any started service to exit, then returns the selected service status.
-    func waitForExitCodeFromAndDown(
+    func waitForExitCodeFromAndStop(
         project: ComposeProject,
+        services: [ComposeService],
         targets: [ServiceContainerTarget],
         exitCodeTargets: [ServiceContainerTarget],
+        timeout: Int?,
     ) async throws -> Int32 {
         let exitCodeTargetNames = Set(exitCodeTargets.map(\.name))
         let lifecycleManager = lifecycleManager
@@ -894,7 +912,12 @@ extension ComposeOrchestrator {
             guard let firstResult = try await group.next() else {
                 throw ComposeError.invalidProject("up exit-control requires at least one service container")
             }
-            try await down(project: project, options: ComposeDownOptions())
+            try await stopUpExitControlServices(
+                project: project,
+                services: services,
+                targets: targets,
+                timeout: timeout,
+            )
             if exitCodeTargetNames.contains(firstResult.containerName) {
                 group.cancelAll()
                 return firstResult.exitCode
@@ -906,6 +929,45 @@ extension ComposeOrchestrator {
                 }
             }
             throw ComposeError.invalidProject("up --exit-code-from service did not report an exit status")
+        }
+    }
+
+    /// Stops exit-controlled services without deleting their containers or logs.
+    private func stopUpExitControlServices(
+        project: ComposeProject,
+        services: [ComposeService],
+        targets: [ServiceContainerTarget],
+        timeout: Int?,
+    ) async throws {
+        for serviceLayer in try serviceDependencyLayers(services: services).reversed() {
+            let serviceNames = Set(serviceLayer.map(\.name))
+            for service in serviceLayer.reversed() where service.provider != nil {
+                _ = try await runProvider(project: project, service: service, action: .stop)
+            }
+            let lifecycleTargets = targets.filter {
+                serviceNames.contains($0.service.name) && $0.service.provider == nil
+            }
+            guard let limit = try engineOperationParallelLimit(operationCount: lifecycleTargets.count) else {
+                for target in lifecycleTargets.reversed() {
+                    try await ignoringMissingContainer {
+                        try await stopContainer(
+                            service: target.service,
+                            containerName: target.name,
+                            timeout: timeout,
+                        )
+                    }
+                }
+                continue
+            }
+            try await runBoundedEngineOperations(lifecycleTargets, limit: limit) { [self] target in
+                try await ignoringMissingContainer {
+                    try await stopContainer(
+                        service: target.service,
+                        containerName: target.name,
+                        timeout: timeout,
+                    )
+                }
+            }
         }
     }
 

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -29,7 +29,7 @@ private let composePluginVersionNumber = composeBuildInfo.version
 private let composePluginVersionString = "container-compose \(composePluginVersionNumber)"
 
 struct ComposeBuildInfo: Codable {
-    var version: String = "0.13.0"
+    var version: String = "0.13.1"
     var source: String = "unspecified"
     var branch: String = "unspecified"
     var lane: String = "unspecified"
@@ -120,7 +120,7 @@ struct ComposeBuildInfo: Codable {
             declaredSource: environment["CONTAINERIZATION_SOURCE"]
         )
         return ComposeBuildInfo(
-            version: "0.13.0",
+            version: "0.13.1",
             source: remoteSource(root: root),
             branch: branch,
             lane: lane(for: branch),

--- a/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
@@ -5254,8 +5254,8 @@ extension ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
-    @Test("up exit-code-from returns selected service status and tears down project")
-    func upExitCodeFromReturnsSelectedServiceStatusAndTearsDownProject() async throws {
+    @Test("up exit-code-from returns selected status and retains stopped containers")
+    func upExitCodeFromReturnsSelectedStatusAndRetainsStoppedContainers() async throws {
         let runner = RecordingRunner(responses: [
             .success,
             .success,
@@ -5326,10 +5326,10 @@ extension ComposeOrchestratorTests {
         #expect(lifecycleRequests.contains(.wait(id: "demo-api-1")))
         #expect(lifecycleRequests.contains(.wait(id: "demo-db-1")))
         #expect(lifecycleRequests.contains(.stop(id: "demo-api-1", signal: "SIGUSR1", timeoutInSeconds: 9)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
         #expect(lifecycleRequests.contains(.stop(id: "demo-db-1", signal: nil, timeoutInSeconds: nil)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-db-1", force: false)))
-        #expect(await discoveryManager.listRequests == [true, true, true, true])
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-db-1", force: false)))
+        #expect(await discoveryManager.listRequests == [true, true, true])
         #expect(await attachManager.requests.sorted { $0.id < $1.id } == [
             ContainerAttachRequest(id: "demo-api-1", stdout: true, stderr: true, mode: .beforeStart),
             ContainerAttachRequest(id: "demo-db-1", stdout: true, stderr: true, mode: .beforeStart),
@@ -5405,9 +5405,9 @@ extension ComposeOrchestratorTests {
         #expect(lifecycleRequests.contains(.wait(id: "demo-db-1")))
         #expect(lifecycleRequests.contains(.wait(id: "demo-api-1")))
         #expect(lifecycleRequests.contains(.stop(id: "demo-api-1", signal: nil, timeoutInSeconds: nil)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
         #expect(lifecycleRequests.contains(.stop(id: "demo-db-1", signal: nil, timeoutInSeconds: nil)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-db-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-db-1", force: false)))
     }
 
     @Test("up exit-code-from preserves selected status when attached log follow ends")
@@ -5488,8 +5488,8 @@ extension ComposeOrchestratorTests {
         #expect(await logManager.requests.isEmpty)
     }
 
-    @Test("up abort-on-container-failure returns failing status and tears down project")
-    func upAbortOnContainerFailureReturnsFailingStatusAndTearsDownProject() async throws {
+    @Test("up abort-on-container-failure returns status and retains stopped containers")
+    func upAbortOnContainerFailureReturnsStatusAndRetainsStoppedContainers() async throws {
         let runner = RecordingRunner(responses: [
             .success,
             .success,
@@ -5553,13 +5553,13 @@ extension ComposeOrchestratorTests {
         #expect(lifecycleRequests.contains(.wait(id: "demo-api-1")))
         #expect(lifecycleRequests.contains(.wait(id: "demo-worker-1")))
         #expect(lifecycleRequests.contains(.stop(id: "demo-api-1", signal: nil, timeoutInSeconds: nil)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
         #expect(lifecycleRequests.contains(.stop(id: "demo-worker-1", signal: nil, timeoutInSeconds: nil)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-worker-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-worker-1", force: false)))
     }
 
-    @Test("up abort-on-container-exit returns first status and tears down project")
-    func upAbortOnContainerExitReturnsFirstStatusAndTearsDownProject() async throws {
+    @Test("up abort-on-container-exit returns status and retains stopped containers")
+    func upAbortOnContainerExitReturnsStatusAndRetainsStoppedContainers() async throws {
         let runner = RecordingRunner(responses: [
             .success,
             .success,
@@ -5623,13 +5623,13 @@ extension ComposeOrchestratorTests {
         #expect(lifecycleRequests.contains(.wait(id: "demo-api-1")))
         #expect(lifecycleRequests.contains(.wait(id: "demo-worker-1")))
         #expect(lifecycleRequests.contains(.stop(id: "demo-api-1", signal: nil, timeoutInSeconds: nil)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
         #expect(lifecycleRequests.contains(.stop(id: "demo-worker-1", signal: nil, timeoutInSeconds: nil)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-worker-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-worker-1", force: false)))
     }
 
-    @Test("up exit-control dry run renders wait then down plan")
-    func upExitControlDryRunRendersWaitThenDownPlan() async throws {
+    @Test("up exit-control dry run renders wait then stop plan")
+    func upExitControlDryRunRendersWaitThenStopPlan() async throws {
         let emitted = MessageRecorder()
         let project = ComposeProject(
             name: "demo",
@@ -5655,9 +5655,9 @@ extension ComposeOrchestratorTests {
         #expect(emitted.messages.contains("+ compose-runtime attach --no-stdin demo-db-1"))
         #expect(emitted.messages.contains("+ compose-runtime wait demo-api-1"))
         #expect(emitted.messages.contains("+ container stop --time 7 demo-api-1"))
-        #expect(emitted.messages.contains("+ container delete demo-api-1"))
         #expect(emitted.messages.contains("+ container stop demo-db-1"))
-        #expect(emitted.messages.contains("+ container delete demo-db-1"))
+        #expect(!emitted.messages.contains("+ container delete demo-api-1"))
+        #expect(!emitted.messages.contains("+ container delete demo-db-1"))
     }
 
     @Test("up exit-control rejects detached mode before side effects")

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,20 +1,20 @@
 {
   "components": {
     "container": {
-      "ref": "94bb6c4bd1ad00deffb68fc40e931ee143c43c65",
+      "ref": "d428123088728c6539c73ac48aa5ce65843f31aa",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
       "image": {
-        "digest": "sha256:c29628471db683a53f4a75bcb759bb9147a65e097ede37c7dde05442afa7518c",
+        "digest": "sha256:d81d12e1dca1133ede535483a809803e6b256555a73d17f207003279539454a4",
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
-        "tag": "current-31545611348-88332c96705b"
+        "tag": "current-32967604909-2df7b287e530"
       },
-      "ref": "e4829be2203b7baa33cae75ca58be967e4b81280",
+      "ref": "db3e99cc3d19b9a328eb51be3a023a178f80ee81",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "fefced145304666076d646609f21397f32909fcf",
+      "ref": "e5a92e86bf03eb2cc244b3b47b0413b3935abfe4",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -597,6 +597,28 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertNotIn("${CONTAINER_SOURCE_DIR}/scripts/update-homebrew-formula.py", renderer)
         self.assertIn("compose/bin/compose", renderer)
 
+    def test_older_release_lines_never_replace_latest_or_unversioned_homebrew(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        lane = workflow[
+            workflow.index("- name: Select release lane") : workflow.index(
+                "- name: Require Homebrew tap token for formula promotion"
+            )
+        ]
+
+        self.assertIn('latest_stable_tag="$(', lane)
+        self.assertIn('release_label="maintenance release"', lane)
+        self.assertIn('release_latest="false"', lane)
+        self.assertIn('update_tap="false"', lane)
+        self.assertIn('package_lane="maintenance"', lane)
+        self.assertIn(
+            "must never downgrade GitHub Latest or the",
+            lane,
+        )
+        self.assertIn(
+            "Homebrew tap repair is limited to the global latest stable tag",
+            workflow,
+        )
+
     def test_homebrew_tap_pushes_authenticate_with_the_tap_token(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertEqual(
@@ -1187,6 +1209,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             ci.count("github.ref == 'refs/heads/main' || github.ref_type == 'tag'"),
             6,
         )
+        self.assertIn('GITHUB_REF_TYPE: ${{ github.ref_type }}', ci)
+        self.assertIn('if [[ "${GITHUB_REF_TYPE}" == "tag" ]]', ci)
+        self.assertIn("printf 'heavy=true\\n' >> \"$GITHUB_OUTPUT\"", ci)
         self.assertIn(
             'gpg_home="$(mktemp -d /private/tmp/container-compose-sonar-gpg.XXXXXX)"',
             sonar_install,
@@ -2118,6 +2143,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow,
         )
         self.assertIn('release_branch="release-${release_line}"', workflow)
+        self.assertIn("run-name: Stable Release Gate · ${{ inputs.ref }}", workflow)
         self.assertIn('"${GITHUB_REF}" != "refs/heads/${release_branch}"', workflow)
         self.assertIn('"${GITHUB_SHA}" != "${release_branch_sha}"', workflow)
         self.assertIn(
@@ -2215,7 +2241,42 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             '"${run_id}" "hosted stable release gate" "${STABLE_RELEASE_GATE_WAIT_SECONDS}"',
             dispatch,
         )
+        self.assertIn(
+            'workflow_ref="$(release_branch_for_version "${version}")"',
+            dispatch,
+        )
+        self.assertIn('--ref "${workflow_ref}"', dispatch)
         self.assertIn("timeout-minutes: 120", STABLE_GATE_WORKFLOW.read_text(encoding="utf-8"))
+
+    def test_release_helper_publishes_and_uses_the_release_control_branch(self) -> None:
+        branch_publisher = self.script[
+            self.script.index("publish_release_line_branch() {") : self.script.index(
+                "# Return the newest workflow-dispatch package run"
+            )
+        ]
+        tag_release = self.script[
+            self.script.index("tag_stable_version() {") : self.script.index(
+                "# Resume the latest signed tag"
+            )
+        ]
+        package_dispatch = self.script[
+            self.script.index("dispatch_compose_stable_workflow() {") : self.script.index(
+                "# Dispatch and wait for a new stable package publication."
+            )
+        ]
+
+        self.assertIn('printf \'release-%s\\n\' "${version%.*}"', self.script)
+        self.assertIn("merge-base --is-ancestor", branch_publisher)
+        self.assertIn('"${main_sha}:refs/heads/${branch}"', branch_publisher)
+        self.assertLess(
+            tag_release.index('publish_release_line_branch "${version}"'),
+            tag_release.index('tag_new_stable_version "${version}"'),
+        )
+        self.assertIn(
+            'workflow_ref="$(release_branch_for_version "${version}")"',
+            package_dispatch,
+        )
+        self.assertIn('--ref "${workflow_ref}"', package_dispatch)
 
     def test_new_stable_release_runs_the_local_gate_before_promotion(self) -> None:
         release = self.script[self.script.index("release_current_stack() {") :]
@@ -3745,6 +3806,7 @@ esac
                         "ensure_latest_stable_retry() { :; }",
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 0; }",
+                        "stable_release_updates_default_tap() { return 0; }",
                         "ensure_stable_release_is_unpublished() { exit 71; }",
                         "dispatch_compose_stable_tap_repair() { printf 'repair %s\\n' \"$1\"; }",
                         "publish_stable_release() { exit 72; }",
@@ -3764,6 +3826,7 @@ esac
                         "ensure_latest_stable_retry() { :; }",
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 1; }",
+                        "stable_release_updates_default_tap() { return 0; }",
                         "ensure_stable_release_is_unpublished() { :; }",
                         "dispatch_compose_stable_tap_repair() { exit 73; }",
                         "publish_stable_release() { printf 'publish %s\\n' \"$1\"; }",
@@ -3773,10 +3836,32 @@ esac
             self.assertEqual(unpublished.returncode, 0, unpublished.stderr)
             self.assertIn("publish 0.6.70", unpublished.stdout)
 
+            maintenance = self.run_release_function(
+                root,
+                "resume_stable_release 0.6.70",
+                shell_setup="\n".join(
+                    [
+                        "ensure_latest_stable_retry() { :; }",
+                        "verify_github_stable_tag_signature() { :; }",
+                        "stable_release_is_published() { return 0; }",
+                        "stable_release_updates_default_tap() { return 1; }",
+                        "dispatch_compose_stable_tap_repair() { exit 73; }",
+                        "verify_compose_stable_package() { printf 'verify %s\\n' \"$1\"; }",
+                        "print_stable_release_point() { printf 'point %s %s\\n' \"$1\" \"$2\"; }",
+                    ]
+                ),
+            )
+            self.assertEqual(maintenance.returncode, 0, maintenance.stderr)
+            self.assertIn("verify 0.6.70", maintenance.stdout)
+            self.assertIn(
+                "immutable maintenance release already published",
+                maintenance.stdout,
+            )
+
     def test_retry_rejects_a_stale_semantic_tag(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            shell_setup = "latest_local_semver_tag() { printf '%s\\n' 0.6.71; }"
+            shell_setup = "latest_remote_release_line_tag() { printf '%s\\n' 0.6.71; }"
 
             latest = self.run_release_function(
                 root,
@@ -3791,7 +3876,10 @@ esac
                 shell_setup=shell_setup,
             )
             self.assertNotEqual(stale.returncode, 0)
-            self.assertIn("stable tag 0.6.70 is not the latest semantic source tag (0.6.71)", stale.stderr)
+            self.assertIn(
+                "stable tag 0.6.70 is not the latest source tag in release line 0.6 (0.6.71)",
+                stale.stderr,
+            )
 
     def create_promotion_review_fixture(
         self,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1109,7 +1109,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("- name: Checkout container dependency", workflow)
         self.assertIn("- name: Checkout containerization dependency", workflow)
 
-    def test_stable_and_current_release_authority_select_main_ci(self) -> None:
+    def test_stable_release_selects_tag_ci_and_current_release_selects_main_ci(
+        self,
+    ) -> None:
         stable_gate = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
         package = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         package_authority = package[
@@ -1121,7 +1123,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             package_authority.index("branch)") : package_authority.index("tag)")
         ]
         self.assertIn("--json databaseId,status,conclusion,headBranch", stable_gate)
-        self.assertIn('select(.headBranch == "main")', stable_gate)
+        self.assertIn('select(.headBranch == $tag)', stable_gate)
+        self.assertIn('--arg tag "${RELEASE_TAG}"', stable_gate)
         self.assertIn("--json event,status,conclusion,headBranch", current_authority)
         self.assertIn('.headBranch == "main"', current_authority)
         self.assertIn('(.event == "push" or .event == "workflow_dispatch")', current_authority)
@@ -1156,7 +1159,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("needs.analyze.result", codeql)
         self.assertIn("needs.analyze-skipped.result", codeql)
 
-    def test_main_sonar_step_preserves_the_complete_retry_budget(self) -> None:
+    def test_release_sonar_step_runs_on_main_and_tags_with_complete_retry_budget(
+        self,
+    ) -> None:
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
         runtime_job = ci[
             ci.index("  validate_runtime:") : ci.index(
@@ -1178,6 +1183,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("timeout-minutes: 25", sonar)
         self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)
         self.assertIn("run: make sonar-scan", sonar)
+        self.assertEqual(
+            ci.count("github.ref == 'refs/heads/main' || github.ref_type == 'tag'"),
+            6,
+        )
         self.assertIn(
             'gpg_home="$(mktemp -d /private/tmp/container-compose-sonar-gpg.XXXXXX)"',
             sonar_install,
@@ -2097,12 +2106,20 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("stable tag %s is not GitHub-verified", workflow)
-        self.assertIn("stable tag %s is not the latest semantic source tag", workflow)
+        self.assertIn("stable tag %s is not the latest %s source tag", workflow)
         self.assertIn("stable release %s already exists and is immutable", workflow)
+        self.assertIn(
+            "stable tag %s is not on release branch %s",
+            workflow,
+        )
+        self.assertIn('"${compare_status}" == "ahead"', workflow)
         self.assertIn(
             "accepting its GitHub-verified unpublished source for a release retry",
             workflow,
         )
+        self.assertIn('release_branch="release-${release_line}"', workflow)
+        self.assertIn('"${GITHUB_REF}" != "refs/heads/${release_branch}"', workflow)
+        self.assertIn('"${GITHUB_SHA}" != "${release_branch_sha}"', workflow)
         self.assertIn(
             "homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}",
             workflow,
@@ -2137,7 +2154,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("run-stack-release-validation.sh hosted", workflow)
         self.assertIn("Run Compose application CI from immutable source lockfile", workflow)
         self.assertIn("make -C container-compose", workflow)
-        self.assertIn("complete main CI, including the 390 tool-policy tests", workflow)
+        self.assertIn("complete tag CI, including the 390 tool-policy tests", workflow)
         for target in (
             "format",
             "core-runtime-neutrality",

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -91,7 +91,7 @@ Rules enforced:
   - Published stable releases are immutable; the latest GitHub-verified signed tag may repair only its matching formula pair from immutable assets.
   - container-compose main updates use only exact-head-reviewed pull-request promotion.
   - An equivalent tree already squash-merged on main is reconciled before tagging.
-  - Long-lived release branches are not used.
+  - Each semantic line uses release-MAJOR.MINOR as the immutable release-control branch.
   - Companion source repositories must already be merged to their fork mains
     through their own reviewable pull requests; this helper never pushes them.
 
@@ -1338,13 +1338,14 @@ stable_tag_exists() {
   git -C "${path}" ls-remote --exit-code --tags "${remote}" "refs/tags/${version}" >/dev/null 2>&1
 }
 
-# Reject a stale unpublished tag so a retry cannot replace a newer stable lane.
+# Reject a stale unpublished tag within its release line. A supported older
+# line may be resumed, but it cannot replace a later patch in that line.
 ensure_latest_stable_retry() {
   local version="$1" latest
-  latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
+  latest="$(latest_remote_release_line_tag "${version}")"
   if [[ "${version}" != "${latest}" ]]; then
-    printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
-      "${version}" "${latest:-missing}" >&2
+    printf 'stable tag %s is not the latest source tag in release line %s (%s)\n' \
+      "${version}" "${version%.*}" "${latest:-missing}" >&2
     exit 1
   fi
 }
@@ -2549,6 +2550,84 @@ github_cli() {
   gh "$@"
 }
 
+# Return the release-control branch for one semantic version.
+release_branch_for_version() {
+  local version="$1"
+  if [[ ! "${version}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+    printf 'release branch requires a semantic version: %s\n' "${version}" >&2
+    return 2
+  fi
+  printf 'release-%s\n' "${version%.*}"
+}
+
+# Return the newest semantic source tag visible on the writable Compose remote.
+latest_remote_semver_tag() {
+  local path remote
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+  git -C "${path}" ls-remote --tags --refs "${remote}" \
+    | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
+    | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
+    | sort -V \
+    | tail -n 1
+}
+
+# Return the newest semantic source tag in one MAJOR.MINOR release line.
+latest_remote_release_line_tag() {
+  local version="$1" path remote release_line release_line_regex
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+  release_line="${version%.*}"
+  release_line_regex="${release_line//./[.]}"
+  git -C "${path}" ls-remote --tags --refs "${remote}" \
+    | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
+    | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
+    | awk -v line="${release_line_regex}" '$0 ~ ("^" line "[.][0-9]+$")' \
+    | sort -V \
+    | tail -n 1
+}
+
+# Return success when a stable release owns the unversioned Homebrew lane.
+stable_release_updates_default_tap() {
+  local version="$1" latest
+  latest="$(latest_remote_semver_tag)"
+  [[ -n "${latest}" && "${version}" == "${latest}" ]]
+}
+
+# Publish the exact reviewed main head as the release-control branch. Existing
+# release lines may only move forward to a descendant of their current head.
+publish_release_line_branch() {
+  local version="$1" path remote branch main_sha remote_sha remote_ref
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+  branch="$(release_branch_for_version "${version}")"
+  main_sha="$(git -C "${path}" rev-parse main)"
+  remote_sha="$(
+    git -C "${path}" ls-remote --heads "${remote}" "refs/heads/${branch}" \
+      | awk '{ print $1 }' \
+      | tail -n 1
+  )"
+
+  if [[ -n "${remote_sha}" && "${remote_sha}" != "${main_sha}" ]]; then
+    remote_ref="refs/remotes/${remote}/${branch}"
+    run git -C "${path}" fetch "${remote}" \
+      "+refs/heads/${branch}:${remote_ref}"
+    if [[ "${EXECUTE}" == "1" ]] && \
+      ! git -C "${path}" merge-base --is-ancestor "${remote_ref}" "${main_sha}"; then
+      printf 'release branch %s is not an ancestor of reviewed main %s\n' \
+        "${branch}" "${main_sha}" >&2
+      exit 1
+    fi
+  fi
+
+  if [[ "${remote_sha}" == "${main_sha}" ]]; then
+    printf '%s already points at reviewed main %s\n' "${branch}" "${main_sha}"
+    return 0
+  fi
+  run git -C "${path}" push "${remote}" \
+    "${main_sha}:refs/heads/${branch}"
+}
+
 # Return the newest workflow-dispatch package run for one stable semantic tag.
 latest_compose_package_dispatch_run() {
   local version="$1" title
@@ -2563,13 +2642,15 @@ latest_compose_package_dispatch_run() {
 }
 
 latest_stable_release_gate_dispatch_run() {
+  local version="$1" title
+  title="Stable Release Gate · ${version}"
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow stable-release-gate.yml \
     --event workflow_dispatch \
-    --limit 1 \
-    --json databaseId \
-    --jq '.[0].databaseId // ""'
+    --limit 100 \
+    --json databaseId,displayTitle \
+    --jq "map(select(.displayTitle == \"${title}\")) | .[0].databaseId // \"\""
 }
 
 # Wait for a GitHub Actions run to complete successfully.
@@ -2679,6 +2760,12 @@ verify_compose_stable_package() {
   "${signature_verifier}" "${tmp}/${runtime_asset}"
   rm -rf "${tmp}"
 
+  if ! stable_release_updates_default_tap "${version}"; then
+    printf 'maintenance release %s package pair verified without changing GitHub Latest or the unversioned Homebrew lane: %s + %s\n' \
+      "${version}" "${asset_sha}" "${runtime_asset_sha}"
+    return 0
+  fi
+
   formula_text="$(
     github_cli api \
       repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose.rb \
@@ -2734,7 +2821,8 @@ verify_compose_stable_package() {
 
 # Dispatch and verify one stable package workflow mode for a semantic tag.
 dispatch_compose_stable_workflow() {
-  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label
+  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label workflow_ref
+  workflow_ref="$(release_branch_for_version "${version}")"
   print_header "dispatch container-compose ${version} ${mode}"
 
   if [[ "${repair_tap}" == "true" ]]; then
@@ -2744,8 +2832,8 @@ dispatch_compose_stable_workflow() {
   fi
 
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run: gh workflow run prebuilt-binaries.yml --repo %s --ref main -f ref=%s' \
-      "$(github_repo "${COMPOSE_REPO}")" "${version}"
+    printf 'would run: gh workflow run prebuilt-binaries.yml --repo %s --ref %s -f ref=%s' \
+      "$(github_repo "${COMPOSE_REPO}")" "${workflow_ref}" "${version}"
     if [[ "${repair_tap}" == "true" ]]; then
       printf ' -f repair_tap=true'
     fi
@@ -2760,13 +2848,13 @@ dispatch_compose_stable_workflow() {
   if [[ "${repair_tap}" == "true" ]]; then
     run github_cli workflow run prebuilt-binaries.yml \
       --repo "$(github_repo "${COMPOSE_REPO}")" \
-      --ref main \
+      --ref "${workflow_ref}" \
       -f "ref=${version}" \
       -f "repair_tap=true"
   else
     run github_cli workflow run prebuilt-binaries.yml \
       --repo "$(github_repo "${COMPOSE_REPO}")" \
-      --ref main \
+      --ref "${workflow_ref}" \
       -f "ref=${version}"
   fi
 
@@ -2801,31 +2889,37 @@ dispatch_compose_stable_package() {
 # Repair a published stable formula pair without rebuilding or replacing release assets.
 dispatch_compose_stable_tap_repair() {
   local version="$1"
+  if ! stable_release_updates_default_tap "${version}"; then
+    printf 'maintenance release %s has no unversioned Homebrew tap state to repair\n' \
+      "${version}" >&2
+    exit 1
+  fi
   dispatch_compose_stable_workflow "${version}" "Homebrew tap repair" "true"
 }
 
 dispatch_stable_release_gate() {
-  local version="$1" previous_run run_id deadline now
+  local version="$1" previous_run run_id deadline now workflow_ref
+  workflow_ref="$(release_branch_for_version "${version}")"
   print_header "dispatch hosted stable release gate for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run: gh workflow run stable-release-gate.yml --repo %s --ref main -f ref=%s\n' \
-      "$(github_repo "${COMPOSE_REPO}")" "${version}"
-    printf 'would wait for the hosted gate to confirm green main CI, SonarQube, and immutable static stack validation.\n'
+    printf 'would run: gh workflow run stable-release-gate.yml --repo %s --ref %s -f ref=%s\n' \
+      "$(github_repo "${COMPOSE_REPO}")" "${workflow_ref}" "${version}"
+    printf 'would wait for the hosted gate to confirm green tag CI, SonarQube, and immutable static stack validation.\n'
     printf 'full runtime integration and Docker Compose parity run locally before the tag is created.\n'
     return 0
   fi
 
   need_command gh
-  previous_run="$(latest_stable_release_gate_dispatch_run || true)"
+  previous_run="$(latest_stable_release_gate_dispatch_run "${version}" || true)"
   run github_cli workflow run stable-release-gate.yml \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
-    --ref main \
+    --ref "${workflow_ref}" \
     -f "ref=${version}"
 
   deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))
   while true; do
-    run_id="$(latest_stable_release_gate_dispatch_run || true)"
+    run_id="$(latest_stable_release_gate_dispatch_run "${version}" || true)"
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
       printf 'stable release gate started: %s\n' "${run_id}"
       wait_for_github_run_success \
@@ -2847,15 +2941,22 @@ dispatch_stable_release_gate() {
 
 # Print the verified boundary for a stable release or its formula-only recovery.
 print_stable_release_point() {
-  local version="$1" generation="$2"
+  local version="$1" generation="$2" label tap_update
+  if stable_release_updates_default_tap "${version}"; then
+    label="latest"
+    tap_update="stable container and container-compose formula pair verified"
+  else
+    label="maintenance"
+    tap_update="unchanged; unversioned formulae remain on the global latest release"
+  fi
   print_component_refs
   cat <<EOF
 
 Stable release point:
   version: ${version}
-  label: latest
+  label: ${label}
   release generation: ${generation}
-  tap update: stable container and container-compose formula pair verified
+  tap update: ${tap_update}
 EOF
 }
 
@@ -2870,7 +2971,8 @@ publish_stable_release() {
 # Tag a compose state as the stable/latest release point.
 tag_stable_version() {
   local version="$1"
-  print_header "tag container-compose main as ${version} latest"
+  print_header "tag container-compose main as ${version}"
+  publish_release_line_branch "${version}"
   tag_new_stable_version "${version}"
   publish_stable_release "${version}"
 }
@@ -2882,8 +2984,13 @@ resume_stable_release() {
   ensure_latest_stable_retry "${version}"
   verify_github_stable_tag_signature "${version}"
   if stable_release_is_published "${version}"; then
-    dispatch_compose_stable_tap_repair "${version}"
-    print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
+    if stable_release_updates_default_tap "${version}"; then
+      dispatch_compose_stable_tap_repair "${version}"
+      print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
+    else
+      verify_compose_stable_package "${version}"
+      print_stable_release_point "${version}" "immutable maintenance release already published"
+    fi
     return 0
   fi
   ensure_stable_release_is_unpublished "${version}"


### PR DESCRIPTION
## Summary

- preserve the 0.13.0 Compose source as the 0.13.1 comparison line
- align Container, Containerization, builder, and TLS pins with the fixed 0.14.1 runtime graph
- add the transitive runtime pins required by the aligned graph
- retain stopped containers and their log histories after foreground exit-control
- support independently recoverable maintenance releases on the 0.13 line
- keep direct source builds and CLI smoke expectations on the 0.13.1 identity
- force semantic tags through full CI and keep this older line out of GitHub Latest and the unversioned Homebrew lane

This gives the artifact-only benchmark an equivalent fixed runtime stack on both patch lines, isolating the Compose 0.13-to-0.14 difference.

## Validation

- stack consistency check passed
- exact 0.13.1 release product compiled against the aligned graph
- six focused exit-control unit regressions passed
- Developer-ID-signed runtime proof passed JSON compression and local rotation reads after exit-control (3.103 s and 1.743 s)
- Container runtime fixes passed targeted tests, exact-head review, and combined PR CI
- direct debug build reports 0.13.1 and the focused ComposeBuildInfo test passes
- seven focused release-policy regressions pass; the complete 118-test release-control suite passed on the shared implementation

Tracks #383.
Runtime fixes: stephenlclarke/container#187, stephenlclarke/container#188, stephenlclarke/container#190.
