### PR TITLE
fix(build): isolate persistent release state

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -278,11 +278,6 @@ jobs:
     needs: resolve-candidate
     runs-on: [self-hosted, macOS, ARM64, container-compose-release]
     timeout-minutes: 120
-    env:
-      # Keep recoverable state on the runner's persistent internal tool cache.
-      # A service-launched job can block indefinitely when mkdir crosses the
-      # removable-volume privacy boundary before the pipeline even starts.
-      RELEASE_PIPELINE_STATE_ROOT: ${{ github.workspace }}/.container-compose-release-pipeline
     steps:
       - name: Checkout the stable candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -365,6 +360,25 @@ jobs:
           [[ "$(git -C container rev-parse HEAD)" == "${CONTAINER_REF}" ]]
           [[ "$(git -C homebrew-tap rev-parse HEAD)" == "${HOMEBREW_TAP_REF}" ]]
           [[ "$(git -C release-tools rev-parse HEAD)" == "${CONTROL_SHA}" ]]
+
+      - name: Resolve persistent release state root
+        env:
+          CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${CANDIDATE_SHA}" =~ ^[[:xdigit:]]{40}$ ]]
+          runner_work_root="$(cd "${RUNNER_TEMP}/.." && pwd -P)"
+          state_root="${runner_work_root}/.container-compose-release-pipeline/${CANDIDATE_SHA}"
+          case "${state_root}" in
+            "${GITHUB_WORKSPACE}"|"${GITHUB_WORKSPACE}"/*)
+              printf 'Release state root must be outside the disposable job workspace: %s\n' \
+                "${state_root}" >&2
+              exit 2
+              ;;
+          esac
+          printf 'RELEASE_PIPELINE_STATE_ROOT=%s\n' "${state_root}" >> "${GITHUB_ENV}"
+          printf 'Candidate-keyed release state: %s\n' "${state_root}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -369,9 +369,25 @@ jobs:
           set -euo pipefail
           [[ "${CANDIDATE_SHA}" =~ ^[[:xdigit:]]{40}$ ]]
           runner_work_root="$(cd "${RUNNER_TEMP}/.." && pwd -P)"
-          state_root="${runner_work_root}/.container-compose-release-pipeline/${CANDIDATE_SHA}"
+          workspace_root="$(cd "${GITHUB_WORKSPACE}" && pwd -P)"
+          state_parent="${runner_work_root}/.container-compose-release-pipeline"
+          if [[ -L "${state_parent}" ]]; then
+            printf 'Release state parent must not be a symbolic link: %s\n' \
+              "${state_parent}" >&2
+            exit 2
+          fi
+          mkdir -p "${state_parent}"
+          state_parent="$(cd "${state_parent}" && pwd -P)"
+          state_root="${state_parent}/${CANDIDATE_SHA}"
+          if [[ -L "${state_root}" ]]; then
+            printf 'Candidate release state must not be a symbolic link: %s\n' \
+              "${state_root}" >&2
+            exit 2
+          fi
+          mkdir -p "${state_root}"
+          state_root="$(cd "${state_root}" && pwd -P)"
           case "${state_root}" in
-            "${GITHUB_WORKSPACE}"|"${GITHUB_WORKSPACE}"/*)
+            "${workspace_root}"|"${workspace_root}"/*)
               printf 'Release state root must be outside the disposable job workspace: %s\n' \
                 "${state_root}" >&2
               exit 2

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -15,7 +15,7 @@
 ## limitations under the License.
 ##===----------------------------------------------------------------------===##
 
-"""Regression tests for history-sensitive release-stage source capture."""
+"""Regression tests for recoverable release-stage policy."""
 
 from pathlib import Path
 import unittest
@@ -28,6 +28,9 @@ PIPELINE_CONFIG = (REPOSITORY_ROOT / "nextflow.config").read_text(
 )
 REPOSITORY_STAGE = (
     REPOSITORY_ROOT / "build-pipeline/modules/repository-stage.nf"
+).read_text(encoding="utf-8")
+STABLE_RELEASE_WORKFLOW = (
+    REPOSITORY_ROOT / ".github/workflows/stable-release-gate.yml"
 ).read_text(encoding="utf-8")
 
 
@@ -71,6 +74,30 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
         self.assertIn("errorStrategy 'terminate'", REPOSITORY_STAGE)
         self.assertNotIn("errorStrategy = 'finish'", PIPELINE_CONFIG)
         self.assertNotIn("errorStrategy 'finish'", REPOSITORY_STAGE)
+
+    def test_release_state_is_persistent_and_candidate_keyed(self) -> None:
+        self.assertNotIn(
+            "RELEASE_PIPELINE_STATE_ROOT: ${{ github.workspace }}",
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn(
+            'runner_work_root="$(cd "${RUNNER_TEMP}/.." && pwd -P)"',
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn(
+            'state_root="${runner_work_root}/.container-compose-release-pipeline/'
+            '${CANDIDATE_SHA}"',
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn(
+            '"${GITHUB_WORKSPACE}"|"${GITHUB_WORKSPACE}"/*)',
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn(
+            "printf 'RELEASE_PIPELINE_STATE_ROOT=%s\\n' \"${state_root}\" "
+            '>> "${GITHUB_ENV}"',
+            STABLE_RELEASE_WORKFLOW,
+        )
 
 
 if __name__ == "__main__":

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -85,14 +85,27 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
             STABLE_RELEASE_WORKFLOW,
         )
         self.assertIn(
-            'state_root="${runner_work_root}/.container-compose-release-pipeline/'
-            '${CANDIDATE_SHA}"',
+            'workspace_root="$(cd "${GITHUB_WORKSPACE}" && pwd -P)"',
             STABLE_RELEASE_WORKFLOW,
         )
         self.assertIn(
-            '"${GITHUB_WORKSPACE}"|"${GITHUB_WORKSPACE}"/*)',
+            'state_parent="${runner_work_root}/.container-compose-release-pipeline"',
             STABLE_RELEASE_WORKFLOW,
         )
+        self.assertIn(
+            'state_root="${state_parent}/${CANDIDATE_SHA}"',
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn(
+            'state_root="$(cd "${state_root}" && pwd -P)"',
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn(
+            '"${workspace_root}"|"${workspace_root}"/*)',
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn('[[ -L "${state_parent}" ]]', STABLE_RELEASE_WORKFLOW)
+        self.assertIn('[[ -L "${state_root}" ]]', STABLE_RELEASE_WORKFLOW)
         self.assertIn(
             "printf 'RELEASE_PIPELINE_STATE_ROOT=%s\\n' \"${state_root}\" "
             '>> "${GITHUB_ENV}"',

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3316,8 +3316,17 @@ github_cli() {{
         self.assertIn("PIPELINE_PROFILE=release-hosted", workflow)
         self.assertIn("make -C release-tools pipeline", workflow)
         self.assertIn("make -C ../release-tools pipeline-bootstrap", workflow)
+        self.assertIn("Resolve persistent release state root", workflow)
         self.assertIn(
-            "RELEASE_PIPELINE_STATE_ROOT: ${{ github.workspace }}/.container-compose-release-pipeline",
+            'state_root="${state_parent}/${CANDIDATE_SHA}"',
+            workflow,
+        )
+        self.assertIn(
+            '"${workspace_root}"|"${workspace_root}"/*)',
+            workflow,
+        )
+        self.assertNotIn(
+            "RELEASE_PIPELINE_STATE_ROOT: ${{ github.workspace }}",
             workflow,
         )
         self.assertNotIn("RELEASE_PIPELINE_STATE_ROOT: /Volumes/", workflow)

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7396,6 +7396,27 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/417"
     },
     {
+      "id": "container-compose-419",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Isolate persistent release state from the job workspace",
+      "state": "active-draft",
+      "lastVerified": "2026-09-02",
+      "commits": [
+        "50031ee49a6570f36181587d773d21af79bfc5cb"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-418.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-419.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/419"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-01
 
-Entries: 401. Document snapshots: 703. Current supporting documents: 97.
+Entries: 402. Document snapshots: 705. Current supporting documents: 99.
 
-States: `active-draft` 13, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 14, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -231,6 +231,7 @@ States: `active-draft` 13, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Keep release state on internal storage](https://github.com/stephenlclarke/container-compose/pull/413) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-412.md); [PR details](container-compose/PR-413.md) |
 | `stephenlclarke/container-compose` | [Fingerprint staged Container checkout content](https://github.com/stephenlclarke/container-compose/pull/415) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-414.md); [PR details](container-compose/PR-415.md) |
 | `stephenlclarke/container-compose` | [Preserve Git history for history-sensitive release stages](https://github.com/stephenlclarke/container-compose/pull/417) | `active-draft` | `7673294e8979`, `df76a83eb1ca` | [Issue details](container-compose/ISSUE-416.md); [PR details](container-compose/PR-417.md) |
+| `stephenlclarke/container-compose` | [Isolate persistent release state from the job workspace](https://github.com/stephenlclarke/container-compose/pull/419) | `active-draft` | `50031ee49a65` | [Issue details](container-compose/ISSUE-418.md); [PR details](container-compose/PR-419.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-418.md
+++ b/docs/upstream/container-compose/ISSUE-418.md
@@ -1,0 +1,26 @@
+# Issue 418: isolate persistent release state from the job workspace
+
+## Problem
+
+Stable release gate run [`33583434090`](https://github.com/stephenlclarke/container-compose/actions/runs/33583434090) failed during bootstrap because its recoverable state root was inside the disposable GitHub job workspace. A preceding job had left that location non-empty without the pipeline safety marker, so `pipeline-state-init` correctly refused to claim it.
+
+Tracking issue: [`#418`](https://github.com/stephenlclarke/container-compose/issues/418).
+
+## Required outcome
+
+- Store recoverable state on internal runner storage outside the checkout workspace.
+- Key the state root by the immutable release-candidate SHA.
+- Retain the existing marker, canonical-path, and non-symbolic-path checks.
+- Reject any resolved state path that falls inside `GITHUB_WORKSPACE`.
+- Cover the workflow contract with a focused regression.
+
+## Acceptance evidence
+
+- The state root resolves from the canonical parent of `RUNNER_TEMP`.
+- Candidate retries select the same state root while different candidates remain isolated.
+- Workflow YAML parsing, focused policy tests, licence checks, `git diff --check`, a signed Conventional Commit, and exact-head review pass.
+- The resumed stable gate enters the recoverable release graph without claiming disposable workspace contents.
+
+## Scope
+
+This changes release-state placement only. Product code, release artifacts, and repository validation commands are unchanged.

--- a/docs/upstream/container-compose/PR-419.md
+++ b/docs/upstream/container-compose/PR-419.md
@@ -1,0 +1,28 @@
+# Pull request 419: isolate persistent release state from the job workspace
+
+## Summary
+
+Pull request [`#419`](https://github.com/stephenlclarke/container-compose/pull/419) closes tracking issue [`#418`](https://github.com/stephenlclarke/container-compose/issues/418).
+
+- Resolve the stable gate's recovery root outside the disposable job workspace.
+- Key retained state by the immutable candidate SHA.
+- Reject workspace-contained state paths before bootstrap.
+- Add a focused workflow-policy regression.
+
+## Validation
+
+- [x] Focused recoverable release-stage policy regression
+- [x] Python compilation
+- [x] Workflow YAML parse
+- [x] Licence checks
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+- [ ] Handoff registry validation
+- [ ] Exact-head review
+- [ ] Resumed stable release gate
+
+## Compatibility and risk
+
+The release graph, source payloads, validation commands, and published artifacts are unchanged. The state path moves from the job workspace to the runner work root and adds the candidate SHA as an isolation boundary. Existing marker and canonical-path checks still own directory contents.
+
+Implementation commit: `50031ee4`.

--- a/docs/upstream/container-compose/PR-419.md
+++ b/docs/upstream/container-compose/PR-419.md
@@ -12,6 +12,7 @@ Pull request [`#419`](https://github.com/stephenlclarke/container-compose/pull/4
 ## Validation
 
 - [x] Focused recoverable release-stage policy regression
+- [x] Existing stable-gate release-policy regression
 - [x] Python compilation
 - [x] Workflow YAML parse
 - [x] Licence checks


### PR DESCRIPTION
Closes #418.

## Summary

- keep recoverable release state outside the disposable job workspace
- key the state directory by the immutable release-candidate SHA
- retain marker and workspace-escape safety checks
- add a focused workflow-policy regression

## Validation

- `/usr/bin/python3 Tools/ci/test_release_stage_git_history.py`
- Python compilation
- workflow YAML parse
- `make check-licenses`
- `git diff --check`

The failed stable gate stopped during bootstrap, before product validation, so this PR intentionally does not rerun product tests.