### PR TITLE
test(runtime): align 0.13 exit-control smoke checks

### DIFF
--- a/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
+++ b/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
@@ -788,7 +788,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(exitControl.stdout.contains(containerDryRun("start \(project)-api-1")))
         #expect(exitControl.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(exitControl.stdout.contains("+ compose-runtime wait \(project)-api-1"))
-        #expect(exitControl.stdout.contains(containerDryRun("delete \(project)-api-1")))
+        #expect(exitControl.stdout.contains(containerDryRun("stop \(project)-api-1")))
+        #expect(!exitControl.stdout.contains(containerDryRun("delete \(project)-api-1")))
 
         let watch = try runProcess(
             composeBinary,
@@ -820,7 +821,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(environmentMenu.stdout.contains(containerDryRun("start \(project)-api-1")))
         #expect(environmentMenu.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(environmentMenu.stdout.contains("+ compose-runtime wait \(project)-api-1"))
-        #expect(environmentMenu.stdout.contains(containerDryRun("delete \(project)-api-1")))
+        #expect(environmentMenu.stdout.contains(containerDryRun("stop \(project)-api-1")))
+        #expect(!environmentMenu.stdout.contains(containerDryRun("delete \(project)-api-1")))
     }
 
     @Test("runtime dry run up renders service privileged command")
@@ -1223,7 +1225,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(dryRun.stdout.contains(containerDryRun("start \(project)-api-1")))
         #expect(dryRun.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(dryRun.stdout.contains("+ compose-runtime wait \(project)-api-1"))
-        #expect(dryRun.stdout.contains(containerDryRun("delete \(project)-api-1")))
+        #expect(dryRun.stdout.contains(containerDryRun("stop \(project)-api-1")))
+        #expect(!dryRun.stdout.contains(containerDryRun("delete \(project)-api-1")))
 
         let result = try runProcess(
             composeBinary,


### PR DESCRIPTION
Closes #407.\n\nAligns the historical 0.13 maintenance-line runtime smoke checks with the intended exit-control behavior introduced for 0.13.1: stop containers while retaining them and their logs for inspection. The focused core tests already covered this contract; these three end-to-end dry-run assertions were stale.\n\nValidation:\n- Matched 0.13.1 runtime smoke suite: 27 tests passed, 0 failed, 0 skipped.\n- Signed commit and clean diff.\n\nRelease evidence: this fixes the only failing stage after sibling-stack and compose-ci checkpoints completed successfully in the local 0.13.1 release gate.