### PR TITLE
fix(parity): bound Compose events shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -590,7 +590,7 @@ SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -
 .PHONY: docker-compose-phase4-parity
 .PHONY: docker-compose-format-template-actions-parity
 .PHONY: docker-compose-stop-defaults-parity docker-compose-cpu-cfs-parity docker-compose-cpu-shares-parity docker-compose-cpuset-parity docker-compose-pid-namespace-parity docker-compose-cgroup-namespace-parity docker-compose-cgroup-parent-parity docker-compose-ipc-uts-namespace-parity docker-compose-userns-mode-parity docker-compose-privileged-parity docker-compose-network-attachable-parity docker-compose-network-ipv6-parity docker-compose-deploy-job-modes-parity
-.PHONY: docker-compose-up-exit-code-from-parity docker-compose-performance-matrix performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test
+.PHONY: docker-compose-up-exit-code-from-parity docker-compose-performance-matrix performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test compose-events-harness-test
 .PHONY: docker-terminal-session-oracle docker-terminal-session-oracle-update docker-terminal-session-candidate-oracle docker-rest-logging-oracle docker-rest-logging-candidate docker-rest-logging-parity docker-rest-discovery-oracle docker-rest-discovery-candidate docker-rest-discovery-parity docker-rest-image-discovery-oracle docker-rest-image-discovery-candidate docker-rest-image-discovery-parity docker-rest-image-mutation-oracle docker-rest-image-mutation-candidate docker-rest-image-mutation-parity
 .PHONY: pipeline-help pipeline-bootstrap pipeline-runtime-check pipeline-state-init pipeline-lint pipeline-plan pipeline-preflight pipeline pipeline-resume pipeline-status pipeline-self-test pipeline-execute
 
@@ -2726,6 +2726,9 @@ isolation-performance-harness-test:
 signal-log-reliability-harness-test:
 	$(PYTHON) Tools/parity/test_signal_log_reliability.py
 
+compose-events-harness-test:
+	$(PYTHON) Tools/parity/test_compose_events_watcher.py
+
 upstream-divergence-report:
 	$(PYTHON) Tools/ci/upstream-divergence-report.py --fetch --output .build/reports/upstream-divergence.md --json-output .build/reports/upstream-divergence.json
 
@@ -2778,9 +2781,9 @@ source-preflight: upstream-handoff-registry-check stack-consistency core-runtime
 
 check: source-preflight lint
 
-lint: lint-static coverage-tools-test performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test
+lint: lint-static coverage-tools-test performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test compose-events-harness-test
 
-source-checks: source-preflight lint-static coverage-python-tools-test performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test
+source-checks: source-preflight lint-static coverage-python-tools-test performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test compose-events-harness-test
 
 lint-static:
 	@while IFS= read -r -d '' script; do \

--- a/Tools/ci/test_makefile_fail_fast.py
+++ b/Tools/ci/test_makefile_fail_fast.py
@@ -61,6 +61,7 @@ class MakefileFailFastTests(unittest.TestCase):
                 "performance-matrix-harness-test",
                 "isolation-performance-harness-test",
                 "signal-log-reliability-harness-test",
+                "compose-events-harness-test",
             ],
         )
 

--- a/Tools/parity/check-compose-events.sh
+++ b/Tools/parity/check-compose-events.sh
@@ -52,6 +52,8 @@ TEXT_EVENTS_FILE=""
 PROJECT_NAME="container-compose-events-$RANDOM-$$"
 EVENTS_PID=""
 DOCKER_COMPOSE_COMMAND=()
+EVENTS_STOP_TIMEOUT_SECONDS="${EVENTS_STOP_TIMEOUT_SECONDS:-5}"
+STARTED_PROCESS_PID=""
 
 # Print a warning message to stderr.
 warning() {
@@ -134,14 +136,48 @@ create_fixture() {
     : >"$EVENTS_FILE"
 }
 
+# Start a command in its own process group so its complete process tree can be
+# stopped without signalling this parity script or its release controller.
+start_process_group() {
+    local output_file="$1"
+    shift
+
+    python3 -c '
+import os
+import sys
+
+os.setsid()
+os.execvp(sys.argv[1], sys.argv[1:])
+' "$@" >"$output_file" &
+    STARTED_PROCESS_PID="$!"
+}
+
+# Stop a process group within a bounded grace period. Docker's CLI wrapper can
+# otherwise survive TERM while waiting for its Compose plugin child forever.
+stop_process_group() {
+    local process_group_pid="$1"
+    local timeout_seconds="$2"
+    local deadline
+
+    kill -TERM -- "-$process_group_pid" >/dev/null 2>&1 || true
+    ((deadline = SECONDS + timeout_seconds))
+    while kill -0 -- "-$process_group_pid" >/dev/null 2>&1; do
+        if ((SECONDS >= deadline)); then
+            kill -KILL -- "-$process_group_pid" >/dev/null 2>&1 || true
+            break
+        fi
+        sleep 0.1
+    done
+    wait "$process_group_pid" >/dev/null 2>&1 || true
+}
+
 # Stop the background event watcher if it is still running.
 stop_events_watcher() {
     if [[ -z "$EVENTS_PID" ]]; then
         return 0
     fi
 
-    kill "$EVENTS_PID" >/dev/null 2>&1 || true
-    wait "$EVENTS_PID" >/dev/null 2>&1 || true
+    stop_process_group "$EVENTS_PID" "$EVENTS_STOP_TIMEOUT_SECONDS"
     EVENTS_PID=""
 }
 
@@ -158,8 +194,9 @@ cleanup() {
 
 # Start `Docker Compose events --json` in the background.
 start_events_watcher() {
-    "${DOCKER_COMPOSE_COMMAND[@]}" -p "$PROJECT_NAME" -f "$COMPOSE_FILE" events --json api >"$EVENTS_FILE" &
-    EVENTS_PID="$!"
+    start_process_group "$EVENTS_FILE" \
+        "${DOCKER_COMPOSE_COMMAND[@]}" -p "$PROJECT_NAME" -f "$COMPOSE_FILE" events --json api
+    EVENTS_PID="$STARTED_PROCESS_PID"
     sleep 1
 }
 
@@ -336,14 +373,14 @@ run_filtered_replay() {
     local replay_pid
     local deadline
 
-    "${DOCKER_COMPOSE_COMMAND[@]}" -p "$PROJECT_NAME" -f "$COMPOSE_FILE" events --json --since "$since" --until "$until" api >"$FILTERED_EVENTS_FILE" &
-    replay_pid="$!"
+    start_process_group "$FILTERED_EVENTS_FILE" \
+        "${DOCKER_COMPOSE_COMMAND[@]}" -p "$PROJECT_NAME" -f "$COMPOSE_FILE" events --json --since "$since" --until "$until" api
+    replay_pid="$STARTED_PROCESS_PID"
     ((deadline = SECONDS + 30))
 
     while kill -0 "$replay_pid" >/dev/null 2>&1; do
         if ((SECONDS >= deadline)); then
-            kill "$replay_pid" >/dev/null 2>&1 || true
-            wait "$replay_pid" >/dev/null 2>&1 || true
+            stop_process_group "$replay_pid" "$EVENTS_STOP_TIMEOUT_SECONDS"
             error 'timed out waiting for docker compose events --since/--until replay'
             return 1
         fi
@@ -366,14 +403,14 @@ run_text_replay() {
     local replay_pid
     local deadline
 
-    "${DOCKER_COMPOSE_COMMAND[@]}" -p "$PROJECT_NAME" -f "$COMPOSE_FILE" events --since "$since" --until "$until" api >"$TEXT_EVENTS_FILE" &
-    replay_pid="$!"
+    start_process_group "$TEXT_EVENTS_FILE" \
+        "${DOCKER_COMPOSE_COMMAND[@]}" -p "$PROJECT_NAME" -f "$COMPOSE_FILE" events --since "$since" --until "$until" api
+    replay_pid="$STARTED_PROCESS_PID"
     ((deadline = SECONDS + 30))
 
     while kill -0 "$replay_pid" >/dev/null 2>&1; do
         if ((SECONDS >= deadline)); then
-            kill "$replay_pid" >/dev/null 2>&1 || true
-            wait "$replay_pid" >/dev/null 2>&1 || true
+            stop_process_group "$replay_pid" "$EVENTS_STOP_TIMEOUT_SECONDS"
             error 'timed out waiting for docker compose events text replay'
             return 1
         fi
@@ -475,4 +512,6 @@ main() {
     printf 'Docker Compose events parity check passed for project %s\n' "$PROJECT_NAME"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/Tools/parity/test_compose_events_watcher.py
+++ b/Tools/parity/test_compose_events_watcher.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Focused tests for bounded Compose events watcher shutdown."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+
+REPOSITORY = Path(__file__).parents[2]
+HARNESS = REPOSITORY / "Tools" / "parity" / "check-compose-events.sh"
+
+
+class EventsWatcherShutdownTests(unittest.TestCase):
+    def test_term_resistant_process_tree_is_killed_within_deadline(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="compose-events-watcher-") as directory:
+            root = Path(directory)
+            resistant = root / "term-resistant.sh"
+            resistant.write_text(
+                "#!/usr/bin/env bash\n"
+                "trap '' TERM\n"
+                "bash -c 'trap \"\" TERM; while true; do sleep 1; done' &\n"
+                "wait\n",
+                encoding="utf-8",
+            )
+            resistant.chmod(0o755)
+            events = root / "events.jsonl"
+
+            started = time.monotonic()
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    (
+                        'EVENTS_STOP_TIMEOUT_SECONDS=1; source "$1"; '
+                        'EVENTS_FILE="$2"; DOCKER_COMPOSE_COMMAND=("$3"); '
+                        "start_events_watcher; watcher_pid=$EVENTS_PID; "
+                        "stop_events_watcher; "
+                        'if kill -0 -- "-$watcher_pid" 2>/dev/null; then exit 91; fi'
+                    ),
+                    "_",
+                    HARNESS,
+                    events,
+                    resistant,
+                ],
+                cwd=REPOSITORY,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=8,
+            )
+            elapsed = time.monotonic() - started
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertLess(elapsed, 5, f"watcher shutdown took {elapsed:.2f}s")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- run Docker Compose event collectors in isolated process groups
- enforce bounded TERM/KILL shutdown for live watchers and timed replays
- add a focused regression with a TERM-resistant wrapper and child
- include the regression in source/lint gates

## Release evidence

The 0.14.2 stable controller completed its fixture actions but hung indefinitely in `stop_events_watcher`: the Docker CLI wrapper and Compose plugin remained alive after TERM while the shell waited without a deadline. The interrupted release was preserved at its parity checkpoint.

## Validation

- `bash -n Tools/parity/check-compose-events.sh`
- `python3 Tools/parity/test_compose_events_watcher.py`
- `python3 -m unittest Tools.ci.test_makefile_fail_fast`
- `./Tools/parity/check-compose-events.sh --strict`
- `git diff --check`

Closes #465.