### PR TITLE
fix(ci): move coverage validation to managed macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,14 +254,15 @@ jobs:
     if: >
       needs.changes.outputs.heavy == 'true' &&
       needs.resolve-canonical-main.result == 'success'
-    runs-on: [self-hosted, macOS, ARM64, container-compose-current]
+    # This lane compiles and exercises unit/CLI coverage only. Keep VM-backed
+    # integration in the recoverable release graph and use a managed runner
+    # here so a host broker disconnect cannot revoke an otherwise valid build.
+    runs-on: macos-26
     # Cover validation/coverage, CLI smoke, up to two queued maintenance
     # transactions, this transaction's two scans, and setup overhead.
     timeout-minutes: 250
     env:
-      # Leave CPU capacity for the self-hosted runner listener to renew its
-      # GitHub job lease while Swift compiles the coverage graph.
-      SWIFT_TEST_FLAGS: "--jobs 8"
+      DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer
     steps:
       - name: Checkout container-compose
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -261,15 +261,19 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
             PIPELINE_MAKEFILE,
         )
 
-    def test_runtime_validation_reserves_capacity_for_runner_lease_renewal(
+    def test_runtime_validation_uses_pinned_managed_macos_toolchain(
         self,
     ) -> None:
         runtime_validation = CI_WORKFLOW.split("  validate_runtime:", 1)[1].split(
             "  prebuilt_binaries:", 1
         )[0]
 
-        self.assertIn('SWIFT_TEST_FLAGS: "--jobs 8"', runtime_validation)
-        self.assertIn("$(SWIFT_TEST_FLAGS)", PIPELINE_MAKEFILE)
+        self.assertIn("runs-on: macos-26", runtime_validation)
+        self.assertIn(
+            "DEVELOPER_DIR: /Applications/Xcode_26.6.app/Contents/Developer",
+            runtime_validation,
+        )
+        self.assertNotIn("self-hosted", runtime_validation)
 
     def test_release_state_is_persistent_and_candidate_keyed(self) -> None:
         self.assertNotIn(

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7655,9 +7655,13 @@
         {
           "kind": "pull-request",
           "path": "docs/upstream/container-compose/PR-443.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-444.md"
         }
       ],
-      "upstream": "https://github.com/stephenlclarke/container-compose/pull/443"
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/444"
     },
     {
       "id": "container-compose-333",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,7 +8,7 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-02
 
-Entries: 413. Document snapshots: 728. Current supporting documents: 122.
+Entries: 413. Document snapshots: 729. Current supporting documents: 123.
 
 States: `active-draft` 25, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
@@ -242,7 +242,7 @@ States: `active-draft` 25, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Pin the deterministic Containerization stack](https://github.com/stephenlclarke/container-compose/pull/435) | `active-draft` | `3a94dab3cdca` | [Issue details](container-compose/ISSUE-434.md); [PR details](container-compose/PR-435.md) |
 | `stephenlclarke/container-compose` | [Pin the final reviewed 0.14.1 support stack](https://github.com/stephenlclarke/container-compose/pull/437) | `active-draft` | `87ca355e4218`, `f77f8d2833b5` | [Issue details](container-compose/ISSUE-436.md); [PR details](container-compose/PR-437.md) |
 | `stephenlclarke/container-compose` | [Pin deterministic NBD integration stack for 0.14.1](https://github.com/stephenlclarke/container-compose/pull/441) | `active-draft` | `818f5917819a`, `ecf6da9fd029` | [Issue details](container-compose/ISSUE-440.md); [PR details](container-compose/PR-441.md) |
-| `stephenlclarke/container-compose` | [Preserve runner control during Swift coverage builds](https://github.com/stephenlclarke/container-compose/pull/443) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-442.md); [PR details](container-compose/PR-443.md) |
+| `stephenlclarke/container-compose` | [Preserve runner control during Swift coverage builds](https://github.com/stephenlclarke/container-compose/pull/444) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-442.md); [PR details](container-compose/PR-443.md); [PR details](container-compose/PR-444.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-442.md
+++ b/docs/upstream/container-compose/ISSUE-442.md
@@ -2,19 +2,22 @@
 
 ## Problem
 
-The self-hosted macOS Current validation lost its GitHub job lease twice while Swift compiled the coverage graph with unbounded concurrency. Runner diagnostics show successful initial lease acquisition followed by a missing renewal window, `TaskAgentJobNotFoundException`, and server-directed worker cancellation before tests produced a result.
+The self-hosted macOS Current validation lost its GitHub job lease three times while Swift compiled the coverage graph. Runner diagnostics show successful initial lease acquisition followed by a missing renewal window, `TaskAgentJobNotFoundException`, and server-directed worker cancellation before tests produced a result.
 
-The source checks and both tool-test lanes had already passed. Replaying the whole workflow would waste those checkpoints and leave the same runner starvation risk in stable release validation.
+The first mitigation bounded SwiftPM concurrency at eight jobs. Pull-request validation then crossed compilation while renewing its lease, but exact-main run [33715390806](https://github.com/stephenlclarke/container-compose/actions/runs/33715390806) lost the same lease after 11 minutes. The runner log also records broker connection resets while the machine is idle. Compiler scheduling therefore cannot make this control channel authoritative.
+
+The source checks and both tool-test lanes passed in every affected run. Replaying the same self-hosted job would waste those checkpoints and retain the known runner-protocol failure.
 
 ## Required work
 
-- Bound SwiftPM build concurrency in the self-hosted runtime-validation job.
+- Run the unit/coverage/CLI-smoke lane on GitHub's managed macOS 26 ARM64 image.
+- Pin Xcode 26.6 explicitly so the toolchain cannot drift with the image default.
+- Keep VM-backed integration on the local, content-addressed release graph where it can resume independently of a GitHub runner lease.
 - Preserve the existing job and step timeouts.
-- Reuse completed workflow jobs when validation resumes.
-- Verify that the runner renews its lease throughout the coverage build and reaches a real test result.
+- Verify that exact-main Current validation reaches a real test result.
 
 ## Acceptance boundary
 
-The issue is complete when the workflow passes `--jobs 8` through the existing `SWIFT_TEST_FLAGS` contract, workflow and tool tests pass, exact-head review is clear, and Current validation completes without losing the runner job lease.
+The issue is complete when workflow and tool tests pass, exact-head review is clear, and managed exact-main Current validation completes with Xcode 26.6 and publishes the matched Current stack.
 
 Related issue: [#442](https://github.com/stephenlclarke/container-compose/issues/442).

--- a/docs/upstream/container-compose/PR-444.md
+++ b/docs/upstream/container-compose/PR-444.md
@@ -1,0 +1,27 @@
+# Pull request 444: move Current validation to managed macOS
+
+## Purpose
+
+Pull request [#444](https://github.com/stephenlclarke/container-compose/pull/444) completes issue [#442](https://github.com/stephenlclarke/container-compose/issues/442) after bounded compiler concurrency proved insufficient to prevent the self-hosted runner's V2 control-channel lease loss.
+
+## Scope
+
+- Run the unit, coverage, and CLI-smoke validation lane on GitHub's managed `macos-26` ARM64 image.
+- Pin `DEVELOPER_DIR` to Xcode 26.6 instead of inheriting the image default.
+- Keep VM-backed integration in the recoverable local release graph.
+- Preserve all existing validation commands, job timeouts, and step timeouts.
+
+## Evidence
+
+- Failed self-hosted exact-main run [33715390806](https://github.com/stephenlclarke/container-compose/actions/runs/33715390806)
+- Focused CI workflow regression test
+- YAML parse of `.github/workflows/ci.yml`
+- Handoff-registry validation
+- Markdown lint on changed documentation
+- Exact-head review
+- Successful managed exact-main Current validation and package publication
+
+## Related work
+
+- Pull request [#443](https://github.com/stephenlclarke/container-compose/pull/443) established that compiler concurrency alone does not remove the self-hosted V2 runner failure.
+- Current stack pull request [#441](https://github.com/stephenlclarke/container-compose/pull/441)


### PR DESCRIPTION
# Pull request 444: move Current validation to managed macOS

## Purpose

Pull request [#444](https://github.com/stephenlclarke/container-compose/pull/444) completes issue [#442](https://github.com/stephenlclarke/container-compose/issues/442) after bounded compiler concurrency proved insufficient to prevent the self-hosted runner's V2 control-channel lease loss.

## Scope

- Run the unit, coverage, and CLI-smoke validation lane on GitHub's managed `macos-26` ARM64 image.
- Pin `DEVELOPER_DIR` to Xcode 26.6 instead of inheriting the image default.
- Keep VM-backed integration in the recoverable local release graph.
- Preserve all existing validation commands, job timeouts, and step timeouts.

## Evidence

- Failed self-hosted exact-main run [33715390806](https://github.com/stephenlclarke/container-compose/actions/runs/33715390806)
- Focused CI workflow regression test
- YAML parse of `.github/workflows/ci.yml`
- Handoff-registry validation
- Markdown lint on changed documentation
- Exact-head review
- Successful managed exact-main Current validation and package publication

## Related work

- Pull request [#443](https://github.com/stephenlclarke/container-compose/pull/443) established that compiler concurrency alone does not remove the self-hosted V2 runner failure.
- Current stack pull request [#441](https://github.com/stephenlclarke/container-compose/pull/441)
