### PR TITLE
fix(ci): recover cancelled Current demo runtime

### DIFF
--- a/.github/workflows/current-demo.yml
+++ b/.github/workflows/current-demo.yml
@@ -275,14 +275,24 @@ jobs:
           tape="${demo_session_root}/container-compose-current-demo.tape"
           demo_init_image_archive="${demo_session_root}/init-image.oci.tar"
           prior_container="${demo_root}/bin/container"
-          if [[ -x "${prior_container}" ]]; then
-            CONTAINER_APP_ROOT="${demo_app_root}" \
-              python3 Tools/ci/run-command-with-deadline.py \
-              --seconds 30 --grace-seconds 5 -- \
-              "${prior_container}" system stop || true
-          fi
-          CONTAINER_APP_ROOT="${demo_app_root}" \
-            bash Tools/release/wait-for-container-system-stop.sh
+          container_binary="${prior_container}"
+          cleanup() {
+            local status=$?
+            trap - EXIT
+            trap '' HUP INT QUIT TERM
+            if ! bash Tools/release/stop-current-demo-runtime.sh \
+              "${demo_session_root}" "${container_binary}"; then
+              status=1
+            fi
+            exit "${status}"
+          }
+          trap cleanup EXIT
+          trap 'exit 129' HUP
+          trap 'exit 130' INT
+          trap 'exit 131' QUIT
+          trap 'exit 143' TERM
+          bash Tools/release/stop-current-demo-runtime.sh \
+            "${demo_session_root}" "${prior_container}"
 
           rm -rf -- \
             "${demo_root}" \
@@ -314,12 +324,6 @@ jobs:
           container_binary="${demo_root}/bin/container"
           test -x "${container_binary}"
           test -x "${demo_root}/libexec/container-plugins/compose/bin/compose"
-          cleanup() {
-            python3 Tools/ci/run-command-with-deadline.py \
-              --seconds 30 --grace-seconds 5 -- \
-              "${container_binary}" system stop || true
-          }
-          trap cleanup EXIT
 
           export CONTAINER_INSTALL_ROOT="${demo_root}"
           export CONTAINER_APP_ROOT="${demo_app_root}"

--- a/Tools/ci/container-runtime-lock.sh
+++ b/Tools/ci/container-runtime-lock.sh
@@ -27,7 +27,7 @@ release_container_runtime_lock() {
         return
     fi
 
-    kill "$keeper_pid" >/dev/null 2>&1 || true
+    kill -USR1 "$keeper_pid" >/dev/null 2>&1 || true
     wait "$keeper_pid" >/dev/null 2>&1 || true
     unset CONTAINER_RUNTIME_LOCK_KEEPER_PID
     unset CONTAINER_RUNTIME_LOCK_HELD
@@ -82,13 +82,41 @@ acquire_container_runtime_lock() {
     # (for example Chrome during VHS capture); those descendants must not keep
     # the host-wide lock after the owner exits.
     local lock_owner_pid=$$
+    local keeper_ready
+    if ! keeper_ready="$(mktemp "${TMPDIR:-/tmp}/container-runtime-lock-keeper.XXXXXX")"; then
+        printf 'failed to create runtime lock-keeper readiness file\n' >&2
+        exec 9>&-
+        return 1
+    fi
+    local keeper_ready_status=0
     (
-        trap 'exit 0' HUP INT QUIT TERM
+        trap '' HUP INT QUIT TERM
+        trap 'exit 0' USR1
+        printf 'ready\n' >"$keeper_ready"
         while kill -0 "$lock_owner_pid" >/dev/null 2>&1; do
             sleep 0.1
         done
     ) </dev/null >/dev/null 2>&1 &
     CONTAINER_RUNTIME_LOCK_KEEPER_PID=$!
+    for _ in {1..100}; do
+        if [[ "$(cat "$keeper_ready" 2>/dev/null || true)" == "ready" ]]; then
+            keeper_ready_status=1
+            break
+        fi
+        if ! kill -0 "$CONTAINER_RUNTIME_LOCK_KEEPER_PID" >/dev/null 2>&1; then
+            break
+        fi
+        sleep 0.01
+    done
+    rm -f -- "$keeper_ready"
+    if [[ "$keeper_ready_status" != "1" ]]; then
+        printf 'runtime lock keeper did not become ready\n' >&2
+        kill -USR1 "$CONTAINER_RUNTIME_LOCK_KEEPER_PID" >/dev/null 2>&1 || true
+        wait "$CONTAINER_RUNTIME_LOCK_KEEPER_PID" >/dev/null 2>&1 || true
+        unset CONTAINER_RUNTIME_LOCK_KEEPER_PID
+        exec 9>&-
+        return 1
+    fi
     exec 9>&-
 
     export CONTAINER_RUNTIME_LOCK_HELD=1

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -4245,6 +4245,78 @@ class ContainerRuntimeLockTest(unittest.TestCase):
             )
             self.assertTrue(contender_acquired.exists())
 
+    def test_keeper_retains_lock_after_group_termination_signal(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            lock_file = temporary_root / "runtime.lock"
+            holder_ready = temporary_root / "holder-ready"
+            holder_release = temporary_root / "holder-release"
+            contender_acquired = temporary_root / "contender-acquired"
+            environment = self.independent_runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_LOCK_FILE": str(lock_file),
+                    "CONTAINER_RUNTIME_LOCK_TIMEOUT_SECONDS": "5",
+                }
+            )
+            holder_script = (
+                f'source "{LOCK_SCRIPT}"; '
+                "acquire_container_runtime_lock; "
+                'kill -TERM "$CONTAINER_RUNTIME_LOCK_KEEPER_PID"; '
+                f'touch "{holder_ready}"; '
+                f'while [[ ! -e "{holder_release}" ]]; do sleep 0.02; done; '
+                "release_container_runtime_lock"
+            )
+            contender_script = (
+                f'source "{LOCK_SCRIPT}"; '
+                "acquire_container_runtime_lock; "
+                f'touch "{contender_acquired}"; '
+                "release_container_runtime_lock"
+            )
+
+            holder = subprocess.Popen(
+                ["/bin/bash", "-c", holder_script],
+                cwd=ROOT,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            deadline = time.monotonic() + 5
+            while not holder_ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            if not holder_ready.exists():
+                holder_stdout, holder_stderr = holder.communicate(timeout=5)
+                self.fail(
+                    "signalled lock holder did not become ready\n"
+                    + holder_stdout
+                    + holder_stderr
+                )
+
+            contender = subprocess.Popen(
+                ["/bin/bash", "-c", contender_script],
+                cwd=ROOT,
+                env=environment,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            time.sleep(0.2)
+            acquired_before_release = contender_acquired.exists()
+
+            holder_release.touch()
+            holder_stdout, holder_stderr = holder.communicate(timeout=5)
+            contender_stdout, contender_stderr = contender.communicate(timeout=5)
+            self.assertEqual(holder.returncode, 0, holder_stdout + holder_stderr)
+            self.assertEqual(
+                contender.returncode, 0, contender_stdout + contender_stderr
+            )
+            self.assertFalse(
+                acquired_before_release,
+                "contender acquired the runtime lock after its keeper was signalled",
+            )
+            self.assertTrue(contender_acquired.exists())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/release/stop-current-demo-runtime.sh
+++ b/Tools/release/stop-current-demo-runtime.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+#===----------------------------------------------------------------------===#
+# Copyright © 2026 container-compose project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===----------------------------------------------------------------------===#
+
+# Stop the marker-protected Current demo runtime. If the CLI cannot reach its
+# API server, recover only the launch agent whose plist belongs to this exact
+# demo root. A production or otherwise unrelated Container service remains a
+# hard failure.
+set -euo pipefail
+# Teardown owns recovery once invoked. A workflow cancellation can deliver
+# several signals while the bounded CLI stop is running; keep the helper alive
+# long enough to execute its verified launchd fallback.
+trap '' HUP INT QUIT TERM
+
+if [[ "$#" -ne 2 ]]; then
+  printf 'usage: %s DEMO_SESSION_ROOT CONTAINER_BINARY\n' "$0" >&2
+  exit 2
+fi
+
+demo_session_root="${1%/}"
+container_binary="$2"
+marker="${demo_session_root}/.container-compose-current-demo-root"
+marker_value=container-compose-current-demo-v1
+demo_app_root="${demo_session_root}/app"
+expected_container="${demo_session_root}/install/bin/container"
+expected_plist="${demo_app_root}/apiserver/apiserver.plist"
+service_label=com.apple.container.apiserver
+user_domain="gui/$(id -u)"
+launchctl_bin="${CONTAINER_DEMO_LAUNCHCTL:-/bin/launchctl}"
+deadline_runner="${CONTAINER_DEMO_DEADLINE_RUNNER:-$(
+  dirname "${BASH_SOURCE[0]}"
+)/../ci/run-command-with-deadline.py}"
+stop_waiter="${CONTAINER_SYSTEM_STOP_WAITER:-$(
+  dirname "${BASH_SOURCE[0]}"
+)/wait-for-container-system-stop.sh}"
+
+if [[ -z "${demo_session_root}" || "${demo_session_root}" != /* ||
+      "${demo_session_root}" == / || ! -d "${demo_session_root}" ||
+      -L "${demo_session_root}" || ! -f "${marker}" || -L "${marker}" ||
+      "$(cat "${marker}")" != "${marker_value}" ]]; then
+  printf 'refusing unsafe Current demo root: %s\n' "${demo_session_root:-<unset>}" >&2
+  exit 2
+fi
+read -r root_owner root_mode < <(
+  python3 -c \
+    'import os, stat, sys; value = os.lstat(sys.argv[1]); print(value.st_uid, oct(stat.S_IMODE(value.st_mode))[2:])' \
+    "${demo_session_root}"
+)
+if [[ "${root_owner}" != "$(id -u)" || "${root_mode}" != 700 ]]; then
+  printf 'Current demo root must be owned by this user with mode 700: %s\n' \
+    "${demo_session_root}" >&2
+  exit 2
+fi
+if [[ "${container_binary}" != "${expected_container}" ]]; then
+  printf 'Current demo container binary is outside the protected root: %s\n' \
+    "${container_binary}" >&2
+  exit 2
+fi
+if [[ ! -x "${launchctl_bin}" ]]; then
+  printf 'Current demo launch-agent inspector is not executable: %s\n' \
+    "${launchctl_bin}" >&2
+  exit 2
+fi
+
+service_state="$(mktemp "${TMPDIR:-/tmp}/container-compose-current-demo-service.XXXXXX")"
+trap 'rm -f -- "${service_state}"' EXIT
+
+demo_service_is_loaded() {
+  if ! "${launchctl_bin}" print "${user_domain}/${service_label}" \
+      >"${service_state}" 2>/dev/null; then
+    return 1
+  fi
+  loaded_plist="$(awk '$1 == "path" && $2 == "=" { print $3; exit }' \
+    "${service_state}")"
+  if [[ "${loaded_plist}" != "${expected_plist}" ]]; then
+    printf 'refusing to boot out unrelated Container launch agent at %s\n' \
+      "${loaded_plist:-<unknown>}" >&2
+    exit 2
+  fi
+}
+
+if demo_service_is_loaded; then
+  if [[ ! -x "${container_binary}" ]]; then
+    printf 'Current demo service is loaded but its CLI is unavailable: %s\n' \
+      "${container_binary}" >&2
+    exit 2
+  fi
+  CONTAINER_APP_ROOT="${demo_app_root}" \
+    python3 "${deadline_runner}" --seconds 30 --grace-seconds 5 -- \
+      "${container_binary}" system stop || true
+fi
+
+if demo_service_is_loaded; then
+  "${launchctl_bin}" bootout "${user_domain}/${service_label}"
+fi
+
+LAUNCHCTL_BIN="${launchctl_bin}" bash "${stop_waiter}"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1708,6 +1708,15 @@ github_cli() {{
         self.assertIn('demo_session_root="/private/tmp/container-compose-current-demo"', workflow)
         self.assertIn(".container-compose-current-demo-root", workflow)
         self.assertIn("container-compose-current-demo-v1", workflow)
+        self.assertIn("stop-current-demo-runtime.sh", workflow)
+        self.assertIn("trap 'exit 143' TERM", workflow)
+        self.assertIn("trap '' HUP INT QUIT TERM", workflow)
+        self.assertLess(
+            workflow.index("trap 'exit 143' TERM"),
+            workflow.index(
+                '"${demo_session_root}" "${prior_container}"'
+            ),
+        )
         self.assertIn(
             '"$(/usr/bin/stat -f %u "${demo_session_root}")" != "$(id -u)"',
             workflow,
@@ -1720,11 +1729,6 @@ github_cli() {{
         self.assertIn(
             "python3 Tools/ci/run-command-with-deadline.py \\\n"
             "              --seconds 2400 --grace-seconds 15 --",
-            workflow,
-        )
-        self.assertIn(
-            "python3 Tools/ci/run-command-with-deadline.py \\\n"
-            "              --seconds 30 --grace-seconds 5 --",
             workflow,
         )
         self.assertIn("bash Tools/release/record-vhs-live-demo.sh", workflow)
@@ -1747,15 +1751,8 @@ github_cli() {{
             workflow.index("Publish exact Current demo"),
         )
         self.assertNotIn('gh release upload current "${DEMO_OUTPUT}"', workflow)
-        self.assertIn(
-            'CONTAINER_APP_ROOT="${demo_app_root}" \\\n'
-            "              python3 Tools/ci/run-command-with-deadline.py",
-            workflow,
-        )
-        self.assertIn(
-            'CONTAINER_APP_ROOT="${demo_app_root}" \\\n'
-            "            bash Tools/release/wait-for-container-system-stop.sh",
-            workflow,
+        self.assertGreaterEqual(
+            workflow.count("bash Tools/release/stop-current-demo-runtime.sh"), 2
         )
         publish_step = workflow[
             workflow.index("- name: Publish exact Current demo") : workflow.index(

--- a/Tools/release/test_stop_current_demo_runtime.py
+++ b/Tools/release/test_stop_current_demo_runtime.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Focused tests for recoverable Current-demo runtime teardown."""
+
+import os
+import signal
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+SCRIPT = ROOT / "Tools" / "release" / "stop-current-demo-runtime.sh"
+
+
+class StopCurrentDemoRuntimeTests(unittest.TestCase):
+    def run_cleanup(
+        self, *, loaded_plist: str | None
+    ) -> tuple[subprocess.CompletedProcess[str], Path]:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        root = Path(temporary_directory.name)
+        session = root / "session"
+        app_root = session / "app"
+        container = session / "install" / "bin" / "container"
+        marker = session / ".container-compose-current-demo-root"
+        launchctl = root / "launchctl"
+        waiter = root / "waiter"
+        state = root / "loaded"
+        stop_log = root / "stop.log"
+        bootout_log = root / "bootout.log"
+
+        container.parent.mkdir(parents=True)
+        app_root.mkdir(parents=True)
+        session.chmod(0o700)
+        marker.write_text("container-compose-current-demo-v1\n", encoding="utf-8")
+        container.write_text(
+            "#!/usr/bin/env bash\nprintf '%s\\n' \"$*\" >> \"${STOP_LOG}\"\n",
+            encoding="utf-8",
+        )
+        container.chmod(0o755)
+        if loaded_plist == "DEMO":
+            loaded_plist = str(app_root / "apiserver" / "apiserver.plist")
+        if loaded_plist is not None:
+            state.write_text(loaded_plist, encoding="utf-8")
+        launchctl.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  print)
+    [[ -f "${SERVICE_STATE}" ]] || exit 113
+    printf 'path = %s\n' "$(cat "${SERVICE_STATE}")"
+    ;;
+  bootout)
+    printf '%s\n' "$2" >> "${BOOTOUT_LOG}"
+    rm -f "${SERVICE_STATE}"
+    ;;
+  list)
+    printf 'PID Status Label\n'
+    ;;
+  *)
+    exit 114
+    ;;
+esac
+""",
+            encoding="utf-8",
+        )
+        waiter.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        launchctl.chmod(0o755)
+        waiter.chmod(0o755)
+        environment = os.environ | {
+            "BOOTOUT_LOG": str(bootout_log),
+            "CONTAINER_DEMO_LAUNCHCTL": str(launchctl),
+            "CONTAINER_SYSTEM_STOP_WAITER": str(waiter),
+            "SERVICE_STATE": str(state),
+            "STOP_LOG": str(stop_log),
+        }
+        result = subprocess.run(
+            ["bash", str(SCRIPT), str(session), str(container)],
+            capture_output=True,
+            check=False,
+            env=environment,
+            text=True,
+        )
+        return result, root
+
+    def test_boots_out_only_the_demo_owned_service_after_cli_stop(self) -> None:
+        result, root = self.run_cleanup(loaded_plist="DEMO")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            (root / "stop.log").read_text(encoding="utf-8"), "system stop\n"
+        )
+        self.assertIn(
+            "com.apple.container.apiserver",
+            (root / "bootout.log").read_text(encoding="utf-8"),
+        )
+        self.assertFalse((root / "loaded").exists())
+
+    def test_refuses_to_boot_out_an_unrelated_service(self) -> None:
+        result, root = self.run_cleanup(
+            loaded_plist=(
+                "/Users/example/Library/Application Support/container/apiserver.plist"
+            )
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn(
+            "refusing to boot out unrelated Container launch agent", result.stderr
+        )
+        self.assertFalse((root / "stop.log").exists())
+        self.assertFalse((root / "bootout.log").exists())
+        self.assertTrue((root / "loaded").exists())
+
+    def test_ignores_termination_until_demo_teardown_completes(self) -> None:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        root = Path(temporary_directory.name)
+        session = root / "session"
+        app_root = session / "app"
+        container = session / "install" / "bin" / "container"
+        marker = session / ".container-compose-current-demo-root"
+        launchctl = root / "launchctl"
+        waiter = root / "waiter"
+        state = root / "loaded"
+        bootout_log = root / "bootout.log"
+
+        container.parent.mkdir(parents=True)
+        app_root.mkdir(parents=True)
+        session.chmod(0o700)
+        marker.write_text("container-compose-current-demo-v1\n", encoding="utf-8")
+        container.write_text("#!/usr/bin/env bash\nsleep 0.3\n", encoding="utf-8")
+        container.chmod(0o755)
+        state.write_text(
+            str(app_root / "apiserver" / "apiserver.plist"), encoding="utf-8"
+        )
+        launchctl.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == print ]]; then
+  [[ -f "${SERVICE_STATE}" ]] || exit 113
+  printf 'path = %s\n' "$(cat "${SERVICE_STATE}")"
+elif [[ "$1" == bootout ]]; then
+  printf '%s\n' "$2" > "${BOOTOUT_LOG}"
+  rm -f "${SERVICE_STATE}"
+else
+  exit 114
+fi
+""",
+            encoding="utf-8",
+        )
+        waiter.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        launchctl.chmod(0o755)
+        waiter.chmod(0o755)
+        process = subprocess.Popen(
+            ["bash", str(SCRIPT), str(session), str(container)],
+            env=os.environ
+            | {
+                "BOOTOUT_LOG": str(bootout_log),
+                "CONTAINER_DEMO_LAUNCHCTL": str(launchctl),
+                "CONTAINER_SYSTEM_STOP_WAITER": str(waiter),
+                "SERVICE_STATE": str(state),
+            },
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        time.sleep(0.1)
+        process.send_signal(signal.SIGTERM)
+        stdout, stderr = process.communicate(timeout=5)
+
+        self.assertEqual(process.returncode, 0, stdout + stderr)
+        self.assertTrue(bootout_log.is_file())
+        self.assertFalse(state.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #450.

## Summary

- route both pre-recording and exit cleanup through one bounded Current-demo teardown helper
- handle explicit termination signals so cancellation reaches cleanup
- boot out `com.apple.container.apiserver` only when launchd proves its plist belongs to the marker-protected demo root
- fail closed for an unrelated production service

## Evidence

- reproduced after cancelling Current Demo run 33734694617: launchd retained `/private/tmp/container-compose-current-demo/app/apiserver/apiserver.plist` and blocked the stable release gate
- focused recovery/refusal tests pass
- workflow policy test passes
- ShellCheck, YAML parse, and `git diff --check` pass
- the same helper cleared the reproduced service and three stable absence observations passed