### PR TITLE
fix(ci): keep release state on internal storage

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -279,7 +279,10 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, container-compose-release]
     timeout-minutes: 120
     env:
-      RELEASE_PIPELINE_STATE_ROOT: /Volumes/SSD/github/.container-compose-release-pipeline
+      # Keep recoverable state on the runner's persistent internal tool cache.
+      # A service-launched job can block indefinitely when mkdir crosses the
+      # removable-volume privacy boundary before the pipeline even starts.
+      RELEASE_PIPELINE_STATE_ROOT: ${{ github.workspace }}/.container-compose-release-pipeline
     steps:
       - name: Checkout the stable candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3317,9 +3317,10 @@ github_cli() {{
         self.assertIn("make -C release-tools pipeline", workflow)
         self.assertIn("make -C ../release-tools pipeline-bootstrap", workflow)
         self.assertIn(
-            "RELEASE_PIPELINE_STATE_ROOT: /Volumes/SSD/github/.container-compose-release-pipeline",
+            "RELEASE_PIPELINE_STATE_ROOT: ${{ github.workspace }}/.container-compose-release-pipeline",
             workflow,
         )
+        self.assertNotIn("RELEASE_PIPELINE_STATE_ROOT: /Volumes/", workflow)
         self.assertIn("make -C release-tools pipeline-resume", workflow)
         self.assertIn('PIPELINE_SESSION="${resume_session}"', workflow)
         self.assertNotIn("make -C container-compose ci", workflow)

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7336,6 +7336,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/406"
     },
     {
+      "id": "container-compose-413",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Keep release state on internal storage",
+      "state": "active-draft",
+      "lastVerified": "2026-09-02",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-412.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-413.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/413"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-01
 
-Entries: 398. Document snapshots: 697. Current supporting documents: 91.
+Entries: 399. Document snapshots: 699. Current supporting documents: 93.
 
-States: `active-draft` 10, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 11, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -228,6 +228,7 @@ States: `active-draft` 10, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Skip packaging immediately for documentation-only CI](https://github.com/stephenlclarke/container-compose/pull/380) | `submitted` | `502aae5a649e` | [Issue details](container-compose/ISSUE-379.md); [PR details](container-compose/PR-380.md) |
 | `stephenlclarke/container-compose` | [Reserve CodeQL for stable releases](https://github.com/stephenlclarke/container-compose/pull/382) | `submitted` | `caea6b4a9e32` | [Issue details](container-compose/ISSUE-381.md); [PR details](container-compose/PR-382.md) |
 | `stephenlclarke/container-compose` | [Stage release VM source mounts locally](https://github.com/stephenlclarke/container-compose/pull/406) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-405.md); [PR details](container-compose/PR-406.md) |
+| `stephenlclarke/container-compose` | [Keep release state on internal storage](https://github.com/stephenlclarke/container-compose/pull/413) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-412.md); [PR details](container-compose/PR-413.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-412.md
+++ b/docs/upstream/container-compose/ISSUE-412.md
@@ -1,0 +1,28 @@
+# Issue 412: keep recoverable release state on internal storage
+
+## Problem
+
+Stable Release Gate run [`33575857011`](https://github.com/stephenlclarke/container-compose/actions/runs/33575857011) blocked before pipeline startup while its service-launched self-hosted runner executed `mkdir -p /Volumes/SSD/github/.container-compose-release-pipeline`. A live sample remained inside the kernel `mkdir(2)` call for more than ten minutes. Cancellation marked the workflow complete but could not reap that blocked child until it was terminated explicitly.
+
+The gate already stages VM and XPC source inputs on internal storage to avoid macOS removable-volume privacy waits. Its recoverable Nextflow state root crossed the same boundary earlier in the workflow and therefore remained capable of blocking unattended releases.
+
+Tracking issue: [`#412`](https://github.com/stephenlclarke/container-compose/issues/412).
+
+## Required outcome
+
+- Store recoverable pipeline state at a stable absolute path on the self-hosted runner's internal workspace.
+- Keep the state outside child checkout paths so `actions/checkout` cleanup does not erase resumable sessions.
+- Preserve the same path across workflow attempts so `pipeline-resume` remains deterministic.
+- Reject reintroduction of a `/Volumes` state root in focused workflow policy coverage.
+- Resume the guarded 0.13.1 publication from its existing signed tag and immutable init-image authority.
+
+## Acceptance evidence
+
+- The focused stable-gate workflow policy test requires the internal workspace path and excludes `/Volumes`.
+- Actionlint accepts the workflow expression at job scope.
+- The replacement Stable Release Gate passes pipeline bootstrap without a removable-volume prompt or blocked filesystem call.
+- The signed 0.13.1 candidate, release authority, assets, and Homebrew pair remain unchanged.
+
+## Scope
+
+This changes only the self-hosted stable-gate state location. It does not weaken state-root markers, cleanup guards, candidate provenance, checkpoint identity, runtime validation, package publication, or Homebrew verification.

--- a/docs/upstream/container-compose/PR-413.md
+++ b/docs/upstream/container-compose/PR-413.md
@@ -1,0 +1,28 @@
+# Pull request 413: keep release state on internal storage
+
+## Summary
+
+Pull request [`#413`](https://github.com/stephenlclarke/container-compose/pull/413) closes tracking issue [`#412`](https://github.com/stephenlclarke/container-compose/issues/412).
+
+- Move the recoverable stable-release pipeline root from `/Volumes/SSD` to a hidden directory beneath the self-hosted runner's persistent internal workspace.
+- Keep the root outside the candidate and immutable-tool child checkouts so retries retain Nextflow history and checkpoints.
+- Add a focused policy assertion that rejects any stable-gate state root under `/Volumes`.
+
+## Failure boundary
+
+The existing pipeline bootstrap still requires an absolute, non-root, non-symbolic, marker-protected state directory and rejects unexpected pre-existing content. This change removes only the removable-volume access boundary; it does not relax those ownership checks.
+
+## Validation
+
+- [x] Focused stable-gate workflow policy test
+- [x] Actionlint
+- [x] Handoff registry validation
+- [x] Markdownlint
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+- [ ] Exact-head review
+- [ ] Replacement 0.13.1 Stable Release Gate
+
+## Compatibility and risk
+
+The self-hosted runner workspace is already on internal storage and has a stable path across workflow attempts. Child checkouts continue to use their existing subdirectories, while the hidden sibling state directory remains available to `pipeline-resume` without crossing macOS removable-volume privacy controls.


### PR DESCRIPTION
## Summary

- keep recoverable release-pipeline state under the self-hosted runner workspace on internal storage
- preserve the stable path across workflow attempts while child checkouts remain isolated
- reject a regression back to `/Volumes` in focused policy coverage

## Validation

- focused stable-gate workflow policy test
- Actionlint
- `git diff --check`

Closes #412.