### PR TITLE
fix(ci): fingerprint staged Container checkout

### DIFF
--- a/Tools/ci/fingerprint-release-environment.py
+++ b/Tools/ci/fingerprint-release-environment.py
@@ -104,14 +104,17 @@ CONTENT_FILE_VARIABLES = frozenset(
     }
 )
 
-# Release validation relocates the exact Containerization checkout beneath a
-# fresh system-volume runtime root on every attempt. Bind these selectors to the
-# tracked Git tree plus the ignored release inputs deliberately copied beside
-# it, rather than to the random absolute checkout path.
+# Release validation relocates the exact Container and Containerization
+# checkouts beneath a fresh system-volume runtime root on every attempt. Bind
+# these selectors to the tracked Git tree plus the ignored release inputs
+# deliberately copied beside it, rather than to the random absolute checkout
+# path.
 CONTENT_GIT_CHECKOUT_VARIABLES = frozenset(
     {
         "CONTAINERIZATION_INIT_SOURCE_PATH",
         "CONTAINERIZATION_STACK_REPO",
+        "CONTAINER_RUNTIME_INIT_BLOCK_REPO",
+        "CONTAINER_STACK_REPO",
     }
 )
 CONTENT_GIT_CHECKOUT_SUPPLEMENTS = (

--- a/Tools/ci/test_fingerprint_release_environment.py
+++ b/Tools/ci/test_fingerprint_release_environment.py
@@ -162,7 +162,9 @@ class FingerprintReleaseEnvironmentTest(unittest.TestCase):
             first = root / "first"
             second = root / "second"
             first.mkdir()
-            subprocess.run(["git", "-C", str(first), "init", "--quiet"], check=True)
+            subprocess.run(
+                ["git", "-C", str(first), "init", "--quiet"], check=True
+            )
             (first / ".gitignore").write_text(".local\nbin\n", encoding="utf-8")
             (first / "tracked.txt").write_text("tracked\n", encoding="utf-8")
             subprocess.run(
@@ -250,6 +252,73 @@ class FingerprintReleaseEnvironmentTest(unittest.TestCase):
             self.assertEqual(first_fingerprint, relocated_fingerprint)
             self.assertNotEqual(relocated_fingerprint, changed_kernel_fingerprint)
             self.assertNotEqual(relocated_fingerprint, changed_tree_fingerprint)
+
+    def test_relocated_container_checkout_uses_content_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            first = root / "first"
+            second = root / "second"
+            first.mkdir()
+            subprocess.run(["git", "-C", str(first), "init", "--quiet"], check=True)
+            (first / ".gitignore").write_text(".local\n", encoding="utf-8")
+            (first / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            subprocess.run(
+                ["git", "-C", str(first), "add", ".gitignore", "tracked.txt"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(first),
+                    "-c",
+                    "user.name=Release Test",
+                    "-c",
+                    "user.email=release-test@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "fixture",
+                ],
+                check=True,
+            )
+            subprocess.run(
+                ["git", "clone", "--quiet", "--no-local", str(first), str(second)],
+                check=True,
+            )
+            for checkout in (first, second):
+                hawkeye = checkout / ".local" / "bin" / "hawkeye"
+                hawkeye.parent.mkdir(parents=True)
+                hawkeye.write_bytes(b"same hawkeye")
+                hawkeye.chmod(0o755)
+
+            def environment(checkout: Path) -> dict[str, str]:
+                return {
+                    "CONTAINER_RUNTIME_INIT_BLOCK_REPO": str(checkout),
+                    "MAKEFLAGS": "s -- CONTAINER_STACK_REPO=" + str(checkout),
+                    "MAKEOVERRIDES": "${-*-command-variables-*-}",
+                    "PATH": "/usr/bin:/bin",
+                }
+
+            first_fingerprint = self.module.fingerprint_environment(
+                environment(first), root
+            )
+            relocated_fingerprint = self.module.fingerprint_environment(
+                environment(second), root
+            )
+            (second / ".local" / "bin" / "hawkeye").write_bytes(
+                b"changed hawkeye"
+            )
+            changed_hawkeye_fingerprint = self.module.fingerprint_environment(
+                environment(second), root
+            )
+
+            self.assertEqual(first_fingerprint, relocated_fingerprint)
+            self.assertNotEqual(
+                relocated_fingerprint, changed_hawkeye_fingerprint
+            )
 
     def test_staged_init_archive_preserves_literal_path_semantics(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7336,6 +7336,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/406"
     },
     {
+      "id": "container-compose-415",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Fingerprint staged Container checkout content",
+      "state": "active-draft",
+      "lastVerified": "2026-09-02",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-414.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-415.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/415"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-01
 
-Entries: 398. Document snapshots: 697. Current supporting documents: 91.
+Entries: 399. Document snapshots: 699. Current supporting documents: 93.
 
-States: `active-draft` 10, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 11, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -228,6 +228,7 @@ States: `active-draft` 10, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Skip packaging immediately for documentation-only CI](https://github.com/stephenlclarke/container-compose/pull/380) | `submitted` | `502aae5a649e` | [Issue details](container-compose/ISSUE-379.md); [PR details](container-compose/PR-380.md) |
 | `stephenlclarke/container-compose` | [Reserve CodeQL for stable releases](https://github.com/stephenlclarke/container-compose/pull/382) | `submitted` | `caea6b4a9e32` | [Issue details](container-compose/ISSUE-381.md); [PR details](container-compose/PR-382.md) |
 | `stephenlclarke/container-compose` | [Stage release VM source mounts locally](https://github.com/stephenlclarke/container-compose/pull/406) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-405.md); [PR details](container-compose/PR-406.md) |
+| `stephenlclarke/container-compose` | [Fingerprint staged Container checkout content](https://github.com/stephenlclarke/container-compose/pull/415) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-414.md); [PR details](container-compose/PR-415.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-414.md
+++ b/docs/upstream/container-compose/ISSUE-414.md
@@ -1,0 +1,27 @@
+# Issue 414: fingerprint staged Container checkout content
+
+## Problem
+
+Stable release validation relocates the exact Container checkout beneath a fresh system-volume runtime root. The release-environment fingerprint already normalizes the relocated Containerization checkout by its Git tree and deliberately copied release inputs, but `CONTAINER_STACK_REPO` and `CONTAINER_RUNTIME_INIT_BLOCK_REPO` remain tied to their literal paths.
+
+That asymmetry prevents equivalent relocated Container checkouts from reusing a valid checkpoint. More importantly, a changed ignored `.local/bin/hawkeye` can retain the same static Git-tree identity and allow a stale Container checkpoint to be reused.
+
+Tracking issue: [`#414`](https://github.com/stephenlclarke/container-compose/issues/414).
+
+## Required outcome
+
+- Bind both Container checkout selectors to the selected Git tree and staged supplement content.
+- Preserve one identity when an equivalent checkout is relocated.
+- Invalidate the identity when the staged Hawkeye executable changes.
+- Cover the direct runtime selector and the Make command-line selector in a focused regression.
+
+## Acceptance evidence
+
+- Two independent clones with the same Git tree and executable Hawkeye supplement produce the same release-environment fingerprint.
+- Changing only the ignored staged Hawkeye executable changes the fingerprint.
+- The existing Containerization relocation regression remains green.
+- Python compilation, `git diff --check`, a signed Conventional Commit, and exact-head review pass.
+
+## Scope
+
+This changes checkpoint identity only. It does not change runtime behavior, broaden checkpoint reuse, run benchmarks, or alter release artifacts.

--- a/docs/upstream/container-compose/PR-415.md
+++ b/docs/upstream/container-compose/PR-415.md
@@ -1,0 +1,24 @@
+# Pull request 415: fingerprint staged Container checkout content
+
+## Summary
+
+Pull request [`#415`](https://github.com/stephenlclarke/container-compose/pull/415) closes tracking issue [`#414`](https://github.com/stephenlclarke/container-compose/issues/414).
+
+- Treat the relocated Container checkout selectors as content-selected Git checkouts, matching the existing Containerization policy.
+- Bind checkpoint identity to the tracked Git tree plus deliberately staged Hawkeye and kernel supplements.
+- Preserve checkpoint reuse across equivalent system-volume relocations while invalidating a changed staged Hawkeye executable.
+
+## Validation
+
+- [x] Focused relocated Container checkout fingerprint regression
+- [x] Existing relocated Containerization checkout fingerprint regression
+- [x] Python compilation
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+- [x] Handoff registry validation
+- [x] Markdown lint
+- [ ] Exact-head review
+
+## Compatibility and risk
+
+Runtime behavior and release artifacts are unchanged. The correction only makes checkpoint reuse follow the staged Container checkout's content instead of its temporary path, and it fails closed when that checkout or its release supplements cannot be identified.


### PR DESCRIPTION
## Summary

- fingerprint both staged Container checkout selectors by Git tree and deliberately copied supplements
- preserve checkpoint reuse across equivalent internal-volume relocations
- invalidate a checkpoint when the staged Hawkeye executable changes
- add the issue/PR handoff pair and generated registry entry

Closes #414.

## Focused validation

- relocated Container fingerprint regression
- existing relocated Containerization fingerprint regression
- Python compilation
- handoff registry check
- Markdown lint
- `git diff --check`
- signed Conventional Commits

This is checkpoint correctness only; it does not alter runtime or release artifacts.