### PR TITLE
[Build] Yield Current packaging to an exact stable promotion

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -321,43 +321,84 @@ jobs:
                     } >> "$GITHUB_OUTPUT"
                     exit 0
                   fi
-                  current_tag_sha="$(
-                    git ls-remote --tags "${remote}" 'refs/tags/current' 'refs/tags/current^{}' \
-                      | awk '$2 == "refs/tags/current^{}" { print $1; found = 1 } END { if (!found) print "" }' \
+                  stable_candidate_tag="$(
+                    git ls-remote --tags "${remote}" \
+                      | awk -v commit="${WORKFLOW_RUN_HEAD_SHA}" '
+                        $1 == commit &&
+                          $2 ~ /^refs\/tags\/[0-9]+[.][0-9]+[.][0-9]+\^\{\}$/ {
+                          tag = $2
+                          sub(/^refs\/tags\//, "", tag)
+                          sub(/\^\{\}$/, "", tag)
+                          print tag
+                        }
+                      ' \
+                      | sort -V \
                       | tail -n 1
                   )"
-                  if [[ -z "${current_tag_sha}" ]]; then
-                    current_tag_sha="$(
-                      git ls-remote --tags --refs "${remote}" 'refs/tags/current' \
-                        | awk '{ print $1 }' \
-                        | tail -n 1
+                  stable_candidate_verified="false"
+                  if [[ -n "${stable_candidate_tag}" ]]; then
+                    stable_candidate_tag_object="$(
+                      github_authority_query "stable candidate ${stable_candidate_tag} tag ref" \
+                        api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${stable_candidate_tag}" \
+                        --jq '.object.sha'
                     )"
-                  fi
-                  current_release_exists="false"
-                  if [[ "${current_tag_sha}" == "${WORKFLOW_RUN_HEAD_SHA}" ]]; then
-                    set +e
-                    current_release_output="$(
-                      gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/current" 2>&1
+                    stable_candidate_record="$(
+                      github_authority_query "stable candidate ${stable_candidate_tag} tag object" \
+                        api "repos/${GITHUB_REPOSITORY}/git/tags/${stable_candidate_tag_object}"
                     )"
-                    current_release_status=$?
-                    set -e
-                    if (( current_release_status == 0 )); then
-                      current_release_exists="true"
-                    elif [[ "${current_release_output}" != *"HTTP 404"* ]]; then
-                      printf 'could not determine whether the current release exists:\n%s\n' \
-                        "${current_release_output}" >&2
-                      exit 1
+                    stable_candidate_verified="$(
+                      jq -r \
+                        --arg commit "${WORKFLOW_RUN_HEAD_SHA}" \
+                        '.verification.verified == true and .object.sha == $commit' \
+                        <<<"${stable_candidate_record}"
+                    )"
+                    if [[ "${stable_candidate_verified}" != "true" ]]; then
+                      printf 'Stable candidate %s is not GitHub-verified for exact main %s; Current remains eligible.\n' \
+                        "${stable_candidate_tag}" "${WORKFLOW_RUN_HEAD_SHA}"
                     fi
                   fi
-                  if [[ "${current_tag_sha}" == "${WORKFLOW_RUN_HEAD_SHA}" && "${current_release_exists}" == "true" ]]; then
-                    printf 'Skipping current package because current already points at %s.\n' \
-                      "${WORKFLOW_RUN_HEAD_SHA}"
+                  if [[ "${stable_candidate_verified}" == "true" ]]; then
+                    printf 'Skipping current package because stable candidate %s owns exact main %s.\n' \
+                      "${stable_candidate_tag}" "${WORKFLOW_RUN_HEAD_SHA}"
                   else
-                    ref_type="branch"
-                    ref_name="${WORKFLOW_RUN_HEAD_BRANCH}"
-                    checkout_ref="${WORKFLOW_RUN_HEAD_SHA}"
-                    sha="${WORKFLOW_RUN_HEAD_SHA}"
-                    publish=true
+                    current_tag_sha="$(
+                      git ls-remote --tags "${remote}" 'refs/tags/current' 'refs/tags/current^{}' \
+                        | awk '$2 == "refs/tags/current^{}" { print $1; found = 1 } END { if (!found) print "" }' \
+                        | tail -n 1
+                    )"
+                    if [[ -z "${current_tag_sha}" ]]; then
+                      current_tag_sha="$(
+                        git ls-remote --tags --refs "${remote}" 'refs/tags/current' \
+                          | awk '{ print $1 }' \
+                          | tail -n 1
+                      )"
+                    fi
+                    current_release_exists="false"
+                    if [[ "${current_tag_sha}" == "${WORKFLOW_RUN_HEAD_SHA}" ]]; then
+                      set +e
+                      current_release_output="$(
+                        gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/current" 2>&1
+                      )"
+                      current_release_status=$?
+                      set -e
+                      if (( current_release_status == 0 )); then
+                        current_release_exists="true"
+                      elif [[ "${current_release_output}" != *"HTTP 404"* ]]; then
+                        printf 'could not determine whether the current release exists:\n%s\n' \
+                          "${current_release_output}" >&2
+                        exit 1
+                      fi
+                    fi
+                    if [[ "${current_tag_sha}" == "${WORKFLOW_RUN_HEAD_SHA}" && "${current_release_exists}" == "true" ]]; then
+                      printf 'Skipping current package because current already points at %s.\n' \
+                        "${WORKFLOW_RUN_HEAD_SHA}"
+                    else
+                      ref_type="branch"
+                      ref_name="${WORKFLOW_RUN_HEAD_BRANCH}"
+                      checkout_ref="${WORKFLOW_RUN_HEAD_SHA}"
+                      sha="${WORKFLOW_RUN_HEAD_SHA}"
+                      publish=true
+                    fi
                   fi
                 fi
               elif [[ "${WORKFLOW_RUN_HEAD_BRANCH}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2671,6 +2671,39 @@ github_cli() {{
         self.assertIn("refs/tags/current^{}", workflow)
         self.assertIn('current_tag_sha="$(', workflow)
 
+    def test_current_package_yields_to_an_exact_stable_candidate(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        stable_skip = (
+            "Skipping current package because stable candidate %s owns exact main %s."
+        )
+
+        self.assertIn('stable_candidate_tag="$(', workflow)
+        self.assertIn(
+            "$2 ~ /^refs\\/tags\\/[0-9]+[.][0-9]+[.][0-9]+\\^\\{\\}$/",
+            workflow,
+        )
+        self.assertIn(
+            'api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${stable_candidate_tag}"',
+            workflow,
+        )
+        self.assertIn(
+            'api "repos/${GITHUB_REPOSITORY}/git/tags/${stable_candidate_tag_object}"',
+            workflow,
+        )
+        self.assertIn(
+            ".verification.verified == true and .object.sha == $commit",
+            workflow,
+        )
+        self.assertIn(
+            'if [[ "${stable_candidate_verified}" == "true" ]]',
+            workflow,
+        )
+        self.assertIn(stable_skip, workflow)
+        self.assertLess(
+            workflow.index(stable_skip),
+            workflow.index('current_tag_sha="$('),
+        )
+
     def test_current_package_rechecks_main_before_release_mutations(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         freshness = workflow[


### PR DESCRIPTION
## Summary

- detect an annotated semantic-version tag whose dereferenced commit exactly matches the validated main SHA
- skip mutable Current packaging when that stable candidate already owns the same source
- preserve the existing Current-pointer and exact-main freshness protections for ordinary main commits

This addresses the duplicate-package portion of #324 without changing runtime behavior or broadening release authority.

## Measured release evidence

During the 0.14.2 promotion:

- redundant Current packaging ran from 18:33:19Z to 18:45:30Z (12m11s)
- the already-resolved stable gate waited for the local runner from 18:33:19Z until 18:45:32Z (12m13s)
- the stable package subsequently ran independently

The resolver now yields Current only when a signed annotated `MAJOR.MINOR.PATCH` tag dereferences to the exact validated main SHA. An untagged main SHA still follows the normal Current path.

## Recovery

A failed stable promotion remains resumable through the stable workflow. A maintainer can still dispatch Current explicitly for `main`; this change only suppresses the automatic duplicate triggered by the same exact stable-tagged SHA.

## Validation

- focused release-policy tests: 4 passed
- `actionlint .github/workflows/prebuilt-binaries.yml`
- `git diff --check`
- live resolver check: 0.14.2 source SHA resolves to `0.14.2`; the later untagged documentation SHA resolves to no stable candidate

Refs #324