### PR TITLE
fix(release): accept safe maintenance backfills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -704,7 +704,7 @@ jobs:
       - name: Enforce SonarQube failures when the service is available
         if: >
           (github.ref == 'refs/heads/main' || github.ref_type == 'tag') &&
-          (steps.sonar_restore_obligation.outputs.required == 'true' || steps.sonar_tcp.outputs.available != 'true' || steps.sonar_api.outputs.available != 'true' || steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
+          ((steps.sonar_restore_obligation.outputs.required == 'true' && steps.sonar_scan.outputs.canonical_restore_completed != 'true') || steps.sonar_tcp.outputs.available != 'true' || steps.sonar_api.outputs.available != 'true' || steps.sonar_install.outcome == 'failure' || steps.sonar_scan.outcome == 'failure')
         env:
           CANONICAL_RESTORE_COMPLETED: ${{ steps.sonar_scan.outputs.canonical_restore_completed }}
           CANONICAL_RESTORE_FAILED: ${{ steps.sonar_scan.outputs.canonical_restore_failed }}

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -583,6 +583,7 @@ jobs:
         shell: bash
         working-directory: container-compose
         env:
+          GH_TOKEN: ${{ github.token }}
           PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
           PUBLISH_REF_NAME: ${{ needs.resolve-publish-context.outputs.ref_name }}
           PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
@@ -628,12 +629,45 @@ jobs:
                 printf 'COMPOSE_VERSION %s does not match stable tag %s\n' "${compose_version}" "${PUBLISH_REF_NAME}" >&2
                 exit 1
               fi
+              latest_response="$(mktemp)"
+              if gh api --include \
+                "repos/${GITHUB_REPOSITORY}/releases/latest" \
+                --jq '.tag_name' > "${latest_response}"; then
+                latest_stable="$(tail -n 1 "${latest_response}")"
+              elif grep -Eq '^HTTP/[0-9.]+ 404 ' "${latest_response}"; then
+                latest_stable=""
+              else
+                printf 'Could not resolve the latest published stable release.\n' >&2
+                cat "${latest_response}" >&2
+                exit 1
+              fi
+              rm "${latest_response}"
+              promote_default_lane="$(
+                python3 - "${PUBLISH_REF_NAME}" "${latest_stable}" <<'PY'
+          import re
+          import sys
+
+          pattern = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
+          candidate, latest = sys.argv[1:]
+          if not pattern.fullmatch(candidate):
+              raise SystemExit(f"invalid stable release candidate: {candidate}")
+          if latest and not pattern.fullmatch(latest):
+              raise SystemExit(f"invalid latest published stable release: {latest}")
+          candidate_key = tuple(int(part) for part in candidate.split("."))
+          latest_key = tuple(int(part) for part in latest.split(".")) if latest else None
+          print("true" if latest_key is None or candidate_key >= latest_key else "false")
+          PY
+              )"
               release_tag="${PUBLISH_REF_NAME}"
               release_title="${compose_version}"
-              release_label="stable release"
-              release_latest="true"
+              if [[ "${promote_default_lane}" == "true" ]]; then
+                release_label="stable release"
+              else
+                release_label="maintenance backfill"
+              fi
+              release_latest="${promote_default_lane}"
               release_prerelease="false"
-              update_tap="true"
+              update_tap="${promote_default_lane}"
               asset="container-compose-plugin-release-arm64.tar.gz"
               highlights_asset="release-highlights.json"
               quality_snapshot_asset="quality-snapshot.svg"

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1424,7 +1424,10 @@ jobs:
             ../release-tools/Tools/release/publish-github-release.sh
 
       - name: Retain only current release assets
-        if: steps.current-freshness.outputs.publish == 'true'
+        if: >
+          steps.current-freshness.outputs.publish == 'true' &&
+          (needs.resolve-publish-context.outputs.ref_type == 'branch' ||
+           steps.lane.outputs.update_tap == 'true')
         env:
           GH_TOKEN: ${{ github.token }}
           PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -91,19 +91,6 @@ jobs:
             exit 1
           fi
 
-          latest_stable_tag="$(
-            git ls-remote --tags --refs "${remote}" \
-              | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
-              | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/' \
-              | sort -V \
-              | tail -n 1
-          )"
-          if [[ "${latest_stable_tag}" != "${RELEASE_TAG}" ]]; then
-            printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
-              "${RELEASE_TAG}" "${latest_stable_tag:-missing}" >&2
-            exit 1
-          fi
-
           release_output=""
           set +e
           release_output="$(
@@ -146,6 +133,31 @@ jobs:
             printf 'stable tag %s is neither current main nor exact %s head\n' \
               "${RELEASE_TAG}" "${release_branch}" >&2
             exit 1
+          fi
+
+          semantic_tags="$(
+            git ls-remote --tags --refs "${remote}" \
+              | awk '{ sub("^refs/tags/", "", $2); print $2 }' \
+              | awk '/^[0-9]+[.][0-9]+[.][0-9]+$/'
+          )"
+          latest_stable_tag="$(sort -V <<<"${semantic_tags}" | tail -n 1)"
+          if [[ "${authority_ref}" == "main" ]]; then
+            if [[ "${latest_stable_tag}" != "${RELEASE_TAG}" ]]; then
+              printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
+                "${RELEASE_TAG}" "${latest_stable_tag:-missing}" >&2
+              exit 1
+            fi
+          else
+            latest_series_tag="$(
+              awk -v prefix="${release_series}." 'index($0, prefix) == 1' <<<"${semantic_tags}" |
+                sort -V |
+                tail -n 1
+            )"
+            if [[ "${latest_series_tag}" != "${RELEASE_TAG}" ]]; then
+              printf 'maintenance tag %s is not the latest semantic tag in series %s (%s)\n' \
+                "${RELEASE_TAG}" "${release_series}" "${latest_series_tag:-missing}" >&2
+              exit 1
+            fi
           fi
 
           homebrew_tap_ref="$(

--- a/Tools/release/stable-release-default-lane.py
+++ b/Tools/release/stable-release-default-lane.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Classify whether a stable release may advance mutable consumer pointers."""
+
+from __future__ import annotations
+
+import argparse
+import re
+
+
+SEMVER = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
+
+
+def version_key(value: str) -> tuple[int, int, int]:
+    """Parse the project's deliberately narrow stable-version format."""
+    if not SEMVER.fullmatch(value):
+        raise ValueError(f"invalid stable release version: {value}")
+    major, minor, patch = value.split(".")
+    return int(major), int(minor), int(patch)
+
+
+def promotes_default_lane(candidate: str, latest: str) -> bool:
+    """Return whether candidate can become GitHub latest and update the tap."""
+    candidate_key = version_key(candidate)
+    return not latest or candidate_key >= version_key(latest)
+
+
+def main() -> int:
+    """Print a shell-compatible Boolean classification."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("candidate")
+    parser.add_argument("latest", nargs="?", default="")
+    arguments = parser.parse_args()
+    try:
+        promotes = promotes_default_lane(arguments.candidate, arguments.latest)
+    except ValueError as error:
+        parser.error(str(error))
+    print("true" if promotes else "false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1329,6 +1329,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "- name: SonarQube scan"
             )
         ]
+        sonar_enforcement = ci[
+            ci.index("- name: Enforce SonarQube failures when the service is available") :
+        ]
         self.assertIn("timeout-minutes: 250", runtime_job)
         self.assertIn("- resolve-canonical-main", runtime_job)
         self.assertIn("continue-on-error: true", sonar)
@@ -1375,6 +1378,14 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("steps.sonar_api.outputs.available == 'true'", obligation)
         self.assertIn("steps.sonar_install.outcome == 'success'", obligation)
         self.assertIn("steps.sonar_restore_obligation.outputs.required", ci)
+        self.assertIn(
+            "steps.sonar_scan.outputs.canonical_restore_completed != 'true'",
+            sonar_enforcement,
+        )
+        self.assertNotIn(
+            "steps.sonar_restore_obligation.outputs.required == 'true' ||",
+            sonar_enforcement,
+        )
         self.assertIn("CANONICAL_RESTORE_COMPLETED", ci)
         self.assertIn("Canonical Sonar restoration did not complete; failing closed.", ci)
         self.assertIn("CANONICAL_RESTORE_FAILED", ci)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -47,6 +47,9 @@ SONAR_RESTORE_WORKFLOW = ROOT / ".github" / "workflows" / "sonar-main-restore.ym
 CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 STACK_RELEASE_VALIDATION = ROOT / "Tools" / "ci" / "run-stack-release-validation.sh"
 FORMULA_RENDERER = ROOT / "Tools" / "release" / "render-homebrew-stack-formulae.sh"
+STABLE_RELEASE_LANE_CLASSIFIER = (
+    ROOT / "Tools" / "release" / "stable-release-default-lane.py"
+)
 RUNNER_INSTALLER = ROOT / "scripts" / "install-scheduled-release-runner.sh"
 HAWKEYE_INSTALLER = ROOT / "scripts" / "install-hawkeye.sh"
 PIPELINE_MAIN = ROOT / "main.nf"
@@ -64,6 +67,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('if stable_tag_exists "${version}"', release)
         self.assertIn('resume_stable_release "${version}"', release)
         self.assertIn('ensure_latest_stable_retry "${version}"', self.script)
+        self.assertIn('ensure_unpublished_stable_retry "${version}"', self.script)
         self.assertIn("ensure_new_stable_release \"${version}\"", release)
         self.assertLess(
             release.index('resume_stable_release "${version}"'),
@@ -617,6 +621,69 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("stable Homebrew formula must derive version", verifier)
         self.assertNotIn('if [[ "${formula_version}" != "${version}" ]]', verifier)
 
+    def test_stable_release_lane_classifier_preserves_newer_consumer_pointers(
+        self,
+    ) -> None:
+        def classify(candidate: str, latest: str = "") -> subprocess.CompletedProcess[str]:
+            return subprocess.run(
+                [
+                    "python3",
+                    str(STABLE_RELEASE_LANE_CLASSIFIER),
+                    candidate,
+                    latest,
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(classify("0.13.1", "0.14.0").stdout.strip(), "false")
+        self.assertEqual(classify("0.14.0", "0.14.0").stdout.strip(), "true")
+        self.assertEqual(classify("0.14.1", "0.14.0").stdout.strip(), "true")
+        self.assertEqual(classify("0.13.1").stdout.strip(), "true")
+        invalid = classify("current", "0.14.0")
+        self.assertNotEqual(invalid.returncode, 0)
+        self.assertIn("invalid stable release version", invalid.stderr)
+
+    def test_maintenance_backfill_does_not_move_latest_or_homebrew(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        lane = workflow[
+            workflow.index("- name: Select release lane") : workflow.index(
+                "- name: Resolve stack refs"
+            )
+        ]
+        verifier = self.script[
+            self.script.index("verify_compose_stable_package() {") : self.script.index(
+                "# Dispatch and verify one stable package workflow mode"
+            )
+        ]
+        dispatcher = self.script[
+            self.script.index("dispatch_compose_stable_workflow() {") : self.script.index(
+                "# Dispatch and wait for a new stable package publication."
+            )
+        ]
+
+        self.assertIn('"repos/${GITHUB_REPOSITORY}/releases/latest"', lane)
+        self.assertIn('candidate_key >= latest_key else "false"', lane)
+        self.assertIn('release_label="maintenance backfill"', lane)
+        self.assertIn('release_latest="${promote_default_lane}"', lane)
+        self.assertIn('update_tap="${promote_default_lane}"', lane)
+        self.assertIn('tap_sha_after="$(homebrew_tap_main_sha)"', verifier)
+        self.assertIn("maintenance backfill moved Homebrew tap main", verifier)
+        self.assertLess(
+            verifier.index('if [[ "${promote_default_lane}" != "true" ]]'),
+            verifier.index('formula_text="$('),
+        )
+        self.assertIn(
+            'promote_default_lane="$(stable_version_promotes_default_lane "${version}")"',
+            dispatcher,
+        )
+        self.assertIn('tap_sha_before="$(homebrew_tap_main_sha)"', dispatcher)
+        self.assertIn(
+            '"${version}" "${promote_default_lane}" "${tap_sha_before}"',
+            dispatcher,
+        )
+
     def test_stable_release_publishes_and_verifies_guest_closure(self) -> None:
         publisher = self.script[
             self.script.index("publish_stable_init_image_asset() {") : self.script.index(
@@ -641,7 +708,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('github_cli release upload "${version}"', publisher)
         self.assertLess(
             dispatcher.index('publish_stable_init_image_asset "${version}"'),
-            dispatcher.index('verify_compose_stable_package "${version}"'),
+            dispatcher.index("verify_compose_stable_package"),
         )
         self.assertIn('init_asset="container-vminit-arm64.oci.tar"', verifier)
         self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${init_asset}"', verifier)
@@ -2394,6 +2461,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             workflow,
         )
         self.assertIn("stable tag %s is not the latest semantic source tag", workflow)
+        self.assertIn(
+            "maintenance tag %s is not the latest semantic tag in series %s",
+            workflow,
+        )
+        self.assertIn('if [[ "${authority_ref}" == "main" ]]', workflow)
         self.assertIn("stable release %s already exists and is immutable", workflow)
         self.assertIn(
             "accepting its GitHub-verified unpublished source for a release retry",
@@ -5231,6 +5303,7 @@ esac
                 shell_setup="\n".join(
                     [
                         "ensure_latest_stable_retry() { :; }",
+                        "ensure_unpublished_stable_retry() { exit 74; }",
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 0; }",
                         "ensure_stable_release_is_unpublished() { exit 71; }",
@@ -5249,7 +5322,8 @@ esac
                 "resume_stable_release 0.6.70",
                 shell_setup="\n".join(
                     [
-                        "ensure_latest_stable_retry() { :; }",
+                        "ensure_latest_stable_retry() { exit 75; }",
+                        "ensure_unpublished_stable_retry() { :; }",
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 1; }",
                         "ensure_stable_release_is_unpublished() { :; }",
@@ -5261,10 +5335,10 @@ esac
             self.assertEqual(unpublished.returncode, 0, unpublished.stderr)
             self.assertIn("publish 0.6.70", unpublished.stdout)
 
-    def test_retry_rejects_a_stale_semantic_tag(self) -> None:
+    def test_published_retry_rejects_a_non_latest_release(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            shell_setup = "latest_local_semver_tag() { printf '%s\\n' 0.6.71; }"
+            shell_setup = "latest_published_stable_release() { printf '%s\\n' 0.6.71; }"
 
             latest = self.run_release_function(
                 root,
@@ -5279,7 +5353,80 @@ esac
                 shell_setup=shell_setup,
             )
             self.assertNotEqual(stale.returncode, 0)
-            self.assertIn("stable tag 0.6.70 is not the latest semantic source tag (0.6.71)", stale.stderr)
+            self.assertIn(
+                "stable tag 0.6.70 is not the latest published stable release (0.6.71)",
+                stale.stderr,
+            )
+
+    def test_latest_published_release_treats_only_not_found_as_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            not_found = self.run_release_function(
+                root,
+                "latest_published_stable_release",
+                shell_setup="""github_cli() {
+  printf '%s\\n' 'gh: Not Found (HTTP 404)' >&2
+  return 1
+}""",
+            )
+            self.assertEqual(not_found.returncode, 0, not_found.stderr)
+            self.assertEqual(not_found.stdout, "")
+
+            unavailable = self.run_release_function(
+                root,
+                "latest_published_stable_release",
+                shell_setup="""github_cli() {
+  printf '%s\\n' 'network unavailable' >&2
+  return 1
+}""",
+            )
+            self.assertNotEqual(unavailable.returncode, 0)
+            self.assertIn("network unavailable", unavailable.stderr)
+
+    def test_unpublished_maintenance_retry_requires_latest_exact_series_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            matching_sha = "a" * 40
+            shell_setup = "\n".join(
+                [
+                    "latest_local_semver_tag() { printf '%s\\n' 0.14.0; }",
+                    "latest_local_semver_tag_for_series() { printf '%s\\n' \"${TEST_SERIES_LATEST:-0.13.1}\"; }",
+                    "repo_path() { printf '%s\\n' /tmp/container-compose-test; }",
+                    "push_remote() { printf '%s\\n' origin; }",
+                    "git() {",
+                    "  if [[ \"$*\" == *'rev-list -n 1 refs/tags/0.13.1'* ]]; then",
+                    f"    printf '%s\\n' {matching_sha}",
+                    "  elif [[ \"$*\" == *'ls-remote --heads origin refs/heads/release-0.13'* ]]; then",
+                    f"    printf '%s\\t%s\\n' \"${{TEST_RELEASE_HEAD:-{matching_sha}}}\" refs/heads/release-0.13",
+                    "  else",
+                    "    command git \"$@\"",
+                    "  fi",
+                    "}",
+                ]
+            )
+
+            accepted = self.run_release_function(
+                root,
+                "ensure_unpublished_stable_retry 0.13.1",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            stale = self.run_release_function(
+                root,
+                "ensure_unpublished_stable_retry 0.13.1",
+                shell_setup=f"export TEST_SERIES_LATEST=0.13.2\n{shell_setup}",
+            )
+            self.assertNotEqual(stale.returncode, 0)
+            self.assertIn("not the latest semantic tag in series 0.13", stale.stderr)
+
+            moved = self.run_release_function(
+                root,
+                "ensure_unpublished_stable_retry 0.13.1",
+                shell_setup=f"export TEST_RELEASE_HEAD={'b' * 40}\n{shell_setup}",
+            )
+            self.assertNotEqual(moved.returncode, 0)
+            self.assertIn("is not the exact release-0.13 head", moved.stderr)
 
     def create_promotion_review_fixture(
         self,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -668,6 +668,15 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('release_label="maintenance backfill"', lane)
         self.assertIn('release_latest="${promote_default_lane}"', lane)
         self.assertIn('update_tap="${promote_default_lane}"', lane)
+        retention = workflow[
+            workflow.index("- name: Retain only current release assets") : workflow.index(
+                "  repair-stable-tap:"
+            )
+        ]
+        self.assertIn("steps.lane.outputs.update_tap == 'true'", retention)
+        self.assertIn(
+            "needs.resolve-publish-context.outputs.ref_type == 'branch'", retention
+        )
         self.assertIn('tap_sha_after="$(homebrew_tap_main_sha)"', verifier)
         self.assertIn("maintenance backfill moved Homebrew tap main", verifier)
         self.assertLess(

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -23,6 +23,7 @@ readonly SELF_DIRECTORY
 readonly COMPOSE_PROMOTION_REVIEW_TOOL="${SELF_DIRECTORY}/../Tools/release/compose_promotion_review.py"
 readonly OCI_IMAGE_LAYOUT_VALIDATOR="${SELF_DIRECTORY}/../Tools/release/validate-oci-image-layout.py"
 readonly RELEASE_COMMAND_DEADLINE_RUNNER="${SELF_DIRECTORY}/../Tools/ci/run-command-with-deadline.py"
+readonly STABLE_RELEASE_LANE_CLASSIFIER="${SELF_DIRECTORY}/../Tools/release/stable-release-default-lane.py"
 # shellcheck disable=SC1091
 source "${SELF_DIRECTORY}/../Tools/ci/container-runtime-lock.sh"
 SCRIPT_NAME="$(basename "${SELF_PATH}")"
@@ -2219,6 +2220,19 @@ print(versions[-1] if versions else "")
 '
 }
 
+# Return the latest local semantic tag in one MAJOR.MINOR maintenance series.
+latest_local_semver_tag_for_series() {
+  local repo="$1" series="$2"
+  git -C "$(repo_path "${repo}")" tag --list "${series}.*" \
+    | python3 -c 'import re, sys
+series = sys.argv[1]
+pattern = re.compile(rf"{re.escape(series)}[.][0-9]+")
+versions = [line.strip() for line in sys.stdin if pattern.fullmatch(line.strip())]
+versions.sort(key=lambda version: tuple(int(part) for part in version.split(".")))
+print(versions[-1] if versions else "")
+' "${series}"
+}
+
 # Decide whether a repository changed since its latest local semver tag.
 repo_changed_since_latest_tag() {
   local repo="$1" latest main_commit tag_commit path
@@ -2264,13 +2278,84 @@ stable_tag_exists() {
   git -C "${path}" ls-remote --exit-code --tags "${remote}" "refs/tags/${version}" >/dev/null 2>&1
 }
 
-# Reject a stale unpublished tag so a retry cannot replace a newer stable lane.
+# Return the release GitHub currently presents as latest. Stable publication
+# uses --latest, so this is the tap-repair authority after assets exist.
+latest_published_stable_release() {
+  local output api_status
+  if output="$(
+    github_cli api "repos/$(github_repo "${COMPOSE_REPO}")/releases/latest" \
+      --jq '.tag_name' 2>&1
+  )"; then
+    printf '%s\n' "${output}"
+    return 0
+  else
+    api_status=$?
+  fi
+
+  if grep -Fq '(HTTP 404)' <<<"${output}"; then
+    return 0
+  fi
+  printf '%s\n' "${output}" >&2
+  return "${api_status}"
+}
+
+# Decide whether a stable publication may advance GitHub's latest release and
+# the Homebrew stable formula pair. Older maintenance lines publish immutable
+# backfill assets without changing either mutable consumer pointer.
+stable_version_promotes_default_lane() {
+  local version="$1" latest
+  latest="$(latest_published_stable_release)"
+  python3 "${STABLE_RELEASE_LANE_CLASSIFIER}" "${version}" "${latest}"
+}
+
+# Resolve the immutable tap main identity used to prove that a maintenance
+# backfill did not move either stable formula.
+homebrew_tap_main_sha() {
+  github_cli api repos/stephenlclarke/homebrew-tap/commits/main --jq '.sha'
+}
+
+# Reject a stale published tag so formula-only recovery cannot downgrade the
+# tap after a newer stable release has become GitHub's latest release.
 ensure_latest_stable_retry() {
   local version="$1" latest
-  latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
+  latest="$(latest_published_stable_release)"
   if [[ "${version}" != "${latest}" ]]; then
-    printf 'stable tag %s is not the latest semantic source tag (%s)\n' \
+    printf 'stable tag %s is not the latest published stable release (%s)\n' \
       "${version}" "${latest:-missing}" >&2
+    exit 1
+  fi
+}
+
+# Permit an unpublished maintenance retry only when its signed tag is the
+# newest patch in that series and still names the exact release-line head.
+# Published formula repairs remain restricted to the global latest tag by
+# ensure_latest_stable_retry so an older line can never downgrade the tap.
+ensure_unpublished_stable_retry() {
+  local version="$1" latest series latest_series path remote tag_sha release_branch_sha
+  latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
+  if [[ "${version}" == "${latest}" ]]; then
+    return 0
+  fi
+
+  series="${version%.*}"
+  latest_series="$(latest_local_semver_tag_for_series "${COMPOSE_REPO}" "${series}")"
+  if [[ "${version}" != "${latest_series}" ]]; then
+    printf 'maintenance tag %s is not the latest semantic tag in series %s (%s)\n' \
+      "${version}" "${series}" "${latest_series:-missing}" >&2
+    exit 1
+  fi
+
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+  tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
+  release_branch_sha="$(
+    git -C "${path}" ls-remote --heads "${remote}" "refs/heads/release-${series}" |
+      awk '{ print $1 }' |
+      tail -n 1
+  )"
+  if [[ -z "${release_branch_sha}" ]] || [[ "${tag_sha}" != "${release_branch_sha}" ]]; then
+    printf 'maintenance tag %s is not the exact release-%s head (%s, got %s)\n' \
+      "${version}" "${series}" "${release_branch_sha:-missing}" "${tag_sha:-missing}" >&2
     exit 1
   fi
 }
@@ -3629,7 +3714,7 @@ publish_stable_init_image_asset() {
 
 # Verify the stable release assets and Homebrew formula agree.
 verify_compose_stable_package() {
-  local version="$1" repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text formula_url formula_version formula_sha runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text container_formula_url container_formula_sha signature_verifier init_asset init_asset_sha init_checksum_sha
+  local version="$1" promote_default_lane="${2:-true}" tap_sha_before="${3:-}" repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text formula_url formula_version formula_sha runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text container_formula_url container_formula_sha signature_verifier init_asset init_asset_sha init_checksum_sha tap_sha_after
   local authority=() containerization_repository containerization_reference
   repo="$(github_repo "${COMPOSE_REPO}")"
   asset="container-compose-plugin-release-arm64.tar.gz"
@@ -3731,6 +3816,22 @@ verify_compose_stable_package() {
   "${signature_verifier}" "${tmp}/${runtime_asset}"
   rm -rf "${tmp}"
 
+  if [[ "${promote_default_lane}" != "true" ]]; then
+    if [[ -z "${tap_sha_before}" ]]; then
+      printf 'maintenance backfill verification requires the original Homebrew tap identity\n' >&2
+      exit 1
+    fi
+    tap_sha_after="$(homebrew_tap_main_sha)"
+    if [[ "${tap_sha_after}" != "${tap_sha_before}" ]]; then
+      printf 'maintenance backfill moved Homebrew tap main: expected %s, got %s\n' \
+        "${tap_sha_before}" "${tap_sha_after}" >&2
+      exit 1
+    fi
+    printf 'stable stack %s maintenance backfill verified without moving Homebrew tap %s: %s + %s + %s\n' \
+      "${version}" "${tap_sha_after}" "${asset_sha}" "${runtime_asset_sha}" "${init_asset_sha}"
+    return 0
+  fi
+
   formula_text="$(
     github_cli api \
       repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose.rb \
@@ -3788,7 +3889,7 @@ verify_compose_stable_package() {
 
 # Dispatch and verify one stable package workflow mode for a semantic tag.
 dispatch_compose_stable_workflow() {
-  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label
+  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane tap_sha_before
   print_header "dispatch container-compose ${version} ${mode}"
 
   if [[ "${repair_tap}" == "true" ]]; then
@@ -3810,6 +3911,13 @@ dispatch_compose_stable_workflow() {
   fi
 
   need_command gh
+  promote_default_lane="$(stable_version_promotes_default_lane "${version}")"
+  tap_sha_before="$(homebrew_tap_main_sha)"
+  if [[ "${repair_tap}" == "true" && "${promote_default_lane}" != "true" ]]; then
+    printf 'Homebrew tap repair cannot promote maintenance backfill %s over the latest stable release\n' \
+      "${version}" >&2
+    exit 1
+  fi
   previous_run="$(latest_compose_package_dispatch_run "${version}" || true)"
   if [[ "${repair_tap}" == "true" ]]; then
     run github_cli workflow run prebuilt-binaries.yml \
@@ -3831,7 +3939,8 @@ dispatch_compose_stable_workflow() {
       printf '%s started: %s\n' "${label}" "${run_id}"
       wait_for_github_run_success "${run_id}" "${label}"
       publish_stable_init_image_asset "${version}"
-      verify_compose_stable_package "${version}"
+      verify_compose_stable_package \
+        "${version}" "${promote_default_lane}" "${tap_sha_before}"
       return 0
     fi
 
@@ -3902,15 +4011,28 @@ dispatch_stable_release_gate() {
 
 # Print the verified boundary for a stable release or its formula-only recovery.
 print_stable_release_point() {
-  local version="$1" generation="$2"
+  local version="$1" generation="$2" latest label tap_update
+  if [[ "${EXECUTE}" == "1" ]]; then
+    latest="$(latest_published_stable_release)"
+    if [[ "${version}" == "${latest}" ]]; then
+      label="latest"
+      tap_update="stable container and container-compose formula pair verified"
+    else
+      label="maintenance backfill"
+      tap_update="stable formula pair left unchanged and exact tap identity verified"
+    fi
+  else
+    label="selected by the stable package workflow"
+    tap_update="verified after publication according to the selected release lane"
+  fi
   print_component_refs
   cat <<EOF
 
 Stable release point:
   version: ${version}
-  label: latest
+  label: ${label}
   release generation: ${generation}
-  tap update: stable container and container-compose formula pair verified
+  tap update: ${tap_update}
 EOF
 }
 
@@ -3934,14 +4056,15 @@ tag_stable_version() {
 resume_stable_release() {
   local version="$1"
   print_header "resume stable release ${version}"
-  ensure_latest_stable_retry "${version}"
   verify_github_stable_tag_signature "${version}"
   if stable_release_is_published "${version}"; then
+    ensure_latest_stable_retry "${version}"
     dispatch_compose_stable_tap_repair "${version}"
     print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
     return 0
   fi
   ensure_stable_release_is_unpublished "${version}"
+  ensure_unpublished_stable_retry "${version}"
   publish_stable_release "${version}"
 }
 


### PR DESCRIPTION
## Summary

- accept an unpublished maintenance candidate only when it is the newest semantic tag in its MAJOR.MINOR series and exactly matches that release branch
- publish older-series maintenance candidates as immutable GitHub backfills without moving GitHub latest or the Homebrew stable formula pair
- skip release retention for maintenance backfills so the actual latest release assets and notes cannot be pruned
- verify the exact Homebrew tap identity remains unchanged for a backfill
- retain normal latest, retention, and paired-formula promotion for equal or newer stable candidates
- accept a successful canonical Sonar restoration instead of failing merely because restoration was required
- authorize formula-only recovery only for the release GitHub currently marks latest

This supersedes #397, #398, and #399 after review fixes and GitHub branch-head synchronization failures. It closes the remaining release-policy gap in #388 and the tag-CI guard defect observed in run 33521297411.

## Focused proof

- focused release-policy tests for lane classification, pointer and latest-asset preservation, package closure, published retry, API failure handling, exact maintenance-series authority, and successful Sonar restoration
- Python compilation of the classifier and policy tests
- Bash syntax and ShellCheck for the release helper
- actionlint for CI, package, and stable-gate workflows
- git diff validation

The Sonar guard is separately ported to release-0.13 in #401 and already merged to release-0.14 in #400.