### PR TITLE
[BUILD] Stabilize release runtime privacy identity

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -204,7 +204,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         ]
         staging = 'staged_containerization_path="${runtime_parent}/containerization"'
         container_staging = 'staged_container_path="${runtime_parent}/container"'
-        stage_call = "stage_local_validation_checkout"
+        stage_call = "stage_stable_local_validation_checkout"
         init_source = 'CONTAINERIZATION_INIT_SOURCE_PATH="${containerization_path}"'
         stack_source = '"CONTAINERIZATION_STACK_REPO=${containerization_path}"'
 
@@ -215,13 +215,23 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn(staging, local_gate)
         self.assertIn(container_staging, local_gate)
         self.assertIn(stage_call, local_gate)
-        self.assertIn("publish_local_validation_checkout_alias", local_gate)
+        self.assertNotIn("publish_local_validation_checkout_alias", local_gate)
         self.assertIn(
             "container-compose-release-containerization-$(id -u)", local_gate
         )
         self.assertIn("container-compose-release-container-$(id -u)", local_gate)
+        self.assertIn('"${stable_container_path}" container', local_gate)
         self.assertIn(
-            '"${container_path}" "${staged_container_path}" container', local_gate
+            'container_validation_namespace="io.github.container.stack-validation.',
+            local_gate,
+        )
+        self.assertIn(
+            "record_stable_container_validation_runtime_identity", local_gate
+        )
+        self.assertIn("recover_stable_container_validation_runtime", self.script)
+        self.assertLess(
+            local_gate.index("record_stable_container_validation_runtime_identity"),
+            local_gate.index("run_local_release_gate_command env"),
         )
         self.assertIn(init_source, local_gate)
         self.assertIn(stack_source, local_gate)
@@ -465,6 +475,365 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 source_hawkeye.read_bytes(),
             )
             self.assertEqual(self.git(staged, "remote"), "")
+
+    def test_stable_container_checkout_has_one_physical_path_and_marker_cleanup(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="c.stable-test.") as directory:
+            root = Path(directory)
+            source = root / "source"
+            temporary = root / "container"
+            stable = Path("/tmp") / (
+                f"container-compose-release-container-{os.getuid()}-"
+                f"test-{os.getpid()}-{time.time_ns()}"
+            )
+            source.mkdir()
+            self.addCleanup(
+                lambda: subprocess.run(
+                    ["find", str(stable), "-depth", "-delete"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if stable.exists()
+                else None
+            )
+            self.run_command("git", "-C", str(source), "init", "--quiet")
+            (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            self.run_command("git", "-C", str(source), "add", "tracked.txt")
+            self.run_command(
+                "git",
+                "-C",
+                str(source),
+                "-c",
+                "user.name=Release Test",
+                "-c",
+                "user.email=release-test@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "fixture",
+            )
+            (source / ".local" / "bin").mkdir(parents=True)
+            hawkeye = source / ".local" / "bin" / "hawkeye"
+            hawkeye.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            hawkeye.chmod(0o755)
+
+            staged = self.run_release_function(
+                root,
+                "stage_stable_local_validation_checkout "
+                f"{shlex.quote(str(source))} {shlex.quote(str(temporary))} "
+                f"{shlex.quote(str(stable))} container",
+                shell_setup="umask 0002",
+            )
+            self.assertEqual(staged.returncode, 0, staged.stderr)
+            self.assertEqual(staged.stdout.strip(), str(stable))
+            self.assertTrue(stable.is_dir())
+            self.assertFalse(stable.is_symlink())
+            self.assertFalse(temporary.exists())
+            self.assertEqual(stable.stat().st_mode & 0o022, 0)
+            self.assertEqual(
+                (
+                    stable / ".container-compose-release-validation-checkout"
+                ).read_text(encoding="utf-8").strip(),
+                "container-compose stable validation checkout v1 container",
+            )
+
+            cleaned = self.run_release_function(
+                root,
+                "cleanup_stable_local_validation_checkout "
+                f"{shlex.quote(str(stable))} container",
+            )
+            self.assertEqual(cleaned.returncode, 0, cleaned.stderr)
+            self.assertFalse(stable.exists())
+
+    def test_stable_checkout_cleanup_retains_a_live_executable_tree(self) -> None:
+        stable = Path("/tmp") / (
+            f"container-compose-release-container-{os.getuid()}-"
+            f"live-test-{os.getpid()}-{time.time_ns()}"
+        )
+        stable.mkdir()
+        self.addCleanup(
+            lambda: subprocess.run(
+                ["find", str(stable), "-depth", "-delete"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if stable.exists()
+            else None
+        )
+        (stable / ".container-compose-release-validation-checkout").write_text(
+            "container-compose stable validation checkout v1 container\n",
+            encoding="utf-8",
+        )
+        sleeper = stable / "runtime-sleeper"
+        sleeper.symlink_to("/bin/sleep")
+        process = subprocess.Popen([str(sleeper), "30"])
+        self.assertIsNone(process.poll())
+        self.addCleanup(lambda: process.kill() if process.poll() is None else None)
+        try:
+            retained = self.run_release_function(
+                Path("/tmp"),
+                "if cleanup_stable_local_validation_checkout "
+                f"{shlex.quote(str(stable))} container; then exit 99; fi; "
+                f"test -d {shlex.quote(str(stable))}",
+            )
+            self.assertEqual(retained.returncode, 0, retained.stderr)
+            self.assertIn("active processes", retained.stderr)
+            self.assertIn(str(process.pid), retained.stderr)
+        finally:
+            process.terminate()
+            process.wait(timeout=5)
+
+        cleaned = self.run_release_function(
+            Path("/tmp"),
+            "cleanup_stable_local_validation_checkout "
+            f"{shlex.quote(str(stable))} container",
+        )
+        self.assertEqual(cleaned.returncode, 0, cleaned.stderr)
+        self.assertFalse(stable.exists())
+
+    def test_retained_recovery_rejects_unsafe_ownership_before_execution(self) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="c.untrusted.") as directory:
+            root = Path(directory)
+            stable = Path("/tmp") / (
+                f"container-compose-release-container-{os.getuid()}-"
+                f"untrusted-test-{os.getpid()}-{time.time_ns()}"
+            )
+            cli = stable / "bin" / "container"
+            executed = root / "executed"
+            cli.parent.mkdir(parents=True)
+            self.addCleanup(
+                lambda: subprocess.run(
+                    ["find", str(stable), "-depth", "-delete"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if stable.exists()
+                else None
+            )
+            cli.write_text(
+                f"#!/usr/bin/env bash\ntouch {shlex.quote(str(executed))}\n",
+                encoding="utf-8",
+            )
+            cli.chmod(0o755)
+            (stable / ".container-compose-release-validation-runtime").write_text(
+                f"app_root={root}/i/stack-release-app-root\n"
+                "namespace=io.github.container.stack-validation.0123456789ab\n",
+                encoding="utf-8",
+            )
+            (stable / ".container-compose-release-validation-checkout").write_text(
+                "container-compose stable validation checkout v1 container\n",
+                encoding="utf-8",
+            )
+            stable.chmod(0o777)
+
+            rejected = self.run_release_function(
+                root,
+                "if recover_stable_container_validation_runtime "
+                f"{shlex.quote(str(stable))}; then exit 99; fi",
+            )
+            self.assertEqual(rejected.returncode, 0, rejected.stderr)
+            self.assertIn("unsafe stable release validation path ownership", rejected.stderr)
+            self.assertFalse(executed.exists())
+
+    def test_failed_retained_recovery_cleans_new_independent_roots(self) -> None:
+        runtime_parent = Path(
+            tempfile.mkdtemp(prefix="c.independent-cleanup.", dir="/tmp")
+        )
+        candidate_root = Path(
+            tempfile.mkdtemp(
+                prefix="container-compose-runtime-candidate.independent-cleanup.",
+                dir="/tmp",
+            )
+        )
+        stable = Path("/tmp") / (
+            f"container-compose-release-container-{os.getuid()}-"
+            f"independent-test-{os.getpid()}-{time.time_ns()}"
+        )
+        for path in (runtime_parent, candidate_root, stable):
+            self.addCleanup(
+                lambda cleanup_path=path: subprocess.run(
+                    ["find", str(cleanup_path), "-depth", "-delete"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if cleanup_path.exists()
+                else None
+            )
+        (runtime_parent / ".container-compose-release-runtime-parent").write_text(
+            "container-compose release runtime parent v1\n", encoding="utf-8"
+        )
+        runtime_app_root = runtime_parent / "app"
+        runtime_app_root.mkdir()
+        (candidate_root / ".container-compose-runtime-candidate-run").write_text(
+            "container-compose runtime candidate run v1 fixture digest\n",
+            encoding="utf-8",
+        )
+        candidate_cli = candidate_root / "bin" / "container"
+        candidate_cli.parent.mkdir()
+        candidate_cli.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        candidate_cli.chmod(0o755)
+        stable.mkdir()
+        (stable / ".container-compose-release-validation-checkout").write_text(
+            "container-compose stable validation checkout v1 container\n",
+            encoding="utf-8",
+        )
+        sleeper = stable / "runtime-sleeper"
+        sleeper.symlink_to("/bin/sleep")
+        process = subprocess.Popen([str(sleeper), "30"])
+        self.addCleanup(lambda: process.kill() if process.poll() is None else None)
+        try:
+            cleaned = self.run_release_function(
+                Path("/tmp"),
+                "if cleanup_local_release_gate_resources "
+                f"{shlex.quote(str(candidate_cli))} "
+                f"{shlex.quote(str(runtime_parent))} "
+                f"{shlex.quote(str(runtime_app_root))} "
+                "io.github.stephenlclarke.container-compose.runtime.independent "
+                f"'' {shlex.quote(str(stable))} '' ''; then exit 99; fi; "
+                f"test ! -e {shlex.quote(str(runtime_parent))}; "
+                f"test ! -e {shlex.quote(str(candidate_root))}; "
+                f"test -d {shlex.quote(str(stable))}",
+                shell_setup=(
+                    f"CONTAINER_RUNTIME_CANDIDATE_ROOT={shlex.quote(str(candidate_root))}"
+                ),
+            )
+            self.assertEqual(cleaned.returncode, 0, cleaned.stderr)
+            self.assertIn("active processes", cleaned.stderr)
+        finally:
+            process.terminate()
+            process.wait(timeout=5)
+
+    def test_nested_container_validation_namespace_is_stopped_exactly(self) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="c.nested-stop.") as directory:
+            root = Path(directory)
+            stable = Path("/tmp") / (
+                f"container-compose-release-container-{os.getuid()}-"
+                f"stop-test-{os.getpid()}-{time.time_ns()}"
+            )
+            cli = stable / "bin" / "container"
+            stop_log = root / "stop.log"
+            launchctl = root / "launchctl"
+            cli.parent.mkdir(parents=True)
+            self.addCleanup(
+                lambda: subprocess.run(
+                    ["find", str(stable), "-depth", "-delete"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if stable.exists()
+                else None
+            )
+            cli.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                'printf "%s|%s|%s\\n" "$CONTAINER_APP_ROOT" '
+                '"$CONTAINER_SERVICE_NAMESPACE" "$*" >"$STOP_LOG"\n',
+                encoding="utf-8",
+            )
+            cli.chmod(0o755)
+            launchctl.write_text(
+                "#!/usr/bin/env bash\n"
+                'case "${1:-}" in\n'
+                "  managername) printf 'Aqua\\n' ;;\n"
+                "  list) exit 0 ;;\n"
+                "  *) exit 64 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+            app_root = root / "i" / "stack-release-app-root"
+            namespace = "io.github.container.stack-validation.0123456789ab"
+
+            stopped = self.run_release_function(
+                root,
+                "stop_stable_container_validation_runtime "
+                f"{shlex.quote(str(stable))} {shlex.quote(str(app_root))} "
+                f"{shlex.quote(namespace)}",
+                shell_setup=f"export STOP_LOG={shlex.quote(str(stop_log))}",
+                environment_overrides={
+                    "CONTAINER_STACK_RELEASE_LAUNCHCTL": str(launchctl)
+                },
+            )
+            self.assertEqual(stopped.returncode, 0, stopped.stderr)
+            self.assertEqual(
+                stop_log.read_text(encoding="utf-8").strip(),
+                f"{app_root}|{namespace}|system stop",
+            )
+
+    def test_failed_nested_stop_boots_out_only_the_exact_namespace(self) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="c.nested-recover.") as directory:
+            root = Path(directory)
+            stable = Path("/tmp") / (
+                f"container-compose-release-container-{os.getuid()}-"
+                f"recover-test-{os.getpid()}-{time.time_ns()}"
+            )
+            cli = stable / "bin" / "container"
+            launchctl = root / "launchctl"
+            launchctl_log = root / "launchctl.log"
+            cli.parent.mkdir(parents=True)
+            self.addCleanup(
+                lambda: subprocess.run(
+                    ["find", str(stable), "-depth", "-delete"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if stable.exists()
+                else None
+            )
+            cli.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+            cli.chmod(0o755)
+            namespace = "io.github.container.stack-validation.0123456789ab"
+            launchctl.write_text(
+                "#!/usr/bin/env bash\n"
+                "set -euo pipefail\n"
+                'case "${1:-}" in\n'
+                "  managername) printf 'Aqua\\n' ;;\n"
+                "  list)\n"
+                f"    printf -- '-\\t0\\t{namespace}.apiserver\\n'\n"
+                "    printf -- '-\\t0\\tcom.apple.container.apiserver\\n'\n"
+                "    ;;\n"
+                '  bootout) printf "%s\\n" "$2" >>"$LAUNCHCTL_LOG" ;;\n'
+                "  *) exit 64 ;;\n"
+                "esac\n",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+            app_root = root / "i" / "stack-release-app-root"
+
+            environment = self.non_interactive_environment()
+            environment["CONTAINER_STACK_RELEASE_LAUNCHCTL"] = str(launchctl)
+            environment["LAUNCHCTL_LOG"] = str(launchctl_log)
+            recovered = subprocess.run(
+                [
+                    "/bin/bash",
+                    "-c",
+                    "set -euo pipefail\n"
+                    "export CONTAINER_STACK_RELEASE_LIBRARY=1\n"
+                    f"source {shlex.quote(str(SCRIPT))}\n"
+                    "stop_stable_container_validation_runtime "
+                    f"{shlex.quote(str(stable))} {shlex.quote(str(app_root))} "
+                    f"{shlex.quote(namespace)}",
+                ],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                check=False,
+                env=environment,
+            )
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            self.assertEqual(
+                launchctl_log.read_text(encoding="utf-8").strip(),
+                f"gui/{os.getuid()}/{namespace}.apiserver",
+            )
 
     def test_release_helper_retains_only_its_unpublished_candidate_before_readiness(self) -> None:
         recovery = self.script[
@@ -7106,6 +7475,7 @@ gh() {
         function_call: str,
         shell_setup: str | None = None,
         shell: str = "bash",
+        environment_overrides: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         lines = [
             "set -euo pipefail",
@@ -7121,6 +7491,8 @@ gh() {
         lines.append(function_call)
         command = "\n".join(lines)
         environment = self.non_interactive_environment()
+        if environment_overrides is not None:
+            environment.update(environment_overrides)
         return subprocess.run(
             [shell, "-c", command],
             capture_output=True,

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -976,6 +976,162 @@ stage_local_validation_checkout() {
   printf '%s\n' "${staged_path}"
 }
 
+# Move one freshly verified checkout to a stable physical system-volume path.
+# macOS Local Network privacy decisions include the executable's canonical path,
+# so a symlink whose target changes on every release still creates a new client.
+stage_stable_local_validation_checkout() {
+  local source_path="$1"
+  local temporary_path="$2"
+  local stable_path="$3"
+  local checkout_kind="${4:-containerization}"
+  local marker_value="container-compose stable validation checkout v1 ${checkout_kind}"
+  local legacy_target=""
+
+  case "${checkout_kind}" in
+    container | containerization) ;;
+    *)
+      printf 'unsupported stable release validation checkout kind: %s\n' \
+        "${checkout_kind:-unset}" >&2
+      return 2
+      ;;
+  esac
+  if [[ ! "${stable_path}" =~ ^(/private)?/tmp/container-compose-release-${checkout_kind}-[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+    printf 'stable release validation checkout path is invalid: %s\n' \
+      "${stable_path:-unset}" >&2
+    return 2
+  fi
+
+  # A previous implementation published this name as a symlink. Remove only
+  # that known legacy shape before replacing it with the physical checkout.
+  if [[ -L "${stable_path}" ]]; then
+    if ! legacy_target="$(readlink "${stable_path}")" || \
+      ! cleanup_local_validation_checkout_alias "${stable_path}" \
+        "${legacy_target}" "${checkout_kind}"; then
+      return 1
+    fi
+  fi
+  if [[ -e "${stable_path}" && "${checkout_kind}" == "container" ]] && \
+    ! recover_stable_container_validation_runtime "${stable_path}"; then
+    return 1
+  fi
+  if [[ -e "${stable_path}" ]] && \
+    ! cleanup_stable_local_validation_checkout "${stable_path}" \
+      "${checkout_kind}"; then
+    return 1
+  fi
+
+  if ! (
+    umask 077
+    stage_local_validation_checkout "${source_path}" "${temporary_path}" \
+      "${checkout_kind}" >/dev/null
+    printf '%s\n' "${marker_value}" \
+      >"${temporary_path}/.container-compose-release-validation-checkout"
+  ); then
+    printf 'failed to stage and privately mark stable release validation checkout: %s\n' \
+      "${temporary_path}" >&2
+    return 1
+  fi
+  if ! mv "${temporary_path}" "${stable_path}"; then
+    printf 'failed to publish stable release validation checkout: %s\n' \
+      "${stable_path}" >&2
+    return 1
+  fi
+  printf '%s\n' "${stable_path}"
+}
+
+# Print PIDs whose executable command begins inside one stable checkout.
+stable_local_validation_checkout_processes() {
+  local checkout_path="$1"
+  local canonical_path
+
+  canonical_path="$(cd "$(dirname "${checkout_path}")" && pwd -P)/$(basename "${checkout_path}")"
+  "${RELEASE_PS}" -axo pid=,command= | /usr/bin/awk \
+    -v supplied="${checkout_path}/" -v canonical="${canonical_path}/" '
+      {
+        pid = $1
+        $1 = ""
+        sub(/^[[:space:]]+/, "")
+        if (index($0, supplied) == 1 || index($0, canonical) == 1) {
+          print pid
+        }
+      }
+    '
+}
+
+# Delete only an owned stable checkout, and never remove its executable tree
+# while a launchd-owned process still refers to it.
+stable_validation_path_has_safe_ownership() {
+  local path="$1"
+  local owner_uid="" mode=""
+
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    owner_uid="$(/usr/bin/stat -f '%u' "${path}" 2>/dev/null || true)"
+    mode="$(/usr/bin/stat -f '%Lp' "${path}" 2>/dev/null || true)"
+  else
+    owner_uid="$(stat -c '%u' "${path}" 2>/dev/null || true)"
+    mode="$(stat -c '%a' "${path}" 2>/dev/null || true)"
+  fi
+  if [[ "${owner_uid}" != "$(id -u)" || ! "${mode}" =~ ^[0-7]{3,4}$ ]] || \
+    (((8#${mode} & 0022) != 0)); then
+    printf 'unsafe stable release validation path ownership or mode (uid=%s mode=%s): %s\n' \
+      "${owner_uid:-unknown}" "${mode:-unknown}" "${path}" >&2
+    return 1
+  fi
+}
+
+validate_stable_local_validation_checkout() {
+  local stable_path="$1"
+  local checkout_kind="${2:-containerization}"
+  local marker marker_value=""
+
+  case "${checkout_kind}" in
+    container | containerization) ;;
+    *)
+      printf 'unsupported stable release validation checkout kind: %s\n' \
+        "${checkout_kind:-unset}" >&2
+      return 2
+      ;;
+  esac
+  if [[ ! "${stable_path}" =~ ^(/private)?/tmp/container-compose-release-${checkout_kind}-[0-9]+(-[A-Za-z0-9.-]+)?$ ]] || \
+    [[ -L "${stable_path}" ]]; then
+    printf 'refusing to remove an unexpected stable release validation checkout: %s\n' \
+      "${stable_path}" >&2
+    return 1
+  fi
+  [[ -e "${stable_path}" ]] || return 0
+  marker="${stable_path}/.container-compose-release-validation-checkout"
+  if [[ -f "${marker}" && ! -L "${marker}" ]]; then
+    IFS= read -r marker_value <"${marker}" || true
+  fi
+  if [[ "${marker_value}" != "container-compose stable validation checkout v1 ${checkout_kind}" ]]; then
+    printf 'refusing to remove an unmarked stable release validation checkout: %s\n' \
+      "${stable_path}" >&2
+    return 1
+  fi
+  stable_validation_path_has_safe_ownership "${stable_path}" || return 1
+  stable_validation_path_has_safe_ownership "${marker}" || return 1
+}
+
+cleanup_stable_local_validation_checkout() {
+  local stable_path="$1"
+  local checkout_kind="${2:-containerization}"
+  local active_pids=""
+
+  [[ -n "${stable_path}" ]] || return 0
+  [[ -e "${stable_path}" ]] || return 0
+  validate_stable_local_validation_checkout "${stable_path}" \
+    "${checkout_kind}" || return 1
+  active_pids="$(stable_local_validation_checkout_processes "${stable_path}")"
+  if [[ -n "${active_pids}" ]]; then
+    printf 'retaining stable release validation checkout with active processes (%s): %s\n' \
+      "$(tr '\n' ' ' <<<"${active_pids}" | sed 's/[[:space:]]*$//')" \
+      "${stable_path}" >&2
+    return 1
+  fi
+  chmod -R u+w "${stable_path}"
+  find "${stable_path}" -depth -delete
+}
+
 # Print the builder image repository, tag, and digest compiled by container.
 container_builder_image_metadata() {
   local package
@@ -1429,19 +1585,201 @@ cleanup_local_release_gate_resources() {
   local runtime_parent="$2"
   local runtime_app_root="$3"
   local runtime_service_namespace="$4"
-  local staged_containerization_alias="${5:-}"
-  local staged_containerization_path="${6:-}"
-  local staged_container_alias="${7:-}"
-  local staged_container_path="${8:-}"
+  local stable_containerization_path="${5:-}"
+  local stable_container_path="${6:-}"
+  local container_validation_app_root="${7:-}"
+  local container_validation_namespace="${8:-}"
+  local cleanup_status=0 nested_stop_failed=0 stable_container_cleanup_failed=0
 
   stop_release_runtime_candidate "${container_binary}" "${runtime_app_root}" \
     "${runtime_service_namespace}" || return 1
-  cleanup_local_validation_checkout_alias "${staged_containerization_alias}" \
-    "${staged_containerization_path}" || return 1
-  cleanup_local_validation_checkout_alias "${staged_container_alias}" \
-    "${staged_container_path}" container || return 1
-  cleanup_release_runtime_parent "${runtime_parent}" || return 1
-  cleanup_container_runtime_candidate
+  if [[ -n "${container_validation_app_root}" || \
+    -n "${container_validation_namespace}" ]]; then
+    if [[ -z "${container_validation_app_root}" || \
+      -z "${container_validation_namespace}" ]] || \
+      ! stop_stable_container_validation_runtime "${stable_container_path}" \
+        "${container_validation_app_root}" "${container_validation_namespace}"; then
+      cleanup_status=1
+      nested_stop_failed=1
+    fi
+  fi
+  cleanup_stable_local_validation_checkout "${stable_containerization_path}" || \
+    cleanup_status=1
+  if ((nested_stop_failed == 0)); then
+    if ! cleanup_stable_local_validation_checkout "${stable_container_path}" \
+      container; then
+      cleanup_status=1
+      stable_container_cleanup_failed=1
+    fi
+  fi
+  # With no current nested identity, a retained stable checkout belongs to an
+  # earlier failed gate; the newly allocated parent is independent and safe to
+  # remove. A current failed stop retains its matching app root instead.
+  if [[ -z "${container_validation_app_root}" && \
+    -z "${container_validation_namespace}" ]] || \
+    ((nested_stop_failed == 0 && stable_container_cleanup_failed == 0)); then
+    cleanup_release_runtime_parent "${runtime_parent}" || cleanup_status=1
+  fi
+  cleanup_container_runtime_candidate || cleanup_status=1
+  return "${cleanup_status}"
+}
+
+# Stop Container's nested integration namespace with the exact CLI that
+# created it. Missing build output means integration never started.
+stop_stable_container_validation_runtime() {
+  local stable_container_path="$1"
+  local app_root="$2"
+  local service_namespace="$3"
+  local cli="${stable_container_path}/bin/container"
+  local stop_status=0
+
+  [[ -n "${stable_container_path}" ]] || return 0
+  if [[ ! -x "${cli}" ]]; then
+    return 0
+  fi
+  if [[ ! "${stable_container_path}" =~ ^(/private)?/tmp/container-compose-release-container-[0-9]+(-[A-Za-z0-9.-]+)?$ ]] || \
+    [[ ! "${app_root}" =~ ^(/private)?/tmp/c\.[^/]+/i/stack-release-app-root$ ]] || \
+    [[ ! "${service_namespace}" =~ ^io\.github\.container\.stack-validation\.[A-Za-z0-9]+$ ]]; then
+    printf 'refusing to stop an unexpected nested Container validation runtime: %s\n' \
+      "${stable_container_path}" >&2
+    return 1
+  fi
+  if env CONTAINER_APP_ROOT="${app_root}" \
+    CONTAINER_SERVICE_NAMESPACE="${service_namespace}" \
+    "${RELEASE_COMMAND_DEADLINE_RUNNER}" \
+      --seconds "${CANDIDATE_STOP_TIMEOUT_SECONDS}" --grace-seconds 0 -- \
+      "${cli}" system stop; then
+    stop_status=0
+  else
+    stop_status="$?"
+  fi
+
+  # SystemStop implementations predating the upstream fix can skip the
+  # APIServer bootout when its health check fails. Constrain the recovery to
+  # this exact namespace and then prove that no checkout executable remains.
+  if force_bootout_stable_container_validation_namespace \
+    "${service_namespace}" "${stable_container_path}"; then
+    return 0
+  fi
+  if [[ "${stop_status}" -eq 124 ]]; then
+    printf 'timed out stopping nested Container validation namespace: %s\n' \
+      "${service_namespace}" >&2
+  elif [[ "${stop_status}" -ne 0 ]]; then
+    printf 'failed to stop nested Container validation namespace: %s\n' \
+      "${service_namespace}" >&2
+  fi
+  return 1
+}
+
+# Boot out only launchd labels owned by one validated nested namespace. This is
+# the bounded recovery path after the exact CLI has attempted graceful stop.
+force_bootout_stable_container_validation_namespace() {
+  local service_namespace="$1"
+  local stable_container_path="$2"
+  local manager domain label active_pids="" launchctl_output=""
+  local -a labels=()
+
+  if [[ ! "${service_namespace}" =~ ^io\.github\.container\.stack-validation\.[A-Za-z0-9]+$ ]] || \
+    [[ ! "${stable_container_path}" =~ ^(/private)?/tmp/container-compose-release-container-[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+    printf 'refusing launchd recovery for an unexpected Container validation namespace: %s\n' \
+      "${service_namespace}" >&2
+    return 1
+  fi
+  manager="$("${RELEASE_LAUNCHCTL}" managername 2>/dev/null || true)"
+  case "${manager}" in
+    Aqua) domain="gui/$(id -u)" ;;
+    Background) domain="user/$(id -u)" ;;
+    System) domain="system" ;;
+    *)
+      printf 'could not resolve launchd domain for Container validation cleanup: %s\n' \
+        "${manager:-unset}" >&2
+      return 1
+      ;;
+  esac
+  if ! launchctl_output="$("${RELEASE_LAUNCHCTL}" list)"; then
+    printf 'failed to enumerate launchd services for Container validation cleanup\n' >&2
+    return 1
+  fi
+  while IFS= read -r label; do
+    [[ -n "${label}" ]] && labels+=("${label}")
+  done < <(/usr/bin/awk -v prefix="${service_namespace}." \
+    'index($3, prefix) == 1 { print $3 }' <<<"${launchctl_output}")
+  for label in "${labels[@]}"; do
+    if ! "${RELEASE_COMMAND_DEADLINE_RUNNER}" \
+      --seconds "${CANDIDATE_STOP_TIMEOUT_SECONDS}" --grace-seconds 0 -- \
+      "${RELEASE_LAUNCHCTL}" bootout "${domain}/${label}"; then
+      printf 'failed to boot out nested Container validation service: %s/%s\n' \
+        "${domain}" "${label}" >&2
+      return 1
+    fi
+  done
+  for _ in {1..50}; do
+    active_pids="$(stable_local_validation_checkout_processes \
+      "${stable_container_path}")"
+    [[ -z "${active_pids}" ]] && return 0
+    sleep 0.1
+  done
+  printf 'nested Container validation processes survived exact namespace cleanup (%s): %s\n' \
+    "$(tr '\n' ' ' <<<"${active_pids}" | sed 's/[[:space:]]*$//')" \
+    "${stable_container_path}" >&2
+  return 1
+}
+
+# Persist the exact nested runtime identity before the validation command can
+# start services. An interrupted gate can then recover the retained checkout
+# without guessing its launchd namespace or application root.
+record_stable_container_validation_runtime_identity() {
+  local stable_container_path="$1"
+  local app_root="$2"
+  local service_namespace="$3"
+  local identity="${stable_container_path}/.container-compose-release-validation-runtime"
+
+  if [[ ! "${stable_container_path}" =~ ^(/private)?/tmp/container-compose-release-container-[0-9]+(-[A-Za-z0-9.-]+)?$ ]] || \
+    [[ ! "${app_root}" =~ ^(/private)?/tmp/c\.[^/]+/i/stack-release-app-root$ ]] || \
+    [[ ! "${service_namespace}" =~ ^io\.github\.container\.stack-validation\.[A-Za-z0-9]+$ ]]; then
+    printf 'refusing to record an unexpected nested Container validation identity\n' >&2
+    return 1
+  fi
+  printf 'app_root=%s\nnamespace=%s\n' "${app_root}" "${service_namespace}" \
+    >"${identity}"
+}
+
+# Recover one interrupted nested runtime before replacing its stable checkout.
+recover_stable_container_validation_runtime() {
+  local stable_container_path="$1"
+  local identity="${stable_container_path}/.container-compose-release-validation-runtime"
+  local key value app_root="" service_namespace="" runtime_parent=""
+
+  validate_stable_local_validation_checkout "${stable_container_path}" \
+    container || return 1
+  [[ -f "${identity}" && ! -L "${identity}" ]] || return 0
+  while IFS='=' read -r key value; do
+    case "${key}" in
+      app_root) app_root="${value}" ;;
+      namespace) service_namespace="${value}" ;;
+    esac
+  done <"${identity}"
+  if [[ -z "${app_root}" || -z "${service_namespace}" ]]; then
+    printf 'stable Container validation identity is incomplete: %s\n' \
+      "${identity}" >&2
+    return 1
+  fi
+  if [[ ! -d "${stable_container_path}/bin" || \
+    -L "${stable_container_path}/bin" || ! -f "${stable_container_path}/bin/container" || \
+    -L "${stable_container_path}/bin/container" ]]; then
+    printf 'stable Container validation CLI is not a trusted regular file: %s\n' \
+      "${stable_container_path}/bin/container" >&2
+    return 1
+  fi
+  stable_validation_path_has_safe_ownership "${identity}" || return 1
+  stable_validation_path_has_safe_ownership \
+    "${stable_container_path}/bin" || return 1
+  stable_validation_path_has_safe_ownership \
+    "${stable_container_path}/bin/container" || return 1
+  runtime_parent="$(dirname "$(dirname "${app_root}")")"
+  stop_stable_container_validation_runtime "${stable_container_path}" \
+    "${app_root}" "${service_namespace}" || return 1
+  cleanup_release_runtime_parent "${runtime_parent}"
 }
 
 # Delete only the fresh short runtime parent created and marked by this gate.
@@ -2552,8 +2890,8 @@ retained_stable_init_image_gate_digest() {
 # Run the full release gate locally before any source branch is promoted.
 run_local_release_gate() {
   (
-  local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive staged_container_path staged_container_alias staged_containerization_path staged_containerization_alias release_gate_path release_gate_make release_gate_tar
-  local containerization_reference required_init_references status runtime_run_id runtime_service_namespace runtime_namespace_digest candidate_sha init_image_digest_before init_image_digest_after
+  local path repository container_path containerization_path container_binary runtime_parent runtime_parent_base runtime_app_root profile_root evidence_root init_image_archive staged_init_image_archive staged_container_path staged_containerization_path stable_container_path stable_containerization_path release_gate_path release_gate_make release_gate_tar
+  local containerization_reference required_init_references status runtime_run_id runtime_service_namespace runtime_namespace_digest candidate_sha init_image_digest_before init_image_digest_after container_validation_suffix container_validation_app_root container_validation_namespace
   local -a RELEASE_QUIESCED_LABELS=()
   local -a RELEASE_QUIESCED_PLISTS=()
   local -a RELEASE_QUIESCED_ACTION_STARTED=()
@@ -2650,10 +2988,10 @@ PY
     if ! cleanup_local_release_gate_resources "${container_binary:-}" \
       "${runtime_parent:-}" "${runtime_app_root:-}" \
       "${runtime_service_namespace:-}" \
-      "${staged_containerization_alias:-}" \
-      "${staged_containerization_path:-}" \
-      "${staged_container_alias:-}" \
-      "${staged_container_path:-}"; then
+      "${stable_containerization_path:-}" \
+      "${stable_container_path:-}" \
+      "${container_validation_app_root:-}" \
+      "${container_validation_namespace:-}"; then
       cleanup_status=1
     fi
     if ! release_local_release_gate_host_state; then
@@ -2677,14 +3015,10 @@ PY
   # copy only its installed release-policy tool and already-provisioned kernel;
   # build outputs remain fresh.
   staged_containerization_path="${runtime_parent}/containerization"
-  if ! staged_containerization_path="$(stage_local_validation_checkout \
-    "${containerization_path}" "${staged_containerization_path}")"; then
-    return 1
-  fi
-  staged_containerization_alias="${runtime_parent_base}/container-compose-release-containerization-$(id -u)"
-  if ! containerization_path="$(publish_local_validation_checkout_alias \
-    "${staged_containerization_path}" \
-    "${staged_containerization_alias}")"; then
+  stable_containerization_path="${runtime_parent_base}/container-compose-release-containerization-$(id -u)"
+  if ! containerization_path="$(stage_stable_local_validation_checkout \
+    "${containerization_path}" "${staged_containerization_path}" \
+    "${stable_containerization_path}")"; then
     return 1
   fi
   # Container's integration target launches freshly built XPC services. Keep
@@ -2692,13 +3026,19 @@ PY
   # launchd can leave an ad-hoc coverage binary suspended in xpcproxy while a
   # background TCC request waits for removable-volume approval.
   staged_container_path="${runtime_parent}/container"
-  if ! staged_container_path="$(stage_local_validation_checkout \
-    "${container_path}" "${staged_container_path}" container)"; then
+  stable_container_path="${runtime_parent_base}/container-compose-release-container-$(id -u)"
+  if ! container_path="$(stage_stable_local_validation_checkout \
+    "${container_path}" "${staged_container_path}" \
+    "${stable_container_path}" container)"; then
     return 1
   fi
-  staged_container_alias="${runtime_parent_base}/container-compose-release-container-$(id -u)"
-  if ! container_path="$(publish_local_validation_checkout_alias \
-    "${staged_container_path}" "${staged_container_alias}" container)"; then
+  container_validation_suffix="$(git -C "${container_path}" rev-parse --verify HEAD \
+    | tr -cd '[:alnum:]' | cut -c1-12)"
+  container_validation_app_root="${runtime_parent}/i/stack-release-app-root"
+  container_validation_namespace="io.github.container.stack-validation.${container_validation_suffix}"
+  if ! record_stable_container_validation_runtime_identity \
+    "${stable_container_path}" "${container_validation_app_root}" \
+    "${container_validation_namespace}"; then
     return 1
   fi
   # Stage the retained init archive on the local system volume. launchd-managed
@@ -2767,14 +3107,14 @@ PY
 
   if ! cleanup_local_release_gate_resources "${container_binary}" \
     "${runtime_parent}" "${runtime_app_root}" "${runtime_service_namespace}" \
-    "${staged_containerization_alias}" "${staged_containerization_path}" \
-    "${staged_container_alias}" "${staged_container_path}"; then
+    "${stable_containerization_path}" "${stable_container_path}" \
+    "${container_validation_app_root}" "${container_validation_namespace}"; then
     status=1
   fi
-  staged_containerization_alias=""
-  staged_containerization_path=""
-  staged_container_alias=""
-  staged_container_path=""
+  stable_containerization_path=""
+  stable_container_path=""
+  container_validation_app_root=""
+  container_validation_namespace=""
   runtime_parent=""
   runtime_app_root=""
   runtime_service_namespace=""


### PR DESCRIPTION
Closes #470.

## What changed

- stage Container and Containerization validation checkouts at stable physical system-volume paths instead of symlinking random `c.*` targets
- record the exact nested app-root and launchd namespace before validation starts
- stop and, when necessary, boot out only the exact nested namespace before removing its executable tree
- retain marked roots when any process survives, and recover an interrupted retained root on the next run

## Why

macOS Local Network privacy records the canonical executable path as part of the client identity. Every random physical checkout therefore generated a new consent dialog even though the Developer ID and bundle identifier were stable. The prior cleanup could also delete the checkout while nested launchd services still referred to it.

## Focused proof

- 19 release-policy tests covering stable staging, exact cleanup, live-process retention, signal cleanup, namespace fallback, and runtime-candidate lifecycle
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `make check-licenses`
- `git diff --check`

No runtime, parity, documentation, CodeQL, or release-wide gate was run for this focused workflow correction.