### PR TITLE
test(ci): remove stale self-hosted runner assertion

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2615,16 +2615,11 @@ github_cli() {{
 
     def test_release_gate_includes_sibling_coverage_and_runtime_integration(self) -> None:
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
-        ci_workflow = CI_WORKFLOW.read_text(encoding="utf-8")
         validation = STACK_RELEASE_VALIDATION.read_text(encoding="utf-8")
         reference_check = (
             ROOT / "Tools" / "parity" / "check-docker-compose-reference.sh"
         ).read_text(encoding="utf-8")
         self.assertIn("check-licenses vet lint coverage build", validation)
-        self.assertIn(
-            "runs-on: [self-hosted, macOS, ARM64, container-compose-current]",
-            ci_workflow,
-        )
         self.assertIn("run-stack-release-validation.sh full", makefile)
         self.assertIn("PIPELINE_PROFILE=release-hosted", makefile)
         direct_full_gate = subprocess.run(

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -7659,9 +7659,13 @@
         {
           "kind": "pull-request",
           "path": "docs/upstream/container-compose/PR-444.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-445.md"
         }
       ],
-      "upstream": "https://github.com/stephenlclarke/container-compose/pull/444"
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/445"
     },
     {
       "id": "container-compose-333",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,7 +8,7 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-02
 
-Entries: 413. Document snapshots: 729. Current supporting documents: 123.
+Entries: 413. Document snapshots: 730. Current supporting documents: 124.
 
 States: `active-draft` 25, `archived` 304, `closed` 17, `merged` 10, `submitted` 15, `tracked-upstream` 15, `unsubmitted` 27.
 
@@ -242,7 +242,7 @@ States: `active-draft` 25, `archived` 304, `closed` 17, `merged` 10, `submitted`
 | `stephenlclarke/container-compose` | [Pin the deterministic Containerization stack](https://github.com/stephenlclarke/container-compose/pull/435) | `active-draft` | `3a94dab3cdca` | [Issue details](container-compose/ISSUE-434.md); [PR details](container-compose/PR-435.md) |
 | `stephenlclarke/container-compose` | [Pin the final reviewed 0.14.1 support stack](https://github.com/stephenlclarke/container-compose/pull/437) | `active-draft` | `87ca355e4218`, `f77f8d2833b5` | [Issue details](container-compose/ISSUE-436.md); [PR details](container-compose/PR-437.md) |
 | `stephenlclarke/container-compose` | [Pin deterministic NBD integration stack for 0.14.1](https://github.com/stephenlclarke/container-compose/pull/441) | `active-draft` | `818f5917819a`, `ecf6da9fd029` | [Issue details](container-compose/ISSUE-440.md); [PR details](container-compose/PR-441.md) |
-| `stephenlclarke/container-compose` | [Preserve runner control during Swift coverage builds](https://github.com/stephenlclarke/container-compose/pull/444) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-442.md); [PR details](container-compose/PR-443.md); [PR details](container-compose/PR-444.md) |
+| `stephenlclarke/container-compose` | [Preserve runner control during Swift coverage builds](https://github.com/stephenlclarke/container-compose/pull/445) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-442.md); [PR details](container-compose/PR-443.md); [PR details](container-compose/PR-444.md); [PR details](container-compose/PR-445.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/PR-445.md
+++ b/docs/upstream/container-compose/PR-445.md
@@ -1,0 +1,24 @@
+# Pull request 445: align the release-policy test with managed validation
+
+## Purpose
+
+Pull request [#445](https://github.com/stephenlclarke/container-compose/pull/445) completes issue [#442](https://github.com/stephenlclarke/container-compose/issues/442) by removing a stale release-policy assertion that required the retired self-hosted Current runner label.
+
+## Scope
+
+- Remove the obsolete runner-label assertion from the release-gate integration test.
+- Retain the dedicated CI workflow regression that requires managed macOS 26, pinned Xcode 26.6, and no self-hosted runner label.
+- Leave product code and release behavior unchanged.
+
+## Evidence
+
+- `python3 -m unittest Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_release_gate_includes_sibling_coverage_and_runtime_integration`
+- Dedicated CI workflow regression test
+- Handoff-registry validation
+- Markdown lint on changed documentation
+- Exact-head review
+
+## Related work
+
+- Pull request [#444](https://github.com/stephenlclarke/container-compose/pull/444) moved Current validation to managed macOS.
+- Failed exact-main run [33720208697](https://github.com/stephenlclarke/container-compose/actions/runs/33720208697) exposed the stale assertion after its managed coverage gate passed.


### PR DESCRIPTION
# Pull request 445: align the release-policy test with managed validation

## Purpose

Pull request [#445](https://github.com/stephenlclarke/container-compose/pull/445) completes issue [#442](https://github.com/stephenlclarke/container-compose/issues/442) by removing a stale release-policy assertion that required the retired self-hosted Current runner label.

## Scope

- Remove the obsolete runner-label assertion from the release-gate integration test.
- Retain the dedicated CI workflow regression that requires managed macOS 26, pinned Xcode 26.6, and no self-hosted runner label.
- Leave product code and release behavior unchanged.

## Evidence

- `python3 -m unittest Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_release_gate_includes_sibling_coverage_and_runtime_integration`
- Dedicated CI workflow regression test
- Handoff-registry validation
- Markdown lint on changed documentation
- Exact-head review

## Related work

- Pull request [#444](https://github.com/stephenlclarke/container-compose/pull/444) moved Current validation to managed macOS.
- Failed exact-main run [33720208697](https://github.com/stephenlclarke/container-compose/actions/runs/33720208697) exposed the stale assertion after its managed coverage gate passed.
