### PR TITLE
[Build] Bind Current VM-init authority to the exact stack

### DIFF
--- a/.github/workflows/current-demo.yml
+++ b/.github/workflows/current-demo.yml
@@ -135,6 +135,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, container-compose-release, container-compose-current]
     timeout-minutes: 50
     permissions:
+      attestations: read
       contents: write
     steps:
       - name: Checkout exact Current source
@@ -176,6 +177,7 @@ jobs:
           short_sha="${PUBLISH_SHA:0:12}"
           plugin_asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"
           runtime_asset="container-current-${short_sha}-arm64.tar.gz"
+          init_asset="container-vminit-current-${short_sha}-arm64.oci.tar"
           download_root="${RUNNER_TEMP}/container-compose-current-demo-downloads"
           rm -rf -- "${download_root}"
           mkdir -p "${download_root}"
@@ -185,24 +187,30 @@ jobs:
             --pattern "${plugin_asset}" \
             --pattern "${plugin_asset}.sha256" \
             --pattern "${runtime_asset}" \
-            --pattern "${runtime_asset}.sha256"
+            --pattern "${runtime_asset}.sha256" \
+            --pattern "${init_asset}" \
+            --pattern "${init_asset}.sha256"
           (
             cd "${download_root}"
             shasum -a 256 -c "${plugin_asset}.sha256"
             shasum -a 256 -c "${runtime_asset}.sha256"
+            shasum -a 256 -c "${init_asset}.sha256"
           )
           Tools/release/verify-developer-id-archive.sh "${download_root}/${plugin_asset}"
           Tools/release/verify-developer-id-archive.sh "${download_root}/${runtime_asset}"
+          gh attestation verify "${download_root}/${init_asset}" \
+            --repo "${GITHUB_REPOSITORY}"
           {
             printf 'PLUGIN_ARCHIVE=%s\n' "${download_root}/${plugin_asset}"
             printf 'RUNTIME_ARCHIVE=%s\n' "${download_root}/${runtime_asset}"
+            printf 'DEMO_INIT_IMAGE_ARCHIVE=%s\n' "${download_root}/${init_asset}"
+            printf 'DEMO_INIT_IMAGE_ARCHIVE_SHA256=%s\n' \
+              "$(awk '{print $1}' "${download_root}/${init_asset}.sha256")"
           } >> "${GITHUB_ENV}"
 
       - name: Validate Current demo init-image authority
         env:
           CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
-          DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: fe3354c60bf0f1eb509bcee36956fda2ce14bf5d40aa001003567067b55ac82f
         shell: bash
         run: |
           set -euo pipefail
@@ -235,8 +243,6 @@ jobs:
       - name: Record bounded Current demo
         env:
           DEMO_ASSET: container-compose-demo-current.gif
-          DEMO_INIT_IMAGE_ARCHIVE: ${{ vars.CURRENT_DEMO_INIT_IMAGE_ARCHIVE }}
-          DEMO_INIT_IMAGE_ARCHIVE_SHA256: fe3354c60bf0f1eb509bcee36956fda2ce14bf5d40aa001003567067b55ac82f
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1062,6 +1062,106 @@ jobs:
             printf 'local_asset=%s\n' "${runtime_local_asset}"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Materialize exact Current VM-init authority
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        id: current-init-image
+        env:
+          # The workflow token cannot read Actions artifacts from a sibling
+          # repository. This existing cross-repository token is read-only here.
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        working-directory: container-compose
+        run: |
+          set -euo pipefail
+          if [[ ! "${CONTAINERIZATION_REF}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'Current VM-init authority requires an exact Containerization ref: %s\n' \
+              "${CONTAINERIZATION_REF:-<unset>}" >&2
+            exit 1
+          fi
+          authority_root="${RUNNER_TEMP}/current-vminit-authority"
+          rm -rf -- "${authority_root}"
+          mkdir -p "${authority_root}"
+
+          gh api --paginate --slurp \
+            "repos/stephenlclarke/containerization/actions/workflows/containerization-build.yml/runs?head_sha=${CONTAINERIZATION_REF}&per_page=100" \
+            > "${authority_root}/run-pages.json"
+          jq '[.[].workflow_runs[] | {
+              databaseId: .id,
+              workflowName: .name,
+              headSha: .head_sha,
+              status,
+              conclusion,
+              event,
+              createdAt: .created_at,
+              url: .html_url
+            }]' "${authority_root}/run-pages.json" > "${authority_root}/runs.json"
+          python3 Tools/parity/historical_reconstruction_benchmark.py \
+            run-candidates \
+            --runs "${authority_root}/runs.json" \
+            --revision "${CONTAINERIZATION_REF}" \
+            > "${authority_root}/run-candidates.json"
+
+          run_id=""
+          while IFS= read -r candidate_id; do
+            candidate_run="${authority_root}/run-${candidate_id}.json"
+            candidate_artifacts="${authority_root}/artifacts-${candidate_id}.json"
+            candidate_provenance="${authority_root}/provenance-${candidate_id}.json"
+            jq --argjson id "${candidate_id}" \
+              '.[] | select(.runId == $id)' \
+              "${authority_root}/run-candidates.json" > "${candidate_run}"
+            gh api \
+              "repos/stephenlclarke/containerization/actions/runs/${candidate_id}/artifacts" \
+              > "${candidate_artifacts}"
+            if python3 Tools/parity/historical_reconstruction_benchmark.py \
+              validate-initfs \
+              --run "${candidate_run}" \
+              --artifacts "${candidate_artifacts}" \
+              > "${candidate_provenance}"; then
+              run_id="${candidate_id}"
+              cp "${candidate_provenance}" "${authority_root}/provenance.json"
+              break
+            fi
+          done < <(jq -r '.[].runId' "${authority_root}/run-candidates.json")
+          if [[ -z "${run_id}" ]]; then
+            printf 'no exact, retained initfs artifact exists for Containerization %s\n' \
+              "${CONTAINERIZATION_REF}" >&2
+            exit 1
+          fi
+
+          artifact_id="$(jq -r '.artifactId' "${authority_root}/provenance.json")"
+          artifact_digest="$(jq -r '.artifactDigest' "${authority_root}/provenance.json")"
+          gh api \
+            "repos/stephenlclarke/containerization/actions/artifacts/${artifact_id}/zip" \
+            > "${authority_root}/initfs.zip"
+          python3 Tools/parity/historical_reconstruction_benchmark.py \
+            extract-initfs \
+            --archive "${authority_root}/initfs.zip" \
+            --digest "${artifact_digest}" \
+            --output "${authority_root}/initfs"
+
+          asset="container-vminit-current-${PUBLISH_SHA:0:12}-arm64.oci.tar"
+          local_asset="${RUNNER_TEMP}/${asset}"
+          python3 Tools/release/create-vminit-oci-archive.py \
+            --rootfs "${authority_root}/initfs/init.rootfs.tar.gz" \
+            --output "${local_asset}" \
+            --source-url "https://github.com/stephenlclarke/containerization" \
+            --reference vminit:container-compose \
+            --reference "ghcr.io/stephenlclarke/containerization/vminit:${CONTAINERIZATION_REF}"
+          Tools/release/validate-oci-image-layout.py \
+            "${local_asset}" \
+            vminit:container-compose \
+            "ghcr.io/stephenlclarke/containerization/vminit:${CONTAINERIZATION_REF}"
+          python3 Tools/release/write-sha256-sidecar.py "${local_asset}"
+          sha256="$(awk '{print $1}' "${local_asset}.sha256")"
+          {
+            printf 'asset=%s\n' "${asset}"
+            printf 'local_asset=%s\n' "${local_asset}"
+            printf 'sha256=%s\n' "${sha256}"
+            printf 'containerization_run_id=%s\n' "${run_id}"
+          } >> "$GITHUB_OUTPUT"
+
       # The Makefile passes these sibling checkouts to Package.swift as local
       # path dependencies. Do not also `swift package edit` them: mixing edit
       # state with manifest paths makes SwiftPM exhaust graph resolution.
@@ -1129,6 +1229,12 @@ jobs:
         with:
           subject-path: ${{ steps.runtime-package.outputs.local_asset }}
 
+      - name: Attest exact Current VM-init authority
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ${{ steps.current-init-image.outputs.local_asset }}
+
       - name: Upload workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -1144,6 +1250,15 @@ jobs:
           path: |
             ${{ steps.runtime-package.outputs.local_asset }}
             ${{ steps.runtime-package.outputs.local_asset }}.sha256
+
+      - name: Upload exact Current VM-init workflow artifact
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.current-init-image.outputs.asset }}
+          path: |
+            ${{ steps.current-init-image.outputs.local_asset }}
+            ${{ steps.current-init-image.outputs.local_asset }}.sha256
 
       - name: Verify current source is still latest
         id: current-freshness
@@ -1215,6 +1330,12 @@ jobs:
           printf '%s\n%s\n' \
             "${{ steps.runtime-package.outputs.local_asset }}" \
             "${{ steps.runtime-package.outputs.local_asset }}.sha256" > "${extra_assets}"
+          if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
+            printf '%s\n%s\n' \
+              "${{ steps.current-init-image.outputs.local_asset }}" \
+              "${{ steps.current-init-image.outputs.local_asset }}.sha256" \
+              >> "${extra_assets}"
+          fi
           notes="${RUNNER_TEMP}/release-notes.md"
           highlights="${RUNNER_TEMP}/${HIGHLIGHTS_ASSET}"
           git fetch --force --tags origin
@@ -1440,6 +1561,7 @@ jobs:
           PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
           ASSET: ${{ steps.lane.outputs.asset }}
           RUNTIME_ASSET: ${{ steps.runtime-package.outputs.asset }}
+          CURRENT_INIT_ASSET: ${{ steps.current-init-image.outputs.asset }}
           HIGHLIGHTS_ASSET: ${{ steps.lane.outputs.highlights_asset }}
           QUALITY_SNAPSHOT_ASSET: ${{ steps.lane.outputs.quality_snapshot_asset }}
         shell: bash
@@ -1463,6 +1585,8 @@ jobs:
               --current-asset "${ASSET}.sha256" \
               --current-asset "${RUNTIME_ASSET}" \
               --current-asset "${RUNTIME_ASSET}.sha256" \
+              --current-asset "${CURRENT_INIT_ASSET}" \
+              --current-asset "${CURRENT_INIT_ASSET}.sha256" \
               --current-asset "${HIGHLIGHTS_ASSET}" \
               --current-asset "${QUALITY_SNAPSHOT_ASSET}"
               # The separately generated demo is non-authoritative, but retain

--- a/Tools/release/create-vminit-oci-archive.py
+++ b/Tools/release/create-vminit-oci-archive.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Create a deterministic OCI image-layout archive from a guest rootfs layer."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+from pathlib import Path
+import tarfile
+from typing import BinaryIO
+
+
+OCI_INDEX = "application/vnd.oci.image.index.v1+json"
+OCI_MANIFEST = "application/vnd.oci.image.manifest.v1+json"
+OCI_CONFIG = "application/vnd.oci.image.config.v1+json"
+OCI_GZIP_LAYER = "application/vnd.oci.image.layer.v1.tar+gzip"
+
+
+def json_bytes(value: object) -> bytes:
+    """Encode OCI JSON reproducibly without host-specific whitespace."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def digest_stream(stream: BinaryIO) -> str:
+    """Return the sha256 digest of a stream without retaining it in memory."""
+    digest = hashlib.sha256()
+    while chunk := stream.read(1024 * 1024):
+        digest.update(chunk)
+    return digest.hexdigest()
+
+
+def descriptor(payload: bytes, media_type: str) -> dict[str, object]:
+    """Describe one in-memory OCI object."""
+    return {
+        "digest": f"sha256:{hashlib.sha256(payload).hexdigest()}",
+        "mediaType": media_type,
+        "size": len(payload),
+    }
+
+
+def add_bytes(archive: tarfile.TarFile, name: str, payload: bytes) -> None:
+    """Add a regular file with stable metadata."""
+    info = tarfile.TarInfo(name)
+    info.mode = 0o644
+    info.mtime = 0
+    info.size = len(payload)
+    archive.addfile(info, io.BytesIO(payload))
+
+
+def add_directory(archive: tarfile.TarFile, name: str) -> None:
+    """Add an extraction-friendly directory with stable metadata."""
+    info = tarfile.TarInfo(name)
+    info.type = tarfile.DIRTYPE
+    info.mode = 0o755
+    info.mtime = 0
+    archive.addfile(info)
+
+
+def add_file(archive: tarfile.TarFile, name: str, path: Path) -> None:
+    """Add a filesystem payload with stable metadata and streaming I/O."""
+    info = tarfile.TarInfo(name)
+    info.mode = 0o644
+    info.mtime = 0
+    info.size = path.stat().st_size
+    with path.open("rb") as stream:
+        archive.addfile(info, stream)
+
+
+def create_archive(
+    rootfs: Path, output: Path, references: list[str], source_url: str
+) -> None:
+    """Create a single-platform OCI archive addressable by every reference."""
+    if not rootfs.is_file() or rootfs.is_symlink():
+        raise ValueError(f"rootfs must be a regular, non-symlink file: {rootfs}")
+    if rootfs.resolve() == output.resolve():
+        raise ValueError("rootfs and output must be different files")
+    if not references or any(not reference.strip() for reference in references):
+        raise ValueError("at least one non-empty image reference is required")
+    if len(set(references)) != len(references):
+        raise ValueError("image references must be unique")
+
+    with rootfs.open("rb") as compressed:
+        if compressed.read(2) != b"\x1f\x8b":
+            raise ValueError(f"rootfs is not a gzip-compressed tar layer: {rootfs}")
+        compressed.seek(0)
+        layer_digest = digest_stream(compressed)
+    try:
+        with tarfile.open(rootfs, "r:gz") as rootfs_archive:
+            if not rootfs_archive.getmembers():
+                raise ValueError(f"rootfs tar archive is empty: {rootfs}")
+    except (OSError, EOFError, tarfile.TarError) as error:
+        raise ValueError(f"rootfs is not a valid gzip-compressed tar: {rootfs}") from error
+
+    layer_descriptor = {
+        "digest": f"sha256:{layer_digest}",
+        "mediaType": OCI_GZIP_LAYER,
+        "size": rootfs.stat().st_size,
+    }
+    config = json_bytes(
+        {
+            "architecture": "arm64",
+            "config": {"Labels": {"org.opencontainers.image.source": source_url}},
+            "os": "linux",
+            # Match Containerization's InitImage.create representation. Its
+            # current loader records the compressed layer digest as diffID.
+            "rootfs": {"diff_ids": [f"sha256:{layer_digest}"], "type": "layers"},
+        }
+    )
+    config_descriptor = descriptor(config, OCI_CONFIG)
+    manifest = json_bytes(
+        {
+            "config": config_descriptor,
+            "layers": [layer_descriptor],
+            "mediaType": OCI_MANIFEST,
+            "schemaVersion": 2,
+        }
+    )
+    manifest_descriptor = descriptor(manifest, OCI_MANIFEST)
+    platform_index = json_bytes(
+        {
+            "manifests": [
+                {
+                    **manifest_descriptor,
+                    "platform": {
+                        "architecture": "arm64",
+                        "os": "linux",
+                        "variant": "v8",
+                    },
+                }
+            ],
+            "mediaType": OCI_INDEX,
+            "schemaVersion": 2,
+        }
+    )
+    platform_descriptor = descriptor(platform_index, OCI_INDEX)
+    index = json_bytes(
+        {
+            "manifests": [
+                {
+                    **platform_descriptor,
+                    "annotations": {
+                        "com.apple.containerization.image.name": reference,
+                        "io.containerd.image.name": reference,
+                        "org.opencontainers.image.ref.name": reference,
+                    },
+                }
+                for reference in references
+            ],
+            "mediaType": OCI_INDEX,
+            "schemaVersion": 2,
+        }
+    )
+
+    blobs = {
+        config_descriptor["digest"].removeprefix("sha256:"): config,
+        manifest_descriptor["digest"].removeprefix("sha256:"): manifest,
+        platform_descriptor["digest"].removeprefix("sha256:"): platform_index,
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp")
+    temporary.unlink(missing_ok=True)
+    try:
+        with tarfile.open(temporary, "w", format=tarfile.PAX_FORMAT) as archive:
+            for directory in (".", "blobs", "blobs/sha256"):
+                add_directory(archive, directory)
+            add_bytes(archive, "oci-layout", json_bytes({"imageLayoutVersion": "1.0.0"}))
+            for digest in sorted(blobs):
+                add_bytes(archive, f"blobs/sha256/{digest}", blobs[digest])
+            add_file(archive, f"blobs/sha256/{layer_digest}", rootfs)
+            add_bytes(archive, "index.json", index)
+        temporary.replace(output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def parse_arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rootfs", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--reference", required=True, action="append", dest="references")
+    parser.add_argument("--source-url", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    arguments = parse_arguments()
+    try:
+        create_archive(
+            arguments.rootfs,
+            arguments.output,
+            arguments.references,
+            arguments.source_url,
+        )
+    except (OSError, ValueError, tarfile.TarError) as error:
+        raise SystemExit(f"could not create VM-init OCI archive: {error}") from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -26,6 +26,7 @@ import shutil
 import signal
 import shlex
 import subprocess
+import sys
 import tarfile
 import tempfile
 import textwrap
@@ -1412,6 +1413,258 @@ github_cli() {{
         self.assertIn("--delete-superseded-current-releases", workflow)
         self.assertIn("release_notes_args=(", workflow)
 
+    def test_current_publishes_an_exact_attested_vm_init_authority(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        materialize_start = workflow.index(
+            "- name: Materialize exact Current VM-init authority"
+        )
+        materialize_end = workflow.index(
+            "# The Makefile passes these sibling checkouts"
+        )
+        materialize = workflow[materialize_start:materialize_end]
+        self.assertIn("run-candidates", materialize)
+        self.assertIn("validate-initfs", materialize)
+        self.assertIn("extract-initfs", materialize)
+        self.assertIn("create-vminit-oci-archive.py", materialize)
+        self.assertIn("validate-oci-image-layout.py", materialize)
+        self.assertIn("vminit:container-compose", materialize)
+        self.assertIn(
+            "ghcr.io/stephenlclarke/containerization/vminit:${CONTAINERIZATION_REF}",
+            materialize,
+        )
+        self.assertIn(
+            'asset="container-vminit-current-${PUBLISH_SHA:0:12}-arm64.oci.tar"',
+            materialize,
+        )
+        self.assertIn("Attest exact Current VM-init authority", workflow)
+        self.assertIn("Upload exact Current VM-init workflow artifact", workflow)
+        self.assertIn(
+            '"${{ steps.current-init-image.outputs.local_asset }}"', workflow
+        )
+        self.assertIn('--current-asset "${CURRENT_INIT_ASSET}"', workflow)
+        self.assertIn('--current-asset "${CURRENT_INIT_ASSET}.sha256"', workflow)
+
+    def test_stable_controller_resolves_current_vm_init_before_release_work(
+        self,
+    ) -> None:
+        release = self.script[self.script.index("release_current_stack() {") :]
+        authority_start = self.script.index(
+            "prepare_stable_init_image_authority() {"
+        )
+        authority_end = self.script.index("# Retain a helper-created candidate")
+        authority = self.script[authority_start:authority_end]
+        self.assertIn("github_cli release download current", authority)
+        self.assertIn("github_cli attestation verify", authority)
+        self.assertIn('shasum -a 256 -c "${asset}.sha256"', authority)
+        self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${archive}"', authority)
+        self.assertIn("vminit:container-compose", authority)
+        self.assertIn("CURRENT_INIT_IMAGE_AUTHORITY_ROOT", authority)
+        self.assertLess(
+            release.index("write_release_stack_manifest"),
+            release.index("prepare_stable_init_image_authority"),
+        )
+        self.assertIn("require_current_stack_matches_sibling_mains() {", self.script)
+        self.assertLess(
+            release.index("require_current_stack_matches_sibling_mains"),
+            release.index("sync_containerization_package_pins"),
+        )
+        self.assertLess(
+            release.index("prepare_stable_init_image_authority"),
+            release.index("run_local_release_gate"),
+        )
+        self.assertIn("trap cleanup_current_init_image_authority EXIT", self.script)
+
+    def test_stable_controller_accepts_only_the_exact_explicit_vm_init(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose"
+            manifest = compose / "Tools" / "release" / "stack-refs.json"
+            manifest.parent.mkdir(parents=True)
+            reference = "a" * 40
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "components": {
+                            "containerization": {"ref": reference},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            archive = root / "vminit.oci.tar"
+            self.create_release_guest_archive(
+                archive,
+                qualified_reference=(
+                    "ghcr.io/stephenlclarke/containerization/vminit:" + reference
+                ),
+            )
+            setup = (
+                "export CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="
+                f"{shlex.quote(str(archive))}"
+            )
+            accepted = self.run_release_function(
+                root,
+                "prepare_stable_init_image_authority",
+                shell_setup=setup,
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+            self.assertIn("stable VM-init authority verified", accepted.stdout)
+
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "components": {
+                            "containerization": {"ref": "b" * 40},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            rejected = self.run_release_function(
+                root,
+                "prepare_stable_init_image_authority",
+                shell_setup=setup,
+            )
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertIn("missing required reference", rejected.stderr)
+
+    def test_unpublished_retry_resolves_vm_init_against_the_tagged_stack(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose"
+            manifest = compose / "Tools" / "release" / "stack-refs.json"
+            manifest.parent.mkdir(parents=True)
+            tagged_reference = "a" * 40
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "components": {
+                            "containerization": {"ref": tagged_reference},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.run_command("git", "-C", str(compose), "init")
+            self.run_command("git", "-C", str(compose), "add", ".")
+            self.run_command(
+                "git",
+                "-C",
+                str(compose),
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "tagged stack",
+            )
+            self.run_command("git", "-C", str(compose), "tag", "0.14.1")
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "components": {
+                            "containerization": {"ref": "b" * 40},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            archive = root / "vminit.oci.tar"
+            self.create_release_guest_archive(
+                archive,
+                qualified_reference=(
+                    "ghcr.io/stephenlclarke/containerization/vminit:"
+                    + tagged_reference
+                ),
+            )
+            accepted = self.run_release_function(
+                root,
+                "prepare_stable_init_image_authority 0.14.1",
+                shell_setup=(
+                    "export CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="
+                    f"{shlex.quote(str(archive))}"
+                ),
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            cache = root / "authority-cache"
+            cached = cache / tagged_reference
+            cached.mkdir(parents=True)
+            cached_name = f"container-vminit-{tagged_reference}-arm64.oci.tar"
+            shutil.copy2(archive, cached / cached_name)
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "Tools" / "release" / "write-sha256-sidecar.py"),
+                    str(cached / cached_name),
+                ],
+                check=True,
+            )
+            cached_digest = hashlib.sha256(
+                (cached / cached_name).read_bytes()
+            ).hexdigest()
+            (cached / ".container-compose-init-authority").write_text(
+                "schema=1\n"
+                f"containerization={tagged_reference}\n"
+                f"current={'c' * 40}\n"
+                f"sha256={cached_digest}\n",
+                encoding="utf-8",
+            )
+            recovered = self.run_release_function(
+                root,
+                "prepare_stable_init_image_authority 0.14.1",
+                shell_setup="\n".join(
+                    [
+                        "unset CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE",
+                        f"RELEASE_INIT_AUTHORITY_CACHE_ROOT={shlex.quote(str(cache))}",
+                        "need_command() { :; }",
+                        (
+                            "github_cli() { [[ \"$1:$2\" == "
+                            "\"attestation:verify\" ]]; }"
+                        ),
+                    ]
+                ),
+            )
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            self.assertIn(str(cached / cached_name), recovered.stdout)
+
+    def test_vm_init_authority_cache_is_retained_until_release_succeeds(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            cache = root / "authority-cache"
+            authority = cache / ("a" * 40)
+            authority.mkdir(parents=True)
+            (authority / ".container-compose-init-authority").write_text(
+                "schema=1\n",
+                encoding="utf-8",
+            )
+            setup = "\n".join(
+                [
+                    f"RELEASE_INIT_AUTHORITY_CACHE_ROOT={shlex.quote(str(cache))}",
+                    f"CURRENT_INIT_IMAGE_AUTHORITY_ROOT={shlex.quote(str(authority))}",
+                ]
+            )
+
+            retained = self.run_release_function(
+                root,
+                "CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=0; "
+                "cleanup_current_init_image_authority",
+                shell_setup=setup,
+            )
+            self.assertEqual(retained.returncode, 0, retained.stderr)
+            self.assertTrue(authority.exists())
+
+            removed = self.run_release_function(
+                root,
+                "CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=1; "
+                "cleanup_current_init_image_authority",
+                shell_setup=setup,
+            )
+            self.assertEqual(removed.returncode, 0, removed.stderr)
+            self.assertFalse(authority.exists())
+
     def test_current_demo_is_recoverable_and_not_release_critical(self) -> None:
         package = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         release_critical = package[
@@ -1476,6 +1729,13 @@ github_cli() {{
         )
         self.assertIn("bash Tools/release/record-vhs-live-demo.sh", workflow)
         self.assertIn("Validate Current demo init-image authority", workflow)
+        self.assertIn(
+            'init_asset="container-vminit-current-${short_sha}-arm64.oci.tar"',
+            workflow,
+        )
+        self.assertIn('gh attestation verify "${download_root}/${init_asset}"', workflow)
+        self.assertIn("attestations: read", workflow)
+        self.assertNotIn("CURRENT_DEMO_INIT_IMAGE_ARCHIVE", workflow)
         self.assertIn('"${DEMO_INIT_IMAGE_ARCHIVE}" == /Volumes/*', workflow)
         self.assertIn('-L "${DEMO_INIT_IMAGE_ARCHIVE}"', workflow)
         self.assertIn("Tools/release/validate-oci-image-layout.py", workflow)
@@ -6154,6 +6414,7 @@ esac
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 1; }",
                         "ensure_stable_release_is_unpublished() { :; }",
+                        "prepare_stable_init_image_authority() { :; }",
                         "dispatch_compose_stable_tap_repair() { exit 73; }",
                         "publish_stable_release() { printf 'publish %s\\n' \"$1\"; }",
                     ]
@@ -6182,6 +6443,7 @@ esac
                             f"printf '%s\\t%s\\n' {'f' * 40} {'a' * 64}; }}"
                         ),
                         "homebrew_stable_formula_identities() { printf '%s\\n' formulae-before; }",
+                        "prepare_stable_init_image_authority() { exit 76; }",
                         "dispatch_compose_stable_tap_repair() { exit 71; }",
                         "publish_stable_init_image_asset() { printf 'init %s %s\\n' \"$1\" \"$2\"; }",
                         "verify_compose_stable_package() { printf 'verify %s %s %s %s\\n' \"$1\" \"$2\" \"$3\" \"$4\"; }",
@@ -6744,7 +7006,9 @@ gh() {
 
     @staticmethod
     def create_release_guest_archive(
-        path: Path, config_variant: str | None = None
+        path: Path,
+        config_variant: str | None = None,
+        qualified_reference: str = "ghcr.io/owner/containerization/vminit:ref",
     ) -> None:
         RunWithContainerRuntimeTest.create_oci_archive(
             path,
@@ -6763,9 +7027,7 @@ gh() {
         index = json.loads(payloads["index.json"])
         qualified = json.loads(json.dumps(index["manifests"][0]))
         qualified["annotations"] = {
-            "org.opencontainers.image.ref.name": (
-                "ghcr.io/owner/containerization/vminit:ref"
-            )
+            "org.opencontainers.image.ref.name": qualified_reference
         }
         index["manifests"].append(qualified)
         payloads["index.json"] = json.dumps(index).encode("utf-8")

--- a/Tools/release/test_create_vminit_oci_archive.py
+++ b/Tools/release/test_create_vminit_oci_archive.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for deterministic, source-bound VM-init OCI archives."""
+
+import gzip
+import io
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+CREATOR = Path(__file__).with_name("create-vminit-oci-archive.py")
+VALIDATOR = Path(__file__).with_name("validate-oci-image-layout.py")
+REFERENCES = [
+    "vminit:container-compose",
+    "ghcr.io/stephenlclarke/containerization/vminit:" + "a" * 40,
+]
+
+
+def write_rootfs(path: Path) -> None:
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w", format=tarfile.PAX_FORMAT) as archive:
+        content = b"#!/bin/sh\n"
+        info = tarfile.TarInfo("sbin/vminitd")
+        info.mode = 0o755
+        info.mtime = 0
+        info.size = len(content)
+        archive.addfile(info, io.BytesIO(content))
+    with path.open("wb") as stream:
+        with gzip.GzipFile(filename="", mode="wb", fileobj=stream, mtime=0) as compressed:
+            compressed.write(payload.getvalue())
+
+
+class CreateVminitOCIArchiveTests(unittest.TestCase):
+    """The Current guest authority must be reproducible and exact."""
+
+    def create(self, rootfs: Path, output: Path) -> subprocess.CompletedProcess[str]:
+        command = [
+            sys.executable,
+            str(CREATOR),
+            "--rootfs",
+            str(rootfs),
+            "--output",
+            str(output),
+            "--source-url",
+            "https://github.com/stephenlclarke/containerization",
+        ]
+        for reference in REFERENCES:
+            command.extend(["--reference", reference])
+        return subprocess.run(command, check=False, text=True, capture_output=True)
+
+    def test_archive_is_deterministic_and_contains_exact_references(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            rootfs = root / "init.rootfs.tar.gz"
+            first = root / "first.oci.tar"
+            second = root / "second.oci.tar"
+            write_rootfs(rootfs)
+
+            self.assertEqual(self.create(rootfs, first).returncode, 0)
+            self.assertEqual(self.create(rootfs, second).returncode, 0)
+            self.assertEqual(first.read_bytes(), second.read_bytes())
+            validation = subprocess.run(
+                [sys.executable, str(VALIDATOR), str(first), *REFERENCES],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(validation.returncode, 0, validation.stderr)
+
+    def test_validator_rejects_a_stale_containerization_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            rootfs = root / "init.rootfs.tar.gz"
+            archive = root / "vminit.oci.tar"
+            write_rootfs(rootfs)
+            self.assertEqual(self.create(rootfs, archive).returncode, 0)
+
+            stale = "ghcr.io/stephenlclarke/containerization/vminit:" + "b" * 40
+            validation = subprocess.run(
+                [sys.executable, str(VALIDATOR), str(archive), REFERENCES[0], stale],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertNotEqual(validation.returncode, 0)
+            self.assertIn("missing required reference", validation.stderr)
+
+    def test_creator_rejects_a_non_gzip_rootfs(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            rootfs = root / "init.rootfs.tar.gz"
+            rootfs.write_bytes(b"not a compressed rootfs")
+            result = self.create(rootfs, root / "vminit.oci.tar")
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("not a gzip-compressed tar layer", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -180,9 +180,10 @@ Environment:
       devcontainer and gh on PATH plus /usr/bin/curl.
 
   CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE
-      Absolute path to the retained OCI init-image archive used by the local
-      release gate. Execute mode requires this hermetic bootstrap input so
-      runtime startup cannot fall back to a mutable registry or host login.
+      Optional absolute path to a retained OCI init-image archive. When unset,
+      the stable controller downloads the attested, source-matched archive from
+      the exact Current release. Runtime startup never falls back to a mutable
+      registry or host login.
 
   CONTAINER_STACK_RELEASE_ROOT
       Override the parent directory containing the four source checkouts and
@@ -270,6 +271,9 @@ SECURITY_REASON="${CONTAINER_STACK_SECURITY_REASON:-}"
 MAINTENANCE_REASON="${CONTAINER_STACK_MAINTENANCE_REASON:-}"
 MILESTONE_SOAK_OVERRIDE_REASON="${CONTAINER_STACK_MILESTONE_SOAK_OVERRIDE_REASON:-}"
 RECOVERED_UNPUBLISHED_RELEASE_BASE=""
+CURRENT_INIT_IMAGE_AUTHORITY_ROOT=""
+CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=0
+RELEASE_INIT_AUTHORITY_CACHE_ROOT="${CONTAINER_STACK_RELEASE_INIT_AUTHORITY_CACHE_ROOT:-$({ getconf DARWIN_USER_CACHE_DIR 2>/dev/null || printf '/private/tmp/'; })container-compose-release-authorities}"
 readonly STABLE_CURRENT_SOAK_SECONDS=604800
 HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"
 REPOS=(
@@ -441,6 +445,190 @@ PY
   elif [[ "${RELEASE_INTENT}" == "milestone" ]]; then
     printf 'milestone Current soak override accepted: %s\n' "${MILESTONE_SOAK_OVERRIDE_REASON}"
   fi
+}
+
+# A stable candidate must be the exact stack already published as Current.
+# Refuse a sibling-main advance before the release helper mutates dependency
+# pins or creates commits; the normal main/Current lane must integrate it first.
+require_current_stack_matches_sibling_mains() {
+  local path current_commit component published_ref local_ref
+  path="$(repo_path "${COMPOSE_REPO}")"
+  current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
+  for component in container-builder-shim containerization container; do
+    published_ref="$(git -C "${path}" show \
+      "${current_commit}:Tools/release/stack-refs.json" | python3 -c \
+      'import json, sys; print(json.load(sys.stdin)["components"][sys.argv[1]]["ref"])' \
+      "${component}")"
+    local_ref="$(git -C "$(repo_path "${component}")" rev-parse main)"
+    if [[ "${published_ref}" != "${local_ref}" ]]; then
+      printf 'Current stack uses %s %s, but sibling main is %s; integrate and publish exact Current before stable release\n' \
+        "${component}" "${published_ref:-missing}" "${local_ref}" >&2
+      return 1
+    fi
+  done
+}
+
+# Remove only the marker-protected authority after stable publication succeeds.
+# A failed or interrupted release intentionally retains the content-addressed
+# input so an unpublished tag can resume even after mutable Current advances.
+cleanup_current_init_image_authority() {
+  local root="${CURRENT_INIT_IMAGE_AUTHORITY_ROOT:-}" parent expected_parent
+  if [[ -z "${root}" || "${CURRENT_INIT_IMAGE_AUTHORITY_RELEASED}" != "1" ]]; then
+    return 0
+  fi
+  parent="$(cd "$(dirname "${root}")" && pwd -P)"
+  expected_parent="$(cd "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}" && pwd -P)"
+  if [[
+    "${parent}" != "${expected_parent}"
+    || ! "$(basename "${root}")" =~ ^[0-9a-f]{40}$
+    || ! -d "${root}"
+    || -L "${root}"
+    || ! -f "${root}/.container-compose-init-authority"
+    || -L "${root}/.container-compose-init-authority"
+    || "$(sed -n '1p' "${root}/.container-compose-init-authority")" != "schema=1"
+  ]]; then
+    printf 'refusing to clean unsafe Current VM-init authority root: %s\n' \
+      "${root}" >&2
+    return 1
+  fi
+  find "${root}" -depth -delete
+  CURRENT_INIT_IMAGE_AUTHORITY_ROOT=""
+}
+
+# Resolve the exact Current guest authority before any release preparation or
+# expensive validation. A caller-supplied archive remains supported for
+# offline/recovery use, but it must carry both exact required references. The
+# normal path downloads a checksum-paired, attested asset whose name and
+# Current tag are bound to the validated source.
+prepare_stable_init_image_authority() {
+  local path repo current_commit remote_current_before remote_current_after
+  local source_ref="${1:-}" containerization_reference archive asset root
+  local cache_root cache_asset cache_sidecar stage downloaded_asset digest
+  path="$(repo_path "${COMPOSE_REPO}")"
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  if [[ -n "${source_ref}" ]]; then
+    containerization_reference="$(git -C "${path}" show \
+      "${source_ref}:Tools/release/stack-refs.json" | python3 -c \
+      'import json, sys; print(json.load(sys.stdin)["components"]["containerization"]["ref"])')"
+  else
+    containerization_reference="$(python3 - "${path}/Tools/release/stack-refs.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(manifest["components"]["containerization"]["ref"])
+PY
+)"
+  fi
+  if [[ ! "${containerization_reference}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'stable VM-init authority requires an exact Containerization ref: %s\n' \
+      "${containerization_reference:-missing}" >&2
+    return 2
+  fi
+
+  archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
+  if [[ -n "${archive}" ]]; then
+    if [[ "${archive}" != /* || ! -f "${archive}" || -L "${archive}" ]]; then
+      printf 'explicit stable VM-init archive must be an absolute, regular file: %s\n' \
+        "${archive}" >&2
+      return 2
+    fi
+    archive="$(cd "$(dirname "${archive}")" && pwd -P)/$(basename "${archive}")"
+  elif [[ "${EXECUTE}" != "1" ]]; then
+    printf 'would download and attest the exact Current VM-init authority\n'
+    return 0
+  else
+    need_command gh
+    mkdir -p "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}"
+    chmod 700 "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}"
+    cache_root="${RELEASE_INIT_AUTHORITY_CACHE_ROOT}/${containerization_reference}"
+    cache_asset="container-vminit-${containerization_reference}-arm64.oci.tar"
+    cache_sidecar="${cache_asset}.sha256"
+    if [[ -e "${cache_root}" ]]; then
+      if [[
+        ! -d "${cache_root}"
+        || -L "${cache_root}"
+        || ! -f "${cache_root}/.container-compose-init-authority"
+        || -L "${cache_root}/.container-compose-init-authority"
+        || ! -f "${cache_root}/${cache_asset}"
+        || -L "${cache_root}/${cache_asset}"
+        || ! -f "${cache_root}/${cache_sidecar}"
+        || -L "${cache_root}/${cache_sidecar}"
+        || "$(sed -n '1p' "${cache_root}/.container-compose-init-authority")" != "schema=1"
+        || "$(sed -n '2p' "${cache_root}/.container-compose-init-authority")" != "containerization=${containerization_reference}"
+        || ! "$(sed -n '3p' "${cache_root}/.container-compose-init-authority")" =~ ^current=[0-9a-f]{40}$
+        || "$(sed -n '4p' "${cache_root}/.container-compose-init-authority")" != "sha256=$(awk '{print $1}' "${cache_root}/${cache_sidecar}")"
+      ]]; then
+        printf 'retained VM-init authority cache is incomplete or malformed; preserving evidence: %s\n' \
+          "${cache_root}" >&2
+        return 1
+      fi
+      (
+        cd "${cache_root}"
+        shasum -a 256 -c "${cache_sidecar}"
+      )
+      github_cli attestation verify "${cache_root}/${cache_asset}" --repo "${repo}"
+    else
+      if find "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}" -mindepth 1 -maxdepth 1 \
+        -type d -name ".${containerization_reference}.*" -print -quit \
+        | grep -q .; then
+        printf 'an incomplete VM-init authority attempt is retained for diagnosis; resolve it before retrying: %s/.%s.*\n' \
+          "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}" "${containerization_reference}" >&2
+        return 1
+      fi
+      current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
+      remote_current_before="$(git -C "${path}" ls-remote --tags origin \
+        'refs/tags/current' 'refs/tags/current^{}' | awk '{print $1}' | tail -n 1)"
+      if [[ "${remote_current_before}" != "${current_commit}" ]]; then
+        printf 'remote Current moved before VM-init authority download: local %s, remote %s\n' \
+          "${current_commit}" "${remote_current_before:-missing}" >&2
+        return 1
+      fi
+      asset="container-vminit-current-${current_commit:0:12}-arm64.oci.tar"
+      stage="$(mktemp -d \
+        "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}/.${containerization_reference}.XXXXXX")"
+      github_cli release download current \
+        --repo "${repo}" \
+        --dir "${stage}" \
+        --pattern "${asset}" \
+        --pattern "${asset}.sha256"
+      (
+        cd "${stage}"
+        shasum -a 256 -c "${asset}.sha256"
+      )
+      github_cli attestation verify "${stage}/${asset}" --repo "${repo}"
+      remote_current_after="$(git -C "${path}" ls-remote --tags origin \
+        'refs/tags/current' 'refs/tags/current^{}' | awk '{print $1}' | tail -n 1)"
+      if [[ "${remote_current_after}" != "${current_commit}" ]]; then
+        printf 'remote Current moved during VM-init authority download: expected %s, got %s\n' \
+          "${current_commit}" "${remote_current_after:-missing}" >&2
+        return 1
+      fi
+      downloaded_asset="${stage}/${asset}"
+      mv "${downloaded_asset}" "${stage}/${cache_asset}"
+      rm "${stage}/${asset}.sha256"
+      python3 "${path}/Tools/release/write-sha256-sidecar.py" \
+        "${stage}/${cache_asset}"
+      digest="$(awk '{print $1}' "${stage}/${cache_sidecar}")"
+      printf 'schema=1\ncontainerization=%s\ncurrent=%s\nsha256=%s\n' \
+        "${containerization_reference}" "${current_commit}" "${digest}" \
+        > "${stage}/.container-compose-init-authority"
+      chmod a-w "${stage}/${cache_asset}" "${stage}/${cache_sidecar}" \
+        "${stage}/.container-compose-init-authority"
+      mv "${stage}" "${cache_root}"
+    fi
+    root="${cache_root}"
+    CURRENT_INIT_IMAGE_AUTHORITY_ROOT="${root}"
+    archive="${root}/${cache_asset}"
+  fi
+
+  "${OCI_IMAGE_LAYOUT_VALIDATOR}" "${archive}" \
+    vminit:container-compose \
+    "ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
+  CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE="${archive}"
+  export CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE
+  printf 'stable VM-init authority verified: %s\n' "${archive}"
 }
 
 # Retain a helper-created candidate after a local release gate fails before
@@ -4891,6 +5079,7 @@ resume_stable_release() {
   fi
   ensure_stable_release_is_unpublished "${version}"
   ensure_stable_retry_source_authority "${version}"
+  prepare_stable_init_image_authority "${version}"
   publish_stable_release "${version}"
 }
 
@@ -4921,6 +5110,7 @@ release_current_stack() {
   ensure_release_intent
   recover_unpublished_release_candidate "${version}"
   ensure_current_build_release_readiness
+  require_current_stack_matches_sibling_mains
   require_release_upstream_alignment
   path="$(repo_path "${COMPOSE_REPO}")"
 
@@ -4942,6 +5132,7 @@ release_current_stack() {
   sync_containerization_package_pins
   sync_container_package_pin
   write_release_stack_manifest
+  prepare_stable_init_image_authority
 
   if [[ "${EXECUTE}" == "1" ]]; then
     git -C "${path}" add Makefile Sources/ComposePlugin/ComposePlugin.swift Tools/release/stack-refs.json
@@ -5044,9 +5235,11 @@ main() {
       plan
       ;;
     release)
+      trap cleanup_current_init_image_authority EXIT
       ensure_compose_promotion_mode
       prepare_all_main
       release_current_stack
+      CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=1
       ;;
   esac
 }


### PR DESCRIPTION
Closes #438.

## What changed

- deterministically materialize a VM-init OCI archive from the exact successful Containerization CI `initfs` artifact pinned by `stack-refs.json`;
- validate the source run, artifact digest, OCI descriptor closure, and both required image references;
- attest and publish the archive plus portable SHA-256 sidecar with Current;
- make the stable controller download/checksum/attest/validate that Current authority before release preparation;
- move Current Demo off the manually maintained stale archive variable;
- clean the controller-owned temporary authority root on exit.

## Focused proof

- 3 deterministic OCI creator tests pass, including stale-reference rejection.
- 6 authority/reconstruction/controller tests pass.
- A 106 MiB rootfs from Containerization `f77f8d2833b54498546c081a0a5d15b4751b62bd` was materialized and accepted by the OCI closure validator for both exact references.
- `bash -n`, YAML parsing, ShellCheck, Hawkeye, and `git diff --check` pass.

This removes the stale `e5a92e86...` manual archive that stopped the 0.14.1 release before its expensive gate.