### PR TITLE
fix(release): use immutable stable preflight controls

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -432,6 +432,13 @@ jobs:
           fetch-depth: 1
           ref: ${{ needs.resolve-publish-context.outputs.checkout_ref }}
 
+      - name: Checkout immutable release control tools
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          path: release-tools
+          fetch-depth: 1
+          ref: ${{ github.sha }}
+
       - name: Require a writable Homebrew promotion token
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -483,7 +490,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          python3 container-compose/Tools/release/homebrew-preflight.py \
+          python3 release-tools/Tools/release/homebrew-preflight.py \
             --tap homebrew-tap \
             --compose-repository container-compose \
             --container-repository container

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1330,9 +1330,21 @@ github_cli() {{
 
     def test_homebrew_configuration_fails_before_codeql_and_product_builds(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        fail_fast = workflow[
+            workflow.index("  release-preflight:") : workflow.index(
+                "  codeql-release:"
+            )
+        ]
 
         self.assertIn("name: Fail-Fast Release Configuration", workflow)
-        self.assertIn("homebrew-preflight.py", workflow)
+        self.assertIn("name: Checkout immutable release control tools", fail_fast)
+        self.assertIn("ref: ${{ github.sha }}", fail_fast)
+        self.assertIn(
+            "python3 release-tools/Tools/release/homebrew-preflight.py", fail_fast
+        )
+        self.assertNotIn(
+            "python3 container-compose/Tools/release/homebrew-preflight.py", fail_fast
+        )
         self.assertIn(".permissions.push", workflow)
         self.assertIn("name: Checkout pinned Container formula source", workflow)
         self.assertIn("--container-repository container", workflow)

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7487,6 +7487,27 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/426"
     },
     {
+      "id": "container-compose-428",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Use immutable release controls for stable preflight",
+      "state": "active-draft",
+      "lastVerified": "2026-09-02",
+      "commits": [
+        "695be0ce4ff59658d1d7a943f171425ff1f238f5"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-427.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-428.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/428"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-02
 
-Entries: 405. Document snapshots: 712. Current supporting documents: 106.
+Entries: 406. Document snapshots: 714. Current supporting documents: 108.
 
-States: `active-draft` 17, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 18, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -235,6 +235,7 @@ States: `active-draft` 17, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Pin release Xcode and run DocC last](https://github.com/stephenlclarke/container-compose/pull/421) | `active-draft` | `7b4e005688cc`, `33e8cf5bd8f1`, `562bf8e4a573` | [Issue details](container-compose/ISSUE-420.md); [Issue details](container-compose/ISSUE-422.md); [PR details](container-compose/PR-421.md) |
 | `stephenlclarke/container-compose` | [Keep Keychain validation unattended](https://github.com/stephenlclarke/container-compose/pull/424) | `active-draft` | `82e3bf3bb32f`, `72ae837a93dc` | [Issue details](container-compose/ISSUE-423.md); [PR details](container-compose/PR-424.md) |
 | `stephenlclarke/container-compose` | [Preserve release receipt tuples](https://github.com/stephenlclarke/container-compose/pull/426) | `active-draft` | `71635b830dde` | [Issue details](container-compose/ISSUE-425.md); [PR details](container-compose/PR-426.md) |
+| `stephenlclarke/container-compose` | [Use immutable release controls for stable preflight](https://github.com/stephenlclarke/container-compose/pull/428) | `active-draft` | `695be0ce4ff5` | [Issue details](container-compose/ISSUE-427.md); [PR details](container-compose/PR-428.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-427.md
+++ b/docs/upstream/container-compose/ISSUE-427.md
@@ -1,0 +1,25 @@
+# Issue 427: use immutable release controls for stable preflight
+
+## Problem
+
+The 0.13.1 stable release gate passed, but its packaging workflow failed before any build because the fail-fast job tried to execute `Tools/release/homebrew-preflight.py` from the historical tagged source. That tool was introduced after the immutable 0.13.1 source commit, so the release could not use the current release controller to publish an older compatible tag.
+
+Tracking issue: [`#427`](https://github.com/stephenlclarke/container-compose/issues/427).
+
+## Required outcome
+
+- Run fail-fast Homebrew validation with an immutable checkout of the current release-control source.
+- Continue validating the exact tagged Compose source, pinned Container source, and Homebrew tap.
+- Reject any regression that resolves the preflight executable from the historical product tag.
+- Fail before CodeQL or packaging when the distribution configuration is invalid.
+
+## Acceptance evidence
+
+- A focused workflow-policy regression requires the immutable release-control checkout and its preflight path.
+- The existing Homebrew preflight behavior tests pass.
+- `actionlint` accepts the workflow.
+- A 0.13.1 packaging retry passes fail-fast validation and reaches packaging.
+
+## Scope
+
+This changes release orchestration only. The historical product source, pinned stack, release assets, Homebrew configuration checks, and publication authority remain unchanged.

--- a/docs/upstream/container-compose/PR-428.md
+++ b/docs/upstream/container-compose/PR-428.md
@@ -1,0 +1,27 @@
+# Pull request 428: use immutable release controls for stable preflight
+
+## Summary
+
+Pull request [`#428`](https://github.com/stephenlclarke/container-compose/pull/428) closes tracking issue [`#427`](https://github.com/stephenlclarke/container-compose/issues/427).
+
+- Check out the workflow commit as immutable release-control tooling in the fail-fast job.
+- Execute the Homebrew preflight from that release-control checkout.
+- Preserve the historical tagged Compose checkout and pinned Container checkout as the data being validated.
+- Add a focused regression that rejects running the preflight from historical product source.
+
+## Validation
+
+- [x] Focused release-controller workflow regression
+- [x] Homebrew preflight behavior tests
+- [x] `actionlint`
+- [x] `git diff --check`
+- [x] Signed Conventional Commit
+- [ ] Exact-head CI
+- [ ] Exact-head review
+- [ ] Stable 0.13.1 package retry and publication
+
+## Compatibility and risk
+
+The preflight logic and all inputs are unchanged. Only the executable's source changes: release policy comes from the immutable workflow commit, while the tool still validates the exact tagged Compose checkout, its pinned Container checkout, and the checked-out Homebrew tap. This permits historical patch publication without weakening fail-fast checks.
+
+Implementation commit: `695be0ce4ff59658d1d7a943f171425ff1f238f5`.


### PR DESCRIPTION
## Summary

- run stable Homebrew preflight from the immutable release-control checkout
- continue validating the exact tagged Compose source and pinned runtime source
- add a focused regression that rejects historical-tag tool lookup

Closes #427.

## Evidence

- focused release-controller regression passes
- Homebrew preflight tests pass
- actionlint passes
- git diff check passes

Release-Note: none