### PR TITLE
test(runtime): retain exit-controlled services in smoke contract

### DIFF
--- a/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
+++ b/Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift
@@ -788,7 +788,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(exitControl.stdout.contains(containerDryRun("start \(project)-api-1")))
         #expect(exitControl.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(exitControl.stdout.contains("+ compose-runtime wait \(project)-api-1"))
-        #expect(exitControl.stdout.contains(containerDryRun("delete \(project)-api-1")))
+        #expect(exitControl.stdout.contains(containerDryRun("stop \(project)-api-1")))
+        #expect(!exitControl.stdout.contains(containerDryRun("delete \(project)-api-1")))
 
         let watch = try runProcess(
             composeBinary,
@@ -820,7 +821,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(environmentMenu.stdout.contains(containerDryRun("start \(project)-api-1")))
         #expect(environmentMenu.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(environmentMenu.stdout.contains("+ compose-runtime wait \(project)-api-1"))
-        #expect(environmentMenu.stdout.contains(containerDryRun("delete \(project)-api-1")))
+        #expect(environmentMenu.stdout.contains(containerDryRun("stop \(project)-api-1")))
+        #expect(!environmentMenu.stdout.contains(containerDryRun("delete \(project)-api-1")))
     }
 
     @Test("runtime dry run up renders service privileged command")
@@ -1223,7 +1225,8 @@ struct ComposeRuntimeSmokeTests {
         #expect(dryRun.stdout.contains(containerDryRun("start \(project)-api-1")))
         #expect(dryRun.stdout.contains("+ compose-runtime attach --no-stdin \(project)-api-1"))
         #expect(dryRun.stdout.contains("+ compose-runtime wait \(project)-api-1"))
-        #expect(dryRun.stdout.contains(containerDryRun("delete \(project)-api-1")))
+        #expect(dryRun.stdout.contains(containerDryRun("stop \(project)-api-1")))
+        #expect(!dryRun.stdout.contains(containerDryRun("delete \(project)-api-1")))
 
         let result = try runProcess(
             composeBinary,

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7533,6 +7533,28 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/429"
     },
     {
+      "id": "container-compose-431",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Retain exit-controlled services in runtime smoke checks",
+      "state": "active-draft",
+      "lastVerified": "2026-09-02",
+      "commits": [
+        "be25d540957fcc97a2ce167c957bc800ee7d9297",
+        "702e75e231586def2a723b325440d297bd420df6"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-430.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-431.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/431"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-02
 
-Entries: 407. Document snapshots: 716. Current supporting documents: 110.
+Entries: 408. Document snapshots: 718. Current supporting documents: 112.
 
-States: `active-draft` 19, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 20, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -237,6 +237,7 @@ States: `active-draft` 19, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Preserve release receipt tuples](https://github.com/stephenlclarke/container-compose/pull/426) | `active-draft` | `71635b830dde` | [Issue details](container-compose/ISSUE-425.md); [PR details](container-compose/PR-426.md) |
 | `stephenlclarke/container-compose` | [Use immutable release controls for stable preflight](https://github.com/stephenlclarke/container-compose/pull/428) | `active-draft` | `695be0ce4ff5` | [Issue details](container-compose/ISSUE-427.md); [PR details](container-compose/PR-428.md) |
 | `stephenlclarke/container-compose` | [Publish the 0.14.1 regression-fix stack](https://github.com/stephenlclarke/container-compose/pull/429) | `active-draft` | `9a3f9c1427b4`, `65eb0f862e78`, `1d62032a2493`, `204a09392d70`, `d8a90f5cc270` | [Issue details](container-compose/ISSUE-383.md); [PR details](container-compose/PR-429.md) |
+| `stephenlclarke/container-compose` | [Retain exit-controlled services in runtime smoke checks](https://github.com/stephenlclarke/container-compose/pull/431) | `active-draft` | `be25d540957f`, `702e75e23158` | [Issue details](container-compose/ISSUE-430.md); [PR details](container-compose/PR-431.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-430.md
+++ b/docs/upstream/container-compose/ISSUE-430.md
@@ -1,0 +1,28 @@
+# Issue 430: align 0.14 exit-control runtime smoke checks
+
+## Problem
+
+The stable 0.14.1 release gate reached the matched Compose runtime stage and
+exposed three stale dry-run assertions. Exit-controlled `compose up`
+intentionally stops and retains containers for later inspection and log access,
+and focused core tests already enforce that contract. The mainline runtime
+smoke checks still expected `container delete`, so correct runtime behavior
+failed the release gate.
+
+The same assertion correction was applied to the 0.13 maintenance line by pull
+request [`#408`](https://github.com/stephenlclarke/container-compose/pull/408),
+but was not propagated to main.
+
+## Required work
+
+- Assert `container stop` for `--abort-on-container-exit` and
+  `--exit-code-from` dry-run plans.
+- Assert that those plans do not emit `container delete`.
+- Re-run only the matched runtime smoke test first, then resume the stable
+  release from its valid checkpoint.
+
+## Acceptance boundary
+
+The issue is complete when the three corrected assertions pass against the
+matched 0.14.1 stack and the exact-head release gate advances beyond the
+checkpointed Compose runtime stage.

--- a/docs/upstream/container-compose/PR-431.md
+++ b/docs/upstream/container-compose/PR-431.md
@@ -1,0 +1,29 @@
+# Pull request 431: retain exit-controlled services in runtime smoke checks
+
+## Purpose
+
+Pull request [`#431`](https://github.com/stephenlclarke/container-compose/pull/431)
+aligns the 0.14 runtime smoke contract with the existing Compose lifecycle.
+Exit-controlled `compose up` operations stop containers and retain them for
+inspection, log access, and subsequent lifecycle commands.
+
+## Scope
+
+- Expect `container stop` after `--abort-on-container-exit` and
+  `--exit-code-from` execution.
+- Reject an accidental `container delete` plan in those focused checks.
+- Carry the reviewed 0.13 maintenance correction from pull request
+  [`#408`](https://github.com/stephenlclarke/container-compose/pull/408) into
+  main without changing production behavior.
+
+## Evidence
+
+- The menu exit-control and watch test passed in 2.983 seconds.
+- The matched-runtime `--exit-code-from` test passed in 28.106 seconds.
+- Markdown lint and `git diff --check` passed.
+
+## Release impact
+
+The correction unblocks the checkpointed 0.14.1 runtime-provider gate. The
+already-passed Containerization and Container release stages do not need to be
+repeated.


### PR DESCRIPTION
Closes #430.

## Summary

- align the 0.14 runtime smoke contract with Docker Compose-compatible exit control
- require stopped containers to remain available after `--abort-on-container-exit` and `--exit-code-from`
- reject accidental `container delete` plans in the same focused checks

The production lifecycle is unchanged. This carries the already-reviewed 0.13 maintenance correction from #408 into main so the stable 0.14.1 gate validates the intended retained-container contract.

## Evidence

- `ComposeRuntimeSmokeTests.runtimeDryRunUpAcceptsMenuExitControlAndMenuWatch`: 1 test passed in 2.983 s
- `ComposeRuntimeSmokeTests.runtimeUpExitCodeFromReturnsSelectedServiceStatus`: 1 matched-runtime test passed in 28.106 s
- `markdownlint docs/upstream/container-compose/ISSUE-430.md`
- `git diff --check`

The full stable release remains checkpointed immediately before this corrected runtime-provider gate; already-passed Containerization and Container stages will not be repeated.