### PR TITLE
ci(release): analyze release tags on supported Sonar branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,9 @@ permissions:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
+  # A replacement branch build can safely supersede stale work. A stable tag
+  # transaction must finish its candidate scan and canonical-main restoration.
+  cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
 jobs:
   changes:
@@ -68,6 +70,14 @@ jobs:
         run: |
           set -euo pipefail
           changed_files="${RUNNER_TEMP}/changed-files.txt"
+
+          # Stable tags are immutable release candidates. Always run the full
+          # validation transaction instead of inferring their scope from a
+          # synthetic tag-push diff (whose before SHA is all zeroes).
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            printf 'heavy=true\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           case "${GITHUB_EVENT_NAME}" in
             pull_request)
@@ -215,18 +225,51 @@ jobs:
 
   validate_runtime:
     name: Validate Runtime
-    needs: changes
-    if: needs.changes.outputs.heavy == 'true'
+    needs:
+      - changes
+      - resolve-canonical-main
+    if: >
+      needs.changes.outputs.heavy == 'true' &&
+      needs.resolve-canonical-main.result == 'success'
     runs-on: [self-hosted, macOS, ARM64, container-compose-current]
-    # Cover the 45-minute validation/coverage budget, 10-minute CLI smoke,
-    # 25-minute Sonar retry budget, and dependency/setup overhead.
-    timeout-minutes: 105
+    # Cover validation/coverage, CLI smoke, up to two queued maintenance
+    # transactions, this transaction's two scans, and setup overhead.
+    timeout-minutes: 250
     steps:
       - name: Checkout container-compose
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: container-compose
           fetch-depth: 0
+
+      - name: Checkout canonical main recovery source
+        if: needs.resolve-canonical-main.outputs.restore == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+          path: sonar-main-recovery
+          ref: ${{ needs.resolve-canonical-main.outputs.sha }}
+
+      - name: Download retained canonical main coverage
+        if: needs.resolve-canonical-main.outputs.restore == 'true'
+        env:
+          ARTIFACT_RUN_ID: ${{ needs.resolve-canonical-main.outputs.artifact_run_id }}
+          EXPECTED_CANONICAL_MAIN_SHA: ${{ needs.resolve-canonical-main.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact_name="sonar-main-inputs-${EXPECTED_CANONICAL_MAIN_SHA}"
+          if [[ ! "${ARTIFACT_RUN_ID}" =~ ^[0-9]+$ ]]; then
+            printf 'canonical main artifact run is invalid: %s\n' "${ARTIFACT_RUN_ID:-missing}" >&2
+            exit 1
+          fi
+          gh run download "${ARTIFACT_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name "${artifact_name}" \
+            --dir sonar-main-recovery
+          test -s sonar-main-recovery/coverage.xml
+          test -s sonar-main-recovery/Tools/compose-normalizer/coverage.out
 
       - name: Resolve stack refs
         id: stack-refs
@@ -365,6 +408,18 @@ jobs:
         env:
           HAWKEYE_AUTO_INSTALL: "1"
 
+      - name: Retain canonical Sonar inputs
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v7
+        with:
+          name: sonar-main-inputs-${{ github.sha }}
+          path: |
+            container-compose/coverage.xml
+            container-compose/Tools/compose-normalizer/coverage.out
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 90
+
       - name: Run built CLI smoke
         if: >
           github.ref == 'refs/heads/main' ||
@@ -481,6 +536,16 @@ jobs:
           fi
           printf '%s\n' "$scanner_bin" >> "$GITHUB_PATH"
 
+      - name: Record canonical restoration obligation
+        id: sonar_restore_obligation
+        if: >
+          needs.resolve-canonical-main.outputs.restore == 'true' &&
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
+          steps.sonar_tcp.outputs.available == 'true' &&
+          steps.sonar_api.outputs.available == 'true' &&
+          steps.sonar_install.outcome == 'success'
+        run: printf 'required=true\n' >> "${GITHUB_OUTPUT}"
+
       - name: SonarQube scan
         id: sonar_scan
         if: >
@@ -489,35 +554,179 @@ jobs:
           steps.sonar_api.outputs.available == 'true' &&
           steps.sonar_install.outcome == 'success'
         continue-on-error: true
-        # make sonar-scan permits three 300-second quality-gate waits plus
-        # scanner work and two 20-second retry delays.
-        timeout-minutes: 25
+        # Two predecessor maintenance transactions can each hold the authority
+        # for two 25-minute scan budgets. Leave 120 minutes for that queue and
+        # 60 minutes for this candidate/restoration pair plus overhead.
+        timeout-minutes: 180
         env:
+          EXPECTED_CANONICAL_MAIN_SHA: ${{ needs.resolve-canonical-main.outputs.sha }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_AUTHORITY_REF: ${{ needs.resolve-canonical-main.outputs.authority_ref }}
+          RESTORE_CANONICAL_MAIN: ${{ needs.resolve-canonical-main.outputs.restore }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_QUALITYGATE_WAIT: "true"
         run: |
           set -euo pipefail
+          sonar_timeout="$(command -v gtimeout || true)"
+          if [[ -z "${sonar_timeout}" ]]; then
+            printf 'gtimeout is required to bound each SonarQube invocation\n' >&2
+            exit 1
+          fi
+          run_bounded_sonar_scan() {
+            "${sonar_timeout}" --kill-after=30s 1500s make sonar-scan
+          }
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
             release_version="${GITHUB_REF_NAME#v}"
             if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
               printf 'release tag is not semantic: %s\n' "${GITHUB_REF_NAME}" >&2
               exit 2
             fi
-            export SONAR_BRANCH="release-${release_version%.*}"
+            release_output=""
+            set +e
+            release_output="$(
+              gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" 2>&1
+            )"
+            release_status="$?"
+            set -e
+            if (( release_status == 0 )); then
+              if [[ "${RESTORE_CANONICAL_MAIN}" == "true" ]]; then
+                printf 'canonical_restore_completed=true\n' >> "${GITHUB_OUTPUT}"
+              fi
+              printf 'Skipping SonarQube scan for published release tag %s\n' "${GITHUB_REF_NAME}"
+              exit 0
+            fi
+            if [[ "${release_output}" != *"HTTP 404"* ]]; then
+              printf 'could not determine release state for tag %s:\n%s\n' "${GITHUB_REF_NAME}" "${release_output}" >&2
+              exit "${release_status}"
+            fi
+
+            release_authority_sha="$(
+              git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/${RELEASE_AUTHORITY_REF}" |
+                awk '{ print $1 }' |
+                tail -n 1
+            )"
+            if [[ "${GITHUB_SHA}" != "${release_authority_sha}" ]]; then
+              printf 'release tag %s is not the exact %s head (%s, got %s)\n' \
+                "${GITHUB_REF_NAME}" "${RELEASE_AUTHORITY_REF}" "${release_authority_sha:-missing}" "${GITHUB_SHA}" >&2
+              exit 2
+            fi
+            export SONAR_BRANCH="main"
           fi
-          make sonar-scan
+          export CONTAINER_RUNTIME_LOCK_FILE="/tmp/container-compose-sonar-${UID}.lock"
+          export CONTAINER_RUNTIME_LOCK_TIMEOUT_SECONDS=7200
+          source Tools/ci/container-runtime-lock.sh
+          acquire_container_runtime_lock
+          trap release_container_runtime_lock EXIT
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            canonical_main_sha="$(
+              git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main |
+                awk '{ print $1 }' |
+                tail -n 1
+            )"
+            if [[ "${canonical_main_sha}" != "${EXPECTED_CANONICAL_MAIN_SHA}" ]]; then
+              printf 'canonical main moved after recovery preflight: expected %s, got %s\n' \
+                "${EXPECTED_CANONICAL_MAIN_SHA}" "${canonical_main_sha:-missing}" >&2
+              exit 75
+            fi
+            release_output=""
+            set +e
+            release_output="$(
+              gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" 2>&1
+            )"
+            release_status="$?"
+            set -e
+            if (( release_status == 0 )); then
+              if [[ "${RESTORE_CANONICAL_MAIN}" == "true" ]]; then
+                printf 'canonical_restore_completed=true\n' >> "${GITHUB_OUTPUT}"
+              fi
+              printf 'Skipping SonarQube scan because release %s was published while waiting for authority\n' \
+                "${GITHUB_REF_NAME}"
+              exit 0
+            fi
+            if [[ "${release_output}" != *"HTTP 404"* ]]; then
+              printf 'could not revalidate release state for tag %s:\n%s\n' \
+                "${GITHUB_REF_NAME}" "${release_output}" >&2
+              exit "${release_status}"
+            fi
+            release_authority_sha="$(
+              git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/${RELEASE_AUTHORITY_REF}" |
+                awk '{ print $1 }' |
+                tail -n 1
+            )"
+            if [[ "${GITHUB_SHA}" != "${release_authority_sha}" ]]; then
+              printf 'release authority %s moved while tag %s waited (expected %s, got %s)\n' \
+                "${RELEASE_AUTHORITY_REF}" "${GITHUB_REF_NAME}" "${GITHUB_SHA}" "${release_authority_sha:-missing}" >&2
+              exit 75
+            fi
+          fi
+          candidate_status=0
+          set +e
+          run_bounded_sonar_scan
+          candidate_status="$?"
+          set -e
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" && "${RESTORE_CANONICAL_MAIN}" == "true" ]]; then
+            restore_status=0
+            set +e
+            (
+              cd ../sonar-main-recovery
+              export SONAR_BRANCH=main
+              export SONAR_QUALITYGATE_WAIT=true
+              run_bounded_sonar_scan
+            )
+            restore_status="$?"
+            set -e
+            canonical_main_sha="$(
+              git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main |
+                awk '{ print $1 }' |
+                tail -n 1
+            )"
+            if [[ "${canonical_main_sha}" != "${EXPECTED_CANONICAL_MAIN_SHA}" ]]; then
+              printf 'canonical_restore_failed=true\n' >> "${GITHUB_OUTPUT}"
+              printf 'canonical main moved during atomic release restoration: expected %s, got %s\n' \
+                "${EXPECTED_CANONICAL_MAIN_SHA}" "${canonical_main_sha:-missing}" >&2
+              exit 75
+            fi
+            if (( restore_status != 0 )); then
+              printf 'canonical_restore_failed=true\n' >> "${GITHUB_OUTPUT}"
+              printf 'atomic canonical main restoration failed with status %s\n' "${restore_status}" >&2
+              exit "${restore_status}"
+            fi
+            printf 'canonical_restore_completed=true\n' >> "${GITHUB_OUTPUT}"
+          fi
+          exit "${candidate_status}"
         working-directory: container-compose
+
+      # `continue-on-error` normalizes the public step conclusion. This marker
+      # exists only when the scanner's raw outcome succeeded, so stable release
+      # control can require durable unmasked evidence from the jobs API.
+      - name: Record successful SonarQube analysis
+        if: >
+          (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
+          steps.sonar_scan.outcome == 'success'
+        run: printf 'SonarQube analysis completed successfully.\n'
 
       - name: Enforce SonarQube failures when the service is available
         if: >
           (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
-          (steps.sonar_tcp.outputs.available != 'true' || steps.sonar_api.outputs.available != 'true' || steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
+          (steps.sonar_restore_obligation.outputs.required == 'true' || steps.sonar_tcp.outputs.available != 'true' || steps.sonar_api.outputs.available != 'true' || steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
         env:
+          CANONICAL_RESTORE_COMPLETED: ${{ steps.sonar_scan.outputs.canonical_restore_completed }}
+          CANONICAL_RESTORE_FAILED: ${{ steps.sonar_scan.outputs.canonical_restore_failed }}
+          CANONICAL_RESTORE_REQUIRED: ${{ steps.sonar_restore_obligation.outputs.required }}
           SONAR_TCP_AVAILABLE: ${{ steps.sonar_tcp.outputs.available }}
           SONAR_API_AVAILABLE: ${{ steps.sonar_api.outputs.available }}
           SONAR_STATUS_URL: https://sonarcloud.io/api/system/status
         run: |
           set -euo pipefail
+          if [[ "${CANONICAL_RESTORE_REQUIRED}" == "true" && "${CANONICAL_RESTORE_COMPLETED}" != "true" ]]; then
+            printf 'Canonical Sonar restoration did not complete; failing closed.\n' >&2
+            exit 1
+          fi
+          if [[ "${CANONICAL_RESTORE_FAILED}" == "true" ]]; then
+            printf 'Canonical Sonar restoration failed; preserving the release validation failure.\n' >&2
+            exit 1
+          fi
           if [[ "${SONAR_TCP_AVAILABLE}" != "true" || "${SONAR_API_AVAILABLE}" != "true" ]]; then
             printf '::warning title=SonarQube unavailable::SonarQube TCP or API preflight failed within five seconds; skipping scanner installation and analysis.\n'
             {
@@ -541,17 +750,142 @@ jobs:
             printf 'The SonarQube API was unavailable after retries, so this external quality scan did not fail CI. Local source checks, tests, coverage gates, and CodeQL remain required.\n'
           } >> "${GITHUB_STEP_SUMMARY}"
 
+  resolve-canonical-main:
+    name: Resolve Canonical Main
+    runs-on: ubuntu-24.04
+    outputs:
+      artifact_run_id: ${{ steps.main.outputs.artifact_run_id }}
+      authority_ref: ${{ steps.main.outputs.authority_ref }}
+      sha: ${{ steps.main.outputs.sha }}
+      restore: ${{ steps.main.outputs.restore }}
+    steps:
+      - name: Resolve canonical main and release state
+        id: main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            {
+              printf 'artifact_run_id=\n'
+              printf 'authority_ref=\n'
+              printf 'restore=false\n'
+              printf 'sha=\n'
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          release_output=""
+          set +e
+          release_output="$(
+            gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" 2>&1
+          )"
+          release_status="$?"
+          set -e
+          if (( release_status == 0 )); then
+            {
+              printf 'artifact_run_id=\n'
+              printf 'authority_ref=\n'
+              printf 'restore=false\n'
+              printf 'sha=\n'
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          elif [[ "${release_output}" == *"HTTP 404"* ]]; then
+            :
+          else
+            printf 'could not determine release state for tag %s:\n%s\n' \
+              "${GITHUB_REF_NAME}" "${release_output}" >&2
+            exit "${release_status}"
+          fi
+
+          main_sha="$(
+            git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" refs/heads/main |
+              awk '{ print $1 }' |
+              tail -n 1
+          )"
+          if [[ ! "${main_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'canonical main SHA is unavailable: %s\n' "${main_sha:-missing}" >&2
+            exit 1
+          fi
+          release_version="${GITHUB_REF_NAME#v}"
+          if [[ ! "${release_version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            printf 'release tag is not semantic: %s\n' "${GITHUB_REF_NAME}" >&2
+            exit 2
+          fi
+          release_branch="release-${release_version%.*}"
+          release_branch_sha="$(
+            git ls-remote --heads "https://github.com/${GITHUB_REPOSITORY}.git" "refs/heads/${release_branch}" |
+              awk '{ print $1 }' |
+              tail -n 1
+          )"
+          if [[ "${GITHUB_SHA}" == "${main_sha}" ]]; then
+            {
+              printf 'artifact_run_id=\n'
+              printf 'authority_ref=main\n'
+              printf 'restore=false\n'
+              printf 'sha=%s\n' "${main_sha}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          if [[ "${GITHUB_SHA}" != "${release_branch_sha}" ]]; then
+            printf 'release tag %s is not the exact main or %s head (main %s, maintenance %s, got %s)\n' \
+              "${GITHUB_REF_NAME}" "${release_branch}" "${main_sha}" "${release_branch_sha:-missing}" "${GITHUB_SHA}" >&2
+            exit 2
+          fi
+          artifact_name="sonar-main-inputs-${main_sha}"
+          run_ids="$(
+            gh run list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --workflow ci.yml \
+              --commit "${main_sha}" \
+              --limit 100 \
+              --json databaseId,event,status,conclusion,headBranch,createdAt \
+              --jq 'map(select(
+                .headBranch == "main" and
+                .status == "completed" and
+                .conclusion == "success" and
+                (.event == "push" or .event == "workflow_dispatch")
+              )) | sort_by(.createdAt) | reverse | .[].databaseId'
+          )"
+          retained_inputs_available=false
+          selected_run=""
+          while IFS= read -r run_id; do
+            if [[ -z "${run_id}" ]]; then
+              continue
+            fi
+            if gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${run_id}/artifacts?per_page=100" \
+              --jq '.artifacts[] | select(.expired == false) | .name' |
+              grep -Fxq "${artifact_name}"; then
+              retained_inputs_available=true
+              selected_run="${run_id}"
+              break
+            fi
+          done <<< "${run_ids}"
+          if [[ "${retained_inputs_available}" != "true" ]]; then
+            printf 'release Sonar scan is unsafe: no retained %s artifact exists for canonical main %s\n' \
+              "${artifact_name}" "${main_sha}" >&2
+            exit 1
+          fi
+          {
+            printf 'artifact_run_id=%s\n' "${selected_run}"
+            printf 'authority_ref=%s\n' "${release_branch}"
+            printf 'restore=true\n'
+            printf 'sha=%s\n' "${main_sha}"
+          } >> "${GITHUB_OUTPUT}"
+
   validate:
     name: Validate
     needs:
       - changes
       - source_checks
       - validate_runtime
+      - resolve-canonical-main
     if: always() && needs.changes.outputs.heavy == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check parallel validation jobs
         env:
+          RESOLVE_CANONICAL_MAIN_RESULT: ${{ needs.resolve-canonical-main.result }}
           SOURCE_CHECKS_RESULT: ${{ needs.source_checks.result }}
           VALIDATE_RUNTIME_RESULT: ${{ needs.validate_runtime.result }}
         run: |
@@ -564,7 +898,11 @@ jobs:
             printf 'Validate Runtime concluded %s\n' "${VALIDATE_RUNTIME_RESULT}" >&2
             exit 1
           fi
-          printf 'Source Checks and Validate Runtime passed.\n'
+          if [[ "${RESOLVE_CANONICAL_MAIN_RESULT}" != "success" && "${RESOLVE_CANONICAL_MAIN_RESULT}" != "skipped" ]]; then
+            printf 'Resolve Canonical Main concluded %s\n' "${RESOLVE_CANONICAL_MAIN_RESULT}" >&2
+            exit 1
+          fi
+          printf 'Source Checks and Validate Runtime passed, including any required atomic Sonar restoration.\n'
 
   validate-lightweight:
     # Branch protection requires one stable aggregate context for both the

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1102,7 +1102,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("needs.analyze.result", codeql)
         self.assertIn("needs.analyze-skipped.result", codeql)
 
-    def test_release_sonar_step_runs_on_main_and_tags_with_complete_retry_budget(
+    def test_release_sonar_step_runs_on_main_and_tags_with_supported_branch_and_retry_budget(
         self,
     ) -> None:
         ci = CI_WORKFLOW.read_text(encoding="utf-8")
@@ -1116,27 +1116,106 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "- name: Enforce SonarQube failures when the service is available"
             )
         ]
+        obligation = ci[
+            ci.index("- name: Record canonical restoration obligation") : ci.index(
+                "- name: SonarQube scan"
+            )
+        ]
         sonar_install = ci[
             ci.index("- name: Install Sonar Scanner CLI") : ci.index(
                 "- name: SonarQube scan"
             )
         ]
-        self.assertIn("timeout-minutes: 105", runtime_job)
+        self.assertIn("timeout-minutes: 250", runtime_job)
+        self.assertIn("- resolve-canonical-main", runtime_job)
         self.assertIn("continue-on-error: true", sonar)
-        self.assertIn("timeout-minutes: 25", sonar)
+        self.assertIn("timeout-minutes: 180", sonar)
+        self.assertIn('GH_TOKEN: ${{ github.token }}', sonar)
         self.assertIn('SONAR_QUALITYGATE_WAIT: "true"', sonar)
         self.assertIn("make sonar-scan", sonar)
+        self.assertIn('if [[ "${GITHUB_REF_TYPE}" == "tag" ]]', sonar)
         self.assertIn('release_version="${GITHUB_REF_NAME#v}"', sonar)
         self.assertIn(
-            'export SONAR_BRANCH="release-${release_version%.*}"',
+            'if [[ ! "${release_version}" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+$ ]]',
             sonar,
+        )
+        self.assertIn("RELEASE_AUTHORITY_REF", sonar)
+        self.assertIn('if [[ "${GITHUB_SHA}" != "${release_authority_sha}" ]]', sonar)
+        self.assertIn(
+            "Skipping SonarQube scan for published release tag",
+            sonar,
+        )
+        self.assertLess(
+            sonar.index("gh api --silent"),
+            sonar.index('release_authority_sha="$('),
+        )
+        self.assertIn('export SONAR_BRANCH="main"', sonar)
+        self.assertIn(
+            'CONTAINER_RUNTIME_LOCK_FILE="/tmp/container-compose-sonar-${UID}.lock"',
+            sonar,
+        )
+        self.assertIn("CONTAINER_RUNTIME_LOCK_TIMEOUT_SECONDS=7200", sonar)
+        self.assertIn("source Tools/ci/container-runtime-lock.sh", sonar)
+        self.assertIn("acquire_container_runtime_lock", sonar)
+        self.assertIn("trap release_container_runtime_lock EXIT", sonar)
+        self.assertIn("EXPECTED_CANONICAL_MAIN_SHA", sonar)
+        self.assertIn("canonical main moved after recovery preflight", sonar)
+        self.assertIn("was published while waiting for authority", sonar)
+        self.assertIn("moved while tag", sonar)
+        self.assertIn("RESTORE_CANONICAL_MAIN", sonar)
+        self.assertIn("../sonar-main-recovery", sonar)
+        self.assertIn("atomic canonical main restoration failed", sonar)
+        self.assertIn("canonical main moved during atomic release restoration", sonar)
+        self.assertIn("canonical_restore_failed=true", sonar)
+        self.assertIn("canonical_restore_completed=true", sonar)
+        self.assertIn("command -v gtimeout", sonar)
+        self.assertIn('"${sonar_timeout}" --kill-after=30s 1500s make sonar-scan', sonar)
+        self.assertEqual(sonar.count("run_bounded_sonar_scan"), 3)
+        self.assertIn("- name: Record successful SonarQube analysis", sonar)
+        self.assertIn("steps.sonar_scan.outcome == 'success'", sonar)
+        self.assertIn("Record canonical restoration obligation", ci)
+        self.assertIn("steps.sonar_tcp.outputs.available == 'true'", obligation)
+        self.assertIn("steps.sonar_api.outputs.available == 'true'", obligation)
+        self.assertIn("steps.sonar_install.outcome == 'success'", obligation)
+        self.assertIn("steps.sonar_restore_obligation.outputs.required", ci)
+        self.assertIn("CANONICAL_RESTORE_COMPLETED", ci)
+        self.assertIn("Canonical Sonar restoration did not complete; failing closed.", ci)
+        self.assertIn("CANONICAL_RESTORE_FAILED", ci)
+        self.assertIn("preserving the release validation failure", ci)
+        self.assertIn("  resolve-canonical-main:", ci)
+        self.assertNotIn("  restore-canonical-sonar:", ci)
+        self.assertIn('if [[ "${GITHUB_REF_TYPE}" != "tag" ]]', ci)
+        self.assertIn('artifact_name="sonar-main-inputs-${main_sha}"', ci)
+        self.assertIn("release Sonar scan is unsafe", ci)
+        self.assertIn("needs.resolve-canonical-main.outputs.restore == 'true'", ci)
+        self.assertIn("Checkout canonical main recovery source", ci)
+        self.assertIn("fetch-depth: 0\n          path: sonar-main-recovery", ci)
+        self.assertIn("Download retained canonical main coverage", ci)
+        self.assertIn("artifact_run_id:", ci)
+        self.assertIn("authority_ref:", ci)
+        self.assertIn("authority_ref=main", ci)
+        self.assertIn("authority_ref=%s\\n", ci)
+        self.assertIn('"${release_branch}"', ci)
+        self.assertIn("test -s sonar-main-recovery/coverage.xml", ci)
+        self.assertIn(
+            "test -s sonar-main-recovery/Tools/compose-normalizer/coverage.out",
+            ci,
+        )
+        self.assertIn("name: sonar-main-inputs-${{ github.sha }}", ci)
+        self.assertIn("container-compose/coverage.xml", ci)
+        self.assertIn("container-compose/Tools/compose-normalizer/coverage.out", ci)
+        self.assertIn("overwrite: true", ci)
+        self.assertIn("cancel-in-progress: ${{ github.ref_type != 'tag' }}", ci)
+        self.assertIn('if [[ "${GITHUB_REF_TYPE}" == "tag" ]]', ci)
+        self.assertIn(
+            "Stable tags are immutable release candidates. Always run the full",
+            ci,
         )
         self.assertEqual(
             ci.count("github.ref == 'refs/heads/main' || github.ref_type == 'tag'"),
-            6,
+            8,
         )
         self.assertIn('GITHUB_REF_TYPE: ${{ github.ref_type }}', ci)
-        self.assertIn('if [[ "${GITHUB_REF_TYPE}" == "tag" ]]', ci)
         self.assertIn("printf 'heavy=true\\n' >> \"$GITHUB_OUTPUT\"", ci)
         self.assertIn(
             'gpg_home="$(mktemp -d /private/tmp/container-compose-sonar-gpg.XXXXXX)"',


### PR DESCRIPTION
## Summary

Analyze unpublished stable tags on SonarCloud's supported `main` branch without leaving a maintenance candidate as the canonical project analysis.

Tag CI accepts either the exact current `main` head (the normal stable-release authority) or the exact `release-MAJOR.MINOR` head used for the explicit 0.14.1 maintenance release. A maintenance tag must preflight an unexpired coverage artifact for the immutable current main SHA. While holding the trusted MBP Sonar lock, CI revalidates main, release publication state, and release authority; it then runs the candidate scan and restores the preflight-proven main source and coverage before releasing the lock. Restoration runs even when candidate quality-gate waiting fails, restoration failure cannot be downgraded as service unavailability, and tag runs cannot cancel an in-flight transaction. The bounded authority budget covers two preceding maintenance transactions.

PR #396 must land first so canonical-main CI retains the recovery artifact and automatically recovers an interrupted tag transaction; this maintenance workflow also contains the producer step so its policy remains self-contained.

## Motivation

SonarCloud accepted the semantic-tag analysis and then rejected quality-gate polling because this project supports only main-branch analysis. The release evidence collector also resolves historical Sonar evidence from `main`. The atomic write/restore transaction records candidate evidence while preserving canonical main state and avoiding the post-dispatch SHA/artifact, timeout, cancellation, and error-downgrade races found in review.

## Focused validation

- focused release-policy regression passes
- Python policy test compiles
- `actionlint .github/workflows/ci.yml` passes
- `git diff --check` passes
- signed exact head: `4589635ffe1814335f2297f741fea70d5a0bf0ba`

Refs #388, #393, #395, and #396.



