### PR TITLE
fix(ci): preserve runner lease during Swift coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,10 @@ jobs:
     # Cover validation/coverage, CLI smoke, up to two queued maintenance
     # transactions, this transaction's two scans, and setup overhead.
     timeout-minutes: 250
+    env:
+      # Leave CPU capacity for the self-hosted runner listener to renew its
+      # GitHub job lease while Swift compiles the coverage graph.
+      SWIFT_TEST_FLAGS: "--jobs 8"
     steps:
       - name: Checkout container-compose
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -261,6 +261,16 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
             PIPELINE_MAKEFILE,
         )
 
+    def test_runtime_validation_reserves_capacity_for_runner_lease_renewal(
+        self,
+    ) -> None:
+        runtime_validation = CI_WORKFLOW.split("  validate_runtime:", 1)[1].split(
+            "  prebuilt_binaries:", 1
+        )[0]
+
+        self.assertIn('SWIFT_TEST_FLAGS: "--jobs 8"', runtime_validation)
+        self.assertIn("$(SWIFT_TEST_FLAGS)", PIPELINE_MAKEFILE)
+
     def test_release_state_is_persistent_and_candidate_keyed(self) -> None:
         self.assertNotIn(
             "RELEASE_PIPELINE_STATE_ROOT: ${{ github.workspace }}",

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7641,6 +7641,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/441"
     },
     {
+      "id": "container-compose-443",
+      "owner": "stephenlclarke/container-compose",
+      "title": "Preserve runner control during Swift coverage builds",
+      "state": "active-draft",
+      "lastVerified": "2026-09-03",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-442.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-443.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/443"
+    },
+    {
       "id": "container-compose-333",
       "owner": "stephenlclarke/container-compose",
       "title": "Prepare and repair Container Compose 0.14.0",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-02
 
-Entries: 412. Document snapshots: 726. Current supporting documents: 120.
+Entries: 413. Document snapshots: 728. Current supporting documents: 122.
 
-States: `active-draft` 24, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 25, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -242,6 +242,7 @@ States: `active-draft` 24, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Pin the deterministic Containerization stack](https://github.com/stephenlclarke/container-compose/pull/435) | `active-draft` | `3a94dab3cdca` | [Issue details](container-compose/ISSUE-434.md); [PR details](container-compose/PR-435.md) |
 | `stephenlclarke/container-compose` | [Pin the final reviewed 0.14.1 support stack](https://github.com/stephenlclarke/container-compose/pull/437) | `active-draft` | `87ca355e4218`, `f77f8d2833b5` | [Issue details](container-compose/ISSUE-436.md); [PR details](container-compose/PR-437.md) |
 | `stephenlclarke/container-compose` | [Pin deterministic NBD integration stack for 0.14.1](https://github.com/stephenlclarke/container-compose/pull/441) | `active-draft` | `818f5917819a`, `ecf6da9fd029` | [Issue details](container-compose/ISSUE-440.md); [PR details](container-compose/PR-441.md) |
+| `stephenlclarke/container-compose` | [Preserve runner control during Swift coverage builds](https://github.com/stephenlclarke/container-compose/pull/443) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-442.md); [PR details](container-compose/PR-443.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-442.md
+++ b/docs/upstream/container-compose/ISSUE-442.md
@@ -1,0 +1,20 @@
+# Issue 442: preserve runner control during Swift coverage builds
+
+## Problem
+
+The self-hosted macOS Current validation lost its GitHub job lease twice while Swift compiled the coverage graph with unbounded concurrency. Runner diagnostics show successful initial lease acquisition followed by a missing renewal window, `TaskAgentJobNotFoundException`, and server-directed worker cancellation before tests produced a result.
+
+The source checks and both tool-test lanes had already passed. Replaying the whole workflow would waste those checkpoints and leave the same runner starvation risk in stable release validation.
+
+## Required work
+
+- Bound SwiftPM build concurrency in the self-hosted runtime-validation job.
+- Preserve the existing job and step timeouts.
+- Reuse completed workflow jobs when validation resumes.
+- Verify that the runner renews its lease throughout the coverage build and reaches a real test result.
+
+## Acceptance boundary
+
+The issue is complete when the workflow passes `--jobs 8` through the existing `SWIFT_TEST_FLAGS` contract, workflow and tool tests pass, exact-head review is clear, and Current validation completes without losing the runner job lease.
+
+Related issue: [#442](https://github.com/stephenlclarke/container-compose/issues/442).

--- a/docs/upstream/container-compose/PR-443.md
+++ b/docs/upstream/container-compose/PR-443.md
@@ -1,0 +1,25 @@
+# Pull request 443: preserve runner control during Swift coverage builds
+
+## Purpose
+
+Pull request [#443](https://github.com/stephenlclarke/container-compose/pull/443) closes issue [#442](https://github.com/stephenlclarke/container-compose/issues/442) by reserving CPU capacity for the self-hosted GitHub runner listener during coverage compilation.
+
+## Scope
+
+- Pass `--jobs 8` through the existing `SWIFT_TEST_FLAGS` Makefile contract for the `Validate Runtime` job.
+- Keep the 250-minute job timeout and existing per-step timeouts unchanged.
+- Leave product code, release identities, tests, and hosted jobs unchanged.
+
+## Evidence
+
+- `python3 -c` YAML parse of `.github/workflows/ci.yml`
+- `make ci-tools-test`
+- `markdownlint` on changed Markdown files
+- `git diff --check`
+- Exact-head review
+- Successful resumed Current validation with continuous runner lease renewal
+
+## Related work
+
+- Current stack pull request [#441](https://github.com/stephenlclarke/container-compose/pull/441)
+- Failed Current validation [run 33695120448](https://github.com/stephenlclarke/container-compose/actions/runs/33695120448)


### PR DESCRIPTION
# Pull request 443: preserve runner control during Swift coverage builds

## Purpose

Pull request [#443](https://github.com/stephenlclarke/container-compose/pull/443) closes issue [#442](https://github.com/stephenlclarke/container-compose/issues/442) by reserving CPU capacity for the self-hosted GitHub runner listener during coverage compilation.

## Scope

- Pass `--jobs 8` through the existing `SWIFT_TEST_FLAGS` Makefile contract for the `Validate Runtime` job.
- Keep the 250-minute job timeout and existing per-step timeouts unchanged.
- Leave product code, release identities, tests, and hosted jobs unchanged.

## Evidence

- `python3 -c` YAML parse of `.github/workflows/ci.yml`
- `make ci-tools-test`
- `markdownlint` on changed Markdown files
- `git diff --check`
- Exact-head review
- Successful resumed Current validation with continuous runner lease renewal

## Related work

- Current stack pull request [#441](https://github.com/stephenlclarke/container-compose/pull/441)
- Failed Current validation [run 33695120448](https://github.com/stephenlclarke/container-compose/actions/runs/33695120448)
