### PR TITLE
fix(release): make local gate recovery deterministic

### DIFF
--- a/Tools/ci/run-release-checkpoint.py
+++ b/Tools/ci/run-release-checkpoint.py
@@ -23,6 +23,9 @@ import argparse
 import hashlib
 import json
 import os
+import secrets
+import signal
+import stat
 import subprocess
 import sys
 import tempfile
@@ -30,8 +33,11 @@ import time
 from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import BinaryIO
 
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
+FAILURE_TAIL_BYTES = 32 * 1024
+FAILURE_TAIL_LINES = 80
 DEADLINE_RUNNER = Path(__file__).with_name("run-command-with-deadline.py")
 
 
@@ -46,6 +52,7 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
     parser.add_argument(
         "--supervised-worker", action="store_true", help=argparse.SUPPRESS
     )
+    parser.add_argument("--active-output", default="", help=argparse.SUPPRESS)
     parser.add_argument("command", nargs=argparse.REMAINDER)
     options = parser.parse_args(arguments)
     if options.command[:1] == ["--"]:
@@ -61,11 +68,34 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
         parser.error("--fingerprint must not be empty")
     if not options.command:
         parser.error("a command is required after --")
+    if options.active_output and not options.supervised_worker:
+        parser.error("--active-output is reserved for the supervised worker")
     return options
 
 
 def utc_timestamp() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def sha256_file(path: Path) -> str:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    descriptor = os.open(path, flags)
+    digest = hashlib.sha256()
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(f"release checkpoint output is not regular: {path}")
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return digest.hexdigest()
 
 
 def stage_digest(
@@ -93,6 +123,24 @@ def read_checkpoint(path: Path) -> dict[str, object] | None:
     if not isinstance(value, dict):
         return None
     return value
+
+
+def checkpoint_output_is_valid(
+    checkpoint: dict[str, object], output_path: Path
+) -> bool:
+    recorded_digest = checkpoint.get("output_sha256")
+    if checkpoint.get("schema") != SCHEMA_VERSION:
+        return False
+    if checkpoint.get("output_file") != output_path.name:
+        return False
+    if not isinstance(recorded_digest, str) or len(recorded_digest) != 64:
+        return False
+    if any(character not in "0123456789abcdef" for character in recorded_digest):
+        return False
+    try:
+        return sha256_file(output_path) == recorded_digest
+    except OSError:
+        return False
 
 
 def write_json_atomically(path: Path, value: dict[str, object]) -> None:
@@ -136,21 +184,105 @@ def run_fingerprint_command(command: str) -> tuple[int, str | None]:
     return 0, lines[0]
 
 
-def run_stage_command(command: Sequence[str]) -> int:
+def open_stage_output(output_path: Path) -> BinaryIO:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    descriptor = os.open(output_path, flags, 0o600)
     try:
-        return normalized_exit_status(
-            subprocess.run(command, check=False).returncode
-        )
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise OSError(
+                f"release checkpoint output is not regular: {output_path}"
+            )
+        return os.fdopen(descriptor, "wb")
+    except BaseException:
+        os.close(descriptor)
+        raise
+
+
+def run_stage_command(command: Sequence[str], output_path: Path | None) -> int:
+    output: BinaryIO | None = None
+    if output_path is not None:
+        try:
+            output = open_stage_output(output_path)
+        except OSError as error:
+            print(
+                f"could not create release checkpoint output: {error}",
+                file=sys.stderr,
+            )
+            return 74
+    try:
+        if output is None:
+            return normalized_exit_status(
+                subprocess.run(command, check=False).returncode
+            )
+        with output:
+            return normalized_exit_status(
+                subprocess.run(
+                    command,
+                    check=False,
+                    stdout=output,
+                    stderr=subprocess.STDOUT,
+                ).returncode
+            )
     except FileNotFoundError:
         print(f"command was not found: {command[0]}", file=sys.stderr)
         return 127
     except PermissionError:
         print(f"command is not executable: {command[0]}", file=sys.stderr)
         return 126
+    except OSError as error:
+        print(f"could not run release checkpoint stage: {error}", file=sys.stderr)
+        return 74
 
 
 def normalized_exit_status(return_code: int) -> int:
     return 128 - return_code if return_code < 0 else return_code
+
+
+def print_failure_tail(
+    path: Path,
+    line_count: int = FAILURE_TAIL_LINES,
+    byte_count: int = FAILURE_TAIL_BYTES,
+) -> None:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    if hasattr(os, "O_NONBLOCK"):
+        flags |= os.O_NONBLOCK
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            return
+        offset = max(0, metadata.st_size - byte_count)
+        os.lseek(descriptor, offset, os.SEEK_SET)
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            output = stream.read(byte_count)
+    except OSError:
+        return
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+    lines = output.decode("utf-8", errors="replace").splitlines()
+    retained_lines = lines[-line_count:]
+    print(
+        f"last {len(retained_lines)} output lines from {path.name} "
+        f"(limited to {byte_count} bytes):",
+        file=sys.stderr,
+    )
+    if offset > 0:
+        print("[earlier output omitted]", file=sys.stderr)
+    for line in retained_lines:
+        print(line, file=sys.stderr)
 
 
 def run_supervised(options: argparse.Namespace) -> int:
@@ -186,13 +318,82 @@ def run_supervised(options: argparse.Namespace) -> int:
         if checkpoint_directory is not None
         else None
     )
+    output_path = (
+        checkpoint_directory / f"{options.stage}.{digest}.log"
+        if checkpoint_directory is not None
+        else None
+    )
+    active_output_path = None
+    if options.active_output:
+        assert checkpoint_directory is not None
+        active_output_path = Path(options.active_output).expanduser().resolve()
+        expected_prefix = f".{options.stage}.active-"
+        if (
+            active_output_path.parent != checkpoint_directory
+            or not active_output_path.name.startswith(expected_prefix)
+            or not active_output_path.name.endswith(".log")
+        ):
+            print(
+                "supervised output path is outside its checkpoint stage",
+                file=sys.stderr,
+            )
+            return 2
     if success_path is not None:
         checkpoint = read_checkpoint(success_path)
         if checkpoint is not None and checkpoint.get("digest") == digest:
-            print(f"reusing exact-input release checkpoint: {options.stage}")
-            return 0
+            assert output_path is not None
+            if checkpoint_output_is_valid(checkpoint, output_path):
+                print(f"reusing exact-input release checkpoint: {options.stage}")
+                return 0
+            print(
+                "invalidating release checkpoint with missing or changed "
+                f"output: {options.stage}"
+            )
+            try:
+                success_path.unlink(missing_ok=True)
+            except OSError as error:
+                print(
+                    f"could not invalidate release checkpoint: {error}",
+                    file=sys.stderr,
+                )
+                return 74
 
-    status = run_stage_command(options.command)
+    stage_output_path = active_output_path or output_path
+    if stage_output_path is not None:
+        print(
+            f"running release checkpoint {options.stage}; durable output: "
+            f"{stage_output_path}"
+        )
+    status = run_stage_command(options.command, stage_output_path)
+    retained_output_path = stage_output_path
+    if (
+        active_output_path is not None
+        and output_path is not None
+        and active_output_path.is_file()
+    ):
+        try:
+            os.replace(active_output_path, output_path)
+            retained_output_path = output_path
+        except OSError as error:
+            print(
+                f"could not retain release checkpoint output: {error}",
+                file=sys.stderr,
+            )
+            if status == 0:
+                status = 74
+    output_digest = None
+    output_file = None
+    if retained_output_path is not None:
+        try:
+            output_digest = sha256_file(retained_output_path)
+            output_file = retained_output_path.name
+        except OSError as error:
+            print(
+                f"could not verify release checkpoint output: {error}",
+                file=sys.stderr,
+            )
+            if status == 0:
+                status = 74
     result: dict[str, object] = {
         "command_sha256": hashlib.sha256(
             json.dumps(options.command, separators=(",", ":")).encode("utf-8")
@@ -208,10 +409,15 @@ def run_supervised(options: argparse.Namespace) -> int:
         "started_at": started_at,
         "status": status,
     }
+    if output_digest is not None and output_file is not None:
+        result["output_sha256"] = output_digest
+        result["output_file"] = output_file
     if result_path is not None:
         write_json_atomically(result_path, result)
     if status == 0 and success_path is not None:
         write_json_atomically(success_path, result)
+    elif status != 0 and retained_output_path is not None:
+        print_failure_tail(retained_output_path)
     return status
 
 
@@ -220,12 +426,19 @@ def run(arguments: Sequence[str]) -> int:
     if options.supervised_worker:
         return run_supervised(options)
 
+    active_output_path = None
     worker_arguments = [
         sys.executable,
         os.path.abspath(__file__),
         "--supervised-worker",
-        *arguments,
     ]
+    if options.checkpoint_dir:
+        checkpoint_directory = Path(options.checkpoint_dir).expanduser().resolve()
+        active_output_path = checkpoint_directory / (
+            f".{options.stage}.active-{os.getpid()}-{secrets.token_hex(8)}.log"
+        )
+        worker_arguments.extend(["--active-output", str(active_output_path)])
+    worker_arguments.extend(arguments)
     deadline_arguments = [
         sys.executable,
         os.path.abspath(DEADLINE_RUNNER),
@@ -234,14 +447,56 @@ def run(arguments: Sequence[str]) -> int:
         "--",
         *worker_arguments,
     ]
+    forwarded_signal: int | None = None
+    deadline_process: subprocess.Popen[bytes] | None = None
+    previous_handlers: dict[int, signal.Handlers] = {}
+    forwarded_signals = (
+        signal.SIGHUP,
+        signal.SIGINT,
+        signal.SIGQUIT,
+        signal.SIGTERM,
+    )
+
+    def forward_signal(number: int, _frame: object) -> None:
+        nonlocal forwarded_signal
+        if forwarded_signal is not None:
+            return
+        forwarded_signal = number
+        if deadline_process is None:
+            return
+        try:
+            deadline_process.send_signal(number)
+        except ProcessLookupError:
+            pass
+
+    for number in forwarded_signals:
+        previous_handlers[number] = signal.signal(number, forward_signal)
     try:
-        os.execv(sys.executable, deadline_arguments)
+        deadline_process = subprocess.Popen(deadline_arguments)
+        if forwarded_signal is not None:
+            try:
+                deadline_process.send_signal(forwarded_signal)
+            except ProcessLookupError:
+                pass
+        return_code = deadline_process.wait()
     except FileNotFoundError:
         print(f"control Python was not found: {sys.executable}", file=sys.stderr)
         return 127
     except PermissionError:
         print(f"control Python is not executable: {sys.executable}", file=sys.stderr)
         return 126
+    except OSError as error:
+        print(f"could not start the deadline controller: {error}", file=sys.stderr)
+        return 74
+    finally:
+        for number, handler in previous_handlers.items():
+            signal.signal(number, handler)
+    status = normalized_exit_status(return_code)
+    if forwarded_signal is not None and status == 0:
+        status = 128 + forwarded_signal
+    if status == 124 and active_output_path is not None:
+        print_failure_tail(active_output_path)
+    return status
 
 
 if __name__ == "__main__":

--- a/Tools/ci/test_run_release_checkpoint.py
+++ b/Tools/ci/test_run_release_checkpoint.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import signal
 import shutil
 import subprocess
 import sys
@@ -346,6 +347,321 @@ class RunReleaseCheckpointTest(unittest.TestCase):
             self.assertEqual(checkpoint["executable"], "/bin/sh")
             self.assertIn("command_sha256", checkpoint)
             self.assertNotIn("command", checkpoint)
+
+    def test_stage_output_is_durable_and_not_forwarded_to_controller(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoints = Path(directory) / "checkpoints"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(checkpoints),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint",
+                    "tree-a",
+                    "--seconds",
+                    "5",
+                    "--",
+                    "/bin/sh",
+                    "-c",
+                    "printf 'durable stage output\\n'",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertNotIn("durable stage output", completed.stdout)
+            output_paths = tuple(checkpoints.glob("compose-ci.*.log"))
+            self.assertEqual(len(output_paths), 1)
+            output_path = output_paths[0]
+            self.assertEqual(
+                output_path.read_text(encoding="utf-8"), "durable stage output\n"
+            )
+            checkpoint = json.loads(
+                (checkpoints / "compose-ci.success.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(checkpoint["output_file"], output_path.name)
+            self.assertEqual(
+                checkpoint["output_sha256"],
+                hashlib.sha256(output_path.read_bytes()).hexdigest(),
+            )
+
+    def test_missing_or_modified_output_invalidates_success_checkpoint(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoints = root / "checkpoints"
+            run_log = root / "runs.log"
+
+            first = self.run_stage(checkpoints, run_log, "tree-a")
+            output_path = next(checkpoints.glob("compose-ci.*.log"))
+            output_path.write_text("modified\n", encoding="utf-8")
+            modified = self.run_stage(checkpoints, run_log, "tree-a")
+            output_path.unlink()
+            missing = self.run_stage(checkpoints, run_log, "tree-a")
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(modified.returncode, 0, modified.stderr)
+            self.assertEqual(missing.returncode, 0, missing.stderr)
+            self.assertEqual(run_log.read_text(encoding="utf-8"), "run\n" * 3)
+            self.assertIn("invalidating release checkpoint", modified.stdout)
+            self.assertIn("invalidating release checkpoint", missing.stdout)
+
+    def test_failed_rerun_cannot_revalidate_an_invalidated_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoints = root / "checkpoints"
+            command = root / "stage.sh"
+            command.write_text("#!/bin/sh\nprintf 'same output\\n'\n", encoding="utf-8")
+            command.chmod(0o700)
+            arguments = [
+                sys.executable,
+                str(SCRIPT),
+                "--checkpoint-dir",
+                str(checkpoints),
+                "--stage",
+                "compose-ci",
+                "--fingerprint",
+                "tree-a",
+                "--seconds",
+                "5",
+                "--",
+                str(command),
+            ]
+
+            first = subprocess.run(
+                arguments, capture_output=True, text=True, check=False
+            )
+            output_path = next(checkpoints.glob("compose-ci.*.log"))
+            output_path.write_text("corrupt\n", encoding="utf-8")
+            command.write_text(
+                "#!/bin/sh\nprintf 'same output\\n'\nexit 9\n", encoding="utf-8"
+            )
+            failed = subprocess.run(
+                arguments, capture_output=True, text=True, check=False
+            )
+            repeated = subprocess.run(
+                arguments, capture_output=True, text=True, check=False
+            )
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(failed.returncode, 9, failed.stderr)
+            self.assertEqual(repeated.returncode, 9, repeated.stderr)
+            self.assertIn("invalidating release checkpoint", failed.stdout)
+            self.assertNotIn("reusing exact-input release checkpoint", repeated.stdout)
+            self.assertFalse((checkpoints / "compose-ci.success.json").exists())
+
+    def test_failure_report_contains_only_the_bounded_output_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoints = Path(directory) / "checkpoints"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(checkpoints),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint",
+                    "tree-a",
+                    "--seconds",
+                    "5",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "import sys\n"
+                    "for number in range(1, 201):\n"
+                    "    print(number)\n"
+                    "sys.exit(9)\n",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 9)
+            self.assertIn("last 80 output lines", completed.stderr)
+            self.assertNotIn("\n120\n", completed.stderr)
+            self.assertIn("\n121\n", completed.stderr)
+            self.assertTrue(completed.stderr.endswith("200\n"))
+
+    def test_failure_report_is_also_bounded_by_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(Path(directory) / "checkpoints"),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint",
+                    "tree-a",
+                    "--seconds",
+                    "5",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "import sys\n"
+                    "print('x' * 131072)\n"
+                    "print('final diagnostic')\n"
+                    "sys.exit(9)\n",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 9)
+            self.assertIn("limited to 32768 bytes", completed.stderr)
+            self.assertIn("[earlier output omitted]", completed.stderr)
+            self.assertTrue(completed.stderr.endswith("final diagnostic\n"))
+            self.assertLess(len(completed.stderr.encode("utf-8")), 34 * 1024)
+
+    def test_stage_timeout_reports_the_durable_output_tail(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(Path(directory) / "checkpoints"),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint",
+                    "tree-a",
+                    "--seconds",
+                    "1",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "import time\n"
+                    "print('timeout diagnostic', flush=True)\n"
+                    "time.sleep(30)\n",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 124)
+            self.assertIn("exceeded 1-second deadline", completed.stderr)
+            self.assertIn("timeout diagnostic", completed.stderr)
+
+    @unittest.skipUnless(hasattr(os, "mkfifo"), "requires FIFO support")
+    def test_timeout_diagnostic_rejects_a_fifo_without_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            checkpoints = Path(directory) / "checkpoints"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(checkpoints),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint",
+                    "tree-a",
+                    "--seconds",
+                    "1",
+                    "--",
+                    sys.executable,
+                    "-c",
+                    "import glob, os, sys, time\n"
+                    "active = glob.glob(os.path.join(sys.argv[1], "
+                    "'.compose-ci.active-*.log'))[0]\n"
+                    "os.unlink(active)\n"
+                    "os.mkfifo(active)\n"
+                    "time.sleep(30)\n",
+                    str(checkpoints),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+
+            self.assertEqual(completed.returncode, 124, completed.stderr)
+
+    def test_controller_signal_cleans_up_the_deadline_worker_session(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            ready = root / "ready"
+            cleanup = root / "cleanup"
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(root / "checkpoints"),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint",
+                    "tree-a",
+                    "--seconds",
+                    "30",
+                    "--",
+                    "/bin/sh",
+                    "-c",
+                    f"trap 'touch {cleanup}; exit 0' TERM; "
+                    f"touch {ready}; while :; do sleep 1; done",
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            ready_deadline = time.monotonic() + 3
+            while not ready.exists():
+                if time.monotonic() >= ready_deadline:
+                    process.kill()
+                    process.communicate(timeout=2)
+                    self.fail("checkpoint worker did not become ready")
+                time.sleep(0.01)
+
+            process.send_signal(signal.SIGTERM)
+            stdout, stderr = process.communicate(timeout=8)
+
+            self.assertEqual(process.returncode, 143, stdout + stderr)
+            self.assertTrue(cleanup.exists(), stdout + stderr)
+
+    def test_stage_cannot_succeed_after_removing_its_durable_output(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoints = root / "checkpoints"
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(checkpoints),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint",
+                    "tree-a",
+                    "--seconds",
+                    "5",
+                    "--",
+                    "/bin/sh",
+                    "-c",
+                    'rm "$1"/.compose-ci.active-*.log',
+                    "remove-output",
+                    str(checkpoints),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 74, completed.stderr)
+            self.assertIn("could not verify release checkpoint output", completed.stderr)
+            self.assertFalse((checkpoints / "compose-ci.success.json").exists())
 
     def test_tightening_the_deadline_invalidates_the_checkpoint(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -50,6 +50,44 @@ class RunWithContainerRuntimeTest(unittest.TestCase):
         return cls.local_execution_root() / f"container-compose-runtime-{os.getuid()}"
 
     @staticmethod
+    def runtime_package_digest(package_root: Path) -> str:
+        encoded_root = os.fsencode(package_root)
+        entries: list[tuple[bytes, bytes, int, bytes]] = []
+
+        def add_path(path: bytes) -> None:
+            relative_path = os.path.relpath(path, encoded_root)
+            metadata = os.lstat(path)
+            mode = metadata.st_mode & 0o7777
+            if os.path.islink(path):
+                raise AssertionError(f"indirect runtime fixture entry: {path!r}")
+            if os.path.isdir(path):
+                entries.append((relative_path, b"d", mode, b""))
+                return
+            digest = hashlib.sha256(Path(os.fsdecode(path)).read_bytes()).hexdigest()
+            entries.append((relative_path, b"f", mode, digest.encode()))
+
+        for binary_name in (
+            b"container",
+            b"container-apiserver",
+            b"container-engine",
+        ):
+            add_path(os.path.join(encoded_root, b"bin", binary_name))
+        libexec_root = os.path.join(encoded_root, b"libexec/container")
+        for current_root, directories, files in os.walk(
+            libexec_root, followlinks=False
+        ):
+            for name in sorted(directories + files):
+                add_path(os.path.join(current_root, name))
+
+        manifest = hashlib.sha256(b"container-runtime-package-v1\0")
+        for relative_path, kind, mode, digest in sorted(entries):
+            manifest.update(kind + b"\0")
+            manifest.update(relative_path + b"\0")
+            manifest.update(f"{mode:04o}".encode() + b"\0")
+            manifest.update(digest + b"\0")
+        return manifest.hexdigest()
+
+    @staticmethod
     def runtime_environment() -> dict[str, str]:
         environment = os.environ.copy()
         for variable in (
@@ -449,6 +487,7 @@ exit 113
         path.write_text(
             "#!/usr/bin/env bash\n"
             "set -euo pipefail\n"
+            f"# isolated fixture: {path}\n"
             'if [[ "$*" == "system status --format json" ]]; then\n'
             f'  printf \'{{"engineSocket":"%s"}}\\n\' "{status_socket}"\n'
             "  exit 1\n"
@@ -959,10 +998,8 @@ exit 113
             )
 
             staged_paths: list[str] = []
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             try:
                 for _ in range(2):
                     result = subprocess.run(
@@ -1003,6 +1040,71 @@ exit 113
                 self.assertTrue(staged_root.is_dir())
                 marker = staged_root / ".container-compose-runtime-candidate-staging"
                 self.assertTrue(marker.is_file())
+            finally:
+                if staged_root.is_dir():
+                    shutil.rmtree(staged_root)
+
+    def test_relocated_identical_packages_share_the_staged_content_root(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            first_root = temporary_root / "first"
+            package_bin = first_root / "bin"
+            package_libexec = first_root / "libexec" / "container"
+            package_bin.mkdir(parents=True)
+            package_libexec.mkdir(parents=True)
+            candidate = package_bin / "container"
+            self.write_fake_container(candidate)
+            for executable_name in ("container-apiserver", "container-engine"):
+                executable = package_bin / executable_name
+                executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+                executable.chmod(0o755)
+            (package_libexec / "payload").write_text("same\n", encoding="utf-8")
+            second_root = temporary_root / "second"
+            shutil.copytree(first_root, second_root)
+
+            package_digest = self.runtime_package_digest(first_root)
+            self.assertEqual(
+                package_digest, self.runtime_package_digest(second_root)
+            )
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
+            environment = self.runtime_environment()
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app-root"),
+                    "CONTAINER_RUNTIME_STAGE_CANDIDATE": "always",
+                    "CONTAINER_RUNTIME_LOCK_FILE": str(temporary_root / "runtime.lock"),
+                    "CONTAINER_TEST_LOG": str(temporary_root / "container.log"),
+                }
+            )
+            try:
+                first = subprocess.run(
+                    [str(SCRIPT), str(candidate), "/usr/bin/true"],
+                    cwd=ROOT,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                    timeout=20,
+                )
+                second = subprocess.run(
+                    [
+                        str(SCRIPT),
+                        str(second_root / "bin" / "container"),
+                        "/usr/bin/true",
+                    ],
+                    cwd=ROOT,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                    timeout=20,
+                )
+
+                self.assertEqual(first.returncode, 0, first.stdout + first.stderr)
+                self.assertTrue(staged_root.is_dir())
+                self.assertEqual(second.returncode, 0, second.stdout + second.stderr)
+                self.assertIn(
+                    "Reusing unchanged staged Container runtime candidate",
+                    second.stdout,
+                )
             finally:
                 if staged_root.is_dir():
                     shutil.rmtree(staged_root)
@@ -1071,10 +1173,8 @@ exit 113
                     f"payload {index}\n", encoding="utf-8"
                 )
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             marker = staged_root / ".container-compose-runtime-candidate-staging"
             environment = self.runtime_environment()
             environment.update(
@@ -1117,7 +1217,7 @@ exit 113
                 if staged_root.is_dir():
                     shutil.rmtree(staged_root)
 
-    def test_interrupted_replacement_preserves_recoverable_marker(self) -> None:
+    def test_interrupted_staging_preserves_the_previous_content_root(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
             package_root = temporary_root / "candidate"
@@ -1138,10 +1238,8 @@ exit 113
                     f"payload {index}\n", encoding="utf-8"
                 )
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             self.local_user_root().mkdir(mode=0o700, exist_ok=True)
             staged_root.mkdir(mode=0o700)
             marker = staged_root / ".container-compose-runtime-candidate-staging"
@@ -1184,6 +1282,10 @@ exit 113
                 self.assertTrue(staged_root.is_dir())
                 self.assertEqual(marker.read_text(encoding="utf-8").strip(), old_marker_value)
 
+                changed_package_digest = self.runtime_package_digest(package_root)
+                changed_staged_root = self.local_user_root() / (
+                    f"candidate-{changed_package_digest[:16]}"
+                )
                 second = subprocess.run(
                     [str(SCRIPT), str(candidate), "/usr/bin/true"],
                     cwd=ROOT,
@@ -1197,7 +1299,12 @@ exit 113
                 )
                 candidate_digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
                 self.assertEqual(
-                    marker.read_text(encoding="utf-8").strip(),
+                    (
+                        changed_staged_root
+                        / ".container-compose-runtime-candidate-staging"
+                    )
+                    .read_text(encoding="utf-8")
+                    .strip(),
                     "container-compose runtime candidate staging v1 "
                     + candidate_digest,
                 )
@@ -1207,6 +1314,11 @@ exit 113
                     first.communicate(timeout=5)
                 if staged_root.is_dir():
                     shutil.rmtree(staged_root)
+                if (
+                    "changed_staged_root" in locals()
+                    and changed_staged_root.is_dir()
+                ):
+                    shutil.rmtree(changed_staged_root)
 
     def test_interrupted_initial_staging_directory_is_recoverable(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1223,10 +1335,8 @@ exit 113
                 executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
                 executable.chmod(0o755)
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             self.local_user_root().mkdir(mode=0o700, exist_ok=True)
             fake_bin = temporary_root / "fake-bin"
             fake_bin.mkdir()
@@ -1314,10 +1424,8 @@ exit 113
                 "complete\n", encoding="utf-8"
             )
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             self.local_user_root().mkdir(mode=0o700, exist_ok=True)
             staged_root.mkdir(mode=0o700)
             marker = staged_root / ".container-compose-runtime-candidate-staging"
@@ -1387,10 +1495,8 @@ exit 113
                 executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
                 executable.chmod(0o755)
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             container_log = temporary_root / "container.log"
             environment = self.runtime_environment()
             environment.update(
@@ -1484,10 +1590,8 @@ exit 113
                     "READY": str(ready),
                 }
             )
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             first = subprocess.Popen(
                 [
                     str(SCRIPT),
@@ -1553,10 +1657,8 @@ exit 113
                 executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
                 executable.chmod(0o755)
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             environment = self.runtime_environment()
             environment.update(
                 {
@@ -1621,10 +1723,8 @@ exit 113
                 '> "$(RESULT_PATH)"\n',
                 encoding="utf-8",
             )
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             environment = self.runtime_environment()
             environment.update(
                 {
@@ -1685,10 +1785,8 @@ exit 113
                 executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
                 executable.chmod(0o755)
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            package_digest = self.runtime_package_digest(package_root)
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             self.local_user_root().mkdir(mode=0o700, exist_ok=True)
             protected_target = temporary_root / "protected-target"
             protected_target.mkdir()
@@ -1741,11 +1839,9 @@ exit 113
                 executable.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
                 executable.chmod(0o755)
 
-            source_digest = hashlib.sha256(
-                str(package_root.resolve()).encode()
-            ).hexdigest()[:16]
+            package_digest = self.runtime_package_digest(package_root)
             candidate_digest = hashlib.sha256(candidate.read_bytes()).hexdigest()
-            staged_root = self.local_user_root() / f"candidate-{source_digest}"
+            staged_root = self.local_user_root() / f"candidate-{package_digest[:16]}"
             self.local_user_root().mkdir(mode=0o700, exist_ok=True)
             staged_root.mkdir(mode=0o700)
             marker = staged_root / ".container-compose-runtime-candidate-staging"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -98,6 +98,32 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"', self.script)
         self.assertIn("CONTAINER_STACK_RELEASE_ROOT", self.script)
 
+    def test_local_release_gate_uses_a_stable_noninteractive_path(self) -> None:
+        completed = subprocess.run(
+            [
+                "/bin/bash",
+                "-c",
+                "CONTAINER_STACK_RELEASE_LIBRARY=1; "
+                f"source {shlex.quote(str(SCRIPT))}; "
+                "release_gate_execution_path",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        path = completed.stdout.strip()
+        self.assertTrue(path)
+        self.assertNotIn(".codex", path)
+        self.assertNotIn(".swiftly", path)
+        for directory in path.split(os.pathsep):
+            self.assertTrue(Path(directory).is_absolute())
+        selected_make = shutil.which("make", path=path)
+        self.assertIsNotNone(selected_make)
+        self.assertTrue(Path(selected_make or "").is_file())
+
     def test_local_release_gate_stages_the_init_archive_on_the_system_volume(self) -> None:
         staging = 'staged_init_image_archive="${runtime_parent}/vminit.oci.tar"'
         copy = 'cp "${init_image_archive}" "${staged_init_image_archive}"'

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -1043,6 +1043,39 @@ require_local_virtualization() {
   fi
 }
 
+# Keep the live release gate independent of whichever interactive application
+# launched it. In particular, Codex and shell updates may prepend transient
+# shims or a developer Swift toolchain to PATH between retries. The gate uses
+# the stable Homebrew front doors plus Apple's selected Xcode toolchain, with
+# GNU Make preferred when it is installed.
+release_gate_execution_path() {
+  local directory
+  local -a candidates=(
+    /opt/homebrew/opt/make/libexec/gnubin
+    /usr/local/opt/make/libexec/gnubin
+    /opt/homebrew/bin
+    /opt/homebrew/sbin
+    /usr/local/bin
+    /usr/bin
+    /bin
+    /usr/sbin
+    /sbin
+  )
+  local result=""
+  for directory in "${candidates[@]}"; do
+    [[ -d "${directory}" ]] || continue
+    case ":${result}:" in
+      *":${directory}:"*) continue ;;
+    esac
+    result="${result:+${result}:}${directory}"
+  done
+  if [[ -z "${result}" ]]; then
+    printf 'could not construct the sealed release-gate PATH\n' >&2
+    return 1
+  fi
+  printf '%s\n' "${result}"
+}
+
 # Build one packaged Container runtime for the exact source head, then unpack
 # it into a fresh read-only root for this gate. Keep the reusable archive and
 # its evidence on the configured artifact volume, but stage launchd-managed
@@ -2494,7 +2527,7 @@ retained_stable_init_image_gate_digest() {
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
   (
-  local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive staged_container_path staged_container_alias staged_containerization_path staged_containerization_alias
+  local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive staged_container_path staged_container_alias staged_containerization_path staged_containerization_alias release_gate_path release_gate_make
   local containerization_reference required_init_references status runtime_run_id runtime_service_namespace runtime_namespace_digest candidate_sha init_image_digest_before init_image_digest_after
   local -a RELEASE_QUIESCED_LABELS=()
   local -a RELEASE_QUIESCED_PLISTS=()
@@ -2663,9 +2696,17 @@ PY
     >"${runtime_parent}/.container-compose-release-runtime-identity"
   profile_root="${runtime_parent}/profiles"
   mkdir -p "${profile_root}"
+  release_gate_path="$(release_gate_execution_path)"
+  release_gate_make="$(PATH="${release_gate_path}" command -v make || true)"
+  if [[ "${release_gate_make}" != /* || ! -x "${release_gate_make}" ]]; then
+    printf 'sealed release-gate PATH has no executable make: %s\n' \
+      "${release_gate_path}" >&2
+    return 1
+  fi
   status=0
   run_local_release_gate_command env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE \
     -u CONTAINER_RUNTIME_SERVICE_NAMESPACE -u CONTAINER_RUNTIME_RUN_ID \
+    PATH="${release_gate_path}" \
     HAWKEYE_AUTO_INSTALL=1 \
     CONTAINER_RUNTIME_APP_ROOT="${runtime_app_root}" \
     CONTAINER_RUNTIME_RUN_ID="${runtime_run_id}" \
@@ -2681,7 +2722,7 @@ PY
     CONTAINER_COMPOSE_CONTAINER="${container_binary}" \
     LLVM_PROFILE_FILE="${profile_root}/%p-%m.profraw" \
     "${path}/scripts/run-with-container-runtime.sh" "${container_binary}" \
-    make -C "${path}" release-gate \
+    "${release_gate_make}" -C "${path}" release-gate \
     "CONTAINER_BUILDER_SHIM_STACK_REPO=$(repo_path "container-builder-shim")" \
     "CONTAINERIZATION_STACK_REPO=${containerization_path}" \
     "CONTAINER_STACK_REPO=${container_path}" \

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -1001,14 +1001,15 @@ stage_runtime_candidate_if_needed() {
             "$container_binary" >&2
         exit 2
     fi
-    local source_package_root_digest
-    source_package_root_digest=$(LC_ALL=C printf '%s' "$source_package_root" \
-        | shasum -a 256 | awk '{print substr($1, 1, 16)}')
-    runtime_candidate_staging_root="$runtime_local_user_root/candidate-$source_package_root_digest"
-    acquire_runtime_candidate_staging_lock "$deadline" || return "$?"
     local source_package_sha256_before
     source_package_sha256_before=$(fingerprint_runtime_package \
         "$deadline" "$source_package_root") || return "$?"
+    # A retry extracts the same signed package below a fresh temporary source
+    # path. Name the persistent system-volume copy from the complete package
+    # identity so an unchanged candidate receives the same checkpoint input
+    # and can be reused across release-controller invocations.
+    runtime_candidate_staging_root="$runtime_local_user_root/candidate-${source_package_sha256_before:0:16}"
+    acquire_runtime_candidate_staging_lock "$deadline" || return "$?"
     local marker="$runtime_candidate_staging_root/.container-compose-runtime-candidate-staging"
     local existing_marker_value=
     if [[ -e "$runtime_candidate_staging_root" ]]; then


### PR DESCRIPTION
## Summary

- key persistent runtime staging by the complete packaged-runtime fingerprint, so identical candidates extracted under different temporary paths reuse the same system-volume root
- seal the local release gate to stable Homebrew/system tool front doors instead of inheriting transient app or Swiftly shims
- persist each checkpoint stage's combined output directly to a digest-bound log, keeping a broken controller PTY from terminating a successful test stage
- record the durable output filename and digest in checkpoint evidence

## Why

The 0.14.1 release gate exposed three independent recovery failures: an identical runtime package received a different staging identity on each extraction, controller retries selected different Swift toolchains from inherited `PATH`, and a closed PTY produced `make: write error: stdout` after a functionally green parity stage. Together they made valid checkpoints impossible to reuse and encouraged expensive clean-and-retry loops.

This PR makes those inputs deterministic and makes stage output independent of the controller transport. It advances the recovery acceptance criteria in #324.

## Validation

- `python3 -m unittest Tools.ci.test_run_release_checkpoint.RunReleaseCheckpointTest` (18 passed)
- 7 focused runtime staging/recovery tests (7 passed)
- stable noninteractive release-PATH policy test (1 passed)
- `python3 -m py_compile` for the four modified Python files
- `bash -n` and `shellcheck` for the two modified shell scripts
- `git diff --check`

No broad release gate is run from this unreviewed branch; after exact-head review and merge, one recoverable main release gate will certify 0.14.1.
