### PR TITLE
fix(build): preserve release receipt tuples

### DIFF
--- a/Tests/BuildPipeline/recovery-proof.nf
+++ b/Tests/BuildPipeline/recovery-proof.nf
@@ -37,6 +37,7 @@ process RUN_DOWNSTREAM {
     input:
     path upstream_marker
     val downstream_fingerprint
+    val receipt_gate
 
     output:
     path 'downstream.txt'
@@ -45,11 +46,13 @@ process RUN_DOWNSTREAM {
     if (downstream_fingerprint == 'corrected-v1') {
         """
         grep -qx 'upstream complete' '${upstream_marker}'
+        test '${receipt_gate}' = true
         printf '%s\\n' 'downstream complete' > downstream.txt
         """
     } else {
         """
         grep -qx 'upstream complete' '${upstream_marker}'
+        test '${receipt_gate}' = true
         printf '%s\\n' 'planned downstream failure' >&2
         exit 42
         """
@@ -57,8 +60,26 @@ process RUN_DOWNSTREAM {
 }
 
 workflow {
+    receiptGate = channel.of(
+        tuple('repository-a', 'validation-a'),
+        tuple('repository-b', 'validation-b'),
+        tuple('repository-c', 'validation-c'),
+        tuple('repository-d', 'validation-d'),
+    )
+        .collect(flat: false)
+        .map { receipts ->
+            if (receipts.size() != 4 ||
+                receipts.any { receipt -> receipt.size() != 2 }) {
+                error 'receipt collection did not preserve four tuples'
+            }
+            true
+        }
     VERIFY_STDIN_CLOSED()
     BUILD_UPSTREAM(VERIFY_STDIN_CLOSED.out, params.upstream_fingerprint)
-    RUN_DOWNSTREAM(BUILD_UPSTREAM.out, params.downstream_fingerprint)
+    RUN_DOWNSTREAM(
+        BUILD_UPSTREAM.out,
+        params.downstream_fingerprint,
+        receiptGate,
+    )
     RUN_DOWNSTREAM.out.view { marker -> "RECOVERY_PROOF_RESULT=${marker.text.trim()}" }
 }

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -36,6 +36,9 @@ STABLE_RELEASE_WORKFLOW = (
 CI_WORKFLOW = (REPOSITORY_ROOT / ".github/workflows/ci.yml").read_text(
     encoding="utf-8"
 )
+RECOVERY_PROOF = (
+    REPOSITORY_ROOT / "Tests/BuildPipeline/recovery-proof.nf"
+).read_text(encoding="utf-8")
 
 
 class ReleaseStageGitHistoryTests(unittest.TestCase):
@@ -120,6 +123,15 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
             "Release documentation requires every functional validation",
             PIPELINE_SOURCE,
         )
+
+    def test_release_validation_barrier_preserves_receipt_tuples(self) -> None:
+        self.assertIn(
+            ".concat(RUN_LIGHTWEIGHT_STAGE.out.receipt)\n"
+            "        .collect(flat: false)",
+            PIPELINE_SOURCE,
+        )
+        self.assertIn("receiptGate = channel.of(", RECOVERY_PROOF)
+        self.assertIn(".collect(flat: false)", RECOVERY_PROOF)
 
     def test_container_validation_checks_the_operator_keychain_just_in_time(
         self,

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7466,6 +7466,27 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/424"
     },
     {
+      "id": "container-compose-426",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Preserve release receipt tuples",
+      "state": "active-draft",
+      "lastVerified": "2026-09-02",
+      "commits": [
+        "71635b830dded1133f8a2a180301574fd6e735cc"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-425.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-426.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/426"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-02
 
-Entries: 404. Document snapshots: 710. Current supporting documents: 104.
+Entries: 405. Document snapshots: 712. Current supporting documents: 106.
 
-States: `active-draft` 16, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 17, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -234,6 +234,7 @@ States: `active-draft` 16, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Isolate persistent release state from the job workspace](https://github.com/stephenlclarke/container-compose/pull/419) | `active-draft` | `50031ee49a65` | [Issue details](container-compose/ISSUE-418.md); [PR details](container-compose/PR-419.md) |
 | `stephenlclarke/container-compose` | [Pin release Xcode and run DocC last](https://github.com/stephenlclarke/container-compose/pull/421) | `active-draft` | `7b4e005688cc`, `33e8cf5bd8f1`, `562bf8e4a573` | [Issue details](container-compose/ISSUE-420.md); [Issue details](container-compose/ISSUE-422.md); [PR details](container-compose/PR-421.md) |
 | `stephenlclarke/container-compose` | [Keep Keychain validation unattended](https://github.com/stephenlclarke/container-compose/pull/424) | `active-draft` | `82e3bf3bb32f`, `72ae837a93dc` | [Issue details](container-compose/ISSUE-423.md); [PR details](container-compose/PR-424.md) |
+| `stephenlclarke/container-compose` | [Preserve release receipt tuples](https://github.com/stephenlclarke/container-compose/pull/426) | `active-draft` | `71635b830dde` | [Issue details](container-compose/ISSUE-425.md); [PR details](container-compose/PR-426.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-425.md
+++ b/docs/upstream/container-compose/ISSUE-425.md
@@ -1,0 +1,27 @@
+# Issue 425: preserve receipt tuples at the release validation barrier
+
+## Problem
+
+The 0.13.1 stable release gate completed all four functional validation stages successfully, including the complete Container test and coverage stage, but stopped before documentation and publication. The validation barrier applied Nextflow `collect()` to seven-field receipt tuples and compared the flattened result with the number of expected stages. Because `collect()` flattens nested lists by default, four receipts became 28 fields and the cardinality check always failed.
+
+Tracking issue: [`#425`](https://github.com/stephenlclarke/container-compose/issues/425).
+
+## Required outcome
+
+- Preserve each receipt tuple while collecting the validation barrier input.
+- Keep documentation blocked until every expected functional validation receipt exists.
+- Add a cheap executable Nextflow fixture that fails if tuple collection flattens the receipts.
+- Retain the existing recoverable-session behavior so the corrected release gate can reuse completed stage checkpoints.
+- Do not rerun product validation while proving the orchestration semantic.
+
+## Acceptance evidence
+
+- An isolated five-run Nextflow 26.04.6 reproduction demonstrates that bare `collect()` turns four two-field tuples into eight fields.
+- The focused recovery fixture preserves four tuples with `collect(flat: false)` and still proves exact-session recovery.
+- Focused release-policy tests pin the production barrier and executable fixture to the tuple-preserving form.
+- Nextflow lint accepts the corrected graph.
+- The retained 0.13.1 stable gate resumes from its completed validation checkpoints and reaches publication.
+
+## Scope
+
+This changes release orchestration and its recovery proof only. Product source, release artifacts, validation commands, documentation contents, and publication authority are unchanged.

--- a/docs/upstream/container-compose/PR-426.md
+++ b/docs/upstream/container-compose/PR-426.md
@@ -1,0 +1,30 @@
+# Pull request 426: preserve release receipt tuples
+
+## Summary
+
+Pull request [`#426`](https://github.com/stephenlclarke/container-compose/pull/426) closes tracking issue [`#425`](https://github.com/stephenlclarke/container-compose/issues/425).
+
+- Preserve each seven-field validation receipt as one tuple when the barrier collects Swift and lightweight stage outputs.
+- Keep the existing expected-stage cardinality check and documentation dependency unchanged.
+- Extend the executable Nextflow recovery fixture so tuple flattening fails before its downstream stage can run.
+- Pin the production graph and fixture to `collect(flat: false)` with a focused policy regression.
+
+## Validation
+
+- [x] 11 focused release-stage policy regressions
+- [x] Executable Nextflow recovery proof, including exact-session reuse and published-evidence restoration
+- [x] Production `release-hosted` Homebrew-only graph reaches `PIPELINE_SUMMARY`
+- [x] Nextflow 26.04.6 lint with no errors
+- [x] Python compilation
+- [x] Markdown lint
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+- [ ] Exact-head CI
+- [ ] Exact-head review
+- [ ] Resumed stable 0.13.1 release gate and publication
+
+## Compatibility and risk
+
+The release graph's validation commands, stage scheduling, documentation ordering, evidence format, cache identity, and publication authority do not change. The correction affects only the aggregation shape at the barrier: four receipt tuples remain four receipt tuples instead of becoming 28 scalar fields. The release can therefore resume the same Nextflow session and reuse completed process checkpoints.
+
+Implementation commit: `71635b831117f02ea13addbc9d9ad1e89ac29152`.

--- a/docs/upstream/container-compose/PR-426.md
+++ b/docs/upstream/container-compose/PR-426.md
@@ -27,4 +27,4 @@ Pull request [`#426`](https://github.com/stephenlclarke/container-compose/pull/4
 
 The release graph's validation commands, stage scheduling, documentation ordering, evidence format, cache identity, and publication authority do not change. The correction affects only the aggregation shape at the barrier: four receipt tuples remain four receipt tuples instead of becoming 28 scalar fields. The release can therefore resume the same Nextflow session and reuse completed process checkpoints.
 
-Implementation commit: `71635b831117f02ea13addbc9d9ad1e89ac29152`.
+Implementation commit: `71635b830dded1133f8a2a180301574fd6e735cc`.

--- a/main.nf
+++ b/main.nf
@@ -1746,7 +1746,7 @@ workflow PIPELINE {
     )
     validationCompletionGate = RUN_SWIFT_STAGE.out.receipt
         .concat(RUN_LIGHTWEIGHT_STAGE.out.receipt)
-        .collect()
+        .collect(flat: false)
         .map { receipts ->
             if (receipts.size() != validationStageNames.size()) {
                 error 'release validation did not produce every expected receipt'


### PR DESCRIPTION
## Summary

- preserve each seven-field validation receipt as one tuple at the release barrier
- extend the executable recovery fixture to reject tuple flattening
- document the failure and recovery contract for issue #425

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

A fully green 0.13.1 stable gate stopped after validation because Nextflow `collect()` flattened four seven-field receipt tuples into 28 values. The barrier then compared 28 fields with four expected stages and failed before documentation or publication.

Closes #425.

## Testing

- [x] Tested locally
- [x] Added/updated tests
- [x] Added/updated docs

Evidence:

- 11 focused release-stage policy tests pass
- executable Nextflow recovery proof passes and reuses its exact session
- production release-hosted Homebrew-only graph reaches `PIPELINE_SUMMARY`
- Nextflow 26.04.6 lint reports no errors
- `git diff --check` passes

## container-compose Checks

- [x] I updated `docs/project/STATUS.md`, `docs/project/BACKLOG.md`, or `docs/upstream/` for current support, planned parity, release, or runtime primitive changes, or no update is needed.
- [x] This pull request is focused on one issue or one coherent change.
- [x] Runtime, release, security, upstream-import, or cross-repository stack changes have review notes and CI attached to this pull request.
- [x] I used Conventional Commits in commit messages and the pull request title.
- [x] I added a user-facing `Release-Note:` / `Release-Highlight:` trailer for visible Compose functionality, or `Release-Note: none` for internal-only work.
- [x] I included original upstream issue or pull request references for upstream-driven changes, or none apply.
- [x] I kept active or iterative work in draft and did not run release-only CodeQL for ordinary review work.
- [x] I signed my commits with a GitHub-supported signature method.
- [x] I removed credentials, tokens, private keys, personal data, and private registry details from code, tests, logs, and screenshots.

Release-Note: none
