### PR TITLE
fix(benchmark): accept maintenance backfill artifacts

### DIFF
--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -40,6 +40,7 @@ on:
 
 permissions:
   actions: write
+  attestations: read
   contents: write
   pull-requests: write
 

--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -231,7 +231,7 @@ jobs:
                 --repo "${GITHUB_REPOSITORY}" \
                 --workflow prebuilt-binaries.yml \
                 --limit 500 \
-                --json databaseId,displayTitle,status,conclusion,event,createdAt,url \
+                --json databaseId,displayTitle,status,conclusion,event,createdAt,url,headBranch,headSha \
                 > "${runs}"
               python3 Tools/parity/published_release_benchmark.py \
                 resolve-package-run \
@@ -239,6 +239,7 @@ jobs:
                 --version "${version}" \
                 > "${resolved}"
               package_run_id="$(jq -r '.runId' "${resolved}")"
+              package_run_head_sha="$(jq -r '.headSha' "${resolved}")"
               artifact_source="$(jq -r '.url' "${resolved}")"
               gh api \
                 "repos/${GITHUB_REPOSITORY}/actions/runs/${package_run_id}/artifacts" \
@@ -263,7 +264,10 @@ jobs:
                 gh attestation verify "${distribution}/${asset}" \
                   --repo "${GITHUB_REPOSITORY}" \
                   --signer-workflow \
-                    "${GITHUB_REPOSITORY}/.github/workflows/prebuilt-binaries.yml"
+                    "${GITHUB_REPOSITORY}/.github/workflows/prebuilt-binaries.yml" \
+                  --signer-digest "${package_run_head_sha}" \
+                  --source-ref refs/heads/main \
+                  --source-digest "${package_run_head_sha}"
               done
             fi
             Tools/release/verify-developer-id-archive.sh \

--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -57,6 +57,7 @@ jobs:
     outputs:
       target: ${{ steps.versions.outputs.target }}
       baseline: ${{ steps.versions.outputs.baseline }}
+      latest: ${{ steps.versions.outputs.latest }}
     steps:
       - name: Checkout benchmark controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -90,8 +91,12 @@ jobs:
             > "${RUNNER_TEMP}/comparison.json"
           target="$(jq -r '.target' "${RUNNER_TEMP}/comparison.json")"
           baseline="$(jq -r '.baseline' "${RUNNER_TEMP}/comparison.json")"
-          printf 'target=%s\n' "${target}" >> "${GITHUB_OUTPUT}"
-          printf 'baseline=%s\n' "${baseline}" >> "${GITHUB_OUTPUT}"
+          latest="$(jq -r '.latest' "${RUNNER_TEMP}/comparison.json")"
+          {
+            printf 'target=%s\n' "${target}"
+            printf 'baseline=%s\n' "${baseline}"
+            printf 'latest=%s\n' "${latest}"
+          } >> "${GITHUB_OUTPUT}"
           printf 'Benchmarking %s against %s.\n' "${target}" "${baseline}" \
             >> "${GITHUB_STEP_SUMMARY}"
 
@@ -107,6 +112,7 @@ jobs:
       BENCHMARK_ROOT: /private/tmp/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}
       TARGET_VERSION: ${{ needs.resolve.outputs.target }}
       BASELINE_VERSION: ${{ needs.resolve.outputs.baseline }}
+      LATEST_STABLE_VERSION: ${{ needs.resolve.outputs.latest }}
       REPETITIONS: ${{ inputs.repetitions }}
       RUNTIME_ROOT_PREFIX: /private/tmp/ccpb-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
@@ -165,8 +171,10 @@ jobs:
         run: |
           set -euo pipefail
           # No source products are built. Both complete runtime/plugin pairs
-          # come from immutable published GitHub assets and must match a
-          # historical Homebrew formula URL and SHA-256 before execution.
+          # come from immutable published GitHub assets. Normal stable assets
+          # must match historical Homebrew formulae; an older maintenance
+          # backfill may instead use its retained, attested package run because
+          # it intentionally never replaced the newer stable formula pair.
           # The exact guest init image is a required release asset: it cannot
           # be recovered from Homebrew, rebuilt, or inherited from the host.
           # A successful retained package run is the recovery authority when
@@ -176,6 +184,7 @@ jobs:
             actions_dir="${BENCHMARK_ROOT}/downloads/${version}/actions"
             distribution="${release_dir}"
             artifact_source="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${version}"
+            backfill_arguments=()
             if ! gh release download "${version}" \
               --repo "${GITHUB_REPOSITORY}" \
               --dir "${release_dir}" \
@@ -246,6 +255,15 @@ jobs:
                 --dir "${actions_dir}" \
                 --name 'container-compose-plugin-release-arm64.tar.gz'
               distribution="${actions_dir}"
+              backfill_arguments+=(--allow-package-run-backfill)
+              for asset in \
+                container-release-arm64.tar.gz \
+                container-compose-plugin-release-arm64.tar.gz; do
+                gh attestation verify "${distribution}/${asset}" \
+                  --repo "${GITHUB_REPOSITORY}" \
+                  --signer-workflow \
+                    "${GITHUB_REPOSITORY}/.github/workflows/prebuilt-binaries.yml"
+              done
             fi
             Tools/release/verify-developer-id-archive.sh \
               "${distribution}/container-release-arm64.tar.gz"
@@ -258,6 +276,8 @@ jobs:
               --tap-repository homebrew-tap \
               --source-repository . \
               --artifact-source "${artifact_source}" \
+              "${backfill_arguments[@]}" \
+              --latest-stable-version "${LATEST_STABLE_VERSION}" \
               --output "${BENCHMARK_ROOT}/prepared/${version}"
             init_archive="${BENCHMARK_ROOT}/prepared/${version}/init/container-vminit-arm64.oci.tar"
             init_references=()

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -124,7 +124,7 @@ def packaging_run_candidates(
 ) -> list[dict[str, object]]:
     version_tuple(version)
     title = f"Prebuilt Binaries · {version}"
-    candidates: list[tuple[str, int, str]] = []
+    candidates: list[tuple[str, int, str, str]] = []
     for run in runs:
         if (
             run.get("displayTitle") != title
@@ -136,6 +136,8 @@ def packaging_run_candidates(
         run_id = run.get("databaseId")
         created_at = run.get("createdAt")
         url = run.get("url")
+        head_branch = run.get("headBranch")
+        head_sha = run.get("headSha")
         if (
             not isinstance(run_id, int)
             or run_id <= 0
@@ -144,16 +146,24 @@ def packaging_run_candidates(
             or not isinstance(url, str)
             or url
             != f"https://github.com/{REPOSITORY}/actions/runs/{run_id}"
+            or head_branch != "main"
+            or not isinstance(head_sha, str)
+            or re.fullmatch(r"[0-9a-f]{40}", head_sha) is None
         ):
             continue
-        candidates.append((created_at, run_id, url))
+        candidates.append((created_at, run_id, url, head_sha))
     if not candidates:
         raise BenchmarkInputError(
             f"no successful immutable package run retained for {version}"
         )
     return [
-        {"runId": run_id, "url": url, "createdAt": created_at}
-        for created_at, run_id, url in sorted(candidates, reverse=True)
+        {
+            "runId": run_id,
+            "url": url,
+            "createdAt": created_at,
+            "headSha": head_sha,
+        }
+        for created_at, run_id, url, head_sha in sorted(candidates, reverse=True)
     ]
 
 

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -102,7 +102,8 @@ def resolve_versions(
         baseline = max(earlier, key=version_tuple)
     if baseline == target:
         raise BenchmarkInputError("target and comparison versions must differ")
-    return {"target": target, "baseline": baseline}
+    latest = max(available, key=version_tuple)
+    return {"target": target, "baseline": baseline, "latest": latest}
 
 
 def canonical_artifact_source(version: str, source: str) -> str:
@@ -229,7 +230,8 @@ def formula_authority(
     version: str,
     asset_name: str,
     digest: str,
-) -> str:
+    allow_package_run_backfill: bool = False,
+) -> str | None:
     expected_url = (
         f"https://github.com/{REPOSITORY}/releases/download/"
         f"{version}/{asset_name}"
@@ -273,6 +275,8 @@ def formula_authority(
             continue
         if f'url "{expected_url}"' in show.stdout and f'sha256 "{digest}"' in show.stdout:
             return commit
+    if allow_package_run_backfill:
+        return None
     raise BenchmarkInputError(
         f"Homebrew main history never distributed {asset_name} for {version} at {digest}"
     )
@@ -372,12 +376,25 @@ def prepare_distribution(
     source_repository: Path,
     artifact_source: str,
     output: Path,
+    allow_package_run_backfill: bool = False,
+    latest_stable_version: str | None = None,
 ) -> dict[str, object]:
     version_tuple(version)
     artifact_source = canonical_artifact_source(version, artifact_source)
     source_commit = release_tag_commit(source_repository, version)
     source_stack = release_tag_stack(source_repository, source_commit)
     release = f"https://github.com/{REPOSITORY}/releases/tag/{version}"
+    if allow_package_run_backfill and artifact_source == release:
+        raise BenchmarkInputError(
+            "maintenance backfill authority requires a retained package run"
+        )
+    if allow_package_run_backfill and (
+        latest_stable_version is None
+        or version_tuple(version) >= version_tuple(latest_stable_version)
+    ):
+        raise BenchmarkInputError(
+            "package-run backfill authority is restricted to an older stable release"
+        )
     init_asset = init_distribution / INIT_ASSET
     init_sidecar = init_distribution / f"{INIT_ASSET}.sha256"
     if not init_asset.is_file() or not init_sidecar.is_file():
@@ -401,6 +418,7 @@ def prepare_distribution(
     output.mkdir(parents=True, exist_ok=False)
     output.chmod(0o700)
     asset_manifest: dict[str, object] = {}
+    homebrew_commits: list[str | None] = []
     for component, (asset_name, formula_path) in ASSETS.items():
         asset = distribution / asset_name
         sidecar = distribution / f"{asset_name}.sha256"
@@ -420,7 +438,9 @@ def prepare_distribution(
             version,
             asset_name,
             actual_digest,
+            allow_package_run_backfill,
         )
+        homebrew_commits.append(tap_commit)
         component_output = output / component
         component_output.mkdir(mode=0o700)
         with tarfile.open(asset, "r:gz") as archive:
@@ -429,12 +449,22 @@ def prepare_distribution(
             if "filter" in inspect.signature(archive.extractall).parameters:
                 extraction_options["filter"] = "fully_trusted"
             archive.extractall(component_output, **extraction_options)
-        asset_manifest[component] = {
+        component_manifest: dict[str, object] = {
             "asset": asset_name,
             "sha256": actual_digest,
             "homebrewFormula": formula_path,
-            "homebrewCommit": tap_commit,
         }
+        if tap_commit is not None:
+            component_manifest["homebrewCommit"] = tap_commit
+        else:
+            component_manifest["packageRun"] = artifact_source
+        asset_manifest[component] = component_manifest
+    if any(commit is None for commit in homebrew_commits) and not all(
+        commit is None for commit in homebrew_commits
+    ):
+        raise BenchmarkInputError(
+            "release assets have mixed Homebrew and maintenance-backfill authority"
+        )
     init_output = output / "init"
     init_output.mkdir(mode=0o700)
     staged_init_asset = init_output / INIT_ASSET
@@ -452,6 +482,11 @@ def prepare_distribution(
         "stack": source_stack,
         "release": release,
         "artifactSource": artifact_source,
+        "distributionAuthority": (
+            "maintenance-package-run"
+            if all(commit is None for commit in homebrew_commits)
+            else "homebrew-history"
+        ),
         "assets": asset_manifest,
     }
     (output / "published-distribution.json").write_text(
@@ -931,8 +966,17 @@ def render_report(
             )
         for component in ("runtime", "compose"):
             asset = manifest["assets"][component]
+            homebrew_commit = asset.get("homebrewCommit")
+            if homebrew_commit:
+                authority = f"Homebrew formula history `{homebrew_commit}`"
+            else:
+                authority = (
+                    "signed maintenance package run "
+                    f"[{manifest['artifactSource']}]({manifest['artifactSource']}); "
+                    "not promoted through Homebrew"
+                )
             lines.append(
-                f"- `{asset['asset']}`: SHA-256 `{asset['sha256']}`; Homebrew formula history `{asset['homebrewCommit']}`."
+                f"- `{asset['asset']}`: SHA-256 `{asset['sha256']}`; {authority}."
             )
         lines.append("")
     lines.extend(
@@ -1007,6 +1051,8 @@ def main() -> None:
     prepare.add_argument("--tap-repository", type=Path, required=True)
     prepare.add_argument("--source-repository", type=Path, required=True)
     prepare.add_argument("--artifact-source", required=True)
+    prepare.add_argument("--allow-package-run-backfill", action="store_true")
+    prepare.add_argument("--latest-stable-version")
     prepare.add_argument("--output", type=Path, required=True)
 
     render = subparsers.add_parser("render")
@@ -1054,6 +1100,8 @@ def main() -> None:
                 arguments.source_repository,
                 arguments.artifact_source,
                 arguments.output,
+                arguments.allow_package_run_backfill,
+                arguments.latest_stable_version,
             )
             print(json.dumps(result, sort_keys=True))
         else:

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -54,13 +54,13 @@ class ResolvePublishedVersionsTests(unittest.TestCase):
     def test_default_comparison_is_immediately_preceding_stable_release(self) -> None:
         self.assertEqual(
             MODULE.resolve_versions(self.releases, "0.14.0", None),
-            {"target": "0.14.0", "baseline": "0.13.0"},
+            {"target": "0.14.0", "baseline": "0.13.0", "latest": "0.14.0"},
         )
 
     def test_explicit_comparison_can_select_any_other_stable_release(self) -> None:
         self.assertEqual(
             MODULE.resolve_versions(self.releases, "0.14.0", "0.12.0"),
-            {"target": "0.14.0", "baseline": "0.12.0"},
+            {"target": "0.14.0", "baseline": "0.12.0", "latest": "0.14.0"},
         )
 
     def test_draft_target_is_rejected(self) -> None:
@@ -284,6 +284,29 @@ class HomebrewAuthorityTests(unittest.TestCase):
             )
             self.assertRegex(authority, r"^[0-9a-f]{40}$")
 
+    def test_retained_package_run_can_authorize_maintenance_backfill(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="published-tap-") as directory:
+            repository = Path(directory)
+            self.git(repository, "init", "-b", "main")
+            self.git(repository, "config", "user.email", "test@example.com")
+            self.git(repository, "config", "user.name", "Test")
+            formula = repository / "Formula" / "container.rb"
+            formula.parent.mkdir()
+            formula.write_text("class Container\nend\n", encoding="utf-8")
+            self.git(repository, "add", str(formula))
+            self.git(repository, "commit", "-m", "chore: initialize formula")
+
+            self.assertIsNone(
+                MODULE.formula_authority(
+                    repository,
+                    "Formula/container.rb",
+                    "0.13.1",
+                    "container-release-arm64.tar.gz",
+                    "a" * 64,
+                    allow_package_run_backfill=True,
+                )
+            )
+
     @staticmethod
     def git(repository: Path, *arguments: str) -> None:
         subprocess.run(
@@ -435,6 +458,43 @@ class PublishedReportTests(unittest.TestCase):
         self.assertIn("exact retained Containerization CI initfs artifact", report)
         self.assertIn("Guest initfs authority:", report)
         self.assertNotIn("No source product was built", report)
+
+    def test_report_labels_unpromoted_maintenance_backfill(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="published-benchmark-") as directory:
+            root = Path(directory)
+            baseline = root / "baseline"
+            target = root / "target"
+            baseline.mkdir()
+            target.mkdir()
+            self.write_evidence(baseline, 1.0, 1.0, "0.13.0")
+            self.write_evidence(target, 0.8, 1.0, "0.14.0")
+            baseline_manifest = self.write_manifest(root, "0.13.0")
+            target_manifest = self.write_manifest(root, "0.14.0")
+            manifest = json.loads(baseline_manifest.read_text(encoding="utf-8"))
+            package_run = (
+                "https://github.com/stephenlclarke/container-compose/"
+                "actions/runs/123"
+            )
+            manifest["artifactSource"] = package_run
+            manifest["distributionAuthority"] = "maintenance-package-run"
+            for component in ("runtime", "compose"):
+                del manifest["assets"][component]["homebrewCommit"]
+                manifest["assets"][component]["packageRun"] = package_run
+            baseline_manifest.write_text(json.dumps(manifest), encoding="utf-8")
+            output = root / "report.md"
+
+            MODULE.render_report(
+                target,
+                baseline,
+                target_manifest,
+                baseline_manifest,
+                output,
+                "https://github.example/actions/runs/1",
+            )
+            report = output.read_text(encoding="utf-8")
+
+        self.assertIn("signed maintenance package run", report)
+        self.assertIn("not promoted through Homebrew", report)
 
     def test_report_rejects_mismatched_benchmark_conditions(self) -> None:
         with tempfile.TemporaryDirectory(prefix="published-benchmark-") as directory:
@@ -841,6 +901,8 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
         self.assertIn("resolve-package-run", workflow)
         self.assertIn("validate-package-artifacts", workflow)
         self.assertIn("gh run download", workflow)
+        self.assertIn("gh attestation verify", workflow)
+        self.assertIn("--allow-package-run-backfill", workflow)
         self.assertIn("--artifact-source", workflow)
         self.assertIn("--init-distribution", workflow)
         self.assertIn("container-vminit-arm64.oci.tar", workflow)

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -902,6 +902,7 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
         self.assertIn("validate-package-artifacts", workflow)
         self.assertIn("gh run download", workflow)
         self.assertIn("gh attestation verify", workflow)
+        self.assertIn("  attestations: read", workflow)
         self.assertIn("--allow-package-run-backfill", workflow)
         self.assertIn("--artifact-source", workflow)
         self.assertIn("--init-distribution", workflow)

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -80,6 +80,8 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
                 "conclusion": "success",
                 "createdAt": "2026-08-23T10:00:00Z",
                 "url": f"{repository}/actions/runs/10",
+                "headBranch": "main",
+                "headSha": "a" * 40,
             },
             {
                 "databaseId": 11,
@@ -89,6 +91,8 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
                 "conclusion": "failure",
                 "createdAt": "2026-08-24T10:00:00Z",
                 "url": f"{repository}/actions/runs/11",
+                "headBranch": "main",
+                "headSha": "b" * 40,
             },
             {
                 "databaseId": 12,
@@ -98,6 +102,8 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
                 "conclusion": "success",
                 "createdAt": "2026-08-24T11:00:00Z",
                 "url": f"{repository}/actions/runs/12",
+                "headBranch": "main",
+                "headSha": "c" * 40,
             },
             {
                 "databaseId": 13,
@@ -107,6 +113,8 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
                 "conclusion": "success",
                 "createdAt": "2026-08-25T10:00:00Z",
                 "url": f"{repository}/actions/runs/13",
+                "headBranch": "main",
+                "headSha": "d" * 40,
             },
         ]
 
@@ -116,14 +124,37 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
                 "runId": 12,
                 "url": f"{repository}/actions/runs/12",
                 "createdAt": "2026-08-24T11:00:00Z",
+                "headSha": "c" * 40,
             },
         )
         self.assertEqual(
-            [candidate["runId"] for candidate in MODULE.packaging_run_candidates(
-                runs, "0.13.0"
-            )],
+            [
+                candidate["runId"]
+                for candidate in MODULE.packaging_run_candidates(runs, "0.13.0")
+            ],
             [12, 10],
         )
+
+    def test_package_run_from_side_branch_is_rejected(self) -> None:
+        run = {
+            "databaseId": 12,
+            "displayTitle": "Prebuilt Binaries · 0.13.0",
+            "event": "workflow_dispatch",
+            "status": "completed",
+            "conclusion": "success",
+            "createdAt": "2026-08-24T11:00:00Z",
+            "url": (
+                "https://github.com/stephenlclarke/container-compose/"
+                "actions/runs/12"
+            ),
+            "headBranch": "feature/untrusted",
+            "headSha": "c" * 40,
+        }
+
+        with self.assertRaisesRegex(
+            MODULE.BenchmarkInputError, "no successful immutable package run"
+        ):
+            MODULE.resolve_packaging_run([run], "0.13.0")
 
     def test_missing_successful_package_run_is_rejected(self) -> None:
         with self.assertRaisesRegex(
@@ -903,6 +934,9 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
         self.assertIn("gh run download", workflow)
         self.assertIn("gh attestation verify", workflow)
         self.assertIn("  attestations: read", workflow)
+        self.assertIn("--signer-digest", workflow)
+        self.assertIn("--source-ref refs/heads/main", workflow)
+        self.assertIn("--source-digest", workflow)
         self.assertIn("--allow-package-run-backfill", workflow)
         self.assertIn("--artifact-source", workflow)
         self.assertIn("--init-distribution", workflow)


### PR DESCRIPTION
## Summary

- allow the artifact-only benchmark to compare an older stable maintenance backfill that intentionally never replaced the newer Homebrew formula pair
- require its runtime and Compose archives to come from a successful retained package run with GitHub provenance attestations
- keep Homebrew history mandatory for ordinary stable releases and reject package-run authority for the latest stable release
- label the resulting evidence clearly as an unpromoted maintenance backfill

## Evidence

- `python3 -m unittest Tools.parity.test_published_release_benchmark` (33 passed)
- `actionlint .github/workflows/published-benchmark.yml`
- exact 0.13.1 preparation from retained package run 33600957516 passed with `distributionAuthority=maintenance-package-run`
- 0.13.1 runtime and Compose archive SHA-256 sidecars, GitHub attestations, and Developer ID signatures verified
- latest-stable use of the backfill escape hatch is rejected before extraction

## Trigger

Published benchmark run 33798095193 failed fast because 0.13.1 was a maintenance backfill and therefore correctly absent from Homebrew main history. No timing work or source build began.
