### PR TITLE
fix(release): accept series maintenance candidates

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -91,19 +91,6 @@ jobs:
             exit 1
           fi
 
-          latest_stable_tag="$(
-            git ls-remote --tags --refs "${remote}" \
-              | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
-              | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
-              | sort -V \
-              | tail -n 1
-          )"
-          if [[ "${latest_stable_tag}" != "${RELEASE_TAG}" ]]; then
-            printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
-              "${RELEASE_TAG}" "${latest_stable_tag:-missing}" >&2
-            exit 1
-          fi
-
           release_output=""
           set +e
           release_output="$(
@@ -146,6 +133,31 @@ jobs:
             printf 'stable tag %s is neither current main nor exact %s head\n' \
               "${RELEASE_TAG}" "${release_branch}" >&2
             exit 1
+          fi
+
+          semantic_tags="$(
+            git ls-remote --tags --refs "${remote}" \
+              | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
+              | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/'
+          )"
+          latest_stable_tag="$(sort -V <<<"${semantic_tags}" | tail -n 1)"
+          if [[ "${authority_ref}" == "main" ]]; then
+            if [[ "${latest_stable_tag}" != "${RELEASE_TAG}" ]]; then
+              printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
+                "${RELEASE_TAG}" "${latest_stable_tag:-missing}" >&2
+              exit 1
+            fi
+          else
+            latest_series_tag="$(
+              awk -v prefix="${release_series}." 'index($0, prefix) == 1' <<<"${semantic_tags}" |
+                sort -V |
+                tail -n 1
+            )"
+            if [[ "${latest_series_tag}" != "${RELEASE_TAG}" ]]; then
+              printf 'maintenance tag %s is not the latest semantic tag in series %s (%s)\n' \
+                "${RELEASE_TAG}" "${release_series}" "${latest_series_tag:-missing}" >&2
+              exit 1
+            fi
           fi
 
           homebrew_tap_ref="$(

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -64,6 +64,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('if stable_tag_exists "${version}"', release)
         self.assertIn('resume_stable_release "${version}"', release)
         self.assertIn('ensure_latest_stable_retry "${version}"', self.script)
+        self.assertIn('ensure_unpublished_stable_retry "${version}"', self.script)
         self.assertIn("ensure_new_stable_release \"${version}\"", release)
         self.assertLess(
             release.index('resume_stable_release "${version}"'),
@@ -2394,6 +2395,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("stable tag %s is not the latest semantic source tag", workflow)
+        self.assertIn(
+            "maintenance tag %s is not the latest semantic tag in series %s",
+            workflow,
+        )
+        self.assertIn('if [[ "${authority_ref}" == "main" ]]', workflow)
         self.assertIn("stable release %s already exists and is immutable", workflow)
         self.assertIn(
             "accepting its GitHub-verified unpublished source for a release retry",
@@ -5231,6 +5237,7 @@ esac
                 shell_setup="\n".join(
                     [
                         "ensure_latest_stable_retry() { :; }",
+                        "ensure_unpublished_stable_retry() { exit 74; }",
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 0; }",
                         "ensure_stable_release_is_unpublished() { exit 71; }",
@@ -5249,7 +5256,8 @@ esac
                 "resume_stable_release 0.6.70",
                 shell_setup="\n".join(
                     [
-                        "ensure_latest_stable_retry() { :; }",
+                        "ensure_latest_stable_retry() { exit 75; }",
+                        "ensure_unpublished_stable_retry() { :; }",
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 1; }",
                         "ensure_stable_release_is_unpublished() { :; }",
@@ -5261,10 +5269,10 @@ esac
             self.assertEqual(unpublished.returncode, 0, unpublished.stderr)
             self.assertIn("publish 0.6.70", unpublished.stdout)
 
-    def test_retry_rejects_a_stale_semantic_tag(self) -> None:
+    def test_published_retry_rejects_a_non_latest_release(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            shell_setup = "latest_local_semver_tag() { printf '%s\\n' 0.6.71; }"
+            shell_setup = "latest_published_stable_release() { printf '%s\\n' 0.6.71; }"
 
             latest = self.run_release_function(
                 root,
@@ -5279,7 +5287,55 @@ esac
                 shell_setup=shell_setup,
             )
             self.assertNotEqual(stale.returncode, 0)
-            self.assertIn("stable tag 0.6.70 is not the latest semantic source tag (0.6.71)", stale.stderr)
+            self.assertIn(
+                "stable tag 0.6.70 is not the latest published stable release (0.6.71)",
+                stale.stderr,
+            )
+
+    def test_unpublished_maintenance_retry_requires_latest_exact_series_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            matching_sha = "a" * 40
+            shell_setup = "\n".join(
+                [
+                    "latest_local_semver_tag() { printf '%s\\n' 0.14.0; }",
+                    "latest_local_semver_tag_for_series() { printf '%s\\n' \"${TEST_SERIES_LATEST:-0.13.1}\"; }",
+                    "repo_path() { printf '%s\\n' /tmp/container-compose-test; }",
+                    "push_remote() { printf '%s\\n' origin; }",
+                    "git() {",
+                    "  if [[ \"$*\" == *'rev-list -n 1 refs/tags/0.13.1'* ]]; then",
+                    f"    printf '%s\\n' {matching_sha}",
+                    "  elif [[ \"$*\" == *'ls-remote --heads origin refs/heads/release-0.13'* ]]; then",
+                    f"    printf '%s\\t%s\\n' \"${{TEST_RELEASE_HEAD:-{matching_sha}}}\" refs/heads/release-0.13",
+                    "  else",
+                    "    command git \"$@\"",
+                    "  fi",
+                    "}",
+                ]
+            )
+
+            accepted = self.run_release_function(
+                root,
+                "ensure_unpublished_stable_retry 0.13.1",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            stale = self.run_release_function(
+                root,
+                "ensure_unpublished_stable_retry 0.13.1",
+                shell_setup=f"export TEST_SERIES_LATEST=0.13.2\n{shell_setup}",
+            )
+            self.assertNotEqual(stale.returncode, 0)
+            self.assertIn("not the latest semantic tag in series 0.13", stale.stderr)
+
+            moved = self.run_release_function(
+                root,
+                "ensure_unpublished_stable_retry 0.13.1",
+                shell_setup=f"export TEST_RELEASE_HEAD={'b' * 40}\n{shell_setup}",
+            )
+            self.assertNotEqual(moved.returncode, 0)
+            self.assertIn("is not the exact release-0.13 head", moved.stderr)
 
     def create_promotion_review_fixture(
         self,

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -2219,6 +2219,19 @@ print(versions[-1] if versions else "")
 '
 }
 
+# Return the latest local semantic tag in one MAJOR.MINOR maintenance series.
+latest_local_semver_tag_for_series() {
+  local repo="$1" series="$2"
+  git -C "$(repo_path "${repo}")" tag --list "${series}.*" \
+    | python3 -c 'import re, sys
+series = sys.argv[1]
+pattern = re.compile(rf"{re.escape(series)}[.][0-9]+")
+versions = [line.strip() for line in sys.stdin if pattern.fullmatch(line.strip())]
+versions.sort(key=lambda version: tuple(int(part) for part in version.split(".")))
+print(versions[-1] if versions else "")
+' "${series}"
+}
+
 # Decide whether a repository changed since its latest local semver tag.
 repo_changed_since_latest_tag() {
   local repo="$1" latest main_commit tag_commit path
@@ -2264,13 +2277,54 @@ stable_tag_exists() {
   git -C "${path}" ls-remote --exit-code --tags "${remote}" "refs/tags/${version}" >/dev/null 2>&1
 }
 
-# Reject a stale unpublished tag so a retry cannot replace a newer stable lane.
+# Return the release GitHub currently presents as latest. Stable publication
+# uses --latest, so this is the tap-repair authority after assets exist.
+latest_published_stable_release() {
+  github_cli api "repos/$(github_repo "${COMPOSE_REPO}")/releases/latest" --jq '.tag_name'
+}
+
+# Reject a stale published tag so formula-only recovery cannot downgrade the
+# tap after a newer stable release has become GitHub's latest release.
 ensure_latest_stable_retry() {
   local version="$1" latest
-  latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
+  latest="$(latest_published_stable_release)"
   if [[ "${version}" != "${latest}" ]]; then
-    printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
+    printf 'stable tag %s is not the latest published stable release (%s)\n' \
       "${version}" "${latest:-missing}" >&2
+    exit 1
+  fi
+}
+
+# Permit an unpublished maintenance retry only when its signed tag is the
+# newest patch in that series and still names the exact release-line head.
+# Published formula repairs remain restricted to the global latest tag by
+# ensure_latest_stable_retry so an older line can never downgrade the tap.
+ensure_unpublished_stable_retry() {
+  local version="$1" latest series latest_series path remote tag_sha release_branch_sha
+  latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
+  if [[ "${version}" == "${latest}" ]]; then
+    return 0
+  fi
+
+  series="${version%.*}"
+  latest_series="$(latest_local_semver_tag_for_series "${COMPOSE_REPO}" "${series}")"
+  if [[ "${version}" != "${latest_series}" ]]; then
+    printf 'maintenance tag %s is not the latest semantic tag in series %s (%s)\n' \
+      "${version}" "${series}" "${latest_series:-missing}" >&2
+    exit 1
+  fi
+
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+  tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
+  release_branch_sha="$(
+    git -C "${path}" ls-remote --heads "${remote}" "refs/heads/release-${series}" |
+      awk '{ print $1 }' |
+      tail -n 1
+  )"
+  if [[ -z "${release_branch_sha}" ]] || [[ "${tag_sha}" != "${release_branch_sha}" ]]; then
+    printf 'maintenance tag %s is not the exact release-%s head (%s, got %s)\n' \
+      "${version}" "${series}" "${release_branch_sha:-missing}" "${tag_sha:-missing}" >&2
     exit 1
   fi
 }
@@ -3934,14 +3988,15 @@ tag_stable_version() {
 resume_stable_release() {
   local version="$1"
   print_header "resume stable release ${version}"
-  ensure_latest_stable_retry "${version}"
   verify_github_stable_tag_signature "${version}"
   if stable_release_is_published "${version}"; then
+    ensure_latest_stable_retry "${version}"
     dispatch_compose_stable_tap_repair "${version}"
     print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
     return 0
   fi
   ensure_stable_release_is_unpublished "${version}"
+  ensure_unpublished_stable_retry "${version}"
   publish_stable_release "${version}"
 }
 


### PR DESCRIPTION
## Summary

- allow an unpublished maintenance candidate when it is the newest semantic tag in its own `MAJOR.MINOR` series and exactly matches that release branch
- retain the global-latest requirement for current-main candidates
- authorize formula-only recovery only for the release GitHub currently marks latest, preventing an older maintenance line from downgrading the tap after a newer release

Closes the remaining release-policy gap in #388.

## Focused proof

- five release-policy unit tests covering current-main, unpublished maintenance, moved/stale maintenance, published recovery, and stale published recovery
- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `actionlint .github/workflows/stable-release-gate.yml`
- `git diff --check`

`0.13.1` remains unpublished and its tag CI continues independently at exact `release-0.13` head `9b061832`.