### PR TITLE
fix(release): retain stable benchmark closure

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1551,7 +1551,7 @@ jobs:
             RELEASE_CHECKSUM_PATH="${RUNNER_TEMP}/${ASSET}.sha256" \
             ../release-tools/Tools/release/publish-github-release.sh
 
-      - name: Retain only current release assets
+      - name: Retain active and stable benchmark assets
         if: >
           steps.current-freshness.outputs.publish == 'true' &&
           (needs.resolve-publish-context.outputs.ref_type == 'branch' ||

--- a/Tools/release/retain-release-assets.py
+++ b/Tools/release/retain-release-assets.py
@@ -15,7 +15,7 @@
 ## limitations under the License.
 ##===----------------------------------------------------------------------===##
 
-"""Retain binary assets for only GitHub latest stable and current releases."""
+"""Retain install assets for active lanes and benchmark assets for stable releases."""
 
 from __future__ import annotations
 
@@ -32,6 +32,16 @@ RETENTION_START = "<!-- container-release-retention:start -->"
 RETENTION_END = "<!-- container-release-retention:end -->"
 LEGACY_PIN_HIGHLIGHT = re.compile(
     r"(?m)^- Release automation pins .+ by exact SwiftPM revision [0-9a-f]{12}\.\n?"
+)
+STABLE_BENCHMARK_ASSETS = frozenset(
+    {
+        "container-release-arm64.tar.gz",
+        "container-release-arm64.tar.gz.sha256",
+        "container-compose-plugin-release-arm64.tar.gz",
+        "container-compose-plugin-release-arm64.tar.gz.sha256",
+        "container-vminit-arm64.oci.tar",
+        "container-vminit-arm64.oci.tar.sha256",
+    }
 )
 
 
@@ -192,7 +202,12 @@ def historical_source_note(
             RETENTION_START,
             "## Historical source installation",
             "",
-            "This release is retained as source history, but its prebuilt assets and tap-backed package have been retired.",
+            (
+                "This release is retained as source history. Its tap-backed package "
+                "and non-benchmark release assets have been retired; any immutable "
+                "runtime, plugin, and guest assets required for a reproducible "
+                "published-version benchmark remain attached."
+            ),
             "The public Homebrew formula intentionally follows only the newest release in each lane, so it cannot select this historical tag.",
             "Use Homebrew to bootstrap the build tools, then build this exact source tag:",
             "",
@@ -254,9 +269,17 @@ def list_releases(repo: str) -> list[dict]:
     return [release for page in pages for release in page]
 
 
-def delete_assets(repo: str, release: dict) -> None:
-    for asset in release.get("assets", []):
-        run_gh("api", "--method", "DELETE", f"repos/{repo}/releases/assets/{asset['id']}")
+def historical_assets_to_retire(release: dict) -> list[dict]:
+    """Return assets not needed to benchmark a historical stable release."""
+
+    assets = list(release.get("assets", []))
+    if release.get("prerelease"):
+        return assets
+    return [
+        asset
+        for asset in assets
+        if asset.get("name") not in STABLE_BENCHMARK_ASSETS
+    ]
 
 
 def stale_current_assets(release: dict, retained_names: set[str]) -> list[dict]:
@@ -364,13 +387,14 @@ def main() -> None:
             install_command=args.install_command,
         )
         body = replace_retention_note(remove_legacy_pin_highlights(current_body), note)
-        asset_count = len(release.get("assets", []))
+        retired_assets = historical_assets_to_retire(release)
+        asset_count = len(retired_assets)
         if not asset_count and body == current_body:
             continue
         print(f"retiring {release['tag_name']}: {asset_count} asset(s)")
         if args.apply:
             if asset_count:
-                delete_assets(args.repo, release)
+                delete_named_assets(args.repo, retired_assets)
             if body != current_body:
                 update_release_notes(args.repo, release, body)
 

--- a/Tools/release/test_capture_quality_snapshot.py
+++ b/Tools/release/test_capture_quality_snapshot.py
@@ -521,7 +521,7 @@ class CaptureQualitySnapshotTests(unittest.TestCase):
             workflow.index("- name: Stage release assets and notes"),
         )
         retention_step = workflow.split(
-            "- name: Retain only current release assets", 1
+            "- name: Retain active and stable benchmark assets", 1
         )[1].split("\n\n  repair-stable-tap:", 1)[0]
         self.assertIn(
             "QUALITY_SNAPSHOT_ASSET: ${{ steps.lane.outputs.quality_snapshot_asset }}",

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -990,9 +990,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('release_latest="${promote_default_lane}"', lane)
         self.assertIn('update_tap="${promote_default_lane}"', lane)
         retention = workflow[
-            workflow.index("- name: Retain only current release assets") : workflow.index(
-                "  repair-stable-tap:"
-            )
+            workflow.index(
+                "- name: Retain active and stable benchmark assets"
+            ) : workflow.index("  repair-stable-tap:")
         ]
         self.assertIn("steps.lane.outputs.update_tap == 'true'", retention)
         self.assertIn(
@@ -1694,7 +1694,7 @@ github_cli() {{
     def test_current_demo_is_recoverable_and_not_release_critical(self) -> None:
         package = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         release_critical = package[
-            : package.index("- name: Retain only current release assets")
+            : package.index("- name: Retain active and stable benchmark assets")
         ]
         workflow = CURRENT_DEMO_WORKFLOW.read_text(encoding="utf-8")
         readme = (ROOT / "README.md").read_text(encoding="utf-8")

--- a/Tools/release/test_retain_release_assets.py
+++ b/Tools/release/test_retain_release_assets.py
@@ -37,7 +37,7 @@ def load_module():
 
 
 class ReleaseAssetRetentionTests(unittest.TestCase):
-    """Only the newest stable and newest prerelease retain packages."""
+    """Active lanes retain installs and stable history retains benchmark closure."""
 
     def test_retains_one_published_release_per_lane(self) -> None:
         module = load_module()
@@ -143,8 +143,47 @@ class ReleaseAssetRetentionTests(unittest.TestCase):
         self.assertIn("brew install go node python", note)
         self.assertIn("make package", note)
         self.assertIn("sudo tar -xzf", note)
+        self.assertIn("reproducible published-version benchmark", note)
         self.assertIn(module.RETENTION_START, note)
         self.assertIn(module.RETENTION_END, note)
+
+    def test_historical_stable_retains_only_benchmark_closure(self) -> None:
+        module = load_module()
+        release = {
+            "prerelease": False,
+            "assets": [
+                {"id": index, "name": name}
+                for index, name in enumerate(
+                    [
+                        *sorted(module.STABLE_BENCHMARK_ASSETS),
+                        "release-highlights.md",
+                        "quality-snapshot.svg",
+                    ],
+                    start=1,
+                )
+            ],
+        }
+
+        retired = module.historical_assets_to_retire(release)
+
+        self.assertEqual(
+            [asset["name"] for asset in retired],
+            ["release-highlights.md", "quality-snapshot.svg"],
+        )
+
+    def test_historical_prerelease_retires_every_asset(self) -> None:
+        module = load_module()
+        release = {
+            "prerelease": True,
+            "assets": [
+                {"id": 1, "name": "container-release-arm64.tar.gz"},
+                {"id": 2, "name": "release-highlights.md"},
+            ],
+        }
+
+        self.assertEqual(
+            module.historical_assets_to_retire(release), release["assets"]
+        )
 
     def test_replacing_a_note_is_idempotent(self) -> None:
         module = load_module()


### PR DESCRIPTION
## Summary

- retain the immutable runtime, compose-plugin, and guest-init asset allowlist on historical stable releases
- continue deleting unrelated historical assets and every superseded prerelease asset
- make the historical release note accurately distinguish retired install assets from retained benchmark authority
- cover stable and prerelease retention behavior with focused tests

## Root cause

Prebuilt Binaries run 33803188223 applied the previous `latest stable only` policy after the exact 0.13.1 guest closure had been restored. It deleted that archive and checksum at 20:53 UTC. Published benchmark run 33806448447 then correctly failed before timing because 0.13.1 had no immutable guest authority.

## Validation

- 14 focused release-retention/workflow tests passed
- `actionlint .github/workflows/prebuilt-binaries.yml`
- `git diff --check`

Closes #458.
