### PR TITLE
ci(release): analyze release tags on supported Sonar branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,7 +479,7 @@ jobs:
               printf 'release tag is not semantic: %s\n' "${GITHUB_REF_NAME}" >&2
               exit 2
             fi
-            export SONAR_BRANCH="release-${release_version%.*}"
+            export SONAR_BRANCH="main"
           fi
           make sonar-scan
         working-directory: container-compose

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1181,7 +1181,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("needs.analyze.result", codeql)
         self.assertIn("needs.analyze-skipped.result", codeql)
 
-    def test_release_sonar_step_runs_on_main_and_tags_with_complete_retry_budget(
+    def test_release_sonar_step_runs_on_main_and_tags_with_supported_branch_and_retry_budget(
         self,
     ) -> None:
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
@@ -1205,17 +1205,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("timeout-minutes: 25", sonar)
         self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)
         self.assertIn("make sonar-scan", sonar)
+        self.assertIn('if [[ "${GITHUB_REF_TYPE}" == "tag" ]]', sonar)
         self.assertIn('release_version="${GITHUB_REF_NAME#v}"', sonar)
         self.assertIn(
-            'export SONAR_BRANCH="release-${release_version%.*}"',
+            'if [[ ! "${release_version}" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]',
             sonar,
         )
+        self.assertIn('export SONAR_BRANCH="main"', sonar)
         self.assertEqual(
             ci.count("github.ref == 'refs/heads/main' || github.ref_type == 'tag'"),
             6,
         )
         self.assertIn('GITHUB_REF_TYPE: ${{ github.ref_type }}', ci)
-        self.assertIn('if [[ "${GITHUB_REF_TYPE}" == "tag" ]]', ci)
         self.assertIn("printf 'heavy=true\\n' >> \"$GITHUB_OUTPUT\"", ci)
         self.assertIn(
             'gpg_home="$(mktemp -d /private/tmp/container-compose-sonar-gpg.XXXXXX)"',


### PR DESCRIPTION
## Summary

Map release-tag Sonar analysis to the supported `main` branch so SonarCloud records the exact 0.13.1 candidate commit without requiring paid branch-analysis support. Semantic tag validation remains mandatory before this mapping.

## Motivation

SonarCloud accepted the scanner report for both the semantic tag and `release-0.13`, then rejected quality-gate polling because the project plan permits main-branch analysis only. The stable-release evidence collector already resolves Sonar history from `main`, so recording the release tag's exact commit there preserves the required authority model.

## Validation

- focused release-policy unit test passes, covering semantic validation and branch mapping
- `actionlint .github/workflows/ci.yml` passes
- `git diff --check` passes
- signed exact head: `9d390524304648bacead628858a1e4c1e7c9429d`

Refs #388.