### PR TITLE
[Bug] Pin cached gateway identity validation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "06192cc7c9d9d543ba8c4d38e20543af79e22508835c517c3186d3c878791bd0",
+  "originHash" : "184fd6d017ec4788629568f5a0fc047a7f5d814fbafc20a8d8b532bb97fdf5da",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "2647090a8af74cf18fae2472342cdb55bab60e45"
+        "revision" : "f2e259d30010e1f7137cd7caa1d67fd71dc660cd"
       }
     },
     {
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container-engine-api.git",
       "state" : {
-        "revision" : "386a40c726ecd25d67a3e5933582aebbfbe4fa2f"
+        "revision" : "d713f12cb362c6646d083537f16e6595d3743c74"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "2647090a8af74cf18fae2472342cdb55bab60e45",
+        revision: "f2e259d30010e1f7137cd7caa1d67fd71dc660cd",
     )
 }()
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "2647090a8af74cf18fae2472342cdb55bab60e45",
+      "ref": "f2e259d30010e1f7137cd7caa1d67fd71dc660cd",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
Closes #460.

Pins Compose’s package dependency and release stack authority to Container `f2e259d30010e1f7137cd7caa1d67fd71dc660cd`, which carries the reviewed provider-handshake code-identity cache from stephenlclarke/container-engine-api#38. SwiftPM resolution also records the corresponding engine-api merge `d713f12cb362c6646d083537f16e6595d3743c74`.

This addresses the false `engine.status not running` failure in published benchmark run 33808143752. The engine remained alive, but repeated Security.framework validation on provider handshakes intermittently exceeded the one-second health probe.

Related evidence:
- engine API bug: stephenlclarke/container-engine-api#37
- reviewed engine API fix: stephenlclarke/container-engine-api#38
- Container propagation issue/PR: stephenlclarke/container#201 / stephenlclarke/container#202

Targeted validation:
- `swift package resolve`
- `python3 Tools/ci/check-stack-consistency.py`
- `swift test --filter ComposeBuildInfoTests` (1 test passed)
- `git diff --check`

No documentation, release packaging, parity matrix, or benchmark suite is run by this propagation change; the next checkpoint is the focused `logging-file` reproduction.