### PR TITLE
test(release): cover Sonar release branch mapping

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1204,7 +1204,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("continue-on-error: true", sonar)
         self.assertIn("timeout-minutes: 25", sonar)
         self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)
-        self.assertIn("run: make sonar-scan", sonar)
+        self.assertIn("make sonar-scan", sonar)
+        self.assertIn('release_version="${GITHUB_REF_NAME#v}"', sonar)
+        self.assertIn(
+            'export SONAR_BRANCH="release-${release_version%.*}"',
+            sonar,
+        )
         self.assertEqual(
             ci.count("github.ref == 'refs/heads/main' || github.ref_type == 'tag'"),
             6,


### PR DESCRIPTION
## Summary

- update the release-policy regression to accept the multiline Sonar step
- require the semantic-tag to `release-MAJOR.MINOR` mapping in that policy test

## Focused proof

- exact `ContainerStackReleasePolicyTests.test_release_sonar_step_runs_on_main_and_tags_with_complete_retry_budget` passes
- actionlint passes
- diff check passes

Refs #388