### PR TITLE
fix(release): make backfill recovery durable

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -23,6 +23,10 @@ on:
         description: "Bare semantic tag to validate and promote"
         required: true
         type: string
+      init_image_sha256:
+        description: "SHA-256 of the retained guest init image that passed the local release gate"
+        required: true
+        type: string
 
 permissions:
   actions: read
@@ -42,17 +46,24 @@ jobs:
       sha: ${{ steps.candidate.outputs.sha }}
       authority_ref: ${{ steps.candidate.outputs.authority_ref }}
       homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}
+      init_image_sha256: ${{ steps.candidate.outputs.init_image_sha256 }}
     steps:
       - name: Require an immutable main tag and green main CI
         id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.ref }}
+          INIT_IMAGE_SHA256: ${{ inputs.init_image_sha256 }}
         shell: bash
         run: |
           set -euo pipefail
           if [[ ! "${RELEASE_TAG}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
             printf 'stable release ref must be a bare semantic tag: %s\n' "${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          if [[ ! "${INIT_IMAGE_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+            printf 'stable release guest init-image digest is invalid: %s\n' \
+              "${INIT_IMAGE_SHA256:-missing}" >&2
             exit 1
           fi
 
@@ -230,6 +241,7 @@ jobs:
             printf 'sha=%s\n' "${tag_sha}"
             printf 'authority_ref=%s\n' "${authority_ref}"
             printf 'homebrew_tap_ref=%s\n' "${homebrew_tap_ref}"
+            printf 'init_image_sha256=%s\n' "${INIT_IMAGE_SHA256}"
           } >> "$GITHUB_OUTPUT"
 
   release-gate:
@@ -410,6 +422,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.ref }}
           CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
           AUTHORITY_REF: ${{ needs.resolve-candidate.outputs.authority_ref }}
+          INIT_IMAGE_SHA256: ${{ needs.resolve-candidate.outputs.init_image_sha256 }}
         shell: bash
         run: |
           set -euo pipefail
@@ -438,6 +451,7 @@ jobs:
           details_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           summary="Hosted Stable Release Gate passed for immutable source"
           summary+=" ${CANDIDATE_SHA}."
+          summary+=" Guest init image SHA-256: ${INIT_IMAGE_SHA256}."
           gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
             -f "name=${authority_name}" \
             -f "head_sha=${CANDIDATE_SHA}" \

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -23,10 +23,6 @@ on:
         description: "Bare semantic tag to validate and promote"
         required: true
         type: string
-      init_image_sha256:
-        description: "SHA-256 of the retained guest init image that passed the local release gate"
-        required: true
-        type: string
 
 permissions:
   actions: read
@@ -47,13 +43,13 @@ jobs:
       authority_ref: ${{ steps.candidate.outputs.authority_ref }}
       homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}
       init_image_sha256: ${{ steps.candidate.outputs.init_image_sha256 }}
+      init_image_authority_object: ${{ steps.candidate.outputs.init_image_authority_object }}
     steps:
       - name: Require an immutable main tag and green main CI
         id: candidate
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ inputs.ref }}
-          INIT_IMAGE_SHA256: ${{ inputs.init_image_sha256 }}
         shell: bash
         run: |
           set -euo pipefail
@@ -61,12 +57,6 @@ jobs:
             printf 'stable release ref must be a bare semantic tag: %s\n' "${RELEASE_TAG}" >&2
             exit 1
           fi
-          if [[ ! "${INIT_IMAGE_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
-            printf 'stable release guest init-image digest is invalid: %s\n' \
-              "${INIT_IMAGE_SHA256:-missing}" >&2
-            exit 1
-          fi
-
           remote="https://github.com/${GITHUB_REPOSITORY}.git"
           tag_sha="$(
             git ls-remote --tags "${remote}" "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" \
@@ -101,6 +91,44 @@ jobs:
             printf 'stable tag %s is not GitHub-verified\n' "${RELEASE_TAG}" >&2
             exit 1
           fi
+
+          init_image_authority_tag="stable-init-image-authority/${RELEASE_TAG}"
+          init_image_authority_object="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${init_image_authority_tag}" \
+              --jq '.object.sha'
+          )"
+          init_image_authority="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags/${init_image_authority_object}"
+          )"
+          init_image_authority_verified="$(
+            jq -r '.verification.verified' <<<"${init_image_authority}"
+          )"
+          init_image_authority_source="$(
+            jq -r '.object.sha' <<<"${init_image_authority}"
+          )"
+          init_image_authority_message="$(
+            jq -r '.message' <<<"${init_image_authority}"
+          )"
+          init_image_digest_lines="$(
+            sed -nE 's/^Guest init image SHA-256: ([0-9a-f]{64})[.]$/\1/p' \
+              <<<"${init_image_authority_message}"
+          )"
+          if [[ "${init_image_authority_verified}" != "true" ]]; then
+            printf 'stable init-image authority tag %s is not GitHub-verified\n' \
+              "${init_image_authority_tag}" >&2
+            exit 1
+          fi
+          if [[ "${init_image_authority_source}" != "${tag_sha}" ]]; then
+            printf 'stable init-image authority tag names %s instead of candidate %s\n' \
+              "${init_image_authority_source:-missing}" "${tag_sha}" >&2
+            exit 1
+          fi
+          if [[ ! "${init_image_digest_lines}" =~ ^[0-9a-f]{64}$ ]]; then
+            printf 'stable init-image authority tag has no unique candidate-bound digest\n' >&2
+            exit 1
+          fi
+          INIT_IMAGE_SHA256="${init_image_digest_lines}"
 
           release_output=""
           set +e
@@ -242,6 +270,7 @@ jobs:
             printf 'authority_ref=%s\n' "${authority_ref}"
             printf 'homebrew_tap_ref=%s\n' "${homebrew_tap_ref}"
             printf 'init_image_sha256=%s\n' "${INIT_IMAGE_SHA256}"
+            printf 'init_image_authority_object=%s\n' "${init_image_authority_object}"
           } >> "$GITHUB_OUTPUT"
 
   release-gate:
@@ -423,6 +452,7 @@ jobs:
           CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
           AUTHORITY_REF: ${{ needs.resolve-candidate.outputs.authority_ref }}
           INIT_IMAGE_SHA256: ${{ needs.resolve-candidate.outputs.init_image_sha256 }}
+          INIT_IMAGE_AUTHORITY_OBJECT: ${{ needs.resolve-candidate.outputs.init_image_authority_object }}
         shell: bash
         run: |
           set -euo pipefail
@@ -445,6 +475,34 @@ jobs:
           if [[ "${tag_sha}" != "${CANDIDATE_SHA}" ]]; then
             printf 'stable tag %s moved after validation: expected %s, got %s\n' \
               "${RELEASE_TAG}" "${CANDIDATE_SHA}" "${tag_sha:-missing}" >&2
+            exit 75
+          fi
+          init_image_authority_tag="stable-init-image-authority/${RELEASE_TAG}"
+          current_init_image_authority_object="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/tags/${init_image_authority_tag}" \
+              --jq '.object.sha'
+          )"
+          if [[ "${current_init_image_authority_object}" != "${INIT_IMAGE_AUTHORITY_OBJECT}" ]]; then
+            printf 'stable init-image authority tag moved after validation: expected %s, got %s\n' \
+              "${INIT_IMAGE_AUTHORITY_OBJECT}" \
+              "${current_init_image_authority_object:-missing}" >&2
+            exit 75
+          fi
+          init_image_authority="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags/${current_init_image_authority_object}"
+          )"
+          if [[ "$(jq -r '.verification.verified' <<<"${init_image_authority}")" != "true" ]] ||
+            [[ "$(jq -r '.object.sha' <<<"${init_image_authority}")" != "${CANDIDATE_SHA}" ]]; then
+            printf 'stable init-image authority no longer verifies the candidate source\n' >&2
+            exit 75
+          fi
+          current_init_image_digest_lines="$(
+            jq -r '.message' <<<"${init_image_authority}" |
+              sed -nE 's/^Guest init image SHA-256: ([0-9a-f]{64})[.]$/\1/p'
+          )"
+          if [[ "${current_init_image_digest_lines}" != "${INIT_IMAGE_SHA256}" ]]; then
+            printf 'stable init-image authority digest changed after validation\n' >&2
             exit 75
           fi
           authority_name="Stable Release Authority (${RELEASE_TAG})"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1825,17 +1825,24 @@ github_cli() {{
 
     def test_stable_gate_records_the_candidate_bound_guest_digest(self) -> None:
         workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        workflow_inputs = workflow[
+            workflow.index("  workflow_dispatch:") : workflow.index("permissions:")
+        ]
         dispatcher = self.script[
             self.script.index("dispatch_stable_release_gate() {") : self.script.index(
                 "# Print the verified boundary for a stable release"
             )
         ]
 
-        self.assertIn("init_image_sha256:", workflow)
-        self.assertIn("required: true", workflow)
-        self.assertIn('INIT_IMAGE_SHA256: ${{ inputs.init_image_sha256 }}', workflow)
+        self.assertNotIn("init_image_sha256:", workflow_inputs)
+        self.assertNotIn("inputs.init_image_sha256", workflow)
+        self.assertIn('init_image_authority_tag="stable-init-image-authority/${RELEASE_TAG}"', workflow)
+        self.assertIn("init_image_authority_verified", workflow)
+        self.assertIn("stable init-image authority tag %s is not GitHub-verified", workflow)
+        self.assertIn("stable init-image authority tag names %s instead of candidate %s", workflow)
         self.assertIn(
-            '[[ ! "${INIT_IMAGE_SHA256}" =~ ^[0-9a-f]{64}$ ]]', workflow
+            "stable init-image authority tag has no unique candidate-bound digest",
+            workflow,
         )
         self.assertIn(
             'summary+=" Guest init image SHA-256: ${INIT_IMAGE_SHA256}."',
@@ -1845,7 +1852,101 @@ github_cli() {{
             'init_image_digest="$(retained_stable_init_image_gate_digest "${version}")"',
             dispatcher,
         )
-        self.assertIn('-f "init_image_sha256=${init_image_digest}"', dispatcher)
+        self.assertIn(
+            'ensure_stable_init_image_authority_tag "${version}" "${init_image_digest}"',
+            dispatcher,
+        )
+        self.assertNotIn('-f "init_image_sha256=', dispatcher)
+
+    def test_promoted_equivalent_tree_receives_immutable_gate_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose"
+            evidence = root / "evidence"
+            self.run_command("git", "init", "-b", "main", str(compose))
+            self.configure_repo(compose)
+            self.commit_file(compose, "candidate.txt", "candidate\n", "feat: candidate")
+            source_sha = self.git(compose, "rev-parse", "HEAD")
+            source_tree = self.git(compose, "rev-parse", "HEAD^{tree}")
+            self.run_command(
+                "git",
+                "-C",
+                str(compose),
+                "commit",
+                "--allow-empty",
+                "-m",
+                "chore: promotion merge identity",
+            )
+            promoted_sha = self.git(compose, "rev-parse", "HEAD")
+            self.assertEqual(self.git(compose, "rev-parse", "HEAD^{tree}"), source_tree)
+            digest = "b" * 64
+            shell_setup = f"export PARITY_EVIDENCE_DIR={shlex.quote(str(evidence))}"
+
+            rebound = self.run_release_function(
+                root,
+                (
+                    f"record_stable_init_image_gate_evidence {source_sha} {digest} && "
+                    f"rebind_stable_init_image_gate_evidence {source_sha} {promoted_sha}"
+                ),
+                shell_setup=shell_setup,
+            )
+
+            self.assertEqual(rebound.returncode, 0, rebound.stderr)
+            promoted_evidence = evidence / "stable-init-image-authority" / f"{promoted_sha}.sha256"
+            self.assertEqual(
+                promoted_evidence.read_text(encoding="utf-8").strip(),
+                f"{digest}  {promoted_sha}",
+            )
+
+    def test_signed_companion_tag_binds_the_guest_digest_to_the_stable_source(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, compose = self.create_compose_checkout(root)
+            self.enable_ssh_signing(root, compose)
+            self.run_command(
+                "git",
+                "-C",
+                str(compose),
+                "tag",
+                "-s",
+                "0.13.1",
+                "main",
+                "-m",
+                "owner/repo 0.13.1",
+            )
+            self.run_command("git", "-C", str(compose), "push", "origin", "0.13.1")
+            digest = "c" * 64
+            result = self.run_release_function(
+                root / "github",
+                f"ensure_stable_init_image_authority_tag 0.13.1 {digest}",
+                shell_setup="\n".join(
+                    [
+                        f"push_remote() {{ printf '%s\\n' {shlex.quote(str(remote))}; }}",
+                        "github_repo() { printf '%s\\n' owner/repo; }",
+                        "verify_github_stable_tag_signature() { :; }",
+                    ]
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            authority_tag = "stable-init-image-authority/0.13.1"
+            self.assertEqual(
+                self.git(compose, "cat-file", "-t", f"refs/tags/{authority_tag}"),
+                "tag",
+            )
+            self.assertEqual(
+                self.git(compose, "rev-list", "-n", "1", f"refs/tags/{authority_tag}"),
+                self.git(compose, "rev-list", "-n", "1", "refs/tags/0.13.1"),
+            )
+            message = self.git(
+                compose,
+                "for-each-ref",
+                "--format=%(contents)",
+                f"refs/tags/{authority_tag}",
+            )
+            self.assertIn(f"Guest init image SHA-256: {digest}.", message)
 
     def test_stable_gate_digest_comes_from_immutable_local_evidence(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -2892,6 +2993,11 @@ github_cli() {{
             "AUTHORITY_REF: ${{ needs.resolve-candidate.outputs.authority_ref }}",
             workflow,
         )
+        self.assertIn(
+            "INIT_IMAGE_AUTHORITY_OBJECT: ${{ needs.resolve-candidate.outputs.init_image_authority_object }}",
+            workflow,
+        )
+        self.assertIn("stable init-image authority tag moved after validation", workflow)
         self.assertIn("release authority %s moved after validation", workflow)
         self.assertIn("stable tag %s moved after validation", workflow)
         self.assertIn(
@@ -3065,6 +3171,16 @@ github_cli() {{
         self.assertLess(release.index("ensure_release_intent"), release.index("run_local_release_gate"))
         self.assertLess(release.index("require_release_upstream_alignment"), release.index("run_local_release_gate"))
         self.assertLess(release.index("run_local_release_gate"), release.index("push_all_main"))
+        promotion = self.script[
+            self.script.index("push_all_main() {") : self.script.index(
+                "# Require an executable command"
+            )
+        ]
+        self.assertIn("rebind_stable_init_image_gate_evidence", promotion)
+        self.assertLess(
+            promotion.index("promote_compose_main"),
+            promotion.index("rebind_stable_init_image_gate_evidence"),
+        )
         self.assertIn('HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"', self.script)
         self.assertIn('"$(repo_path "container-builder-shim")"', self.script)
         self.assertIn('containerization_path="$(repo_path "containerization")"', self.script)
@@ -5772,6 +5888,14 @@ esac
             self.assertIn("maintenance backfill asset recovery", recovered.stdout)
 
     def test_published_recovery_uses_immutable_candidate_gate_authority(self) -> None:
+        recovery = self.script[
+            self.script.index("ensure_published_stable_recovery_authority() {") :
+            self.script.index("# Refuse to retry a semantic tag")
+        ]
+        self.assertIn(
+            'test("Guest init image SHA-256: [0-9a-f]{64}[.]")',
+            recovery,
+        )
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             tag_sha = "a" * 40

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -109,6 +109,20 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertLess(
             self.script.index(use), self.script.index("run_local_release_gate_command env")
         )
+        local_gate = self.script[
+            self.script.index("run_local_release_gate() {") : self.script.index(
+                "# Verify that Apple remotes cannot be pushed"
+            )
+        ]
+        self.assertIn('candidate_sha="$(git -C "${path}" rev-parse HEAD)"', local_gate)
+        self.assertIn('init_image_digest_before="$(shasum -a 256', local_gate)
+        self.assertIn('init_image_digest_after="$(shasum -a 256', local_gate)
+        self.assertIn("local release gate guest snapshot changed", local_gate)
+        self.assertIn("record_stable_init_image_gate_evidence", local_gate)
+        self.assertLess(
+            local_gate.index("release_local_release_gate_host_state"),
+            local_gate.rindex("record_stable_init_image_gate_evidence"),
+        )
 
     def test_release_helper_retains_only_its_unpublished_candidate_before_readiness(self) -> None:
         recovery = self.script[
@@ -833,12 +847,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             digest = hashlib.sha256(local_asset.read_bytes()).hexdigest()
             local_checksum.write_text(f"{digest}  {asset}\n", encoding="utf-8")
 
-            for existing, missing in (
-                (asset, f"{asset}.sha256"),
-                (f"{asset}.sha256", asset),
+            for label, existing, missing in (
+                ("archive-only", asset, [f"{asset}.sha256"]),
+                ("sidecar-only", f"{asset}.sha256", [asset]),
+                ("both-missing", "", [asset, f"{asset}.sha256"]),
             ):
                 with self.subTest(existing=existing):
-                    fixture = root / existing.replace(".", "-")
+                    fixture = root / label
                     remote = fixture / "remote"
                     remote.mkdir(parents=True)
                     uploads = fixture / "uploads"
@@ -893,7 +908,9 @@ github_cli() {{
                     )
 
                     self.assertEqual(recovered.returncode, 0, recovered.stderr)
-                    self.assertEqual(uploads.read_text(encoding="utf-8").strip(), missing)
+                    self.assertEqual(
+                        uploads.read_text(encoding="utf-8").splitlines(), missing
+                    )
 
     def test_stable_guest_asset_pair_handles_sidecar_race_and_cleanup_edges(self) -> None:
         asset = "container-vminit-arm64.oci.tar"
@@ -1822,8 +1839,57 @@ github_cli() {{
             'summary+=" Guest init image SHA-256: ${INIT_IMAGE_SHA256}."',
             workflow,
         )
-        self.assertIn('init_image_digest="$(shasum -a 256 "${archive}"', dispatcher)
+        self.assertIn(
+            'init_image_digest="$(retained_stable_init_image_gate_digest "${version}")"',
+            dispatcher,
+        )
         self.assertIn('-f "init_image_sha256=${init_image_digest}"', dispatcher)
+
+    def test_stable_gate_digest_comes_from_immutable_local_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose"
+            compose.mkdir()
+            evidence = root / "evidence"
+            archive = root / "retained.oci.tar"
+            archive.write_bytes(b"locally gated guest snapshot\n")
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            candidate_sha = "a" * 40
+            shell_setup = "\n".join(
+                [
+                    f"export TEST_COMPOSE={shlex.quote(str(compose))}",
+                    f"export PARITY_EVIDENCE_DIR={shlex.quote(str(evidence))}",
+                    f"export CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE={shlex.quote(str(archive))}",
+                    "repo_path() { printf '%s\\n' \"${TEST_COMPOSE}\"; }",
+                    f"git() {{ printf '%s\\n' {candidate_sha}; }}",
+                ]
+            )
+
+            recorded = self.run_release_function(
+                root,
+                f"record_stable_init_image_gate_evidence {candidate_sha} {digest} && "
+                "retained_stable_init_image_gate_digest 0.13.1",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(recorded.returncode, 0, recorded.stderr)
+            self.assertEqual(recorded.stdout.strip(), digest)
+
+            conflicting = self.run_release_function(
+                root,
+                f"record_stable_init_image_gate_evidence {candidate_sha} {'b' * 64}",
+                shell_setup=shell_setup,
+            )
+            self.assertNotEqual(conflicting.returncode, 0)
+            self.assertIn("refusing to replace immutable", conflicting.stderr)
+
+            archive.write_bytes(b"replaced after the local gate\n")
+            replaced = self.run_release_function(
+                root,
+                "retained_stable_init_image_gate_digest 0.13.1",
+                shell_setup=shell_setup,
+            )
+            self.assertNotEqual(replaced.returncode, 0)
+            self.assertIn("no longer matches the locally gated snapshot", replaced.stderr)
 
     def test_release_archives_require_developer_id_signatures(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -115,6 +115,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
         ]
         self.assertIn('candidate_sha="$(git -C "${path}" rev-parse HEAD)"', local_gate)
+        self.assertIn('run python3 "${HOMEBREW_PREFLIGHT_TOOL}"', local_gate)
+        self.assertNotIn('${path}/Tools/release/homebrew-preflight.py', local_gate)
         self.assertIn('init_image_digest_before="$(shasum -a 256', local_gate)
         self.assertIn('init_image_digest_after="$(shasum -a 256', local_gate)
         self.assertIn("local release gate guest snapshot changed", local_gate)
@@ -1062,7 +1064,7 @@ github_cli() {{
             )
         ]
         self.assertLess(
-            local_gate.index("homebrew-preflight.py"),
+            local_gate.index('run python3 "${HOMEBREW_PREFLIGHT_TOOL}"'),
             local_gate.index("require_local_virtualization"),
         )
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -5900,6 +5900,7 @@ esac
             root = Path(directory)
             tag_sha = "a" * 40
             init_digest = "b" * 64
+            authority_object = "c" * 40
             shell_setup = "\n".join(
                 [
                     "repo_path() { printf '%s\\n' /tmp/container-compose-test; }",
@@ -5913,7 +5914,24 @@ esac
                     "  fi",
                     "}",
                     "github_cli() {",
-                    "  if [[ \"$1\" == api ]]; then",
+                    (
+                        '  if [[ "$1:$2" == '
+                        "api:repos/owner/repo/git/ref/tags/"
+                        "stable-init-image-authority/0.13.1 ]]; then"
+                    ),
+                    f"    printf '%s\\n' {authority_object}",
+                    (
+                        f'  elif [[ "$1:$2" == api:repos/owner/repo/git/tags/'
+                        f'{authority_object} ]]; then'
+                    ),
+                    (
+                        "    printf '{\"verification\":{\"verified\":true},"
+                        "\"object\":{\"sha\":\"%s\"},\"message\":"
+                        "\"Guest init image SHA-256: %s.\"}\\n' "
+                        f'"${{TEST_SIGNED_SOURCE:-{tag_sha}}}" '
+                        f'"${{TEST_SIGNED_DIGEST:-{init_digest}}}"'
+                    ),
+                    "  elif [[ \"$1\" == api ]]; then",
                     "    printf '%s\\t%s\\n' \"${TEST_AUTHORITY_RUN_ID:-29288195238}\" \"${TEST_AUTHORITY_SUMMARY:-Guest init image SHA-256: " + init_digest + ".}\"",
                     "  elif [[ \"$1:$2\" == run:view ]]; then",
                     "    printf '%s\\n' \"${TEST_GATE_CONCLUSION:-success}\"",
@@ -5955,6 +5973,22 @@ esac
             )
             self.assertNotEqual(failed_gate.returncode, 0)
             self.assertIn("successful Stable Release Gate authority", failed_gate.stderr)
+
+            replaced_authority = self.run_release_function(
+                root,
+                "ensure_published_stable_recovery_authority 0.13.1",
+                shell_setup=f"export TEST_SIGNED_DIGEST={'d' * 64}\n{shell_setup}",
+            )
+            self.assertNotEqual(replaced_authority.returncode, 0)
+            self.assertIn("instead of signed init-image digest", replaced_authority.stderr)
+
+            wrong_source = self.run_release_function(
+                root,
+                "ensure_published_stable_recovery_authority 0.13.1",
+                shell_setup=f"export TEST_SIGNED_SOURCE={'e' * 40}\n{shell_setup}",
+            )
+            self.assertNotEqual(wrong_source.returncode, 0)
+            self.assertIn("instead of source", wrong_source.stderr)
 
     def test_published_retry_rejects_a_non_latest_release(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -17,6 +17,7 @@
 
 """Regression tests for stable release policy in the stack helper."""
 
+import hashlib
 import json
 import os
 import re
@@ -677,8 +678,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn(
             "needs.resolve-publish-context.outputs.ref_type == 'branch'", retention
         )
-        self.assertIn('tap_sha_after="$(homebrew_tap_main_sha)"', verifier)
-        self.assertIn("maintenance backfill moved Homebrew tap main", verifier)
+        self.assertIn(
+            'stable_formula_identities_after="$(homebrew_stable_formula_identities)"',
+            verifier,
+        )
+        self.assertIn("maintenance backfill moved stable Homebrew formulae", verifier)
         self.assertLess(
             verifier.index('if [[ "${promote_default_lane}" != "true" ]]'),
             verifier.index('formula_text="$('),
@@ -687,13 +691,21 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             'promote_default_lane="$(stable_version_promotes_default_lane "${version}")"',
             dispatcher,
         )
-        self.assertIn('tap_sha_before="$(homebrew_tap_main_sha)"', dispatcher)
         self.assertIn(
-            '"${version}" "${promote_default_lane}" "${tap_sha_before}"',
+            'stable_formula_identities_before="$(homebrew_stable_formula_identities)"',
+            dispatcher,
+        )
+        self.assertIn(
+            '"${version}" "${promote_default_lane}" "${stable_formula_identities_before}"',
             dispatcher,
         )
 
     def test_stable_release_publishes_and_verifies_guest_closure(self) -> None:
+        asset_pair = self.script[
+            self.script.index("publish_stable_asset_pair() {") : self.script.index(
+                "# Publish the exact guest archive"
+            )
+        ]
         publisher = self.script[
             self.script.index("publish_stable_init_image_asset() {") : self.script.index(
                 "# Verify the stable release assets and Homebrew formula agree."
@@ -714,13 +726,112 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE", publisher)
         self.assertIn("stable_containerization_authority", publisher)
         self.assertIn("OCI_IMAGE_LAYOUT_VALIDATOR", publisher)
-        self.assertIn('github_cli release upload "${version}"', publisher)
+        self.assertIn('github_cli release upload "${version}"', asset_pair)
+        self.assertIn("publish_stable_asset_pair", publisher)
         self.assertLess(
             dispatcher.index('publish_stable_init_image_asset "${version}"'),
             dispatcher.index("verify_compose_stable_package"),
         )
         self.assertIn('init_asset="container-vminit-arm64.oci.tar"', verifier)
         self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${init_asset}"', verifier)
+
+    def test_stable_guest_asset_pair_recovers_each_missing_member(self) -> None:
+        asset = "container-vminit-arm64.oci.tar"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            local = root / "local"
+            local.mkdir()
+            local_asset = local / asset
+            local_checksum = local / f"{asset}.sha256"
+            local_asset.write_bytes(b"immutable release-gate guest archive\n")
+            digest = hashlib.sha256(local_asset.read_bytes()).hexdigest()
+            local_checksum.write_text(f"{digest}  {asset}\n", encoding="utf-8")
+
+            for existing, missing in (
+                (asset, f"{asset}.sha256"),
+                (f"{asset}.sha256", asset),
+            ):
+                with self.subTest(existing=existing):
+                    fixture = root / existing.replace(".", "-")
+                    remote = fixture / "remote"
+                    remote.mkdir(parents=True)
+                    uploads = fixture / "uploads"
+                    if existing == asset:
+                        (remote / asset).write_bytes(local_asset.read_bytes())
+                    else:
+                        (remote / f"{asset}.sha256").write_text(
+                            f"{digest}  {asset}\n", encoding="utf-8"
+                        )
+
+                    shell_setup = f"""\
+export TEST_ASSET_NAMES={shlex.quote(existing)}
+export TEST_REMOTE={shlex.quote(str(remote))}
+export TEST_UPLOADS={shlex.quote(str(uploads))}
+github_cli() {{
+  case "$1:$2" in
+    release:view)
+      printf '%s\\n' "${{TEST_ASSET_NAMES}}"
+      ;;
+    release:download)
+      shift 3
+      local pattern='' destination=''
+      while (( $# > 0 )); do
+        case "$1" in
+          --pattern) pattern="$2"; shift 2 ;;
+          --dir) destination="$2"; shift 2 ;;
+          *) shift ;;
+        esac
+      done
+      cp "${{TEST_REMOTE}}/${{pattern}}" "${{destination}}/${{pattern}}"
+      ;;
+    release:upload)
+      shift 3
+      while (( $# > 0 )); do
+        if [[ "$1" == --repo ]]; then shift 2; continue; fi
+        basename "$1" >>"${{TEST_UPLOADS}}"
+        shift
+      done
+      ;;
+    *) return 2 ;;
+  esac
+}}
+"""
+                    recovered = self.run_release_function(
+                        root,
+                        "publish_stable_asset_pair "
+                        "0.13.1 owner/container-compose "
+                        f"{shlex.quote(str(local_asset))} "
+                        f"{shlex.quote(str(local_checksum))} "
+                        f"{asset} {digest}",
+                        shell_setup=shell_setup,
+                    )
+
+                    self.assertEqual(recovered.returncode, 0, recovered.stderr)
+                    self.assertEqual(uploads.read_text(encoding="utf-8").strip(), missing)
+
+    def test_homebrew_backfill_identity_uses_only_stable_formula_blobs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            identity = self.run_release_function(
+                root,
+                "homebrew_stable_formula_identities",
+                shell_setup="""github_cli() {
+  case "$*" in
+    *Formula/container-compose.rb*) printf '%s\\n' compose-blob ;;
+    *Formula/container.rb*) printf '%s\\n' container-blob ;;
+    *) return 2 ;;
+  esac
+}""",
+            )
+
+            self.assertEqual(identity.returncode, 0, identity.stderr)
+            self.assertEqual(
+                identity.stdout.splitlines(),
+                [
+                    "container-compose.rb=compose-blob",
+                    "container.rb=container-blob",
+                ],
+            )
 
     def test_homebrew_tap_pushes_authenticate_with_the_tap_token(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
@@ -5356,7 +5467,9 @@ esac
             self.assertEqual(unpublished.returncode, 0, unpublished.stderr)
             self.assertIn("publish 0.6.70", unpublished.stdout)
 
-    def test_resume_recovers_published_maintenance_assets_without_moving_tap(self) -> None:
+    def test_resume_recovers_published_maintenance_assets_without_moving_stable_formulae(
+        self,
+    ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             recovered = self.run_release_function(
@@ -5368,8 +5481,9 @@ esac
                         "stable_release_is_published() { return 0; }",
                         "stable_version_promotes_default_lane() { printf '%s\\n' false; }",
                         "ensure_latest_stable_retry() { exit 70; }",
-                        "ensure_stable_retry_source_authority() { printf 'authority %s\\n' \"$1\"; }",
-                        "homebrew_tap_main_sha() { printf '%s\\n' tap-before; }",
+                        "ensure_stable_retry_source_authority() { exit 72; }",
+                        "ensure_published_stable_recovery_authority() { printf 'immutable-authority %s\\n' \"$1\"; }",
+                        "homebrew_stable_formula_identities() { printf '%s\\n' formulae-before; }",
                         "dispatch_compose_stable_tap_repair() { exit 71; }",
                         "publish_stable_init_image_asset() { printf 'init %s\\n' \"$1\"; }",
                         "verify_compose_stable_package() { printf 'verify %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }",
@@ -5379,10 +5493,61 @@ esac
             )
 
             self.assertEqual(recovered.returncode, 0, recovered.stderr)
-            self.assertIn("authority 0.13.1", recovered.stdout)
+            self.assertIn("immutable-authority 0.13.1", recovered.stdout)
             self.assertIn("init 0.13.1", recovered.stdout)
-            self.assertIn("verify 0.13.1 false tap-before", recovered.stdout)
+            self.assertIn("verify 0.13.1 false formulae-before", recovered.stdout)
             self.assertIn("maintenance backfill asset recovery", recovered.stdout)
+
+    def test_published_recovery_uses_immutable_candidate_gate_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            tag_sha = "a" * 40
+            shell_setup = "\n".join(
+                [
+                    "repo_path() { printf '%s\\n' /tmp/container-compose-test; }",
+                    "github_repo() { printf '%s\\n' owner/repo; }",
+                    "git() {",
+                    "  if [[ \"$*\" == *'rev-list -n 1 refs/tags/0.13.1'* ]]; then",
+                    "    printf '%s\\n' \"${TEST_TAG_SHA:-" + tag_sha + "}\"",
+                    "  else",
+                    "    printf 'unexpected movable-source query: %s\\n' \"$*\" >&2",
+                    "    return 3",
+                    "  fi",
+                    "}",
+                    "github_cli() {",
+                    "  if [[ \"$1\" == api ]]; then",
+                    "    printf '%s\\n' \"${TEST_AUTHORITY_RUN_ID:-29288195238}\"",
+                    "  elif [[ \"$1:$2\" == run:view ]]; then",
+                    "    printf '%s\\n' \"${TEST_GATE_CONCLUSION:-success}\"",
+                    "  else",
+                    "    return 2",
+                    "  fi",
+                    "}",
+                ]
+            )
+
+            accepted = self.run_release_function(
+                root,
+                "ensure_published_stable_recovery_authority 0.13.1",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            missing_gate = self.run_release_function(
+                root,
+                "ensure_published_stable_recovery_authority 0.13.1",
+                shell_setup=f"export TEST_AUTHORITY_RUN_ID=missing\n{shell_setup}",
+            )
+            self.assertNotEqual(missing_gate.returncode, 0)
+            self.assertIn("candidate-bound Stable Release Authority", missing_gate.stderr)
+
+            failed_gate = self.run_release_function(
+                root,
+                "ensure_published_stable_recovery_authority 0.13.1",
+                shell_setup=f"export TEST_GATE_CONCLUSION=failure\n{shell_setup}",
+            )
+            self.assertNotEqual(failed_gate.returncode, 0)
+            self.assertIn("successful Stable Release Gate authority", failed_gate.stderr)
 
     def test_published_retry_rejects_a_non_latest_release(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -762,6 +762,13 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('expected_init_digest="$4"', verifier)
         self.assertIn('"${init_asset_sha}" != "${expected_init_digest}"', verifier)
         self.assertIn("guest archive is not authorized by the signed release gate", verifier)
+        unauthorized = verifier[
+            verifier.index('if [[ ! "${expected_init_digest}"') : verifier.index(
+                "  while IFS= read -r value"
+            )
+        ]
+        self.assertIn('find "${tmp}" -depth -delete', unauthorized)
+        self.assertLess(unauthorized.index('find "${tmp}"'), unauthorized.index("exit 1"))
         self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${init_asset}"', verifier)
 
     def test_stable_guest_publisher_binds_the_validated_snapshot_to_gate_evidence(

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -5872,11 +5872,15 @@ esac
                         "stable_version_promotes_default_lane() { printf '%s\\n' false; }",
                         "ensure_latest_stable_retry() { exit 70; }",
                         "ensure_stable_retry_source_authority() { exit 72; }",
-                        f"ensure_published_stable_recovery_authority() {{ printf '%s\\n' {'a' * 64}; }}",
+                        (
+                            "ensure_published_stable_recovery_authority() { "
+                            f"printf '%s\\t%s\\n' {'f' * 40} {'a' * 64}; }}"
+                        ),
                         "homebrew_stable_formula_identities() { printf '%s\\n' formulae-before; }",
                         "dispatch_compose_stable_tap_repair() { exit 71; }",
                         "publish_stable_init_image_asset() { printf 'init %s %s\\n' \"$1\" \"$2\"; }",
                         "verify_compose_stable_package() { printf 'verify %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }",
+                        "require_stable_init_image_authority_unchanged() { printf 'authority %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }",
                         "print_stable_release_point() { printf 'point %s %s\\n' \"$1\" \"$2\"; }",
                     ]
                 ),
@@ -5885,7 +5889,11 @@ esac
             self.assertEqual(recovered.returncode, 0, recovered.stderr)
             self.assertIn(f"init 0.13.1 {'a' * 64}", recovered.stdout)
             self.assertIn("verify 0.13.1 false formulae-before", recovered.stdout)
+            self.assertIn(f"authority 0.13.1 {'f' * 40} {'a' * 64}", recovered.stdout)
             self.assertIn("maintenance backfill asset recovery", recovered.stdout)
+            self.assertLess(recovered.stdout.index("init 0.13.1"), recovered.stdout.index("verify 0.13.1"))
+            self.assertLess(recovered.stdout.index("verify 0.13.1"), recovered.stdout.index("authority 0.13.1"))
+            self.assertLess(recovered.stdout.index("authority 0.13.1"), recovered.stdout.index("point 0.13.1"))
 
     def test_published_recovery_uses_immutable_candidate_gate_authority(self) -> None:
         recovery = self.script[
@@ -5919,10 +5927,10 @@ esac
                         "api:repos/owner/repo/git/ref/tags/"
                         "stable-init-image-authority/0.13.1 ]]; then"
                     ),
-                    f"    printf '%s\\n' {authority_object}",
+                    f"    printf '%s\\n' \"${{TEST_AUTHORITY_OBJECT:-{authority_object}}}\"",
                     (
                         f'  elif [[ "$1:$2" == api:repos/owner/repo/git/tags/'
-                        f'{authority_object} ]]; then'
+                        '* ]]; then'
                     ),
                     (
                         "    printf '{\"verification\":{\"verified\":true},"
@@ -5948,7 +5956,10 @@ esac
                 shell_setup=shell_setup,
             )
             self.assertEqual(accepted.returncode, 0, accepted.stderr)
-            self.assertEqual(accepted.stdout.strip(), init_digest)
+            self.assertEqual(
+                accepted.stdout.strip(),
+                f"{authority_object}\t{init_digest}",
+            )
 
             missing_gate = self.run_release_function(
                 root,
@@ -5989,6 +6000,29 @@ esac
             )
             self.assertNotEqual(wrong_source.returncode, 0)
             self.assertIn("instead of source", wrong_source.stderr)
+
+            unchanged = self.run_release_function(
+                root,
+                (
+                    "require_stable_init_image_authority_unchanged "
+                    f"0.13.1 {authority_object} {init_digest}"
+                ),
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(unchanged.returncode, 0, unchanged.stderr)
+
+            moved = self.run_release_function(
+                root,
+                (
+                    "require_stable_init_image_authority_unchanged "
+                    f"0.13.1 {authority_object} {init_digest}"
+                ),
+                shell_setup=(
+                    f"export TEST_AUTHORITY_OBJECT={'f' * 40}\n{shell_setup}"
+                ),
+            )
+            self.assertNotEqual(moved.returncode, 0)
+            self.assertIn("moved during recovery", moved.stderr)
 
     def test_published_retry_rejects_a_non_latest_release(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -716,7 +716,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             dispatcher,
         )
         self.assertIn(
-            '"${version}" "${promote_default_lane}" "${stable_formula_identities_before}"',
+            '"${stable_formula_identities_before}" "${authority_init_digest}"',
             dispatcher,
         )
 
@@ -759,6 +759,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             dispatcher.index("verify_compose_stable_package"),
         )
         self.assertIn('init_asset="container-vminit-arm64.oci.tar"', verifier)
+        self.assertIn('expected_init_digest="$4"', verifier)
+        self.assertIn('"${init_asset_sha}" != "${expected_init_digest}"', verifier)
+        self.assertIn("guest archive is not authorized by the signed release gate", verifier)
         self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${init_asset}"', verifier)
 
     def test_stable_guest_publisher_binds_the_validated_snapshot_to_gate_evidence(
@@ -5879,7 +5882,7 @@ esac
                         "homebrew_stable_formula_identities() { printf '%s\\n' formulae-before; }",
                         "dispatch_compose_stable_tap_repair() { exit 71; }",
                         "publish_stable_init_image_asset() { printf 'init %s %s\\n' \"$1\" \"$2\"; }",
-                        "verify_compose_stable_package() { printf 'verify %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }",
+                        "verify_compose_stable_package() { printf 'verify %s %s %s %s\\n' \"$1\" \"$2\" \"$3\" \"$4\"; }",
                         "require_stable_init_image_authority_unchanged() { printf 'authority %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }",
                         "print_stable_release_point() { printf 'point %s %s\\n' \"$1\" \"$2\"; }",
                     ]
@@ -5888,7 +5891,10 @@ esac
 
             self.assertEqual(recovered.returncode, 0, recovered.stderr)
             self.assertIn(f"init 0.13.1 {'a' * 64}", recovered.stdout)
-            self.assertIn("verify 0.13.1 false formulae-before", recovered.stdout)
+            self.assertIn(
+                f"verify 0.13.1 false formulae-before {'a' * 64}",
+                recovered.stdout,
+            )
             self.assertIn(f"authority 0.13.1 {'f' * 40} {'a' * 64}", recovered.stdout)
             self.assertIn("maintenance backfill asset recovery", recovered.stdout)
             self.assertLess(recovered.stdout.index("init 0.13.1"), recovered.stdout.index("verify 0.13.1"))

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -18,18 +18,22 @@
 """Regression tests for stable release policy in the stack helper."""
 
 import hashlib
+import io
 import json
 import os
 import re
 import signal
 import shlex
 import subprocess
+import tarfile
 import tempfile
 import textwrap
 import time
 import unittest
 from pathlib import Path
 from unittest import mock
+
+from Tools.ci.test_run_with_container_runtime import RunWithContainerRuntimeTest
 
 
 SCRIPT = Path(__file__).parents[2] / "scripts" / "CONTAINER_STACK_RELEASE.sh"
@@ -724,8 +728,14 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
         self.assertIn('asset="container-vminit-arm64.oci.tar"', publisher)
         self.assertIn("CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE", publisher)
+        self.assertIn('expected_digest="$2"', publisher)
         self.assertIn("stable_containerization_authority", publisher)
         self.assertIn("OCI_IMAGE_LAYOUT_VALIDATOR", publisher)
+        self.assertLess(
+            publisher.index('cp "${archive}" "${tmp}/${asset}"'),
+            publisher.index('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${asset}"'),
+        )
+        self.assertIn('"${digest}" != "${expected_digest}"', publisher)
         self.assertIn('github_cli release upload "${version}"', asset_pair)
         self.assertIn("publish_stable_asset_pair", publisher)
         self.assertLess(
@@ -734,6 +744,82 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )
         self.assertIn('init_asset="container-vminit-arm64.oci.tar"', verifier)
         self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${init_asset}"', verifier)
+
+    def test_stable_guest_publisher_binds_the_validated_snapshot_to_gate_evidence(
+        self,
+    ) -> None:
+        asset = "container-vminit-arm64.oci.tar"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive = root / "retained.oci.tar"
+            self.create_release_guest_archive(archive)
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            upload_marker = root / "upload"
+            validator_capture = root / "validated"
+            shell_setup = "\n".join(
+                [
+                    f"export CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE={shlex.quote(str(archive))}",
+                    f"export TEST_SOURCE_ARCHIVE={shlex.quote(str(archive))}",
+                    f"export TEST_VALIDATOR_CAPTURE={shlex.quote(str(validator_capture))}",
+                    f"export TEST_UPLOAD_MARKER={shlex.quote(str(upload_marker))}",
+                    "stable_containerization_authority() { printf '%s\\n' owner/containerization ref; }",
+                    "github_repo() { printf '%s\\n' owner/container-compose; }",
+                    "cp() {",
+                    "  command cp \"$@\"",
+                    "  if [[ \"$1\" == \"${TEST_SOURCE_ARCHIVE}\" ]]; then",
+                    "    command cp \"$2\" \"${TEST_VALIDATOR_CAPTURE}\"",
+                    "    printf '%s\\n' changed-after-snapshot >\"${TEST_SOURCE_ARCHIVE}\"",
+                    "  fi",
+                    "}",
+                    "publish_stable_asset_pair() { touch \"${TEST_UPLOAD_MARKER}\"; }",
+                ]
+            )
+
+            published = self.run_release_function(
+                root,
+                f"publish_stable_init_image_asset 0.13.1 {digest}",
+                shell_setup=shell_setup,
+            )
+
+            self.assertEqual(published.returncode, 0, published.stderr)
+            self.assertEqual(hashlib.sha256(validator_capture.read_bytes()).hexdigest(), digest)
+            self.assertTrue(upload_marker.exists())
+
+            self.create_release_guest_archive(archive, config_variant="v8")
+            upload_marker.unlink()
+            rejected = self.run_release_function(
+                root,
+                f"publish_stable_init_image_asset 0.13.1 {digest}",
+                shell_setup=shell_setup,
+            )
+
+            self.assertEqual(rejected.returncode, 2, rejected.stderr)
+            self.assertIn("candidate-bound release-gate digest", rejected.stderr)
+            self.assertFalse(upload_marker.exists())
+
+    def test_stable_guest_publisher_propagates_outer_cleanup_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive = root / "retained.oci.tar"
+            self.create_release_guest_archive(archive)
+            digest = hashlib.sha256(archive.read_bytes()).hexdigest()
+            shell_setup = "\n".join(
+                [
+                    f"export CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE={shlex.quote(str(archive))}",
+                    "stable_containerization_authority() { printf '%s\\n' owner/containerization ref; }",
+                    "github_repo() { printf '%s\\n' owner/container-compose; }",
+                    "publish_stable_asset_pair() { :; }",
+                    "find() { return 17; }",
+                ]
+            )
+
+            result = self.run_release_function(
+                root,
+                f"publish_stable_init_image_asset 0.13.1 {digest}",
+                shell_setup=shell_setup,
+            )
+
+            self.assertEqual(result.returncode, 17, result.stderr)
 
     def test_stable_guest_asset_pair_recovers_each_missing_member(self) -> None:
         asset = "container-vminit-arm64.oci.tar"
@@ -1717,6 +1803,27 @@ github_cli() {{
         self.assertIn("workflow_dispatch", tag_authority)
         self.assertNotIn('workflow="stable-release-gate.yml"', tag_authority)
         self.assertNotIn('--commit "${PUBLISH_SHA}"', tag_authority)
+
+    def test_stable_gate_records_the_candidate_bound_guest_digest(self) -> None:
+        workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        dispatcher = self.script[
+            self.script.index("dispatch_stable_release_gate() {") : self.script.index(
+                "# Print the verified boundary for a stable release"
+            )
+        ]
+
+        self.assertIn("init_image_sha256:", workflow)
+        self.assertIn("required: true", workflow)
+        self.assertIn('INIT_IMAGE_SHA256: ${{ inputs.init_image_sha256 }}', workflow)
+        self.assertIn(
+            '[[ ! "${INIT_IMAGE_SHA256}" =~ ^[0-9a-f]{64}$ ]]', workflow
+        )
+        self.assertIn(
+            'summary+=" Guest init image SHA-256: ${INIT_IMAGE_SHA256}."',
+            workflow,
+        )
+        self.assertIn('init_image_digest="$(shasum -a 256 "${archive}"', dispatcher)
+        self.assertIn('-f "init_image_sha256=${init_image_digest}"', dispatcher)
 
     def test_release_archives_require_developer_id_signatures(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
@@ -5581,10 +5688,10 @@ esac
                         "stable_version_promotes_default_lane() { printf '%s\\n' false; }",
                         "ensure_latest_stable_retry() { exit 70; }",
                         "ensure_stable_retry_source_authority() { exit 72; }",
-                        "ensure_published_stable_recovery_authority() { printf 'immutable-authority %s\\n' \"$1\"; }",
+                        f"ensure_published_stable_recovery_authority() {{ printf '%s\\n' {'a' * 64}; }}",
                         "homebrew_stable_formula_identities() { printf '%s\\n' formulae-before; }",
                         "dispatch_compose_stable_tap_repair() { exit 71; }",
-                        "publish_stable_init_image_asset() { printf 'init %s\\n' \"$1\"; }",
+                        "publish_stable_init_image_asset() { printf 'init %s %s\\n' \"$1\" \"$2\"; }",
                         "verify_compose_stable_package() { printf 'verify %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }",
                         "print_stable_release_point() { printf 'point %s %s\\n' \"$1\" \"$2\"; }",
                     ]
@@ -5592,8 +5699,7 @@ esac
             )
 
             self.assertEqual(recovered.returncode, 0, recovered.stderr)
-            self.assertIn("immutable-authority 0.13.1", recovered.stdout)
-            self.assertIn("init 0.13.1", recovered.stdout)
+            self.assertIn(f"init 0.13.1 {'a' * 64}", recovered.stdout)
             self.assertIn("verify 0.13.1 false formulae-before", recovered.stdout)
             self.assertIn("maintenance backfill asset recovery", recovered.stdout)
 
@@ -5601,6 +5707,7 @@ esac
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             tag_sha = "a" * 40
+            init_digest = "b" * 64
             shell_setup = "\n".join(
                 [
                     "repo_path() { printf '%s\\n' /tmp/container-compose-test; }",
@@ -5615,7 +5722,7 @@ esac
                     "}",
                     "github_cli() {",
                     "  if [[ \"$1\" == api ]]; then",
-                    "    printf '%s\\n' \"${TEST_AUTHORITY_RUN_ID:-29288195238}\"",
+                    "    printf '%s\\t%s\\n' \"${TEST_AUTHORITY_RUN_ID:-29288195238}\" \"${TEST_AUTHORITY_SUMMARY:-Guest init image SHA-256: " + init_digest + ".}\"",
                     "  elif [[ \"$1:$2\" == run:view ]]; then",
                     "    printf '%s\\n' \"${TEST_GATE_CONCLUSION:-success}\"",
                     "  else",
@@ -5631,6 +5738,7 @@ esac
                 shell_setup=shell_setup,
             )
             self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            self.assertEqual(accepted.stdout.strip(), init_digest)
 
             missing_gate = self.run_release_function(
                 root,
@@ -5639,6 +5747,14 @@ esac
             )
             self.assertNotEqual(missing_gate.returncode, 0)
             self.assertIn("candidate-bound Stable Release Authority", missing_gate.stderr)
+
+            missing_digest = self.run_release_function(
+                root,
+                "ensure_published_stable_recovery_authority 0.13.1",
+                shell_setup=f"export TEST_AUTHORITY_SUMMARY=missing\n{shell_setup}",
+            )
+            self.assertNotEqual(missing_digest.returncode, 0)
+            self.assertIn("candidate-bound guest init-image digest", missing_digest.stderr)
 
             failed_gate = self.run_release_function(
                 root,
@@ -6057,6 +6173,39 @@ gh() {
             check=False,
             env=environment,
         )
+
+    @staticmethod
+    def create_release_guest_archive(
+        path: Path, config_variant: str | None = None
+    ) -> None:
+        RunWithContainerRuntimeTest.create_oci_archive(
+            path,
+            "vminit:container-compose",
+            config_variant=config_variant,
+        )
+        with tarfile.open(path, "r") as archive:
+            payloads: dict[str, bytes] = {}
+            for member in archive.getmembers():
+                if not member.isfile():
+                    continue
+                stream = archive.extractfile(member)
+                if stream is None:
+                    raise AssertionError(f"fixture member is unreadable: {member.name}")
+                payloads[member.name] = stream.read()
+        index = json.loads(payloads["index.json"])
+        qualified = json.loads(json.dumps(index["manifests"][0]))
+        qualified["annotations"] = {
+            "org.opencontainers.image.ref.name": (
+                "ghcr.io/owner/containerization/vminit:ref"
+            )
+        }
+        index["manifests"].append(qualified)
+        payloads["index.json"] = json.dumps(index).encode("utf-8")
+        with tarfile.open(path, "w") as archive:
+            for name, payload in payloads.items():
+                member = tarfile.TarInfo(name)
+                member.size = len(payload)
+                archive.addfile(member, io.BytesIO(payload))
 
     def run_release_function(
         self,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -809,6 +809,104 @@ github_cli() {{
                     self.assertEqual(recovered.returncode, 0, recovered.stderr)
                     self.assertEqual(uploads.read_text(encoding="utf-8").strip(), missing)
 
+    def test_stable_guest_asset_pair_handles_sidecar_race_and_cleanup_edges(self) -> None:
+        asset = "container-vminit-arm64.oci.tar"
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            local_asset = root / asset
+            local_checksum = root / f"{asset}.sha256"
+            local_asset.write_bytes(b"immutable release-gate guest archive\n")
+            digest = hashlib.sha256(local_asset.read_bytes()).hexdigest()
+            local_checksum.write_text(f"{digest}  {asset}\n", encoding="utf-8")
+
+            for mode, expected_status in (
+                ("strict-sidecar", "failure"),
+                ("upload-race", "success"),
+                ("cleanup-failure", "cleanup-failure"),
+            ):
+                with self.subTest(mode=mode):
+                    fixture = root / mode
+                    remote = fixture / "remote"
+                    remote.mkdir(parents=True)
+                    names = fixture / "asset-names"
+                    upload_marker = fixture / "upload-called"
+                    cleanup_root = fixture / "cleanup"
+                    if mode == "strict-sidecar":
+                        names.write_text(f"{asset}.sha256\n", encoding="utf-8")
+                        (remote / f"{asset}.sha256").write_text(
+                            f"{digest}  wrong-name.tar\n", encoding="utf-8"
+                        )
+                    elif mode == "upload-race":
+                        names.write_text(f"{asset}\n", encoding="utf-8")
+                        (remote / asset).write_bytes(local_asset.read_bytes())
+                    else:
+                        names.write_text(f"{asset}\n{asset}.sha256\n", encoding="utf-8")
+                        (remote / asset).write_bytes(local_asset.read_bytes())
+                        (remote / f"{asset}.sha256").write_bytes(
+                            local_checksum.read_bytes()
+                        )
+
+                    shell_setup = f"""\
+export TEST_MODE={shlex.quote(mode)}
+export TEST_ASSET_NAMES_FILE={shlex.quote(str(names))}
+export TEST_REMOTE={shlex.quote(str(remote))}
+export TEST_LOCAL_CHECKSUM={shlex.quote(str(local_checksum))}
+export TEST_UPLOAD_MARKER={shlex.quote(str(upload_marker))}
+export TEST_CLEANUP_ROOT={shlex.quote(str(cleanup_root))}
+mktemp() {{
+  mkdir "${{TEST_CLEANUP_ROOT}}"
+  printf '%s\\n' "${{TEST_CLEANUP_ROOT}}"
+}}
+if [[ "${{TEST_MODE}}" == cleanup-failure ]]; then
+  find() {{ return 17; }}
+fi
+github_cli() {{
+  case "$1:$2" in
+    release:view)
+      command cat "${{TEST_ASSET_NAMES_FILE}}"
+      ;;
+    release:download)
+      shift 3
+      local pattern='' destination=''
+      while (( $# > 0 )); do
+        case "$1" in
+          --pattern) pattern="$2"; shift 2 ;;
+          --dir) destination="$2"; shift 2 ;;
+          *) shift ;;
+        esac
+      done
+      cp "${{TEST_REMOTE}}/${{pattern}}" "${{destination}}/${{pattern}}"
+      ;;
+    release:upload)
+      if [[ "${{TEST_MODE}}" == upload-race ]]; then
+        cp "${{TEST_LOCAL_CHECKSUM}}" "${{TEST_REMOTE}}/{asset}.sha256"
+        printf '%s\\n' {asset} {asset}.sha256 >"${{TEST_ASSET_NAMES_FILE}}"
+        return 1
+      fi
+      touch "${{TEST_UPLOAD_MARKER}}"
+      ;;
+    *) return 2 ;;
+  esac
+}}
+"""
+                    recovered = self.run_release_function(
+                        root,
+                        "publish_stable_asset_pair "
+                        "0.13.1 owner/container-compose "
+                        f"{shlex.quote(str(local_asset))} "
+                        f"{shlex.quote(str(local_checksum))} "
+                        f"{asset} {digest}",
+                        shell_setup=shell_setup,
+                    )
+
+                    if expected_status == "success":
+                        self.assertEqual(recovered.returncode, 0, recovered.stderr)
+                    elif expected_status == "cleanup-failure":
+                        self.assertEqual(recovered.returncode, 17, recovered.stderr)
+                    else:
+                        self.assertNotEqual(recovered.returncode, 0)
+                        self.assertFalse(upload_marker.exists())
+
     def test_homebrew_backfill_identity_uses_only_stable_formula_blobs(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -817,8 +915,9 @@ github_cli() {{
                 "homebrew_stable_formula_identities",
                 shell_setup="""github_cli() {
   case "$*" in
-    *Formula/container-compose.rb*) printf '%s\\n' compose-blob ;;
-    *Formula/container.rb*) printf '%s\\n' container-blob ;;
+    *homebrew-tap/commits/main*) printf '%s\\n' tap-head ;;
+    *Formula/container-compose.rb?ref=tap-head*) printf '%s\\n' compose-blob ;;
+    *Formula/container.rb?ref=tap-head*) printf '%s\\n' container-blob ;;
     *) return 2 ;;
   esac
 }""",

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -2385,7 +2385,8 @@ ensure_stable_retry_source_authority() {
 # movable release branch must not make later recovery of immutable assets
 # time-dependent.
 ensure_published_stable_recovery_authority() {
-  local version="$1" path repo tag_sha authority_name authority_filter authority_run_id authority_conclusion
+  local version="$1" path repo tag_sha authority_name authority_filter authority_record
+  local authority_run_id authority_summary authority_conclusion authority_init_digest
   path="$(repo_path "${COMPOSE_REPO}")"
   repo="$(github_repo "${COMPOSE_REPO}")"
   tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
@@ -2399,16 +2400,23 @@ ensure_published_stable_recovery_authority() {
   authority_filter+=' and .status == "completed"'
   authority_filter+=' and .conclusion == "success"'
   authority_filter+=' and .app.slug == "github-actions")'
-  authority_filter+=' | .external_id'
-  authority_run_id="$(
+  authority_filter+=' | [.external_id, .output.summary] | @tsv'
+  authority_record="$(
     github_cli api --paginate \
       "repos/${repo}/commits/${tag_sha}/check-runs?per_page=100" \
       --jq "${authority_filter}" |
       tail -n 1
   )"
+  IFS=$'\t' read -r authority_run_id authority_summary <<<"${authority_record}"
   if [[ ! "${authority_run_id}" =~ ^[0-9]+$ ]]; then
     printf 'refusing published recovery without candidate-bound Stable Release Authority %s\n' \
       "${authority_name}" >&2
+    return 1
+  fi
+  if [[ "${authority_summary}" =~ Guest\ init\ image\ SHA-256:\ ([0-9a-f]{64})[.] ]]; then
+    authority_init_digest="${BASH_REMATCH[1]}"
+  else
+    printf 'refusing published recovery without a candidate-bound guest init-image digest\n' >&2
     return 1
   fi
   authority_conclusion="$(
@@ -2420,6 +2428,7 @@ ensure_published_stable_recovery_authority() {
     printf 'refusing published recovery without a successful Stable Release Gate authority\n' >&2
     return 1
   fi
+  printf '%s\n' "${authority_init_digest}"
 }
 
 # Refuse to retry a semantic tag once GitHub has made it a published release.
@@ -3800,7 +3809,7 @@ publish_stable_asset_pair() {
 
 # Publish the exact guest archive that passed the local stable release gate.
 publish_stable_init_image_asset() {
-  local version="$1" repo archive asset tmp digest status
+  local version="$1" expected_digest="$2" repo archive asset tmp digest status cleanup_status
   local authority=() containerization_repository containerization_reference
   repo="$(github_repo "${COMPOSE_REPO}")"
   archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
@@ -3808,6 +3817,10 @@ publish_stable_init_image_asset() {
   if [[ "${archive}" != /* || ! -f "${archive}" ]]; then
     printf 'stable guest publication requires the absolute retained release-gate archive via CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE: %s\n' \
       "${archive:-unset}" >&2
+    return 2
+  fi
+  if [[ ! "${expected_digest}" =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'stable guest publication requires a candidate-bound release-gate digest\n' >&2
     return 2
   fi
   while IFS= read -r value; do
@@ -3819,22 +3832,47 @@ publish_stable_init_image_asset() {
   fi
   containerization_repository="${authority[0]}"
   containerization_reference="${authority[1]}"
-  "${OCI_IMAGE_LAYOUT_VALIDATOR}" "${archive}" \
-    vminit:container-compose \
-    "ghcr.io/${containerization_repository}/vminit:${containerization_reference}"
-
   tmp="$(mktemp -d)"
-  cp "${archive}" "${tmp}/${asset}"
-  digest="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"
-  printf '%s  %s\n' "${digest}" "${asset}" >"${tmp}/${asset}.sha256"
-  if publish_stable_asset_pair \
-    "${version}" "${repo}" "${tmp}/${asset}" "${tmp}/${asset}.sha256" \
-    "${asset}" "${digest}"; then
+  if cp "${archive}" "${tmp}/${asset}"; then
     status=0
   else
     status=$?
   fi
-  find "${tmp}" -depth -delete
+  if (( status == 0 )); then
+    if "${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${asset}" \
+      vminit:container-compose \
+      "ghcr.io/${containerization_repository}/vminit:${containerization_reference}"; then
+      status=0
+    else
+      status=$?
+    fi
+  fi
+  if (( status == 0 )); then
+    digest="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"
+    if [[ "${digest}" != "${expected_digest}" ]]; then
+      printf 'stable guest archive differs from the candidate-bound release-gate digest: expected %s, got %s\n' \
+        "${expected_digest}" "${digest:-missing}" >&2
+      status=2
+    fi
+  fi
+  if (( status == 0 )); then
+    printf '%s  %s\n' "${digest}" "${asset}" >"${tmp}/${asset}.sha256"
+    if publish_stable_asset_pair \
+      "${version}" "${repo}" "${tmp}/${asset}" "${tmp}/${asset}.sha256" \
+      "${asset}" "${digest}"; then
+      status=0
+    else
+      status=$?
+    fi
+  fi
+  if find "${tmp}" -depth -delete; then
+    cleanup_status=0
+  else
+    cleanup_status=$?
+  fi
+  if (( status == 0 && cleanup_status != 0 )); then
+    status="${cleanup_status}"
+  fi
   return "${status}"
 }
 
@@ -4015,7 +4053,7 @@ verify_compose_stable_package() {
 
 # Dispatch and verify one stable package workflow mode for a semantic tag.
 dispatch_compose_stable_workflow() {
-  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane stable_formula_identities_before=""
+  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane authority_init_digest stable_formula_identities_before=""
   print_header "dispatch container-compose ${version} ${mode}"
 
   if [[ "${repair_tap}" == "true" ]]; then
@@ -4066,7 +4104,8 @@ dispatch_compose_stable_workflow() {
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
       printf '%s started: %s\n' "${label}" "${run_id}"
       wait_for_github_run_success "${run_id}" "${label}"
-      publish_stable_init_image_asset "${version}"
+      authority_init_digest="$(ensure_published_stable_recovery_authority "${version}")"
+      publish_stable_init_image_asset "${version}" "${authority_init_digest}"
       verify_compose_stable_package \
         "${version}" "${promote_default_lane}" "${stable_formula_identities_before}"
       return 0
@@ -4097,11 +4136,11 @@ dispatch_compose_stable_tap_repair() {
 }
 
 dispatch_stable_release_gate() {
-  local version="$1" previous_run run_id deadline now
+  local version="$1" previous_run run_id deadline now archive init_image_digest
   print_header "dispatch hosted stable release gate for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run: gh workflow run stable-release-gate.yml --repo %s --ref main -f ref=%s\n' \
+    printf 'would run: gh workflow run stable-release-gate.yml --repo %s --ref main -f ref=%s -f init_image_sha256=<retained-release-gate-digest>\n' \
       "$(github_repo "${COMPOSE_REPO}")" "${version}"
     printf 'would wait for the hosted gate to confirm green main CI, SonarQube, and immutable static stack validation.\n'
     printf 'full runtime integration and Docker Compose parity run locally before the tag is created.\n'
@@ -4109,11 +4148,19 @@ dispatch_stable_release_gate() {
   fi
 
   need_command gh
+  archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
+  if [[ "${archive}" != /* || ! -f "${archive}" ]]; then
+    printf 'hosted stable release gate requires the absolute retained OCI init-image archive: %s\n' \
+      "${archive:-unset}" >&2
+    exit 2
+  fi
+  init_image_digest="$(shasum -a 256 "${archive}" | awk '{print $1}')"
   previous_run="$(latest_stable_release_gate_dispatch_run || true)"
   run github_cli workflow run stable-release-gate.yml \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --ref main \
-    -f "ref=${version}"
+    -f "ref=${version}" \
+    -f "init_image_sha256=${init_image_digest}"
 
   deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))
   while true; do
@@ -4182,7 +4229,7 @@ tag_stable_version() {
 
 # Resume the latest signed tag without mutating its stable source identity.
 resume_stable_release() {
-  local version="$1" promote_default_lane stable_formula_identities_before
+  local version="$1" promote_default_lane stable_formula_identities_before authority_init_digest
   print_header "resume stable release ${version}"
   verify_github_stable_tag_signature "${version}"
   if stable_release_is_published "${version}"; then
@@ -4192,9 +4239,9 @@ resume_stable_release() {
       dispatch_compose_stable_tap_repair "${version}"
       print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
     else
-      ensure_published_stable_recovery_authority "${version}"
+      authority_init_digest="$(ensure_published_stable_recovery_authority "${version}")"
       stable_formula_identities_before="$(homebrew_stable_formula_identities)"
-      publish_stable_init_image_asset "${version}"
+      publish_stable_init_image_asset "${version}" "${authority_init_digest}"
       verify_compose_stable_package \
         "${version}" "false" "${stable_formula_identities_before}"
       print_stable_release_point "${version}" "maintenance backfill asset recovery"

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -4198,7 +4198,8 @@ publish_stable_init_image_asset() {
 
 # Verify the stable release assets and Homebrew formula agree.
 verify_compose_stable_package() {
-  local version="$1" promote_default_lane="${2:-true}" stable_formula_identities_before="${3:-}" repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text formula_url formula_version formula_sha runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text container_formula_url container_formula_sha signature_verifier init_asset init_asset_sha init_checksum_sha stable_formula_identities_after
+  local version="$1" promote_default_lane="${2:-true}" stable_formula_identities_before="${3:-}" expected_init_digest="$4"
+  local repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text formula_url formula_version formula_sha runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text container_formula_url container_formula_sha signature_verifier init_asset init_asset_sha init_checksum_sha stable_formula_identities_after
   local authority=() containerization_repository containerization_reference
   repo="$(github_repo "${COMPOSE_REPO}")"
   asset="container-compose-plugin-release-arm64.tar.gz"
@@ -4274,6 +4275,12 @@ verify_compose_stable_package() {
   if [[ "${init_asset_sha}" != "${init_checksum_sha}" ]]; then
     printf 'release %s guest checksum mismatch: asset %s, checksum file %s\n' \
       "${version}" "${init_asset_sha}" "${init_checksum_sha}" >&2
+    exit 1
+  fi
+  if [[ ! "${expected_init_digest}" =~ ^[0-9a-f]{64}$ || \
+    "${init_asset_sha}" != "${expected_init_digest}" ]]; then
+    printf 'release %s guest archive is not authorized by the signed release gate: expected %s, got %s\n' \
+      "${version}" "${expected_init_digest:-missing}" "${init_asset_sha:-missing}" >&2
     exit 1
   fi
   while IFS= read -r value; do
@@ -4428,7 +4435,8 @@ dispatch_compose_stable_workflow() {
       IFS=$'\t' read -r authority_object authority_init_digest <<<"${authority_record}"
       publish_stable_init_image_asset "${version}" "${authority_init_digest}"
       verify_compose_stable_package \
-        "${version}" "${promote_default_lane}" "${stable_formula_identities_before}"
+        "${version}" "${promote_default_lane}" \
+        "${stable_formula_identities_before}" "${authority_init_digest}"
       require_stable_init_image_authority_unchanged \
         "${version}" "${authority_object}" "${authority_init_digest}"
       return 0
@@ -4563,7 +4571,8 @@ resume_stable_release() {
       stable_formula_identities_before="$(homebrew_stable_formula_identities)"
       publish_stable_init_image_asset "${version}" "${authority_init_digest}"
       verify_compose_stable_package \
-        "${version}" "false" "${stable_formula_identities_before}"
+        "${version}" "false" \
+        "${stable_formula_identities_before}" "${authority_init_digest}"
       require_stable_init_image_authority_unchanged \
         "${version}" "${authority_object}" "${authority_init_digest}"
       print_stable_release_point "${version}" "maintenance backfill asset recovery"

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -2308,10 +2308,23 @@ stable_version_promotes_default_lane() {
   python3 "${STABLE_RELEASE_LANE_CLASSIFIER}" "${version}" "${latest}"
 }
 
-# Resolve the immutable tap main identity used to prove that a maintenance
-# backfill did not move either stable formula.
-homebrew_tap_main_sha() {
-  github_cli api repos/stephenlclarke/homebrew-tap/commits/main --jq '.sha'
+# Resolve the two stable formula blob identities used to prove that a
+# maintenance backfill did not move either stable consumer. Unrelated Current
+# formula commits may advance tap main without invalidating this evidence.
+homebrew_stable_formula_identities() {
+  local formula sha
+  for formula in container-compose container; do
+    sha="$(
+      github_cli api \
+        "repos/stephenlclarke/homebrew-tap/contents/Formula/${formula}.rb" \
+        --jq '.sha'
+    )"
+    if [[ -z "${sha}" ]]; then
+      printf 'Homebrew stable formula has no blob identity: %s.rb\n' "${formula}" >&2
+      return 1
+    fi
+    printf '%s.rb=%s\n' "${formula}" "${sha}"
+  done
 }
 
 # Reject a stale published tag so formula-only recovery cannot downgrade the
@@ -2326,9 +2339,8 @@ ensure_latest_stable_retry() {
   fi
 }
 
-# Permit a maintenance retry only when its signed tag is the newest patch in
-# that series and still names the exact release-line head. This is the source
-# authority for both unpublished publication and published asset recovery.
+# Permit an unpublished maintenance retry only when its signed tag is the
+# newest patch in that series and still names the exact release-line head.
 # Formula repairs remain restricted to the global latest tag by
 # ensure_latest_stable_retry so an older line can never downgrade the tap.
 ensure_stable_retry_source_authority() {
@@ -2358,6 +2370,48 @@ ensure_stable_retry_source_authority() {
     printf 'maintenance tag %s is not the exact release-%s head (%s, got %s)\n' \
       "${version}" "${series}" "${release_branch_sha:-missing}" "${tag_sha:-missing}" >&2
     exit 1
+  fi
+}
+
+# Authenticate recovery of an already-published stable release against the
+# immutable signed tag and its successful candidate-bound hosted gate. A
+# movable release branch must not make later recovery of immutable assets
+# time-dependent.
+ensure_published_stable_recovery_authority() {
+  local version="$1" path repo tag_sha authority_name authority_filter authority_run_id authority_conclusion
+  path="$(repo_path "${COMPOSE_REPO}")"
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
+  if [[ -z "${tag_sha}" ]]; then
+    printf 'published stable recovery tag is missing locally: %s\n' "${version}" >&2
+    return 1
+  fi
+
+  authority_name="Stable Release Authority (${version})"
+  authority_filter=".check_runs[] | select(.name == \"${authority_name}\""
+  authority_filter+=' and .status == "completed"'
+  authority_filter+=' and .conclusion == "success"'
+  authority_filter+=' and .app.slug == "github-actions")'
+  authority_filter+=' | .external_id'
+  authority_run_id="$(
+    github_cli api --paginate \
+      "repos/${repo}/commits/${tag_sha}/check-runs?per_page=100" \
+      --jq "${authority_filter}" |
+      tail -n 1
+  )"
+  if [[ ! "${authority_run_id}" =~ ^[0-9]+$ ]]; then
+    printf 'refusing published recovery without candidate-bound Stable Release Authority %s\n' \
+      "${authority_name}" >&2
+    return 1
+  fi
+  authority_conclusion="$(
+    github_cli run view "${authority_run_id}" --repo "${repo}" \
+      --json workflowName,event,status,conclusion \
+      --jq 'select(.workflowName == "Stable Release Gate" and .event == "workflow_dispatch" and .status == "completed" and .conclusion == "success") | .conclusion'
+  )"
+  if [[ "${authority_conclusion}" != "success" ]]; then
+    printf 'refusing published recovery without a successful Stable Release Gate authority\n' >&2
+    return 1
   fi
 }
 
@@ -3648,10 +3702,71 @@ print(component["ref"])
 PY
 }
 
+# Publish or recover one immutable asset/checksum pair. Existing members must
+# match the retained candidate; missing members are uploaded independently so
+# a partially successful GitHub upload remains resumable.
+publish_stable_asset_pair() {
+  local version="$1" repo="$2" asset_path="$3" checksum_path="$4" asset="$5" digest="$6"
+  local remote_tmp asset_names local_digest local_checksum remote_digest remote_checksum
+  local missing_assets=() status=0
+  if [[ ! -f "${asset_path}" || ! -f "${checksum_path}" ]]; then
+    printf 'stable asset pair is incomplete locally: %s + %s\n' \
+      "${asset_path}" "${checksum_path}" >&2
+    return 2
+  fi
+  local_digest="$(shasum -a 256 "${asset_path}" | awk '{print $1}')"
+  local_checksum="$(awk '{print $1}' "${checksum_path}")"
+  if [[ "${local_digest}" != "${digest}" || "${local_checksum}" != "${digest}" ]]; then
+    printf 'stable asset pair does not match its retained candidate digest: %s\n' \
+      "${digest}" >&2
+    return 2
+  fi
+  asset_names="$(
+    github_cli release view "${version}" --repo "${repo}" --json assets \
+      --jq '.assets[].name'
+  )"
+  remote_tmp="$(mktemp -d)"
+  if grep -Fxq "${asset}" <<<"${asset_names}"; then
+    github_cli release download "${version}" --repo "${repo}" \
+      --pattern "${asset}" --dir "${remote_tmp}"
+    remote_digest="$(shasum -a 256 "${remote_tmp}/${asset}" | awk '{print $1}')"
+    if [[ "${remote_digest}" != "${digest}" ]]; then
+      printf 'stable release %s guest asset differs from the retained release-gate archive\n' \
+        "${version}" >&2
+      status=1
+    fi
+  else
+    missing_assets+=("${asset_path}")
+  fi
+  if grep -Fxq "${asset}.sha256" <<<"${asset_names}"; then
+    github_cli release download "${version}" --repo "${repo}" \
+      --pattern "${asset}.sha256" --dir "${remote_tmp}"
+    remote_checksum="$(awk '{print $1}' "${remote_tmp}/${asset}.sha256")"
+    if [[ "${remote_checksum}" != "${digest}" ]]; then
+      printf 'stable release %s guest checksum differs from the retained release-gate archive\n' \
+        "${version}" >&2
+      status=1
+    fi
+  else
+    missing_assets+=("${checksum_path}")
+  fi
+  if (( status == 0 && ${#missing_assets[@]} > 0 )); then
+    if github_cli release upload "${version}" --repo "${repo}" "${missing_assets[@]}"; then
+      printf 'published stable guest asset: %s at %s\n' "${asset}" "${digest}"
+    else
+      status=$?
+    fi
+  elif (( status == 0 )); then
+    printf 'stable guest asset already published: %s at %s\n' "${asset}" "${digest}"
+  fi
+  find "${remote_tmp}" -depth -delete
+  return "${status}"
+}
+
 # Publish the exact guest archive that passed the local stable release gate.
 publish_stable_init_image_asset() {
-  local version="$1" repo archive asset tmp digest asset_names remote_digest
-  local authority=() containerization_repository containerization_reference status=0
+  local version="$1" repo archive asset tmp digest status
+  local authority=() containerization_repository containerization_reference
   repo="$(github_repo "${COMPOSE_REPO}")"
   archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
   asset="container-vminit-arm64.oci.tar"
@@ -3677,37 +3792,12 @@ publish_stable_init_image_asset() {
   cp "${archive}" "${tmp}/${asset}"
   digest="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"
   printf '%s  %s\n' "${digest}" "${asset}" >"${tmp}/${asset}.sha256"
-  asset_names="$(
-    github_cli release view "${version}" --repo "${repo}" --json assets \
-      --jq '.assets[].name'
-  )"
-  if grep -Fxq "${asset}" <<<"${asset_names}" || \
-    grep -Fxq "${asset}.sha256" <<<"${asset_names}"; then
-    if ! grep -Fxq "${asset}" <<<"${asset_names}" || \
-      ! grep -Fxq "${asset}.sha256" <<<"${asset_names}"; then
-      printf 'stable release %s has an incomplete guest asset pair\n' "${version}" >&2
-      find "${tmp}" -depth -delete
-      return 1
-    fi
-    install -d -m 0700 "${tmp}/remote"
-    github_cli release download "${version}" --repo "${repo}" \
-      --pattern "${asset}" --pattern "${asset}.sha256" --dir "${tmp}/remote"
-    remote_digest="$(shasum -a 256 "${tmp}/remote/${asset}" | awk '{print $1}')"
-    if [[ "${remote_digest}" != "${digest}" ]] || \
-      [[ "$(awk '{print $1}' "${tmp}/remote/${asset}.sha256")" != "${digest}" ]]; then
-      printf 'stable release %s guest asset differs from the retained release-gate archive\n' \
-        "${version}" >&2
-      status=1
-    else
-      printf 'stable guest asset already published: %s at %s\n' "${asset}" "${digest}"
-    fi
+  if publish_stable_asset_pair \
+    "${version}" "${repo}" "${tmp}/${asset}" "${tmp}/${asset}.sha256" \
+    "${asset}" "${digest}"; then
+    status=0
   else
-    if github_cli release upload "${version}" --repo "${repo}" \
-      "${tmp}/${asset}" "${tmp}/${asset}.sha256"; then
-      printf 'published stable guest asset: %s at %s\n' "${asset}" "${digest}"
-    else
-      status=$?
-    fi
+    status=$?
   fi
   find "${tmp}" -depth -delete
   return "${status}"
@@ -3715,7 +3805,7 @@ publish_stable_init_image_asset() {
 
 # Verify the stable release assets and Homebrew formula agree.
 verify_compose_stable_package() {
-  local version="$1" promote_default_lane="${2:-true}" tap_sha_before="${3:-}" repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text formula_url formula_version formula_sha runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text container_formula_url container_formula_sha signature_verifier init_asset init_asset_sha init_checksum_sha tap_sha_after
+  local version="$1" promote_default_lane="${2:-true}" stable_formula_identities_before="${3:-}" repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text formula_url formula_version formula_sha runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text container_formula_url container_formula_sha signature_verifier init_asset init_asset_sha init_checksum_sha stable_formula_identities_after
   local authority=() containerization_repository containerization_reference
   repo="$(github_repo "${COMPOSE_REPO}")"
   asset="container-compose-plugin-release-arm64.tar.gz"
@@ -3818,18 +3908,18 @@ verify_compose_stable_package() {
   rm -rf "${tmp}"
 
   if [[ "${promote_default_lane}" != "true" ]]; then
-    if [[ -z "${tap_sha_before}" ]]; then
-      printf 'maintenance backfill verification requires the original Homebrew tap identity\n' >&2
+    if [[ -z "${stable_formula_identities_before}" ]]; then
+      printf 'maintenance backfill verification requires the original stable formula identities\n' >&2
       exit 1
     fi
-    tap_sha_after="$(homebrew_tap_main_sha)"
-    if [[ "${tap_sha_after}" != "${tap_sha_before}" ]]; then
-      printf 'maintenance backfill moved Homebrew tap main: expected %s, got %s\n' \
-        "${tap_sha_before}" "${tap_sha_after}" >&2
+    stable_formula_identities_after="$(homebrew_stable_formula_identities)"
+    if [[ "${stable_formula_identities_after}" != "${stable_formula_identities_before}" ]]; then
+      printf 'maintenance backfill moved stable Homebrew formulae: expected %s, got %s\n' \
+        "${stable_formula_identities_before}" "${stable_formula_identities_after}" >&2
       exit 1
     fi
-    printf 'stable stack %s maintenance backfill verified without moving Homebrew tap %s: %s + %s + %s\n' \
-      "${version}" "${tap_sha_after}" "${asset_sha}" "${runtime_asset_sha}" "${init_asset_sha}"
+    printf 'stable stack %s maintenance backfill verified without moving stable Homebrew formulae %s: %s + %s + %s\n' \
+      "${version}" "${stable_formula_identities_after}" "${asset_sha}" "${runtime_asset_sha}" "${init_asset_sha}"
     return 0
   fi
 
@@ -3890,7 +3980,7 @@ verify_compose_stable_package() {
 
 # Dispatch and verify one stable package workflow mode for a semantic tag.
 dispatch_compose_stable_workflow() {
-  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane tap_sha_before
+  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane stable_formula_identities_before=""
   print_header "dispatch container-compose ${version} ${mode}"
 
   if [[ "${repair_tap}" == "true" ]]; then
@@ -3913,7 +4003,9 @@ dispatch_compose_stable_workflow() {
 
   need_command gh
   promote_default_lane="$(stable_version_promotes_default_lane "${version}")"
-  tap_sha_before="$(homebrew_tap_main_sha)"
+  if [[ "${promote_default_lane}" != "true" ]]; then
+    stable_formula_identities_before="$(homebrew_stable_formula_identities)"
+  fi
   if [[ "${repair_tap}" == "true" && "${promote_default_lane}" != "true" ]]; then
     printf 'Homebrew tap repair cannot promote maintenance backfill %s over the latest stable release\n' \
       "${version}" >&2
@@ -3941,7 +4033,7 @@ dispatch_compose_stable_workflow() {
       wait_for_github_run_success "${run_id}" "${label}"
       publish_stable_init_image_asset "${version}"
       verify_compose_stable_package \
-        "${version}" "${promote_default_lane}" "${tap_sha_before}"
+        "${version}" "${promote_default_lane}" "${stable_formula_identities_before}"
       return 0
     fi
 
@@ -4055,7 +4147,7 @@ tag_stable_version() {
 
 # Resume the latest signed tag without mutating its stable source identity.
 resume_stable_release() {
-  local version="$1" promote_default_lane tap_sha_before
+  local version="$1" promote_default_lane stable_formula_identities_before
   print_header "resume stable release ${version}"
   verify_github_stable_tag_signature "${version}"
   if stable_release_is_published "${version}"; then
@@ -4065,10 +4157,11 @@ resume_stable_release() {
       dispatch_compose_stable_tap_repair "${version}"
       print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
     else
-      ensure_stable_retry_source_authority "${version}"
-      tap_sha_before="$(homebrew_tap_main_sha)"
+      ensure_published_stable_recovery_authority "${version}"
+      stable_formula_identities_before="$(homebrew_stable_formula_identities)"
       publish_stable_init_image_asset "${version}"
-      verify_compose_stable_package "${version}" "false" "${tap_sha_before}"
+      verify_compose_stable_package \
+        "${version}" "false" "${stable_formula_identities_before}"
       print_stable_release_point "${version}" "maintenance backfill asset recovery"
     fi
     return 0

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -2550,7 +2550,7 @@ ensure_stable_retry_source_authority() {
 ensure_published_stable_recovery_authority() {
   local version="$1" path repo tag_sha authority_name authority_filter authority_record
   local authority_run_id authority_summary authority_conclusion authority_init_digest
-  local signed_authority_init_digest
+  local signed_authority_record signed_authority_object signed_authority_init_digest
   path="$(repo_path "${COMPOSE_REPO}")"
   repo="$(github_repo "${COMPOSE_REPO}")"
   tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
@@ -2559,9 +2559,11 @@ ensure_published_stable_recovery_authority() {
     return 1
   fi
 
-  signed_authority_init_digest="$(
-    verified_stable_init_image_authority_digest "${version}"
+  signed_authority_record="$(
+    verified_stable_init_image_authority_record "${version}"
   )"
+  IFS=$'\t' read -r signed_authority_object signed_authority_init_digest \
+    <<<"${signed_authority_record}"
 
   authority_name="Stable Release Authority (${version})"
   authority_filter=".check_runs[] | select(.name == \"${authority_name}\""
@@ -2603,7 +2605,7 @@ ensure_published_stable_recovery_authority() {
     printf 'refusing published recovery without a successful Stable Release Gate authority\n' >&2
     return 1
   fi
-  printf '%s\n' "${authority_init_digest}"
+  printf '%s\t%s\n' "${signed_authority_object}" "${authority_init_digest}"
 }
 
 # Refuse to retry a semantic tag once GitHub has made it a published release.
@@ -2705,10 +2707,11 @@ stable_init_image_authority_tag() {
   printf 'stable-init-image-authority/%s\n' "${version}"
 }
 
-# Verify the current GitHub companion authority tag and return its guest digest.
+# Verify the current GitHub companion authority tag and return its object and
+# guest digest.
 # Published recovery uses this read-only path so deletion or replacement of the
 # signed trust root cannot be papered over by a historical hosted check.
-verified_stable_init_image_authority_digest() {
+verified_stable_init_image_authority_record() {
   local version="$1" path repo tag_sha authority_tag authority_object
   local authority_record authority_verified authority_source authority_message digest_lines
   path="$(repo_path "${COMPOSE_REPO}")"
@@ -2746,7 +2749,24 @@ verified_stable_init_image_authority_digest() {
       "${authority_tag}" >&2
     return 1
   fi
-  printf '%s\n' "${digest_lines}"
+  printf '%s\t%s\n' "${authority_object}" "${digest_lines}"
+}
+
+# Require the signed recovery trust root to remain unchanged through asset and
+# package verification so a concurrent ref replacement cannot authorize stale
+# bytes immediately before success is reported.
+require_stable_init_image_authority_unchanged() {
+  local version="$1" expected_object="$2" expected_digest="$3"
+  local current_record current_object current_digest
+  current_record="$(verified_stable_init_image_authority_record "${version}")"
+  IFS=$'\t' read -r current_object current_digest <<<"${current_record}"
+  if [[ "${current_object}" != "${expected_object}" || \
+    "${current_digest}" != "${expected_digest}" ]]; then
+    printf 'stable init-image authority moved during recovery: expected %s at %s, got %s at %s\n' \
+      "${expected_digest}" "${expected_object}" \
+      "${current_digest:-missing}" "${current_object:-missing}" >&2
+    return 1
+  fi
 }
 
 # Create or validate the GitHub-verified signed companion authority tag for a
@@ -4353,7 +4373,7 @@ verify_compose_stable_package() {
 
 # Dispatch and verify one stable package workflow mode for a semantic tag.
 dispatch_compose_stable_workflow() {
-  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane authority_init_digest stable_formula_identities_before=""
+  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane authority_record authority_object authority_init_digest stable_formula_identities_before=""
   print_header "dispatch container-compose ${version} ${mode}"
 
   if [[ "${repair_tap}" == "true" ]]; then
@@ -4404,10 +4424,13 @@ dispatch_compose_stable_workflow() {
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
       printf '%s started: %s\n' "${label}" "${run_id}"
       wait_for_github_run_success "${run_id}" "${label}"
-      authority_init_digest="$(ensure_published_stable_recovery_authority "${version}")"
+      authority_record="$(ensure_published_stable_recovery_authority "${version}")"
+      IFS=$'\t' read -r authority_object authority_init_digest <<<"${authority_record}"
       publish_stable_init_image_asset "${version}" "${authority_init_digest}"
       verify_compose_stable_package \
         "${version}" "${promote_default_lane}" "${stable_formula_identities_before}"
+      require_stable_init_image_authority_unchanged \
+        "${version}" "${authority_object}" "${authority_init_digest}"
       return 0
     fi
 
@@ -4524,7 +4547,8 @@ tag_stable_version() {
 
 # Resume the latest signed tag without mutating its stable source identity.
 resume_stable_release() {
-  local version="$1" promote_default_lane stable_formula_identities_before authority_init_digest
+  local version="$1" promote_default_lane stable_formula_identities_before
+  local authority_record authority_object authority_init_digest
   print_header "resume stable release ${version}"
   verify_github_stable_tag_signature "${version}"
   if stable_release_is_published "${version}"; then
@@ -4534,11 +4558,14 @@ resume_stable_release() {
       dispatch_compose_stable_tap_repair "${version}"
       print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
     else
-      authority_init_digest="$(ensure_published_stable_recovery_authority "${version}")"
+      authority_record="$(ensure_published_stable_recovery_authority "${version}")"
+      IFS=$'\t' read -r authority_object authority_init_digest <<<"${authority_record}"
       stable_formula_identities_before="$(homebrew_stable_formula_identities)"
       publish_stable_init_image_asset "${version}" "${authority_init_digest}"
       verify_compose_stable_package \
         "${version}" "false" "${stable_formula_identities_before}"
+      require_stable_init_image_authority_unchanged \
+        "${version}" "${authority_object}" "${authority_init_digest}"
       print_stable_release_point "${version}" "maintenance backfill asset recovery"
     fi
     return 0

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -1891,11 +1891,116 @@ resolve_release_evidence_root() {
   printf '%s\n' "${evidence_root}"
 }
 
+# Return the candidate-specific local gate evidence path. The candidate SHA
+# prevents a successful gate for one source revision authorizing another.
+stable_init_image_gate_evidence_path() {
+  local candidate_sha="$1" path evidence_root authority_root
+  if [[ ! "${candidate_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'stable init-image gate evidence requires an immutable candidate SHA: %s\n' \
+      "${candidate_sha:-missing}" >&2
+    return 2
+  fi
+  path="$(repo_path "${COMPOSE_REPO}")"
+  evidence_root="$(resolve_release_evidence_root "${path}" \
+    "${PARITY_EVIDENCE_DIR:-.build/release-evidence}")"
+  authority_root="${evidence_root}/stable-init-image-authority"
+  if [[ -L "${authority_root}" ]]; then
+    printf 'stable init-image authority directory must not be a symlink: %s\n' \
+      "${authority_root}" >&2
+    return 2
+  fi
+  mkdir -p "${authority_root}"
+  printf '%s/%s.sha256\n' "${authority_root}" "${candidate_sha}"
+}
+
+# Persist the exact guest snapshot digest only after its full local release
+# gate and host restoration complete. Existing evidence is immutable.
+record_stable_init_image_gate_evidence() {
+  local candidate_sha="$1" digest="$2" evidence_path tmp record existing
+  if [[ ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'stable init-image gate evidence has an invalid digest: %s\n' \
+      "${digest:-missing}" >&2
+    return 2
+  fi
+  evidence_path="$(stable_init_image_gate_evidence_path "${candidate_sha}")"
+  record="${digest}  ${candidate_sha}"
+  if [[ -e "${evidence_path}" || -L "${evidence_path}" ]]; then
+    if [[ -f "${evidence_path}" && ! -L "${evidence_path}" ]]; then
+      existing="$(<"${evidence_path}")"
+      if [[ "${existing}" == "${record}" ]]; then
+        return 0
+      fi
+    fi
+    printf 'refusing to replace immutable stable init-image gate evidence: %s\n' \
+      "${evidence_path}" >&2
+    return 1
+  fi
+  tmp="$(mktemp "${evidence_path}.XXXXXX")"
+  if ! printf '%s\n' "${record}" >"${tmp}"; then
+    find "${tmp}" -delete >/dev/null 2>&1 || true
+    return 1
+  fi
+  chmod a-w "${tmp}"
+  if mv -n "${tmp}" "${evidence_path}" && \
+    [[ -f "${evidence_path}" && ! -L "${evidence_path}" ]]; then
+    existing="$(<"${evidence_path}")"
+    find "${tmp}" -delete >/dev/null 2>&1 || true
+    if [[ "${existing}" == "${record}" ]]; then
+      return 0
+    fi
+  fi
+  find "${tmp}" -delete >/dev/null 2>&1 || true
+  printf 'failed to publish immutable stable init-image gate evidence: %s\n' \
+    "${evidence_path}" >&2
+  return 1
+}
+
+# Read the digest produced by the local gate and prove the retained archive is
+# still that exact snapshot before sending its identity to hosted authority.
+retained_stable_init_image_gate_digest() {
+  local version="$1" path tag_sha evidence_path record digest recorded_sha archive archive_digest
+  path="$(repo_path "${COMPOSE_REPO}")"
+  tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
+  evidence_path="$(stable_init_image_gate_evidence_path "${tag_sha}")"
+  if [[ ! -f "${evidence_path}" || -L "${evidence_path}" ]]; then
+    printf 'stable tag %s has no immutable local init-image gate evidence\n' \
+      "${version}" >&2
+    return 1
+  fi
+  record="$(<"${evidence_path}")"
+  if [[ "${record}" =~ ^([0-9a-f]{64})\ \ ([0-9a-f]{40})$ ]]; then
+    digest="${BASH_REMATCH[1]}"
+    recorded_sha="${BASH_REMATCH[2]}"
+  else
+    printf 'stable init-image gate evidence is malformed: %s\n' \
+      "${evidence_path}" >&2
+    return 1
+  fi
+  if [[ "${recorded_sha}" != "${tag_sha}" ]]; then
+    printf 'stable init-image gate evidence names %s instead of tag source %s\n' \
+      "${recorded_sha}" "${tag_sha}" >&2
+    return 1
+  fi
+  archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
+  if [[ "${archive}" != /* || ! -f "${archive}" ]]; then
+    printf 'stable init-image gate evidence requires the absolute retained archive: %s\n' \
+      "${archive:-unset}" >&2
+    return 2
+  fi
+  archive_digest="$(shasum -a 256 "${archive}" | awk '{print $1}')"
+  if [[ "${archive_digest}" != "${digest}" ]]; then
+    printf 'retained guest archive no longer matches the locally gated snapshot: expected %s, got %s\n' \
+      "${digest}" "${archive_digest:-missing}" >&2
+    return 1
+  fi
+  printf '%s\n' "${digest}"
+}
+
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
   (
   local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive
-  local containerization_reference required_init_references status runtime_run_id runtime_service_namespace runtime_namespace_digest
+  local containerization_reference required_init_references status runtime_run_id runtime_service_namespace runtime_namespace_digest candidate_sha init_image_digest_before init_image_digest_after
   local -a RELEASE_QUIESCED_LABELS=()
   local -a RELEASE_QUIESCED_PLISTS=()
   local -a RELEASE_QUIESCED_ACTION_STARTED=()
@@ -1903,6 +2008,7 @@ run_local_release_gate() {
   local -a RELEASE_QUIESCED_RESTARTED_UNREADY=()
   local -a RELEASE_SUSPENDED_RUNNER_PGIDS=()
   path="$(repo_path "${COMPOSE_REPO}")"
+  candidate_sha="$(git -C "${path}" rev-parse HEAD)"
   container_path="$(repo_path "${CONTAINER_REPO}")"
   containerization_path="$(repo_path "containerization")"
   if [[ ! -f "${HOMEBREW_TAP_REPO}/Formula/container-compose.rb" ]]; then
@@ -2015,6 +2121,7 @@ PY
   fi
   chmod a-w "${staged_init_image_archive}"
   init_image_archive="${staged_init_image_archive}"
+  init_image_digest_before="$(shasum -a 256 "${init_image_archive}" | awk '{print $1}')"
   runtime_app_root="${runtime_parent}/app"
   runtime_run_id="release-$(id -u)-$$-${RANDOM}-${SECONDS}"
   runtime_namespace_digest="$(LC_ALL=C printf '%s' \
@@ -2050,6 +2157,15 @@ PY
     "CONTAINER_STACK_REPO=${container_path}" \
     "HOMEBREW_TAP_REPO=${HOMEBREW_TAP_REPO}" || status=$?
 
+  if (( status == 0 )); then
+    init_image_digest_after="$(shasum -a 256 "${init_image_archive}" | awk '{print $1}')"
+    if [[ "${init_image_digest_after}" != "${init_image_digest_before}" ]]; then
+      printf 'local release gate guest snapshot changed while it was exercised: expected %s, got %s\n' \
+        "${init_image_digest_before}" "${init_image_digest_after:-missing}" >&2
+      status=1
+    fi
+  fi
+
   if ! cleanup_local_release_gate_resources "${container_binary}" \
     "${runtime_parent}" "${runtime_app_root}" "${runtime_service_namespace}"; then
     status=1
@@ -2062,6 +2178,12 @@ PY
     trap - EXIT
   else
     status=1
+  fi
+  if (( status == 0 )); then
+    if ! record_stable_init_image_gate_evidence \
+      "${candidate_sha}" "${init_image_digest_before}"; then
+      status=1
+    fi
   fi
   return "${status}"
   )
@@ -4136,7 +4258,7 @@ dispatch_compose_stable_tap_repair() {
 }
 
 dispatch_stable_release_gate() {
-  local version="$1" previous_run run_id deadline now archive init_image_digest
+  local version="$1" previous_run run_id deadline now init_image_digest
   print_header "dispatch hosted stable release gate for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -4148,13 +4270,7 @@ dispatch_stable_release_gate() {
   fi
 
   need_command gh
-  archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
-  if [[ "${archive}" != /* || ! -f "${archive}" ]]; then
-    printf 'hosted stable release gate requires the absolute retained OCI init-image archive: %s\n' \
-      "${archive:-unset}" >&2
-    exit 2
-  fi
-  init_image_digest="$(shasum -a 256 "${archive}" | awk '{print $1}')"
+  init_image_digest="$(retained_stable_init_image_gate_digest "${version}")"
   previous_run="$(latest_stable_release_gate_dispatch_run || true)"
   run github_cli workflow run stable-release-gate.yml \
     --repo "$(github_repo "${COMPOSE_REPO}")" \

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -2312,11 +2312,18 @@ stable_version_promotes_default_lane() {
 # maintenance backfill did not move either stable consumer. Unrelated Current
 # formula commits may advance tap main without invalidating this evidence.
 homebrew_stable_formula_identities() {
-  local formula sha
+  local formula sha tap_sha
+  tap_sha="$(
+    github_cli api repos/stephenlclarke/homebrew-tap/commits/main --jq '.sha'
+  )"
+  if [[ -z "${tap_sha}" ]]; then
+    printf 'Homebrew tap main has no immutable commit identity\n' >&2
+    return 1
+  fi
   for formula in container-compose container; do
     sha="$(
       github_cli api \
-        "repos/stephenlclarke/homebrew-tap/contents/Formula/${formula}.rb" \
+        "repos/stephenlclarke/homebrew-tap/contents/Formula/${formula}.rb?ref=${tap_sha}" \
         --jq '.sha'
     )"
     if [[ -z "${sha}" ]]; then
@@ -3707,7 +3714,7 @@ PY
 # a partially successful GitHub upload remains resumable.
 publish_stable_asset_pair() {
   local version="$1" repo="$2" asset_path="$3" checksum_path="$4" asset="$5" digest="$6"
-  local remote_tmp asset_names local_digest local_checksum remote_digest remote_checksum
+  local mode="${7:-recover}" remote_tmp asset_names local_digest upload_status cleanup_status
   local missing_assets=() status=0
   if [[ ! -f "${asset_path}" || ! -f "${checksum_path}" ]]; then
     printf 'stable asset pair is incomplete locally: %s + %s\n' \
@@ -3715,8 +3722,11 @@ publish_stable_asset_pair() {
     return 2
   fi
   local_digest="$(shasum -a 256 "${asset_path}" | awk '{print $1}')"
-  local_checksum="$(awk '{print $1}' "${checksum_path}")"
-  if [[ "${local_digest}" != "${digest}" || "${local_checksum}" != "${digest}" ]]; then
+  if [[ "${local_digest}" != "${digest}" ]] || ! awk \
+    -v expected_digest="${digest}" -v expected_asset="${asset}" \
+    'NR == 1 && NF == 2 && $1 == expected_digest && $2 == expected_asset { valid = 1 }
+     END { exit !(valid && NR == 1) }' \
+    "${checksum_path}"; then
     printf 'stable asset pair does not match its retained candidate digest: %s\n' \
       "${digest}" >&2
     return 2
@@ -3741,8 +3751,7 @@ publish_stable_asset_pair() {
   if grep -Fxq "${asset}.sha256" <<<"${asset_names}"; then
     github_cli release download "${version}" --repo "${repo}" \
       --pattern "${asset}.sha256" --dir "${remote_tmp}"
-    remote_checksum="$(awk '{print $1}' "${remote_tmp}/${asset}.sha256")"
-    if [[ "${remote_checksum}" != "${digest}" ]]; then
+    if ! cmp -s "${remote_tmp}/${asset}.sha256" "${checksum_path}"; then
       printf 'stable release %s guest checksum differs from the retained release-gate archive\n' \
         "${version}" >&2
       status=1
@@ -3751,15 +3760,41 @@ publish_stable_asset_pair() {
     missing_assets+=("${checksum_path}")
   fi
   if (( status == 0 && ${#missing_assets[@]} > 0 )); then
-    if github_cli release upload "${version}" --repo "${repo}" "${missing_assets[@]}"; then
+    if [[ "${mode}" == "verify-only" ]]; then
+      printf 'stable release %s guest asset pair is still incomplete after upload collision\n' \
+        "${version}" >&2
+      status=1
+    elif github_cli release upload "${version}" --repo "${repo}" "${missing_assets[@]}"; then
       printf 'published stable guest asset: %s at %s\n' "${asset}" "${digest}"
     else
-      status=$?
+      upload_status=$?
+      printf 'stable guest upload raced another recovery; revalidating immutable closure\n'
+      if find "${remote_tmp}" -depth -delete; then
+        cleanup_status=0
+      else
+        cleanup_status=$?
+      fi
+      if (( cleanup_status != 0 )); then
+        return "${cleanup_status}"
+      fi
+      if publish_stable_asset_pair \
+        "${version}" "${repo}" "${asset_path}" "${checksum_path}" \
+        "${asset}" "${digest}" verify-only; then
+        return 0
+      fi
+      return "${upload_status}"
     fi
   elif (( status == 0 )); then
     printf 'stable guest asset already published: %s at %s\n' "${asset}" "${digest}"
   fi
-  find "${remote_tmp}" -depth -delete
+  if find "${remote_tmp}" -depth -delete; then
+    cleanup_status=0
+  else
+    cleanup_status=$?
+  fi
+  if (( status == 0 && cleanup_status != 0 )); then
+    status="${cleanup_status}"
+  fi
   return "${status}"
 }
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -21,6 +21,7 @@ readonly SELF_PATH="${BASH_SOURCE[0]:-$0}"
 SELF_DIRECTORY="$(cd "$(dirname "${SELF_PATH}")" && pwd -P)"
 readonly SELF_DIRECTORY
 readonly COMPOSE_PROMOTION_REVIEW_TOOL="${SELF_DIRECTORY}/../Tools/release/compose_promotion_review.py"
+readonly HOMEBREW_PREFLIGHT_TOOL="${SELF_DIRECTORY}/../Tools/release/homebrew-preflight.py"
 readonly OCI_IMAGE_LAYOUT_VALIDATOR="${SELF_DIRECTORY}/../Tools/release/validate-oci-image-layout.py"
 readonly RELEASE_COMMAND_DEADLINE_RUNNER="${SELF_DIRECTORY}/../Tools/ci/run-command-with-deadline.py"
 readonly STABLE_RELEASE_LANE_CLASSIFIER="${SELF_DIRECTORY}/../Tools/release/stable-release-default-lane.py"
@@ -2021,7 +2022,7 @@ run_local_release_gate() {
   # identity, and source templates are all knowable before any product build.
   # Keep this ahead of virtualization, signing, and candidate packaging so a
   # broken tap cannot waste the expensive release gate.
-  run python3 "${path}/Tools/release/homebrew-preflight.py" \
+  run python3 "${HOMEBREW_PREFLIGHT_TOOL}" \
     --tap "${HOMEBREW_TAP_REPO}" \
     --compose-repository "${path}" \
     --container-repository "${container_path}"

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -4281,6 +4281,9 @@ verify_compose_stable_package() {
     "${init_asset_sha}" != "${expected_init_digest}" ]]; then
     printf 'release %s guest archive is not authorized by the signed release gate: expected %s, got %s\n' \
       "${version}" "${expected_init_digest:-missing}" "${init_asset_sha:-missing}" >&2
+    if ! find "${tmp}" -depth -delete; then
+      printf 'failed to clean rejected stable package download: %s\n' "${tmp}" >&2
+    fi
     exit 1
   fi
   while IFS= read -r value; do

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -1956,6 +1956,46 @@ record_stable_init_image_gate_evidence() {
   return 1
 }
 
+# Bind a locally gated source snapshot to an equivalent promoted commit. GitHub
+# merge commits have a different identity even when they preserve the exact
+# reviewed tree, so the promoted source needs its own immutable evidence record
+# before it can be tagged.
+rebind_stable_init_image_gate_evidence() {
+  local source_sha="$1" promoted_sha="$2" path source_tree promoted_tree
+  local source_evidence record digest recorded_sha
+  if [[ "${source_sha}" == "${promoted_sha}" ]]; then
+    return 0
+  fi
+  path="$(repo_path "${COMPOSE_REPO}")"
+  source_tree="$(git -C "${path}" rev-parse "${source_sha}^{tree}")"
+  promoted_tree="$(git -C "${path}" rev-parse "${promoted_sha}^{tree}")"
+  if [[ "${source_tree}" != "${promoted_tree}" ]]; then
+    printf 'refusing to bind local gate evidence to a different promoted tree\n' >&2
+    return 1
+  fi
+  source_evidence="$(stable_init_image_gate_evidence_path "${source_sha}")"
+  if [[ ! -f "${source_evidence}" || -L "${source_evidence}" ]]; then
+    printf 'locally gated source %s has no immutable init-image evidence\n' \
+      "${source_sha}" >&2
+    return 1
+  fi
+  record="$(<"${source_evidence}")"
+  if [[ "${record}" =~ ^([0-9a-f]{64})\ \ ([0-9a-f]{40})$ ]]; then
+    digest="${BASH_REMATCH[1]}"
+    recorded_sha="${BASH_REMATCH[2]}"
+  else
+    printf 'stable init-image gate evidence is malformed: %s\n' \
+      "${source_evidence}" >&2
+    return 1
+  fi
+  if [[ "${recorded_sha}" != "${source_sha}" ]]; then
+    printf 'stable init-image gate evidence names %s instead of gated source %s\n' \
+      "${recorded_sha}" "${source_sha}" >&2
+    return 1
+  fi
+  record_stable_init_image_gate_evidence "${promoted_sha}" "${digest}"
+}
+
 # Read the digest produced by the local gate and prove the retained archive is
 # still that exact snapshot before sending its identity to hosted authority.
 retained_stable_init_image_gate_digest() {
@@ -2523,6 +2563,8 @@ ensure_published_stable_recovery_authority() {
   authority_filter+=' and .status == "completed"'
   authority_filter+=' and .conclusion == "success"'
   authority_filter+=' and .app.slug == "github-actions")'
+  authority_filter+=' | select((.external_id // "") | test("^[0-9]+$"))'
+  authority_filter+=' | select((.output.summary // "") | test("Guest init image SHA-256: [0-9a-f]{64}[.]"))'
   authority_filter+=' | [.external_id, .output.summary] | @tsv'
   authority_record="$(
     github_cli api --paginate \
@@ -2644,6 +2686,79 @@ verify_github_stable_tag_signature() {
       "${version}" "${reason:-missing}" >&2
     exit 1
   fi
+}
+
+# Return the immutable companion tag that binds a stable source tag to the
+# locally gated guest snapshot without trusting workflow-dispatch input.
+stable_init_image_authority_tag() {
+  local version="$1"
+  printf 'stable-init-image-authority/%s\n' "${version}"
+}
+
+# Create or validate the GitHub-verified signed companion authority tag for a
+# locally gated guest snapshot. Existing matching tags are reusable so an
+# interrupted unpublished release can resume without rewriting source tags.
+ensure_stable_init_image_authority_tag() {
+  local version="$1" digest="$2" path remote tag_sha authority_tag
+  local local_object remote_object authority_source authority_message authority_digest
+  path="$(repo_path "${COMPOSE_REPO}")"
+  remote="$(push_remote "${COMPOSE_REPO}")"
+  tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
+  authority_tag="$(stable_init_image_authority_tag "${version}")"
+  remote_object="$(
+    git -C "${path}" ls-remote --tags --refs "${remote}" \
+      "refs/tags/${authority_tag}" | awk '{ print $1 }' | tail -n 1
+  )"
+  local_object="$(
+    git -C "${path}" rev-parse -q --verify "refs/tags/${authority_tag}" 2>/dev/null || true
+  )"
+
+  if [[ -n "${remote_object}" && -n "${local_object}" && "${remote_object}" != "${local_object}" ]]; then
+    printf 'stable init-image authority tag differs between local and remote: %s\n' \
+      "${authority_tag}" >&2
+    return 1
+  fi
+  if [[ -n "${remote_object}" && -z "${local_object}" ]]; then
+    run git -C "${path}" fetch "${remote}" \
+      "+refs/tags/${authority_tag}:refs/tags/${authority_tag}"
+    local_object="$(git -C "${path}" rev-parse "refs/tags/${authority_tag}")"
+  fi
+  if [[ -z "${local_object}" ]]; then
+    run env GIT_EDITOR=: git -C "${path}" tag -s "${authority_tag}" "${tag_sha}" \
+      -m "$(github_repo "${COMPOSE_REPO}") ${version} stable init-image authority" \
+      -m "Guest init image SHA-256: ${digest}."
+    local_object="$(git -C "${path}" rev-parse "refs/tags/${authority_tag}")"
+  fi
+
+  if [[ "$(git -C "${path}" cat-file -t "${local_object}")" != "tag" ]]; then
+    printf 'stable init-image authority ref is not an annotated tag: %s\n' \
+      "${authority_tag}" >&2
+    return 1
+  fi
+  authority_source="$(git -C "${path}" rev-list -n 1 "refs/tags/${authority_tag}")"
+  if [[ "${authority_source}" != "${tag_sha}" ]]; then
+    printf 'stable init-image authority tag names %s instead of source %s\n' \
+      "${authority_source}" "${tag_sha}" >&2
+    return 1
+  fi
+  authority_message="$(git -C "${path}" for-each-ref \
+    --format='%(contents)' "refs/tags/${authority_tag}")"
+  if [[ "${authority_message}" =~ Guest\ init\ image\ SHA-256:\ ([0-9a-f]{64})[.] ]]; then
+    authority_digest="${BASH_REMATCH[1]}"
+  else
+    printf 'stable init-image authority tag has no candidate-bound digest: %s\n' \
+      "${authority_tag}" >&2
+    return 1
+  fi
+  if [[ "${authority_digest}" != "${digest}" ]]; then
+    printf 'stable init-image authority tag records %s instead of retained digest %s\n' \
+      "${authority_digest}" "${digest}" >&2
+    return 1
+  fi
+  if [[ -z "${remote_object}" ]]; then
+    run git -C "${path}" push "${remote}" "refs/tags/${authority_tag}"
+  fi
+  verify_github_stable_tag_signature "${authority_tag}"
 }
 
 # Create a new signed stable tag at the validated current container-compose
@@ -3716,7 +3831,7 @@ promote_compose_main() {
 }
 
 push_all_main() {
-  local version="$1" repo path local_head remote_head body
+  local version="$1" repo path local_head remote_head body gated_sha promoted_sha
   print_header "verify reviewed sibling mains and promote container-compose"
   for repo in "${REPOS[@]}"; do
     if [[ "${repo}" == "${COMPOSE_REPO}" ]]; then
@@ -3732,11 +3847,19 @@ push_all_main() {
   done
 
   body="$(compose_source_promotion_body "${version}")"
+  path="$(repo_path "${COMPOSE_REPO}")"
+  gated_sha="$(git -C "${path}" rev-parse main)"
   promote_compose_main \
     "${version}" \
     "source" \
     "chore(release): promote ${version} source" \
     "${body}"
+  if [[ "${EXECUTE}" == "1" ]]; then
+    promoted_sha="$(git -C "${path}" rev-parse main)"
+    rebind_stable_init_image_gate_evidence "${gated_sha}" "${promoted_sha}"
+  else
+    printf 'would bind the locally gated source evidence to the equivalent promoted commit\n'
+  fi
 }
 
 # Require an executable command when an executed workflow depends on it.
@@ -4263,7 +4386,8 @@ dispatch_stable_release_gate() {
   print_header "dispatch hosted stable release gate for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
-    printf 'would run: gh workflow run stable-release-gate.yml --repo %s --ref main -f ref=%s -f init_image_sha256=<retained-release-gate-digest>\n' \
+    printf 'would create or verify the signed stable init-image authority tag\n'
+    printf 'would run: gh workflow run stable-release-gate.yml --repo %s --ref main -f ref=%s\n' \
       "$(github_repo "${COMPOSE_REPO}")" "${version}"
     printf 'would wait for the hosted gate to confirm green main CI, SonarQube, and immutable static stack validation.\n'
     printf 'full runtime integration and Docker Compose parity run locally before the tag is created.\n'
@@ -4272,12 +4396,12 @@ dispatch_stable_release_gate() {
 
   need_command gh
   init_image_digest="$(retained_stable_init_image_gate_digest "${version}")"
+  ensure_stable_init_image_authority_tag "${version}" "${init_image_digest}"
   previous_run="$(latest_stable_release_gate_dispatch_run || true)"
   run github_cli workflow run stable-release-gate.yml \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --ref main \
-    -f "ref=${version}" \
-    -f "init_image_sha256=${init_image_digest}"
+    -f "ref=${version}"
 
   deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))
   while true; do

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -2550,6 +2550,7 @@ ensure_stable_retry_source_authority() {
 ensure_published_stable_recovery_authority() {
   local version="$1" path repo tag_sha authority_name authority_filter authority_record
   local authority_run_id authority_summary authority_conclusion authority_init_digest
+  local signed_authority_init_digest
   path="$(repo_path "${COMPOSE_REPO}")"
   repo="$(github_repo "${COMPOSE_REPO}")"
   tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
@@ -2557,6 +2558,10 @@ ensure_published_stable_recovery_authority() {
     printf 'published stable recovery tag is missing locally: %s\n' "${version}" >&2
     return 1
   fi
+
+  signed_authority_init_digest="$(
+    verified_stable_init_image_authority_digest "${version}"
+  )"
 
   authority_name="Stable Release Authority (${version})"
   authority_filter=".check_runs[] | select(.name == \"${authority_name}\""
@@ -2582,6 +2587,11 @@ ensure_published_stable_recovery_authority() {
     authority_init_digest="${BASH_REMATCH[1]}"
   else
     printf 'refusing published recovery without a candidate-bound guest init-image digest\n' >&2
+    return 1
+  fi
+  if [[ "${authority_init_digest}" != "${signed_authority_init_digest}" ]]; then
+    printf 'refusing published recovery because hosted authority records %s instead of signed init-image digest %s\n' \
+      "${authority_init_digest}" "${signed_authority_init_digest}" >&2
     return 1
   fi
   authority_conclusion="$(
@@ -2693,6 +2703,50 @@ verify_github_stable_tag_signature() {
 stable_init_image_authority_tag() {
   local version="$1"
   printf 'stable-init-image-authority/%s\n' "${version}"
+}
+
+# Verify the current GitHub companion authority tag and return its guest digest.
+# Published recovery uses this read-only path so deletion or replacement of the
+# signed trust root cannot be papered over by a historical hosted check.
+verified_stable_init_image_authority_digest() {
+  local version="$1" path repo tag_sha authority_tag authority_object
+  local authority_record authority_verified authority_source authority_message digest_lines
+  path="$(repo_path "${COMPOSE_REPO}")"
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
+  authority_tag="$(stable_init_image_authority_tag "${version}")"
+  authority_object="$(
+    github_cli api "repos/${repo}/git/ref/tags/${authority_tag}" --jq '.object.sha'
+  )"
+  if [[ ! "${authority_object}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'stable init-image authority tag is missing or malformed: %s\n' \
+      "${authority_tag}" >&2
+    return 1
+  fi
+  authority_record="$(github_cli api "repos/${repo}/git/tags/${authority_object}")"
+  authority_verified="$(jq -r '.verification.verified // false' <<<"${authority_record}")"
+  authority_source="$(jq -r '.object.sha // empty' <<<"${authority_record}")"
+  authority_message="$(jq -r '.message // empty' <<<"${authority_record}")"
+  if [[ "${authority_verified}" != "true" ]]; then
+    printf 'stable init-image authority tag is not GitHub-verified: %s\n' \
+      "${authority_tag}" >&2
+    return 1
+  fi
+  if [[ "${authority_source}" != "${tag_sha}" ]]; then
+    printf 'stable init-image authority tag names %s instead of source %s\n' \
+      "${authority_source:-missing}" "${tag_sha}" >&2
+    return 1
+  fi
+  digest_lines="$(
+    sed -nE 's/^Guest init image SHA-256: ([0-9a-f]{64})[.]$/\1/p' \
+      <<<"${authority_message}"
+  )"
+  if [[ ! "${digest_lines}" =~ ^[0-9a-f]{64}$ ]]; then
+    printf 'stable init-image authority tag has no unique candidate-bound digest: %s\n' \
+      "${authority_tag}" >&2
+    return 1
+  fi
+  printf '%s\n' "${digest_lines}"
 }
 
 # Create or validate the GitHub-verified signed companion authority tag for a


### PR DESCRIPTION
## Summary

- recover either missing member of a partially uploaded immutable guest asset/checksum pair after validating the member that already exists
- authorize published maintenance recovery from the immutable signed tag and its candidate-bound successful Stable Release Gate evidence, not the movable release branch
- compare the two stable Homebrew formula blob identities instead of tap main so unrelated Current-lane commits cannot create false failures
- preserve fail-closed validation for mismatched local or remote release assets

This is the focused follow-up to the three late exact-head findings on #403. Release publication remains stopped until this exact head is reviewed, validated, and merged.

## Focused proof

- both one-sided guest asset upload interruptions recover by uploading only the missing member
- published maintenance recovery accepts immutable hosted-gate authority and rejects missing or failed authority
- stable formula identity proof reads only Formula/container-compose.rb and Formula/container.rb
- latest-lane formula repair and unpublished maintenance source authority remain separate
- Python compile, Bash syntax, ShellCheck, focused policy tests, and diff validation are green.