### PR TITLE
fix(release): keep staged source checkout clean

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -378,6 +378,67 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "--no-dangling",
             )
 
+    def test_stable_containerization_checkout_is_marked_and_git_clean(self) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp", prefix="c.") as directory:
+            root = Path(directory)
+            source = root / "source"
+            staged = root / "containerization"
+            stable = Path("/tmp") / (
+                f"container-compose-release-containerization-{os.getuid()}-"
+                f"test-{os.getpid()}"
+            )
+            source.mkdir()
+            self.run_command("git", "-C", str(source), "init", "--quiet")
+            (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            self.run_command("git", "-C", str(source), "add", "tracked.txt")
+            self.run_command(
+                "git",
+                "-C",
+                str(source),
+                "-c",
+                "user.name=Release Test",
+                "-c",
+                "user.email=release-test@example.invalid",
+                "-c",
+                "commit.gpgsign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "fixture",
+            )
+            (source / "bin").mkdir()
+            (source / "bin" / "vmlinux-arm64").write_bytes(b"kernel")
+            (source / ".local" / "bin").mkdir(parents=True)
+            source_hawkeye = source / ".local" / "bin" / "hawkeye"
+            source_hawkeye.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            source_hawkeye.chmod(0o755)
+
+            try:
+                result = self.run_release_function(
+                    root,
+                    (
+                        "published=$(stage_stable_local_validation_checkout "
+                        f"{shlex.quote(str(source))} {shlex.quote(str(staged))} "
+                        f"{shlex.quote(str(stable))}); "
+                        f"test \"$published\" = {shlex.quote(str(stable))}; "
+                        "test -f "
+                        f"{shlex.quote(str(stable / '.container-compose-release-validation-checkout'))}; "
+                        "printf 'identity fixture\\n' >"
+                        f"{shlex.quote(str(stable / '.container-compose-release-validation-runtime'))}; "
+                        "test -z \"$(git -C "
+                        f"{shlex.quote(str(stable))} "
+                        "status --porcelain --untracked-files=all)\"; "
+                        "cleanup_stable_local_validation_checkout "
+                        f"{shlex.quote(str(stable))}"
+                    ),
+                )
+
+                self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+                self.assertFalse(stable.exists())
+            finally:
+                if stable.exists() and not stable.is_symlink():
+                    shutil.rmtree(stable)
+
     def test_local_validation_checkout_propagates_copy_failure_in_condition(
         self,
     ) -> None:

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -985,6 +985,7 @@ stage_stable_local_validation_checkout() {
   local stable_path="$3"
   local checkout_kind="${4:-containerization}"
   local marker_value="container-compose stable validation checkout v1 ${checkout_kind}"
+  local exclude_path=""
   local legacy_target="" staged_identity="" published_identity=""
 
   case "${checkout_kind}" in
@@ -1024,6 +1025,24 @@ stage_stable_local_validation_checkout() {
     umask 077
     stage_local_validation_checkout "${source_path}" "${temporary_path}" \
       "${checkout_kind}" >/dev/null
+    exclude_path="${temporary_path}/.git/info/exclude"
+    if [[ ! -f "${exclude_path}" || -L "${exclude_path}" ]]; then
+      printf 'stable release validation checkout has no trusted local exclude file: %s\n' \
+        "${exclude_path}" >&2
+      exit 1
+    fi
+    # These files are release-owned tools, artifacts, and lifecycle metadata,
+    # not source inputs. Keep them in the physical checkout for validation and
+    # recovery, but hide only their exact root-relative paths from the
+    # clean-source contract enforced by run-with-container-runtime.sh. Do not
+    # depend on the source repository retaining equivalent .gitignore rules.
+    printf '\n/%s\n/%s\n/%s\n/%s\n/%s\n' \
+      '.local/bin/hawkeye' \
+      'bin/vmlinux-*' \
+      'bin/vmlinuz-*' \
+      '.container-compose-release-validation-checkout' \
+      '.container-compose-release-validation-runtime' \
+      >>"${exclude_path}"
     printf '%s\n' "${marker_value}" \
       >"${temporary_path}/.container-compose-release-validation-checkout"
   ); then


### PR DESCRIPTION
## Summary

- keep the marker-protected physical validation checkout compatible with the runtime wrapper’s clean-source contract
- exclude only the two release-owned root metadata files through checkout-local Git metadata
- add a focused regression proving the ownership marker exists while the checkout remains Git-clean

## Release evidence

The preserved 0.14.2 release transaction stopped before testing with:

```text
containerization init source checkout must be clean before staging: /private/tmp/container-compose-release-containerization-501
```

The staged checkout is fresh. `.local` and `bin` are already ignored by Containerization; the release ownership marker was the sole untracked entry.

## Validation

- 3 focused release-staging tests pass
- Python compilation passes
- ShellCheck passes
- `git diff --check` passes

Closes #473