### PR TITLE
fix(benchmark): use Docker-shared local fixture root

### DIFF
--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -110,13 +110,28 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, container-compose-release]
     timeout-minutes: 240
     env:
-      BENCHMARK_ROOT: /private/tmp/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}
       TARGET_VERSION: ${{ needs.resolve.outputs.target }}
       BASELINE_VERSION: ${{ needs.resolve.outputs.baseline }}
       LATEST_STABLE_VERSION: ${{ needs.resolve.outputs.latest }}
       REPETITIONS: ${{ inputs.repetitions }}
       RUNTIME_ROOT_PREFIX: /private/tmp/ccpb-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
+      - name: Select Docker-shared local benchmark root
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${RUNNER_TEMP}" in
+            "${HOME}"/*) ;;
+            *)
+              printf 'RUNNER_TEMP must be on local storage under HOME so Docker can bind-mount benchmark fixtures: %s\n' \
+                "${RUNNER_TEMP}" >&2
+              exit 1
+              ;;
+          esac
+          printf 'BENCHMARK_ROOT=%s/container-compose-published-benchmark-%s-%s\n' \
+            "${RUNNER_TEMP}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}" \
+            >> "${GITHUB_ENV}"
+
       - name: Checkout documentation and benchmark controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -358,9 +373,9 @@ jobs:
         with:
           name: published-benchmark-${{ needs.resolve.outputs.target }}-vs-${{ needs.resolve.outputs.baseline }}
           path: |
-            ${{ env.BENCHMARK_ROOT }}/evidence
-            ${{ env.BENCHMARK_ROOT }}/prepared/*/published-distribution.json
-            ${{ env.BENCHMARK_ROOT }}/downloads/*/*/*.sha256
+            ${{ runner.temp }}/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}/evidence
+            ${{ runner.temp }}/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}/prepared/*/published-distribution.json
+            ${{ runner.temp }}/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}/downloads/*/*/*.sha256
           if-no-files-found: warn
           retention-days: 90
 

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -975,6 +975,31 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
         self.assertIn("if: always()", retain)
         self.assertIn("if-no-files-found: warn", retain)
 
+    def test_workflow_keeps_bind_mounted_fixtures_on_docker_shared_storage(
+        self,
+    ) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        root_selection = workflow[
+            workflow.index("Select Docker-shared local benchmark root") :
+            workflow.index("Checkout documentation and benchmark controls")
+        ]
+
+        self.assertIn('case "${RUNNER_TEMP}"', root_selection)
+        self.assertIn('"${HOME}"/*', root_selection)
+        self.assertIn(
+            '"${RUNNER_TEMP}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}"',
+            root_selection,
+        )
+        self.assertNotIn("/private/tmp", root_selection)
+        self.assertIn(
+            "${{ runner.temp }}/container-compose-published-benchmark-",
+            workflow,
+        )
+        self.assertNotIn(
+            "BENCHMARK_ROOT: /private/tmp/container-compose-published-benchmark",
+            workflow,
+        )
+
     def test_workflow_rejects_interactive_documentation_signing(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         preflight = workflow.index("Verify unattended documentation signing")


### PR DESCRIPTION
## Summary

- select the published benchmark root from the self-hosted runner temporary directory under `$HOME`
- fail before downloads or timing when that root is not on Docker-shared local storage
- retain `/private/tmp` only for the Container runtime execution root
- cover the workflow storage invariant with a focused regression test

## Evidence

Run 33801600205 recorded Docker `logging-write-json-compression` as a 300.004s timeout while the same 0.13.1 container-compose workload completed in 1.751s. The subsequent Docker file-logging fixture entered the same invalid wait. The generated completion directory was under `/private/tmp`, contrary to the harness requirement that bind-mounted markers live on a path shared with Docker.

A direct Docker bind-mount read/write probe passed under the selected runner temp directory:

`/Users/sclarke/.local/share/container-compose-release-runner/_work/_temp`

## Validation

- `python3 -m unittest Tools.parity.test_published_release_benchmark.PublishedBenchmarkWorkflowTests` (11 passed)
- `actionlint .github/workflows/published-benchmark.yml`
- `git diff --check`
- local Docker bind-mount read/write probe under the runner temp directory

Closes #456.
