### PR TITLE
ci(release): pin Sonar tag analysis to release line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,7 +471,17 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_QUALITYGATE_WAIT: "true"
-        run: make sonar-scan
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            release_version="${GITHUB_REF_NAME#v}"
+            if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              printf 'release tag is not semantic: %s\n' "${GITHUB_REF_NAME}" >&2
+              exit 2
+            fi
+            export SONAR_BRANCH="release-${release_version%.*}"
+          fi
+          make sonar-scan
         working-directory: container-compose
 
       - name: Enforce SonarQube failures when the service is available


### PR DESCRIPTION
## Summary

- map semantic release tags to their long-lived `release-MAJOR.MINOR` Sonar branch
- keep normal main-branch analysis unchanged
- reject non-semantic tags before an invalid short-branch analysis is uploaded

## Evidence

- tag CI 33498045050 uploaded `refs/tags/0.13.1` as a Sonar short branch and failed every quality-gate poll
- main CI 33476512636 passed with the same project and token on the long-lived `main` branch
- `actionlint .github/workflows/ci.yml`
- focused derivation checks for `0.13.1`, `v0.14.1`, branch pushes, and invalid tags
- `git diff --check`

Refs #388