### PR TITLE
fix(ci): accept successful Sonar restoration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,7 +709,7 @@ jobs:
       - name: Enforce SonarQube failures when the service is available
         if: >
           (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
-          (steps.sonar_restore_obligation.outputs.required == 'true' || steps.sonar_tcp.outputs.available != 'true' || steps.sonar_api.outputs.available != 'true' || steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
+          ((steps.sonar_restore_obligation.outputs.required == 'true' && steps.sonar_scan.outputs.canonical_restore_completed != 'true') || steps.sonar_tcp.outputs.available != 'true' || steps.sonar_api.outputs.available != 'true' || steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
         env:
           CANONICAL_RESTORE_COMPLETED: ${{ steps.sonar_scan.outputs.canonical_restore_completed }}
           CANONICAL_RESTORE_FAILED: ${{ steps.sonar_scan.outputs.canonical_restore_failed }}

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1126,6 +1126,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "- name: SonarQube scan"
             )
         ]
+        sonar_enforcement = ci[
+            ci.index("- name: Enforce SonarQube failures when the service is available") :
+        ]
         self.assertIn("timeout-minutes: 250", runtime_job)
         self.assertIn("- resolve-canonical-main", runtime_job)
         self.assertIn("continue-on-error: true", sonar)
@@ -1178,6 +1181,14 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("steps.sonar_api.outputs.available == 'true'", obligation)
         self.assertIn("steps.sonar_install.outcome == 'success'", obligation)
         self.assertIn("steps.sonar_restore_obligation.outputs.required", ci)
+        self.assertIn(
+            "steps.sonar_scan.outputs.canonical_restore_completed != 'true'",
+            sonar_enforcement,
+        )
+        self.assertNotIn(
+            "steps.sonar_restore_obligation.outputs.required == 'true' ||",
+            sonar_enforcement,
+        )
         self.assertIn("CANONICAL_RESTORE_COMPLETED", ci)
         self.assertIn("Canonical Sonar restoration did not complete; failing closed.", ci)
         self.assertIn("CANONICAL_RESTORE_FAILED", ci)


### PR DESCRIPTION
## Summary

- make the tag-CI Sonar enforcement guard run for an incomplete restoration, not merely because restoration was required
- preserve fail-closed behavior for unavailable services, installation failures, scan failures, and incomplete canonical restoration

This is the release-0.14 port of b083d675, preventing the same false tag-CI failure before the 0.14.1 candidate is tagged.

## Focused proof

- targeted Sonar restoration policy test
- Python compilation of the policy tests
- actionlint for CI
- git diff validation

Part of #388.