### PR TITLE
fix(release): stage VM source mounts locally

### DIFF
--- a/Tools/ci/fingerprint-release-environment.py
+++ b/Tools/ci/fingerprint-release-environment.py
@@ -26,6 +26,7 @@ import re
 import shlex
 import shutil
 import stat
+import subprocess
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -101,6 +102,22 @@ CONTENT_FILE_VARIABLES = frozenset(
         "CONTAINER_RUNTIME_BUILDER_IMAGE_TAR",
         "CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE",
     }
+)
+
+# Release validation relocates the exact Containerization checkout beneath a
+# fresh system-volume runtime root on every attempt. Bind these selectors to the
+# tracked Git tree plus the ignored release inputs deliberately copied beside
+# it, rather than to the random absolute checkout path.
+CONTENT_GIT_CHECKOUT_VARIABLES = frozenset(
+    {
+        "CONTAINERIZATION_INIT_SOURCE_PATH",
+        "CONTAINERIZATION_STACK_REPO",
+    }
+)
+CONTENT_GIT_CHECKOUT_SUPPLEMENTS = (
+    ".local/bin/hawkeye",
+    "bin/vmlinux-*",
+    "bin/vmlinuz-*",
 )
 
 # The release helper extracts the same immutable Container candidate below a
@@ -263,6 +280,79 @@ def selected_file_entry(
     }
 
 
+def selected_git_checkout_entry(
+    value: str, environment: Mapping[str, str], working_directory: Path
+) -> dict[str, str] | None:
+    try:
+        checkout = Path(value)
+        if not checkout.is_absolute():
+            checkout = working_directory / checkout
+        checkout = checkout.resolve()
+    except (OSError, RuntimeError):
+        return None
+    if not checkout.is_dir():
+        return None
+
+    git = shutil.which("git", path=environment.get("PATH"))
+    if git is None:
+        return None
+    git_environment = {
+        "LC_ALL": "C",
+        "PATH": environment.get("PATH", ""),
+    }
+
+    def git_output(*arguments: str) -> str | None:
+        try:
+            result = subprocess.run(
+                [git, "-C", str(checkout), *arguments],
+                check=True,
+                capture_output=True,
+                env=git_environment,
+                text=True,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        return result.stdout.strip()
+
+    source_root = git_output("rev-parse", "--show-toplevel")
+    tree = git_output("rev-parse", "--verify", "HEAD^{tree}")
+    if source_root is None or tree is None:
+        return None
+    try:
+        if Path(source_root).resolve() != checkout:
+            return None
+    except (OSError, RuntimeError):
+        return None
+
+    supplements: list[dict[str, str]] = []
+    for pattern in CONTENT_GIT_CHECKOUT_SUPPLEMENTS:
+        for artifact in sorted(checkout.glob(pattern)):
+            try:
+                metadata = artifact.lstat()
+                if artifact.is_symlink() or not artifact.is_file():
+                    return None
+                supplements.append(
+                    {
+                        "mode": f"{stat.S_IMODE(metadata.st_mode):04o}",
+                        "name_sha256": sha256_bytes(
+                            artifact.relative_to(checkout).as_posix().encode("utf-8")
+                        ),
+                        "sha256": sha256_file(artifact),
+                    }
+                )
+            except (OSError, RuntimeError):
+                return None
+
+    return {
+        "selected_git_supplements_sha256": sha256_bytes(
+            json.dumps(supplements, sort_keys=True, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        ),
+        "selected_git_tree_sha256": sha256_bytes(tree.encode("ascii")),
+    }
+
+
 def relocatable_path_directories(
     environment: Mapping[str, str], working_directory: Path
 ) -> dict[Path, str]:
@@ -340,6 +430,16 @@ def value_entry(
             "normalized_path_sha256": normalized_path_identity(
                 value, relocatable_directories
             )
+        }
+    if name in CONTENT_GIT_CHECKOUT_VARIABLES:
+        checkout_entry = selected_git_checkout_entry(
+            value, environment, working_directory
+        )
+        if checkout_entry is not None:
+            return checkout_entry
+        return {
+            "selected_git_checkout_state": "missing",
+            "value_sha256": sha256_bytes(value.encode("utf-8")),
         }
     if name in CONTENT_FILE_VARIABLES:
         try:

--- a/Tools/ci/test_fingerprint_release_environment.py
+++ b/Tools/ci/test_fingerprint_release_environment.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -154,6 +155,101 @@ class FingerprintReleaseEnvironmentTest(unittest.TestCase):
 
             self.assertEqual(first_fingerprint, relocated_fingerprint)
             self.assertNotEqual(relocated_fingerprint, changed_fingerprint)
+
+    def test_relocated_containerization_checkout_uses_content_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first"
+            second = root / "second"
+            first.mkdir()
+            subprocess.run(["git", "-C", str(first), "init", "--quiet"], check=True)
+            (first / ".gitignore").write_text(".local\nbin\n", encoding="utf-8")
+            (first / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(first), "add", ".gitignore", "tracked.txt"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(first),
+                    "-c",
+                    "user.name=Release Test",
+                    "-c",
+                    "user.email=release-test@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "fixture",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "clone", "--quiet", "--no-local", str(first), str(second)],
+                check=True,
+            )
+            for checkout in (first, second):
+                hawkeye = checkout / ".local" / "bin" / "hawkeye"
+                hawkeye.parent.mkdir(parents=True)
+                hawkeye.write_bytes(b"same hawkeye")
+                hawkeye.chmod(0o755)
+                kernel = checkout / "bin" / "vmlinux-arm64"
+                kernel.parent.mkdir()
+                kernel.write_bytes(b"same kernel")
+
+            def environment(checkout: Path) -> dict[str, str]:
+                return {
+                    "CONTAINERIZATION_INIT_SOURCE_PATH": str(checkout),
+                    "MAKEFLAGS": (
+                        "s -- CONTAINERIZATION_STACK_REPO=" + str(checkout)
+                    ),
+                    "MAKEOVERRIDES": "${-*-command-variables-*-}",
+                    "PATH": "/usr/bin:/bin",
+                }
+
+            first_fingerprint = self.module.fingerprint_environment(
+                environment(first), root
+            )
+            relocated_fingerprint = self.module.fingerprint_environment(
+                environment(second), root
+            )
+            (second / "bin" / "vmlinux-arm64").write_bytes(b"changed kernel")
+            changed_kernel_fingerprint = self.module.fingerprint_environment(
+                environment(second), root
+            )
+            (second / "bin" / "vmlinux-arm64").write_bytes(b"same kernel")
+            (second / "tracked.txt").write_text("changed tracked tree\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(second), "add", "tracked.txt"], check=True
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(second),
+                    "-c",
+                    "user.name=Release Test",
+                    "-c",
+                    "user.email=release-test@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "changed fixture",
+                ],
+                check=True,
+            )
+            changed_tree_fingerprint = self.module.fingerprint_environment(
+                environment(second), root
+            )
+
+            self.assertEqual(first_fingerprint, relocated_fingerprint)
+            self.assertNotEqual(relocated_fingerprint, changed_kernel_fingerprint)
+            self.assertNotEqual(relocated_fingerprint, changed_tree_fingerprint)
 
     def test_staged_init_archive_preserves_literal_path_semantics(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -22,6 +22,7 @@ import io
 import json
 import os
 import re
+import shutil
 import signal
 import shlex
 import subprocess
@@ -125,6 +126,278 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             local_gate.index("release_local_release_gate_host_state"),
             local_gate.rindex("record_stable_init_image_gate_evidence"),
         )
+
+    def test_local_release_gate_stages_vm_mounted_source_on_the_system_volume(
+        self,
+    ) -> None:
+        local_gate = self.script[
+            self.script.index("run_local_release_gate() {") : self.script.index(
+                "# Verify that Apple remotes cannot be pushed"
+            )
+        ]
+        staging = 'staged_containerization_path="${runtime_parent}/containerization"'
+        container_staging = 'staged_container_path="${runtime_parent}/container"'
+        stage_call = "stage_local_validation_checkout"
+        init_source = 'CONTAINERIZATION_INIT_SOURCE_PATH="${containerization_path}"'
+        stack_source = '"CONTAINERIZATION_STACK_REPO=${containerization_path}"'
+
+        self.assertIn("stage_local_validation_checkout() {", self.script)
+        self.assertIn("clone --no-local --no-checkout --quiet", self.script)
+        self.assertIn("remote remove origin", self.script)
+        self.assertIn("objects/info/alternates", self.script)
+        self.assertIn(staging, local_gate)
+        self.assertIn(container_staging, local_gate)
+        self.assertIn(stage_call, local_gate)
+        self.assertIn("publish_local_validation_checkout_alias", local_gate)
+        self.assertIn(
+            "container-compose-release-containerization-$(id -u)", local_gate
+        )
+        self.assertIn("container-compose-release-container-$(id -u)", local_gate)
+        self.assertIn(
+            '"${container_path}" "${staged_container_path}" container', local_gate
+        )
+        self.assertIn(init_source, local_gate)
+        self.assertIn(stack_source, local_gate)
+        self.assertLess(local_gate.index(staging), local_gate.index(stage_call))
+        self.assertLess(local_gate.index(stage_call), local_gate.index(init_source))
+
+    def test_local_validation_checkout_alias_is_stable_and_exactly_cleaned(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="c.") as directory:
+            staged = Path(directory) / "containerization"
+            staged.mkdir()
+            alias = Path("/tmp") / (
+                f"container-compose-release-containerization-{os.getuid()}-"
+                f"test-{os.getpid()}"
+            )
+            try:
+                result = self.run_release_function(
+                    Path(directory),
+                    (
+                        "published=$(publish_local_validation_checkout_alias "
+                        f"{shlex.quote(str(staged))} {shlex.quote(str(alias))}); "
+                        f"test \"$published\" = {shlex.quote(str(alias))}; "
+                        "cleanup_local_validation_checkout_alias "
+                        f"{shlex.quote(str(alias))} {shlex.quote(str(staged))}"
+                    ),
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertFalse(alias.exists())
+                self.assertFalse(alias.is_symlink())
+
+                alias.symlink_to("/tmp/c.stale/containerization")
+                retry = self.run_release_function(
+                    Path(directory),
+                    (
+                        "published=$(publish_local_validation_checkout_alias "
+                        f"{shlex.quote(str(staged))} {shlex.quote(str(alias))}); "
+                        f"test \"$published\" = {shlex.quote(str(alias))}; "
+                        "cleanup_local_validation_checkout_alias "
+                        f"{shlex.quote(str(alias))} {shlex.quote(str(staged))}"
+                    ),
+                )
+                self.assertEqual(retry.returncode, 0, retry.stdout + retry.stderr)
+                self.assertFalse(alias.is_symlink())
+            finally:
+                if alias.is_symlink():
+                    alias.unlink()
+
+    def test_local_container_validation_alias_is_stable_and_exactly_cleaned(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="c.") as directory:
+            staged = Path(directory) / "container"
+            staged.mkdir()
+            alias = Path("/tmp") / (
+                f"container-compose-release-container-{os.getuid()}-"
+                f"test-{os.getpid()}"
+            )
+            try:
+                result = self.run_release_function(
+                    Path(directory),
+                    (
+                        "published=$(publish_local_validation_checkout_alias "
+                        f"{shlex.quote(str(staged))} {shlex.quote(str(alias))} "
+                        "container); "
+                        f"test \"$published\" = {shlex.quote(str(alias))}; "
+                        "cleanup_local_validation_checkout_alias "
+                        f"{shlex.quote(str(alias))} {shlex.quote(str(staged))} "
+                        "container"
+                    ),
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertFalse(alias.exists())
+                self.assertFalse(alias.is_symlink())
+            finally:
+                if alias.is_symlink():
+                    alias.unlink()
+
+    def test_local_validation_checkout_is_exact_self_contained_and_keeps_tools(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            staged = root / "staged"
+            source.mkdir()
+            self.run_command("git", "-C", str(source), "init", "--quiet")
+            (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            self.run_command("git", "-C", str(source), "add", "tracked.txt")
+            self.run_command(
+                "git",
+                "-C",
+                str(source),
+                "-c",
+                "user.name=Release Test",
+                "-c",
+                "user.email=release-test@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "fixture",
+            )
+            (source / "bin").mkdir()
+            (source / "bin" / "vmlinux-arm64").write_bytes(b"kernel")
+            (source / ".local" / "bin").mkdir(parents=True)
+            source_hawkeye = source / ".local" / "bin" / "hawkeye"
+            source_hawkeye.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            source_hawkeye.chmod(0o755)
+            source_tree = self.git(source, "rev-parse", "HEAD^{tree}")
+
+            result = self.run_release_function(
+                root,
+                (
+                    "stage_local_validation_checkout "
+                    f"{shlex.quote(str(source))} {shlex.quote(str(staged))}"
+                ),
+                shell_setup=(
+                    "export GIT_ALTERNATE_OBJECT_DIRECTORIES="
+                    f"{shlex.quote(str(source / '.git' / 'objects'))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(result.stdout.strip(), str(staged))
+            self.assertEqual(source_tree, self.git(staged, "rev-parse", "HEAD^{tree}"))
+            self.assertEqual((staged / "bin" / "vmlinux-arm64").read_bytes(), b"kernel")
+            staged_hawkeye = staged / ".local" / "bin" / "hawkeye"
+            self.assertEqual(staged_hawkeye.read_bytes(), source_hawkeye.read_bytes())
+            self.assertTrue(os.access(staged_hawkeye, os.X_OK))
+            self.assertFalse((staged / ".git" / "objects" / "info" / "alternates").exists())
+            self.assertEqual(self.git(staged, "remote"), "")
+            shutil.rmtree(source)
+            self.run_command(
+                "git",
+                "-C",
+                str(staged),
+                "fsck",
+                "--full",
+                "--strict",
+                "--no-dangling",
+            )
+
+    def test_local_validation_checkout_propagates_copy_failure_in_condition(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            staged = root / "staged"
+            source.mkdir()
+            self.run_command("git", "-C", str(source), "init", "--quiet")
+            (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            self.run_command("git", "-C", str(source), "add", "tracked.txt")
+            self.run_command(
+                "git",
+                "-C",
+                str(source),
+                "-c",
+                "user.name=Release Test",
+                "-c",
+                "user.email=release-test@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "fixture",
+            )
+            (source / "bin").mkdir()
+            (source / "bin" / "vmlinux-arm64").write_bytes(b"kernel")
+            (source / ".local" / "bin").mkdir(parents=True)
+            source_hawkeye = source / ".local" / "bin" / "hawkeye"
+            source_hawkeye.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            source_hawkeye.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                (
+                    "if staged_output=$(stage_local_validation_checkout "
+                    f"{shlex.quote(str(source))} {shlex.quote(str(staged))}); "
+                    "then exit 91; fi"
+                ),
+                shell_setup="cp() { return 73; }",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertIn(
+                "failed to copy installed Hawkeye into release validation checkout",
+                result.stderr,
+            )
+            self.assertFalse((staged / ".local" / "bin" / "hawkeye").exists())
+
+    def test_local_container_validation_checkout_does_not_require_a_kernel(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            staged = root / "staged"
+            source.mkdir()
+            self.run_command("git", "-C", str(source), "init", "--quiet")
+            (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            self.run_command("git", "-C", str(source), "add", "tracked.txt")
+            self.run_command(
+                "git",
+                "-C",
+                str(source),
+                "-c",
+                "user.name=Release Test",
+                "-c",
+                "user.email=release-test@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "fixture",
+            )
+            (source / ".local" / "bin").mkdir(parents=True)
+            source_hawkeye = source / ".local" / "bin" / "hawkeye"
+            source_hawkeye.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            source_hawkeye.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                (
+                    "stage_local_validation_checkout "
+                    f"{shlex.quote(str(source))} {shlex.quote(str(staged))} container"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(result.stdout.strip(), str(staged))
+            self.assertFalse((staged / "bin").exists())
+            self.assertEqual(
+                (staged / ".local" / "bin" / "hawkeye").read_bytes(),
+                source_hawkeye.read_bytes(),
+            )
+            self.assertEqual(self.git(staged, "remote"), "")
 
     def test_release_helper_retains_only_its_unpublished_candidate_before_readiness(self) -> None:
         recovery = self.script[

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7317,6 +7317,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/382"
     },
     {
+      "id": "container-compose-406",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Stage release VM source mounts locally",
+      "state": "active-draft",
+      "lastVerified": "2026-09-01",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-405.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-406.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/406"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-01
 
-Entries: 397. Document snapshots: 695. Current supporting documents: 89.
+Entries: 398. Document snapshots: 697. Current supporting documents: 91.
 
-States: `active-draft` 9, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 10, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -227,6 +227,7 @@ States: `active-draft` 9, `archived` 304, `closed` 17, `merged` 10, `submitted` 
 | `stephenlclarke/container-compose` | [Make release validation deterministic](https://github.com/stephenlclarke/container-compose/pull/363) | `submitted` | `d4691370576e` | [Issue details](container-compose/ISSUE-362.md); [PR details](container-compose/PR-363.md) |
 | `stephenlclarke/container-compose` | [Skip packaging immediately for documentation-only CI](https://github.com/stephenlclarke/container-compose/pull/380) | `submitted` | `502aae5a649e` | [Issue details](container-compose/ISSUE-379.md); [PR details](container-compose/PR-380.md) |
 | `stephenlclarke/container-compose` | [Reserve CodeQL for stable releases](https://github.com/stephenlclarke/container-compose/pull/382) | `submitted` | `caea6b4a9e32` | [Issue details](container-compose/ISSUE-381.md); [PR details](container-compose/PR-382.md) |
+| `stephenlclarke/container-compose` | [Stage release VM source mounts locally](https://github.com/stephenlclarke/container-compose/pull/406) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-405.md); [PR details](container-compose/PR-406.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-405.md
+++ b/docs/upstream/container-compose/ISSUE-405.md
@@ -1,0 +1,35 @@
+# Issue 405: stage release VM source mounts on the system volume
+
+## Problem
+
+The checkpointed 0.13.1 stable-release gate completed its earlier sibling stages, then remained indefinitely in `created/starting` while macOS Virtualization opened the Containerization checkout through `VZSharedDirectory`. The checkout lived on `/Volumes/SSD`; a live process sample showed the launchd-managed VM helper blocked at `open(2)` on that removable-volume bind mount instead of returning a test result.
+
+After the Containerization source was localized, the next exact gate reached Container coverage integration and exposed the same boundary in its sibling checkout. Unified macOS evidence showed the freshly built `container-apiserver` remained inside `xpcproxy`: TCC attributed the ad-hoc coverage binary to `/Volumes/SSD`, denied its unattended background access, and the CLI eventually reported an XPC ping timeout.
+
+Tracking issue: [`#405`](https://github.com/stephenlclarke/container-compose/issues/405).
+
+## Required outcome
+
+- Stage the exact tracked Containerization checkout under the marker-protected release runtime parent on the internal system volume before VM-backed validation.
+- Prove the staged Git tree equals the selected source tree and has neither an inherited object-directory override, object-store alternate, incomplete object closure, nor removable-volume remote.
+- Preserve the installed release-policy tool and already-provisioned kernel without copying prior build outputs.
+- Use the local checkout for both the Containerization init source and sibling validation input.
+- Stage the exact Container sibling checkout beside Containerization so its freshly built launchd/XPC services also execute from the internal system volume.
+- Publish one stable, exact-target system-volume alias so historical release sources do not fingerprint a random path; current sources additionally fingerprint the relocated checkout by its Git tree, Hawkeye, and kernel content.
+- Remove the checkout through the existing runtime-parent cleanup lifecycle after success, failure, or interruption.
+- Preserve exact-input checkpoints so a corrected retry does not repeat completed validation stages.
+
+## Acceptance evidence
+
+- Focused functional regression supplies an inherited object-directory override, creates an exact self-contained local clone, preserves its executable Hawkeye tool and kernel, removes its source remote, deletes the source repository, and then rechecks the staged object closure and tree hash.
+- Focused failure-injection regression invokes staging through the production conditional boundary and proves a tool-copy failure cannot be reported as success.
+- Focused fingerprint regression proves two relocated copies of the same checkout reuse one identity while a changed kernel invalidates it.
+- Focused alias regression proves the stable historical-source path is exactly targeted, removes a stale release alias safely, and is removed after the attempt.
+- Focused policy regression proves both VM consumers receive the staged path after the runtime parent is created.
+- Focused Container regression proves the second exact checkout needs no kernel supplement, retains only Hawkeye outside its tracked tree, and receives a distinct stable alias with exact-target cleanup.
+- Bash syntax, ShellCheck, Markdown lint, `git diff --check`, and exact-head review pass.
+- The checkpointed 0.13.1 gate resumes through Containerization and Container coverage integration without a removable-volume approval prompt or an `xpcproxy` startup stall.
+
+## Scope
+
+This changes only local stable-release validation staging. It does not change Compose functionality, weaken exact-tree or signing authority, grant privacy permissions, copy prior build outputs, or move benchmark inputs onto removable storage.

--- a/docs/upstream/container-compose/PR-406.md
+++ b/docs/upstream/container-compose/PR-406.md
@@ -1,0 +1,37 @@
+# Pull request 406: stage release VM source mounts locally
+
+## Summary
+
+Pull request [`#406`](https://github.com/stephenlclarke/container-compose/pull/406) closes tracking issue [`#405`](https://github.com/stephenlclarke/container-compose/issues/405).
+
+- Clone the exact Containerization and Container validation trees beneath the internal-volume release runtime parent before a VM bind mount or freshly built launchd/XPC service uses them.
+- Unset inherited Git object/worktree overrides and reject tracked source drift, mismatched staged trees, incomplete object closure, Git object alternates, and a retained removable-volume remote.
+- Copy only the installed Hawkeye policy tool into both checkouts and the fetched kernel into Containerization; product binaries and integration images remain fresh gate outputs.
+- Supply the staged checkouts to Containerization init-image selection and sibling validation.
+- Publish a stable exact-target alias for historical release fingerprint tools, and normalize current checkpoint identity to the tracked Git tree plus copied Hawkeye and kernel content.
+- Reuse the marker-protected runtime-parent cleanup after success, failure, or interruption.
+
+## Failure boundary
+
+An invalid source, dirty tracked tree, existing destination, incomplete clone, tree mismatch, object-store alternate, unexpected stable alias, or missing fetched Containerization kernel fails before the runtime starts. Earlier exact-input validation checkpoints remain reusable because historical sources see stable internal-volume paths and current sources fingerprint the tracked trees and copied release inputs.
+
+## Validation
+
+- [x] Twenty focused release-policy, stable-alias, cleanup, and checkpoint-fingerprint checks
+- [x] Functional inherited-alternate, exact-tree, independent-object-closure, source-deletion, remote-removal, tool-preservation, and kernel-preservation regression
+- [x] Production-shaped conditional invocation propagates a tool-copy failure
+- [x] Relocated identical checkouts share one checkpoint identity; changed kernel content invalidates it
+- [x] Stable alias publication, stale-alias replacement, exact-target cleanup, and retry
+- [x] Container sibling staging without a kernel supplement and with an independent stable alias
+- [x] Bash syntax
+- [x] ShellCheck
+- [x] Python compilation
+- [x] Markdown lint
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+- [ ] Exact-head review
+- [ ] Resumed 0.13.1 release gate
+
+## Compatibility and risk
+
+Compose runtime behavior and package contents are unchanged. The local release gate performs two local Git clones and one kernel copy so launchd-managed Virtualization and freshly built Container services never execute from a removable-volume checkout. Both staged trees remain cryptographically tied to their selected source trees and are removed with the existing release runtime lifecycle.

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -636,6 +636,158 @@ repo_path() {
   printf '%s/%s' "${ROOT}" "$1"
 }
 
+# Stage one exact checkout on the system volume for Virtualization directory sharing.
+stage_local_validation_checkout() {
+  local source_path="$1"
+  local staged_path="$2"
+  local checkout_kind="${3:-containerization}"
+  local source_commit source_tree staged_tree kernel kernel_count hawkeye_path
+  local source_hawkeye_digest staged_hawkeye_digest
+  local -a isolated_git=(
+    env
+    -u GIT_ALTERNATE_OBJECT_DIRECTORIES
+    -u GIT_OBJECT_DIRECTORY
+    -u GIT_COMMON_DIR
+    -u GIT_DIR
+    -u GIT_WORK_TREE
+    git
+  )
+
+  case "${checkout_kind}" in
+    container | containerization) ;;
+    *)
+      printf 'unsupported release validation checkout kind: %s\n' \
+        "${checkout_kind:-unset}" >&2
+      return 2
+      ;;
+  esac
+
+  if [[ "${source_path}" != /* || ! -d "${source_path}" ]]; then
+    printf 'release validation source checkout is invalid: %s\n' \
+      "${source_path:-unset}" >&2
+    return 2
+  fi
+  if [[ "${staged_path}" != /* || "${staged_path}" == / || -e "${staged_path}" ]]; then
+    printf 'release validation staging path must be a new absolute path other than /: %s\n' \
+      "${staged_path:-unset}" >&2
+    return 2
+  fi
+  if ! "${isolated_git[@]}" -C "${source_path}" diff --quiet HEAD --; then
+    printf 'tracked changes block release validation checkout staging: %s\n' \
+      "${source_path}" >&2
+    return 1
+  fi
+
+  if ! source_commit="$("${isolated_git[@]}" -C "${source_path}" \
+    rev-parse --verify HEAD)" || \
+    ! source_tree="$("${isolated_git[@]}" -C "${source_path}" \
+      rev-parse --verify 'HEAD^{tree}')"; then
+    printf 'failed to resolve release validation source identity: %s\n' \
+      "${source_path}" >&2
+    return 1
+  fi
+  if ! "${isolated_git[@]}" clone --no-local --no-checkout --quiet \
+    "${source_path}" "${staged_path}"; then
+    printf 'failed to stage release validation checkout locally: %s\n' \
+      "${source_path}" >&2
+    return 1
+  fi
+  if ! "${isolated_git[@]}" -C "${staged_path}" cat-file -e \
+    "${source_commit}^{commit}" 2>/dev/null; then
+    if ! "${isolated_git[@]}" -C "${staged_path}" fetch --quiet --no-tags \
+      origin "${source_commit}"; then
+      printf 'failed to fetch exact release validation commit %s: %s\n' \
+        "${source_commit}" "${source_path}" >&2
+      return 1
+    fi
+  fi
+  if ! "${isolated_git[@]}" -C "${staged_path}" checkout --quiet \
+    --detach "${source_commit}"; then
+    printf 'failed to check out exact release validation commit %s: %s\n' \
+      "${source_commit}" "${staged_path}" >&2
+    return 1
+  fi
+  if ! "${isolated_git[@]}" -C "${staged_path}" fsck --full --strict \
+    --no-dangling "${source_commit}"; then
+    printf 'staged release validation checkout has an incomplete object closure: %s\n' \
+      "${staged_path}" >&2
+    return 1
+  fi
+  if ! "${isolated_git[@]}" -C "${staged_path}" remote remove origin; then
+    printf 'failed to remove release validation source remote: %s\n' \
+      "${staged_path}" >&2
+    return 1
+  fi
+  if ! staged_tree="$("${isolated_git[@]}" -C "${staged_path}" \
+    rev-parse --verify 'HEAD^{tree}')"; then
+    printf 'failed to resolve staged release validation tree: %s\n' \
+      "${staged_path}" >&2
+    return 1
+  fi
+  if [[ "${staged_tree}" != "${source_tree}" ]] || \
+    ! "${isolated_git[@]}" -C "${staged_path}" diff --quiet HEAD --; then
+    printf 'staged release validation checkout does not match source tree %s: %s\n' \
+      "${source_tree}" "${staged_path}" >&2
+    return 1
+  fi
+  if [[ -f "${staged_path}/.git/objects/info/alternates" ]]; then
+    printf 'staged release validation checkout is not self-contained: %s\n' \
+      "${staged_path}" >&2
+    return 1
+  fi
+
+  hawkeye_path="${source_path}/.local/bin/hawkeye"
+  if [[ ! -x "${hawkeye_path}" || -L "${hawkeye_path}" ]]; then
+    printf 'release validation source checkout has no installed regular Hawkeye executable: %s\n' \
+      "${hawkeye_path}" >&2
+    return 1
+  fi
+  if ! mkdir -p "${staged_path}/.local/bin" || \
+    ! cp -p "${hawkeye_path}" "${staged_path}/.local/bin/hawkeye"; then
+    printf 'failed to copy installed Hawkeye into release validation checkout: %s\n' \
+      "${staged_path}" >&2
+    return 1
+  fi
+  if ! staged_hawkeye_digest="$(shasum -a 256 \
+    "${staged_path}/.local/bin/hawkeye" | awk '{print $1}')" || \
+    ! source_hawkeye_digest="$(shasum -a 256 "${hawkeye_path}" | \
+      awk '{print $1}')"; then
+    printf 'failed to digest staged release validation Hawkeye: %s\n' \
+      "${staged_path}/.local/bin/hawkeye" >&2
+    return 1
+  fi
+  if [[ "${staged_hawkeye_digest}" != "${source_hawkeye_digest}" ]]; then
+    printf 'staged release validation Hawkeye does not match its installed source: %s\n' \
+      "${staged_path}/.local/bin/hawkeye" >&2
+    return 1
+  fi
+
+  if [[ "${checkout_kind}" == "containerization" ]]; then
+    if ! mkdir -p "${staged_path}/bin"; then
+      printf 'failed to create staged release validation kernel directory: %s\n' \
+        "${staged_path}/bin" >&2
+      return 1
+    fi
+    kernel_count=0
+    for kernel in "${source_path}"/bin/vmlinux-* "${source_path}"/bin/vmlinuz-*; do
+      [[ -f "${kernel}" ]] || continue
+      if ! cp -p "${kernel}" "${staged_path}/bin/"; then
+        printf 'failed to copy release validation kernel locally: %s\n' \
+          "${kernel}" >&2
+        return 1
+      fi
+      ((kernel_count += 1))
+    done
+    if ((kernel_count == 0)); then
+      printf 'release validation source checkout has no fetched kernel: %s\n' \
+        "${source_path}/bin" >&2
+      return 1
+    fi
+  fi
+
+  printf '%s\n' "${staged_path}"
+}
+
 # Print the builder image repository, tag, and digest compiled by container.
 container_builder_image_metadata() {
   local package
@@ -918,16 +1070,130 @@ stop_release_runtime_candidate() {
   return 1
 }
 
-# Stop the exact runtime and then remove its marker-protected runtime and
-# candidate roots in dependency order.
+# Publish one stable system-volume alias for the randomly allocated validation
+# checkout. Historical release sources hash literal checkout paths in their
+# checkpoint environment fingerprint; the stable alias lets those releases
+# recover while its target remains inside this gate's marker-protected root.
+publish_local_validation_checkout_alias() {
+  local staged_path="$1"
+  local alias_path="$2"
+  local checkout_kind="${3:-containerization}"
+  local staged_pattern alias_pattern
+  local stale_target=""
+
+  case "${checkout_kind}" in
+    container | containerization) ;;
+    *)
+      printf 'unsupported release validation alias kind: %s\n' \
+        "${checkout_kind:-unset}" >&2
+      return 2
+      ;;
+  esac
+  staged_pattern="^(/private)?/tmp/c\\.[^/]+/${checkout_kind}$"
+  alias_pattern="^(/private)?/tmp/container-compose-release-${checkout_kind}-[0-9]+(-[A-Za-z0-9.-]+)?$"
+
+  if [[ ! "${staged_path}" =~ ${staged_pattern} ]] || \
+    [[ ! -d "${staged_path}" || -L "${staged_path}" ]]; then
+    printf 'release validation alias target is invalid: %s\n' \
+      "${staged_path:-unset}" >&2
+    return 2
+  fi
+  if [[ ! "${alias_path}" =~ ${alias_pattern} ]]; then
+    printf 'release validation alias path is invalid: %s\n' \
+      "${alias_path:-unset}" >&2
+    return 2
+  fi
+
+  if [[ -L "${alias_path}" ]]; then
+    if ! stale_target="$(readlink "${alias_path}")" || \
+      [[ ! "${stale_target}" =~ ${staged_pattern} ]]; then
+      printf 'refusing to replace an unexpected release validation alias: %s\n' \
+        "${alias_path}" >&2
+      return 1
+    fi
+    if ! rm -f -- "${alias_path}"; then
+      printf 'failed to remove stale release validation alias: %s\n' \
+        "${alias_path}" >&2
+      return 1
+    fi
+  elif [[ -e "${alias_path}" ]]; then
+    printf 'release validation alias path already exists and is not a symlink: %s\n' \
+      "${alias_path}" >&2
+    return 1
+  fi
+
+  if ! ln -s "${staged_path}" "${alias_path}"; then
+    printf 'failed to publish release validation alias: %s\n' \
+      "${alias_path}" >&2
+    return 1
+  fi
+  printf '%s\n' "${alias_path}"
+}
+
+# Remove only the exact alias that still points at this gate's checkout.
+cleanup_local_validation_checkout_alias() {
+  local alias_path="$1"
+  local staged_path="$2"
+  local checkout_kind="${3:-containerization}"
+  local staged_pattern alias_pattern
+  local current_target=""
+
+  [[ -n "${alias_path}" ]] || return 0
+  case "${checkout_kind}" in
+    container | containerization) ;;
+    *)
+      printf 'unsupported release validation alias kind: %s\n' \
+        "${checkout_kind:-unset}" >&2
+      return 2
+      ;;
+  esac
+  staged_pattern="^(/private)?/tmp/c\\.[^/]+/${checkout_kind}$"
+  alias_pattern="^(/private)?/tmp/container-compose-release-${checkout_kind}-[0-9]+(-[A-Za-z0-9.-]+)?$"
+  if [[ ! "${alias_path}" =~ ${alias_pattern} ]] || \
+    [[ ! "${staged_path}" =~ ${staged_pattern} ]]; then
+    printf 'refusing to remove an unexpected release validation alias: %s\n' \
+      "${alias_path}" >&2
+    return 1
+  fi
+  if [[ ! -L "${alias_path}" ]]; then
+    if [[ -e "${alias_path}" ]]; then
+      printf 'release validation alias was replaced by a non-symlink: %s\n' \
+        "${alias_path}" >&2
+      return 1
+    fi
+    return 0
+  fi
+  if ! current_target="$(readlink "${alias_path}")" || \
+    [[ "${current_target}" != "${staged_path}" ]]; then
+    printf 'release validation alias no longer names this gate checkout: %s\n' \
+      "${alias_path}" >&2
+    return 1
+  fi
+  if ! rm -f -- "${alias_path}"; then
+    printf 'failed to remove release validation alias: %s\n' \
+      "${alias_path}" >&2
+    return 1
+  fi
+}
+
+# Stop the exact runtime and then remove its stable alias, marker-protected
+# runtime root, and candidate root in dependency order.
 cleanup_local_release_gate_resources() {
   local container_binary="$1"
   local runtime_parent="$2"
   local runtime_app_root="$3"
   local runtime_service_namespace="$4"
+  local staged_containerization_alias="${5:-}"
+  local staged_containerization_path="${6:-}"
+  local staged_container_alias="${7:-}"
+  local staged_container_path="${8:-}"
 
   stop_release_runtime_candidate "${container_binary}" "${runtime_app_root}" \
     "${runtime_service_namespace}" || return 1
+  cleanup_local_validation_checkout_alias "${staged_containerization_alias}" \
+    "${staged_containerization_path}" || return 1
+  cleanup_local_validation_checkout_alias "${staged_container_alias}" \
+    "${staged_container_path}" container || return 1
   cleanup_release_runtime_parent "${runtime_parent}" || return 1
   cleanup_container_runtime_candidate
 }
@@ -2040,7 +2306,7 @@ retained_stable_init_image_gate_digest() {
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
   (
-  local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive
+  local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive staged_container_path staged_container_alias staged_containerization_path staged_containerization_alias
   local containerization_reference required_init_references status runtime_run_id runtime_service_namespace runtime_namespace_digest candidate_sha init_image_digest_before init_image_digest_after
   local -a RELEASE_QUIESCED_LABELS=()
   local -a RELEASE_QUIESCED_PLISTS=()
@@ -2134,7 +2400,11 @@ PY
     local cleanup_status="${trapped_status}"
     if ! cleanup_local_release_gate_resources "${container_binary:-}" \
       "${runtime_parent:-}" "${runtime_app_root:-}" \
-      "${runtime_service_namespace:-}"; then
+      "${runtime_service_namespace:-}" \
+      "${staged_containerization_alias:-}" \
+      "${staged_containerization_path:-}" \
+      "${staged_container_alias:-}" \
+      "${staged_container_path:-}"; then
       cleanup_status=1
     fi
     if ! release_local_release_gate_host_state; then
@@ -2151,6 +2421,37 @@ PY
   # Keep both this candidate's provider socket and Container integration's
   # nested provider socket below Darwin's 103-byte sockaddr_un limit.
   runtime_parent="$(create_release_runtime_parent "${runtime_parent_base}")"
+  # Virtualization opens bind-mounted source directories from a launchd helper.
+  # On removable build volumes macOS can block that open behind a TCC prompt,
+  # which makes an unattended release gate wait forever. Clone the exact tracked
+  # Containerization tree into the marker-protected system-volume lifecycle and
+  # copy only its installed release-policy tool and already-provisioned kernel;
+  # build outputs remain fresh.
+  staged_containerization_path="${runtime_parent}/containerization"
+  if ! staged_containerization_path="$(stage_local_validation_checkout \
+    "${containerization_path}" "${staged_containerization_path}")"; then
+    return 1
+  fi
+  staged_containerization_alias="${runtime_parent_base}/container-compose-release-containerization-$(id -u)"
+  if ! containerization_path="$(publish_local_validation_checkout_alias \
+    "${staged_containerization_path}" \
+    "${staged_containerization_alias}")"; then
+    return 1
+  fi
+  # Container's integration target launches freshly built XPC services. Keep
+  # that exact source/build checkout on the system volume as well; otherwise
+  # launchd can leave an ad-hoc coverage binary suspended in xpcproxy while a
+  # background TCC request waits for removable-volume approval.
+  staged_container_path="${runtime_parent}/container"
+  if ! staged_container_path="$(stage_local_validation_checkout \
+    "${container_path}" "${staged_container_path}" container)"; then
+    return 1
+  fi
+  staged_container_alias="${runtime_parent_base}/container-compose-release-container-$(id -u)"
+  if ! container_path="$(publish_local_validation_checkout_alias \
+    "${staged_container_path}" "${staged_container_alias}" container)"; then
+    return 1
+  fi
   # Stage the retained init archive on the local system volume. launchd-managed
   # services can be denied access to archives on removable volumes even after
   # the release helper has validated them successfully.
@@ -2208,9 +2509,15 @@ PY
   fi
 
   if ! cleanup_local_release_gate_resources "${container_binary}" \
-    "${runtime_parent}" "${runtime_app_root}" "${runtime_service_namespace}"; then
+    "${runtime_parent}" "${runtime_app_root}" "${runtime_service_namespace}" \
+    "${staged_containerization_alias}" "${staged_containerization_path}" \
+    "${staged_container_alias}" "${staged_container_path}"; then
     status=1
   fi
+  staged_containerization_alias=""
+  staged_containerization_path=""
+  staged_container_alias=""
+  staged_container_path=""
   runtime_parent=""
   runtime_app_root=""
   runtime_service_namespace=""


### PR DESCRIPTION
## Summary

- clone the exact Containerization and Container validation trees beneath the internal-volume release runtime parent
- reject tracked drift, Git alternates, mismatched staged trees, and unsafe stable aliases
- preserve only Hawkeye in both checkouts and the fetched kernel in Containerization; rebuild all product outputs
- use stable system-volume aliases so historical release checkpoints remain recoverable across attempts

## Failure evidence

The first checkpointed 0.13.1 gate stalled while Virtualization opened the Containerization checkout through `VZSharedDirectory` on `/Volumes/SSD`. After localizing that tree, the next exact gate reached Container coverage integration and timed out pinging its freshly built API server. Unified macOS evidence showed `container-apiserver` remained in `xpcproxy`; TCC attributed the ad-hoc binary to `/Volumes/SSD` and denied unattended background access.

This change localizes both launchd/VM source and build boundaries. It grants no privacy permission and copies no previous product output.

## Validation

- 20 focused release-policy, stable-alias, cleanup, and checkpoint-fingerprint checks
- exact self-contained Git object closure after source deletion
- Hawkeye and Containerization kernel preservation
- Container staging without a kernel supplement
- Bash syntax and ShellCheck
- Markdownlint and Python compilation
- `git diff --check`
- signed Conventional Commit

Closes #405