### PR TITLE
test(up): align 0.14.1 exit-control retention assertions

### DIFF
--- a/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift
@@ -5038,7 +5038,7 @@ extension ComposeOrchestratorTests {
         #expect(emitted.messages.contains("+ compose-runtime attach --no-stdin demo-api-1"))
         #expect(emitted.messages.contains("+ compose-runtime wait demo-api-1"))
         #expect(emitted.messages.contains("+ container stop demo-api-1"))
-        #expect(emitted.messages.contains("+ container delete demo-api-1"))
+        #expect(!emitted.messages.contains("+ container delete demo-api-1"))
         #expect(await menuController.requests.isEmpty)
         #expect(await logManager.requests.isEmpty)
     }
@@ -5157,7 +5157,7 @@ extension ComposeOrchestratorTests {
         let lifecycleRequests = await lifecycleManager.requests
         #expect(lifecycleRequests.contains(.wait(id: "demo-api-1")))
         #expect(lifecycleRequests.contains(.stop(id: "demo-api-1", signal: nil, timeoutInSeconds: 3)))
-        #expect(lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
+        #expect(!lifecycleRequests.contains(.delete(id: "demo-api-1", force: false)))
     }
 
     @Test("up menu watch toggle validates before reporting watch enabled")


### PR DESCRIPTION
## Summary

- correct the two stale menu exit-control assertions shared by the 0.14.1 release line
- require stopped containers to remain available after exit control so post-exit logs stay readable
- preserve the reviewed 0.14.1 runtime behavior; this changes test contracts only

## Validation

- targeted Swift Testing filter: 2 tests passed
- git diff --check
- signed commit verified locally

## Links

- Fixes the release-gate test contract for #383
- Follows #385