### PR TITLE
[MAINTENANCE] Refresh Apple-current release stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "f2e259d30010e1f7137cd7caa1d67fd71dc660cd"
+        "revision" : "83cfab33d0b1ca5976ce979b3755761e58cc957a"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "818f5917819a32dac1bc233605c253b4a105e0e0"
+        "revision" : "7807badff6a8bd1d53fa1c6696543f7fffab0fa4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "f2e259d30010e1f7137cd7caa1d67fd71dc660cd",
+        revision: "83cfab33d0b1ca5976ce979b3755761e58cc957a",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "818f5917819a32dac1bc233605c253b4a105e0e0",
+        revision: "7807badff6a8bd1d53fa1c6696543f7fffab0fa4",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 3 September 2026 snapshot, the three support forks are **1093 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 4 September 2026 snapshot, the three support forks are **1098 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 287 ahead** at [`818f5917819a`](https://github.com/stephenlclarke/containerization/commit/818f5917819a32dac1bc233605c253b4a105e0e0).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 758 ahead** at [`2647090a8af7`](https://github.com/stephenlclarke/container/commit/2647090a8af74cf18fae2472342cdb55bab60e45).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 289 ahead** at [`7807badff6a8`](https://github.com/stephenlclarke/containerization/commit/7807badff6a8bd1d53fa1c6696543f7fffab0fa4).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 761 ahead** at [`83cfab33d0b1`](https://github.com/stephenlclarke/container/commit/83cfab33d0b1ca5976ce979b3755761e58cc957a).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 48 ahead** at [`4aff0ea2e7ff`](https://github.com/stephenlclarke/container-builder-shim/commit/4aff0ea2e7ff293544a4efac28b508da53aac3d6).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "f2e259d30010e1f7137cd7caa1d67fd71dc660cd",
+      "ref": "83cfab33d0b1ca5976ce979b3755761e58cc957a",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "818f5917819a32dac1bc233605c253b4a105e0e0",
+      "ref": "7807badff6a8bd1d53fa1c6696543f7fffab0fa4",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-09-03",
+  "reviewedAt": "2026-09-04",
   "repositories": {
     "container": {
       "upstreamHead": "025f57c6c0fed55bc155af0ddc13b11fff6f22e6",
-      "forkHead": "2647090a8af74cf18fae2472342cdb55bab60e45",
+      "forkHead": "83cfab33d0b1ca5976ce979b3755761e58cc957a",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -475,7 +475,9 @@
             "f558eb452a2315d87153d4f4828950d783387a80",
             "239345a8a955930a352cc651a50222a72f511ff7",
             "c4356f8795790ef2e5dc1a75644cf83085515b7a",
-            "44eef61528dba8e0193056c3a80143ba4e977cb4"
+            "44eef61528dba8e0193056c3a80143ba4e977cb4",
+            "f2e259d30010e1f7137cd7caa1d67fd71dc660cd",
+            "36bc521f305b78b2a70c3cd8a6de796c003c90d0"
           ]
         },
         {
@@ -720,8 +722,8 @@
       ]
     },
     "containerization": {
-      "upstreamHead": "fc9e63846f365151aa6d3bf39d65e662abf431fc",
-      "forkHead": "818f5917819a32dac1bc233605c253b4a105e0e0",
+      "upstreamHead": "d7fc7c15a257e348000f3ed3708e84a9d33add97",
+      "forkHead": "7807badff6a8bd1d53fa1c6696543f7fffab0fa4",
       "slices": [
         {
           "id": "containerization-support-maintenance",

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 3 September 2026
+Updated: 4 September 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `025f57c6c0fed55bc155af0ddc13b11fff6f22e6` | `2647090a8af74cf18fae2472342cdb55bab60e45` | 0 | 758 | 639 |
-| `containerization` | `fc9e63846f365151aa6d3bf39d65e662abf431fc` | `818f5917819a32dac1bc233605c253b4a105e0e0` | 0 | 287 | 230 |
+| `container` | `025f57c6c0fed55bc155af0ddc13b11fff6f22e6` | `83cfab33d0b1ca5976ce979b3755761e58cc957a` | 0 | 761 | 641 |
+| `containerization` | `d7fc7c15a257e348000f3ed3708e84a9d33add97` | `7807badff6a8bd1d53fa1c6696543f7fffab0fa4` | 0 | 289 | 230 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `4aff0ea2e7ff293544a4efac28b508da53aac3d6` | 0 | 48 | 40 |
-| **Total** | | | **0** | **1093** | **909** |
+| **Total** | | | **0** | **1098** | **911** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 654 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 656 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 230 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -257,3 +257,11 @@ The 3 September 2026 release refresh advances Apple Container through
 `container clean` correction and release-action update are upstream history.
 The signed fork handoff is support maintenance. No generic runtime primitive,
 temporary port, or rejected-policy disposition changed in this refresh.
+
+The 4 September 2026 maintenance refresh advances Apple Containerization
+through `d7fc7c15a257`, Containerization through `7807badff6a8`, and Container
+through `83cfab33d0b1`. Apple's `cctl run` ENTRYPOINT/CMD resolution is upstream
+history after the reviewed merge. Container's cached gateway-identity pin and
+the exact Containerization dependency pin are support maintenance. No generic
+runtime primitive, temporary port, or rejected Compose-policy disposition
+changed in this refresh.


### PR DESCRIPTION
## Summary

- pin Container `83cfab33d0b1` and Containerization `7807badff6a8`
- carry Apple Containerization `d7fc7c15` (`apple/containerization#906`) into the matched stack
- classify the cached gateway-identity fix and Containerization pin as support maintenance
- refresh the machine-readable and human-readable upstream snapshot

## Focused proof

- `swift package resolve` resolved the exact new heads
- `make upstream-divergence-release-check`
- `make stack-consistency`
- `make source-preflight`
- `make readme-upstream-metrics-check`
- `git diff --check`

Cross-repo: stephenlclarke/containerization#71 and stephenlclarke/container#204.

Closes #462