### PR TITLE
fix(release): recover cancelled Current demos

### DIFF
--- a/.github/workflows/current-demo.yml
+++ b/.github/workflows/current-demo.yml
@@ -15,16 +15,9 @@
 #===----------------------------------------------------------------------===#
 
 name: Current Demo
-run-name: Current Demo · ${{ inputs.ref || github.event.workflow_run.head_sha }}
+run-name: Current Demo · ${{ inputs.ref }}
 
 on:
-  workflow_run:
-    workflows:
-      - Prebuilt Binaries
-    types:
-      - completed
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       ref:
@@ -47,8 +40,7 @@ jobs:
   resolve-current:
     name: Resolve Current Demo Source
     if: >
-      github.repository == 'stephenlclarke/container-compose' &&
-      (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+      github.repository == 'stephenlclarke/container-compose'
     runs-on: ubuntu-24.04
     outputs:
       publish: ${{ steps.resolve.outputs.publish }}
@@ -59,33 +51,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           REQUESTED_REF: ${{ inputs.ref }}
-          WORKFLOW_RUN_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
-          WORKFLOW_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_run" &&
-                "${WORKFLOW_RUN_DISPLAY_TITLE}" != "Prebuilt Binaries · main" ]]; then
-            printf 'Skipping non-Current package workflow: %s\n' \
-              "${WORKFLOW_RUN_DISPLAY_TITLE:-<unset>}"
-            {
-              printf 'publish=false\n'
-              printf 'sha=%s\n' "${WORKFLOW_HEAD_SHA}"
-            } >> "${GITHUB_OUTPUT}"
-            exit 0
-          fi
           remote="https://github.com/${GITHUB_REPOSITORY}.git"
           main_sha="$(
             git ls-remote --heads "${remote}" refs/heads/main \
               | awk '{ print $1 }' \
               | tail -n 1
           )"
-          source_sha="${WORKFLOW_HEAD_SHA}"
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            source_sha="${REQUESTED_REF}"
-            if [[ "${source_sha}" == "main" ]]; then
-              source_sha="${main_sha}"
-            fi
+          source_sha="${REQUESTED_REF}"
+          if [[ "${source_sha}" == "main" ]]; then
+            source_sha="${main_sha}"
           fi
           if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
             printf 'Current demo source is not an immutable commit: %s\n' \
@@ -280,8 +257,12 @@ jobs:
             local status=$?
             trap - EXIT
             trap '' HUP INT QUIT TERM
-            if ! bash Tools/release/stop-current-demo-runtime.sh \
-              "${demo_session_root}" "${container_binary}"; then
+            if ((status >= 128)); then
+              CONTAINER_DEMO_SKIP_GRACEFUL_STOP=true \
+                bash Tools/release/stop-current-demo-runtime.sh \
+                  "${demo_session_root}" "${container_binary}" || status=1
+            elif ! bash Tools/release/stop-current-demo-runtime.sh \
+                "${demo_session_root}" "${container_binary}"; then
               status=1
             fi
             exit "${status}"

--- a/Tools/release/stop-current-demo-runtime.sh
+++ b/Tools/release/stop-current-demo-runtime.sh
@@ -40,12 +40,16 @@ expected_plist="${demo_app_root}/apiserver/apiserver.plist"
 service_label=com.apple.container.apiserver
 user_domain="gui/$(id -u)"
 launchctl_bin="${CONTAINER_DEMO_LAUNCHCTL:-/bin/launchctl}"
+ps_bin="${CONTAINER_DEMO_PS:-/bin/ps}"
+kill_bin="${CONTAINER_DEMO_KILL:-/bin/kill}"
 deadline_runner="${CONTAINER_DEMO_DEADLINE_RUNNER:-$(
   dirname "${BASH_SOURCE[0]}"
 )/../ci/run-command-with-deadline.py}"
 stop_waiter="${CONTAINER_SYSTEM_STOP_WAITER:-$(
   dirname "${BASH_SOURCE[0]}"
 )/wait-for-container-system-stop.sh}"
+graceful_stop_seconds="${CONTAINER_DEMO_GRACEFUL_STOP_SECONDS:-3}"
+skip_graceful_stop="${CONTAINER_DEMO_SKIP_GRACEFUL_STOP:-false}"
 
 if [[ -z "${demo_session_root}" || "${demo_session_root}" != /* ||
       "${demo_session_root}" == / || ! -d "${demo_session_root}" ||
@@ -69,9 +73,21 @@ if [[ "${container_binary}" != "${expected_container}" ]]; then
     "${container_binary}" >&2
   exit 2
 fi
-if [[ ! -x "${launchctl_bin}" ]]; then
-  printf 'Current demo launch-agent inspector is not executable: %s\n' \
-    "${launchctl_bin}" >&2
+if [[ ! -x "${launchctl_bin}" || ! -x "${ps_bin}" ||
+      ! -x "${kill_bin}" ]]; then
+  printf 'Current demo cleanup tools are not executable: %s %s %s\n' \
+    "${launchctl_bin}" "${ps_bin}" "${kill_bin}" >&2
+  exit 2
+fi
+if ! [[ "${graceful_stop_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'Current demo graceful-stop seconds must be a positive integer: %s\n' \
+    "${graceful_stop_seconds}" >&2
+  exit 2
+fi
+if [[ "${skip_graceful_stop}" != "true" &&
+      "${skip_graceful_stop}" != "false" ]]; then
+  printf 'CONTAINER_DEMO_SKIP_GRACEFUL_STOP must be true or false: %s\n' \
+    "${skip_graceful_stop}" >&2
   exit 2
 fi
 
@@ -92,19 +108,134 @@ demo_service_is_loaded() {
   fi
 }
 
-if demo_service_is_loaded; then
-  if [[ ! -x "${container_binary}" ]]; then
-    printf 'Current demo service is loaded but its CLI is unavailable: %s\n' \
-      "${container_binary}" >&2
-    exit 2
+# Boot out every remaining service only after proving that every matching
+# launch agent belongs to this marker-protected demo root. Validation happens
+# before mutation so an unrelated production service remains a hard failure.
+bootout_demo_owned_services() {
+  local label=""
+  local loaded_plist=""
+  local services=""
+  local -a labels=()
+
+  if ! services="$("${launchctl_bin}" list)"; then
+    printf 'failed to list Container launch agents with %s\n' \
+      "${launchctl_bin}" >&2
+    return 1
   fi
-  CONTAINER_APP_ROOT="${demo_app_root}" \
-    python3 "${deadline_runner}" --seconds 30 --grace-seconds 5 -- \
-      "${container_binary}" system stop || true
-fi
+  while read -r _ _ label; do
+    if [[ "${label}" == com.apple.container.* ]]; then
+      if ! [[ "${label}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        printf 'refusing unsafe Current demo launch-agent label: %s\n' \
+          "${label}" >&2
+        return 2
+      fi
+      if ! "${launchctl_bin}" print "${user_domain}/${label}" \
+          >"${service_state}" 2>/dev/null; then
+        printf 'cannot inspect Current demo launch agent: %s\n' \
+          "${label}" >&2
+        return 2
+      fi
+      loaded_plist="$(awk '$1 == "path" && $2 == "=" { print $3; exit }' \
+        "${service_state}")"
+      case "${loaded_plist}" in
+        "${demo_app_root}"/*)
+          labels+=("${label}")
+          ;;
+        *)
+          printf 'refusing to boot out unrelated Container launch agent at %s\n' \
+            "${loaded_plist:-<unknown>}" >&2
+          return 2
+          ;;
+      esac
+    fi
+  done <<<"${services}"
+
+  for label in "${labels[@]}"; do
+    # A parent service may have removed a child between the snapshot and this
+    # loop. Revalidate every survivor immediately before mutation and accept a
+    # service that is already absent.
+    if ! "${launchctl_bin}" print "${user_domain}/${label}" \
+        >"${service_state}" 2>/dev/null; then
+      continue
+    fi
+    loaded_plist="$(awk '$1 == "path" && $2 == "=" { print $3; exit }' \
+      "${service_state}")"
+    case "${loaded_plist}" in
+      "${demo_app_root}"/*)
+        "${launchctl_bin}" bootout "${user_domain}/${label}"
+        ;;
+      *)
+        printf 'refusing to boot out replaced Container launch agent at %s\n' \
+          "${loaded_plist:-<unknown>}" >&2
+        return 2
+        ;;
+    esac
+  done
+}
+
+# The Compose engine is not launchd-managed. Recover it and any other
+# demo-root executable with bounded TERM/KILL escalation after all verified
+# demo launch agents have been booted out.
+stop_demo_owned_processes() {
+  local attempt=0
+  local process_id=""
+  local process_uid=""
+  local executable=""
+  local snapshot=""
+  local -a process_ids=()
+
+  if ! snapshot="$("${ps_bin}" -axo pid=,uid=,command=)"; then
+    printf 'failed to inspect Current demo processes with %s\n' \
+      "${ps_bin}" >&2
+    return 1
+  fi
+  while read -r process_id process_uid executable _; do
+    case "${executable}" in
+      "${demo_session_root}"/*)
+        if ! [[ "${process_id}" =~ ^[1-9][0-9]*$ ]] ||
+           [[ "${process_uid}" != "$(id -u)" ]]; then
+          printf 'refusing unsafe Current demo process: pid=%s uid=%s executable=%s\n' \
+            "${process_id:-missing}" "${process_uid:-missing}" \
+            "${executable:-missing}" >&2
+          return 2
+        fi
+        process_ids+=("${process_id}")
+        ;;
+    esac
+  done <<<"${snapshot}"
+
+  if ((${#process_ids[@]} == 0)); then
+    return 0
+  fi
+  "${kill_bin}" -TERM "${process_ids[@]}" 2>/dev/null || true
+  for ((attempt = 1; attempt <= 10; attempt++)); do
+    local -a remaining=()
+    for process_id in "${process_ids[@]}"; do
+      if "${kill_bin}" -0 "${process_id}" 2>/dev/null; then
+        remaining+=("${process_id}")
+      fi
+    done
+    process_ids=("${remaining[@]}")
+    ((${#process_ids[@]} == 0)) && return 0
+    sleep 0.1
+  done
+  "${kill_bin}" -KILL "${process_ids[@]}" 2>/dev/null || true
+}
 
 if demo_service_is_loaded; then
-  "${launchctl_bin}" bootout "${user_domain}/${service_label}"
+  if [[ "${skip_graceful_stop}" == "false" ]]; then
+    if [[ ! -x "${container_binary}" ]]; then
+      printf 'Current demo service is loaded but its CLI is unavailable: %s\n' \
+        "${container_binary}" >&2
+      exit 2
+    fi
+    CONTAINER_APP_ROOT="${demo_app_root}" \
+      python3 "${deadline_runner}" --seconds "${graceful_stop_seconds}" \
+        --grace-seconds 1 -- "${container_binary}" system stop || true
+  fi
 fi
+
+bootout_demo_owned_services
+stop_demo_owned_processes
 
 LAUNCHCTL_BIN="${launchctl_bin}" bash "${stop_waiter}"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1760,9 +1760,8 @@ github_cli() {{
             '--current-asset "container-compose-demo-current.gif"', package
         )
 
-        self.assertIn("- Prebuilt Binaries", workflow)
-        self.assertIn('"${WORKFLOW_RUN_DISPLAY_TITLE}" != "Prebuilt Binaries · main"', workflow)
-        self.assertIn("Skipping non-Current package workflow", workflow)
+        self.assertNotIn("workflow_run:", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
         self.assertIn("group: container-compose-current-demo", workflow)
         self.assertIn("cancel-in-progress: false", workflow)
         self.assertIn(
@@ -1777,6 +1776,7 @@ github_cli() {{
         self.assertIn("stop-current-demo-runtime.sh", workflow)
         self.assertIn("trap 'exit 143' TERM", workflow)
         self.assertIn("trap '' HUP INT QUIT TERM", workflow)
+        self.assertIn("CONTAINER_DEMO_SKIP_GRACEFUL_STOP=true", workflow)
         self.assertLess(
             workflow.index("trap 'exit 143' TERM"),
             workflow.index(

--- a/Tools/release/test_stop_current_demo_runtime.py
+++ b/Tools/release/test_stop_current_demo_runtime.py
@@ -19,6 +19,7 @@
 
 import os
 import signal
+import shutil
 import subprocess
 import tempfile
 import time
@@ -74,6 +75,9 @@ case "$1" in
     ;;
   list)
     printf 'PID Status Label\n'
+    if [[ -f "${SERVICE_STATE}" ]]; then
+      printf '123 0 com.apple.container.apiserver\n'
+    fi
     ;;
   *)
     exit 114
@@ -161,7 +165,14 @@ elif [[ "$1" == bootout ]]; then
   printf '%s\n' "$2" > "${BOOTOUT_LOG}"
   rm -f "${SERVICE_STATE}"
 else
-  exit 114
+  if [[ "$1" == list ]]; then
+    printf 'PID Status Label\n'
+    if [[ -f "${SERVICE_STATE}" ]]; then
+      printf '123 0 com.apple.container.apiserver\n'
+    fi
+  else
+    exit 114
+  fi
 fi
 """,
             encoding="utf-8",
@@ -189,6 +200,99 @@ fi
         self.assertEqual(process.returncode, 0, stdout + stderr)
         self.assertTrue(bootout_log.is_file())
         self.assertFalse(state.exists())
+
+    def test_forced_cleanup_skips_cli_and_removes_all_demo_services(self) -> None:
+        temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary_directory.cleanup)
+        root = Path(temporary_directory.name)
+        session = root / "session"
+        app_root = session / "app"
+        container = session / "install" / "bin" / "container"
+        marker = session / ".container-compose-current-demo-root"
+        launchctl = root / "launchctl"
+        waiter = root / "waiter"
+        service_directory = root / "services"
+        stop_log = root / "stop.log"
+        bootout_log = root / "bootout.log"
+
+        container.parent.mkdir(parents=True)
+        app_root.mkdir(parents=True)
+        service_directory.mkdir()
+        session.chmod(0o700)
+        marker.write_text("container-compose-current-demo-v1\n", encoding="utf-8")
+        worker = session / "install" / "bin" / "demo-worker"
+        shutil.copyfile("/bin/sleep", worker)
+        worker.chmod(0o755)
+        worker_process = subprocess.Popen([str(worker), "30"])
+        self.addCleanup(
+            lambda: worker_process.kill() if worker_process.poll() is None else None
+        )
+        services = {
+            "com.apple.container.apiserver": app_root
+            / "apiserver"
+            / "apiserver.plist",
+            "com.apple.container.container-runtime-linux.demo": app_root
+            / "containers"
+            / "demo"
+            / "service.plist",
+        }
+        for label, plist in services.items():
+            (service_directory / label).write_text(str(plist), encoding="utf-8")
+        launchctl.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+argument="${2:-}"
+label="${argument##*/}"
+case "$1" in
+  print)
+    [[ -f "${SERVICE_DIRECTORY}/${label}" ]] || exit 113
+    printf 'path = %s\n' "$(cat "${SERVICE_DIRECTORY}/${label}")"
+    ;;
+  bootout)
+    printf '%s\n' "$2" >> "${BOOTOUT_LOG}"
+    rm -f "${SERVICE_DIRECTORY}/${label}"
+    ;;
+  list)
+    printf 'PID Status Label\n'
+    for service in "${SERVICE_DIRECTORY}"/*; do
+      [[ -f "${service}" ]] || continue
+      printf '123 0 %s\n' "${service##*/}"
+    done
+    ;;
+  *)
+    exit 114
+    ;;
+esac
+""",
+            encoding="utf-8",
+        )
+        waiter.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        launchctl.chmod(0o755)
+        waiter.chmod(0o755)
+        result = subprocess.run(
+            ["bash", str(SCRIPT), str(session), str(container)],
+            capture_output=True,
+            check=False,
+            env=os.environ
+            | {
+                "BOOTOUT_LOG": str(bootout_log),
+                "CONTAINER_DEMO_LAUNCHCTL": str(launchctl),
+                "CONTAINER_DEMO_SKIP_GRACEFUL_STOP": "true",
+                "CONTAINER_SYSTEM_STOP_WAITER": str(waiter),
+                "SERVICE_DIRECTORY": str(service_directory),
+                "STOP_LOG": str(stop_log),
+            },
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(stop_log.exists())
+        self.assertEqual(list(service_directory.iterdir()), [])
+        worker_process.wait(timeout=2)
+        self.assertIsNotNone(worker_process.returncode)
+        booted_out = bootout_log.read_text(encoding="utf-8")
+        for label in services:
+            self.assertIn(label, booted_out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- make the optional VHS Current Demo manual-only so Current packaging no longer blocks stable release work
- use immediate, marker-verified cancellation recovery instead of a graceful stop that can outlive the runner cancellation grace
- validate every `com.apple.container.*` launch agent before mutation, boot out only demo-owned services, and terminate remaining demo-root executables with bounded TERM/KILL escalation

## Evidence

- Reproduced after cancelling [Current Demo run 33842339422](https://github.com/stephenlclarke/container-compose/actions/runs/33842339422): eight demo-owned launch agents and the direct Compose engine survived and caused the stable gate to fail closed.
- The repaired helper removed the preserved orphan in 2.4 seconds; no `com.apple.container.*` launch agent or demo-root runtime process remained.
- Focused regression: 5 tests passed, including a cancellation path with two launch agents, a missing CLI, and a live direct demo-root process.
- `bash -n`, ShellCheck, Actionlint, license checks, and `git diff --check` pass.

Closes #467.