### PR TITLE
perf(build): consolidate recoverable family validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -607,7 +607,7 @@ pipeline-help:
 		'' \
 		'Important selectors:' \
 		'  PIPELINE_PROFILE=focused|repository|stack|hosted-safe|release-hosted|benchmark-reconstruction' \
-		'  PIPELINE_STAGE_SELECTOR=compose-source,compose-swift-test,compose-go-test,compose-cli-smoke' \
+		'  PIPELINE_STAGE_SELECTOR=compose-source,compose-swift-validation,compose-go-validation' \
 		'  PIPELINE_ATTEMPT_ID=<safe-unique-id-for-a-known-evidence-directory>' \
 		'  PIPELINE_SESSION=<failed-session-uuid>' \
 		'  CONTAINER_FAMILY_SOURCE_ROOT=<directory-containing-sibling-repositories>' \

--- a/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-REVIEW-2026-09-05.md
+++ b/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-REVIEW-2026-09-05.md
@@ -1,0 +1,153 @@
+# Container-family build workflow review — 5 September 2026
+
+## Purpose
+
+This record captures observed build defects, elapsed timings, and the first
+workflow consolidation pass. It is deliberately separate from release and
+benchmark evidence. The goal is to make a later build-system refinement use
+measured failures rather than repeat discovery.
+
+## Changes in this iteration
+
+The recoverable Nextflow stack graph previously used 12 isolated functional
+stages. It now uses eight. Each stage still receives an immutable source
+snapshot and keeps a durable receipt, but related build and test commands for
+one repository share the same checkout and compiler cache.
+
+- Compose Swift tests, the debug product build, and CLI smoke tests now run in
+  one stage. Compose Go tests and the stripped normalizer build run in one
+  parallel stage. This removes the third isolated Compose checkout that rebuilt
+  both languages only for smoke tests.
+- Builder coverage and its executable build now share one Go cache instead of
+  running in separate isolated stages.
+- Containerization tests and the signed host product build now share one Swift
+  cache instead of running in separate isolated stages.
+- Container now runs its unit suite before its product build. The previous
+  stack graph built Container but did not test it.
+- Engine API now runs the test bundle it builds before compiling the
+  performance fixture. The previous graph built tests without executing them.
+- Devcontainer now runs its unit suite before the product build. The previous
+  graph built it but did not test it.
+- Container Kubernetes tests, product build, and CLI smoke checks now share one
+  Swift cache instead of using two isolated stages.
+- Source stages use the already installed Hawkeye executable directly. They no
+  longer create a disposable `.local/bin` link in every snapshot.
+- Builder source validation now asks Go to load the vendored package graph so a
+  stale `vendor/modules.txt` fails before the expensive functional stage.
+
+This consolidation removes four whole task sandboxes and their duplicate
+dependency planning/build work while increasing functional coverage in three
+repositories.
+
+## Timings observed during the corrective work
+
+These are wall-clock measurements on the same Apple silicon host. They are
+diagnostic timings, not performance benchmarks: cache temperature and the
+source graph differed between commands.
+
+- Containerization `make check`: 3.27 seconds.
+- Containerization full `swift test`: 47.37 seconds wall time; 912 tests passed.
+- Containerization focused terminal test after the relevant build: 22.65
+  seconds; three tests passed.
+- SwiftNIO SSL first focused build: 49.13 seconds for a very small test subset.
+- SwiftNIO SSL full suite after compilation: 18.63 seconds wall time; 347 tests
+  passed.
+- SwiftNIO SSL exact parser regression after warm-up: 5.65 seconds.
+- Builder grouped tests with dependency preparation: 26.91 seconds.
+- Builder warm Go test run: 5.60 seconds.
+- Container first focused invocation compiled roughly 3,100 targets and spent
+  92.84 seconds to execute a millisecond-scale test.
+- Adding the vmnet test target invalidated the Container package test plan. The
+  first attempt compiled for 97.94 seconds before rejecting an availability
+  annotation; the corrected retry then compiled for 88.48 seconds and ran three
+  focused tests in 0.001 seconds. The second focused vmnet suite reused that
+  build and completed in 1.30 seconds.
+- Container's first broad direct `swift test` completed in 166.41 seconds but
+  reported 32 missing semantic-helper issues because the direct invocation had
+  bypassed the Make prerequisite. `make semantic-helper` took 5.21 seconds;
+  the no-rebuild rerun then passed 2,472 tests in 49.50 seconds wall time.
+
+The Nextflow trace, report, timeline, receipts, stdout, and stderr from every
+future pipeline execution remain under the marked pipeline state root. Those
+records provide stage-level timings suitable for comparing this eight-stage
+graph with later refinements.
+
+## Defects and reliability risks found
+
+### Fixed here
+
+- Functional stages used fresh task roots for test and build steps from the
+  same repository, forcing duplicate Swift and Go work.
+- The normal stack graph omitted Container and devcontainer unit execution and
+  omitted Engine API test execution.
+- Builder vendoring drift was discovered only after a functional command had
+  started.
+- Three Makefiles tried to bootstrap Hawkeye even when a verified executable
+  was already on `PATH`. The corresponding fork fixes now support direct reuse;
+  paths containing spaces are quoted.
+- Direct raw `swift test` for Container can bypass the semantic-helper producer.
+  The supported pipeline command now uses Make, which owns that prerequisite.
+
+### Still open for a later build-system iteration
+
+- The top-level plain `make` path is not the recoverable family pipeline. It
+  builds and packages Compose locally, but a failure requires manually deciding
+  what can be reused. The recoverable command remains `make pipeline-bootstrap`
+  followed by `PIPELINE_PROFILE=stack make pipeline`; a successful build can be
+  resumed with its exact session UUID.
+- The recoverable stack phase validates source, unit behavior, builds, and
+  smoke checks, but it does not yet publish a reusable local distribution
+  artifact. Artifact-producing packaging should become a downstream task that
+  consumes validated build outputs rather than rebuilding them.
+- Source and functional stages still use separate immutable snapshots. That is
+  a valuable fail-fast boundary, but Swift formatting/license checks and
+  dependency planning can both touch much of a large tree. Trace evidence is
+  needed before deciding whether any source work should be consolidated.
+- SwiftPM repeatedly warns about two dependency URLs with the
+  `swift-nio-ssl` package identity. A future SwiftPM release will turn this into
+  an error. The matched dependency graph needs one canonical URL.
+- SwiftPM emitted `maintenance.lock doesn't exist` warnings. Cache ownership
+  and cleanup should be audited before enabling more concurrent Swift stages.
+- Container's package graph makes genuinely focused tests expensive after any
+  manifest or test-target change. Target-specific build products or a smaller
+  test-support graph would give the largest cold-feedback improvement.
+- A direct macOS build of the Linux-only `vminitd` package fails on its
+  `FoundationEssentials` imports. The supported Containerization Make path
+  correctly builds it in Linux; the CLI should fail fast with an explanatory
+  message if someone invokes the unsupported host path.
+- Nextflow 26.04.6 reports that six `shell` blocks are deprecated. Migration to
+  `script` needs its own exact recovery proof because quoting and interpolation
+  are security-sensitive here.
+- Pipeline scheduling currently permits two repository stages but serializes
+  all Swift-labelled stages. This was a deliberate response to contention in
+  the 0.14 release. A later iteration should use trace CPU, memory-pressure, and
+  duration evidence to determine whether one small Swift stage can safely run
+  beside one large Swift stage.
+- Failure cleanup is marker-protected, but stale Swift build products outside
+  the Nextflow task roots are not centrally inventoried. A preflight should
+  distinguish reusable content-addressed caches from incompatible products and
+  quarantine only the latter, recording the producer and reason.
+- The ordinary Compose workflow builds the Go normalizer during `ci` and again
+  through `package-release`. Packaging should consume the already validated
+  normalizer rather than rebuild it.
+
+## Next refinement priorities
+
+1. Add a recoverable artifact-assembly stage that consumes validated Compose
+   Swift and Go outputs and produces the local plugin archive without compiling
+   either language again.
+2. Make the plain `make` experience select that recoverable repository graph,
+   while retaining explicit `make ci` and release commands for automation.
+3. Add a content-addressed compatibility manifest for Swift build products,
+   semantic-helper archives, Go vendoring, Xcode/SDK identity, and signing
+   inputs. Quarantine mismatches before compilation and identify their producer.
+4. Compare old and new Nextflow traces using cold and warm runs. Change
+   concurrency only where elapsed time improves without memory pressure,
+   approval dialogs, nondeterminism, or cache corruption.
+5. Migrate deprecated Nextflow syntax with the recovery self-test as the
+   acceptance gate.
+
+The intended end state is a single unattended command with fail-fast
+preflight, deterministic inputs, resumable checkpoints, no interactive
+credential or local-network prompts, one execution of each necessary test, and
+a usable local artifact at completion.

--- a/main.nf
+++ b/main.nf
@@ -94,13 +94,13 @@ def sourceStageSpecs() {
             'HAWKEYE_AUTO_INSTALL=0 make --no-print-directory PYTHON=python3 SWIFT=/usr/bin/swift GO=go MARKDOWNLINT=markdownlint HAWKEYE=hawkeye check',
             'make,apple-swift,go,gofmt,python3,ruby,markdownlint,hawkeye', '.', 'commit'],
         ['container-builder-shim', 'builder-source', 'source', params.sourceTimeoutSeconds as Integer,
-            'mkdir -p .local/bin && ln -s "$(command -v hawkeye)" .local/bin/hawkeye && GOTOOLCHAIN=local make --no-print-directory GO=go GOLANGCI_LINT="$(command -v golangci-lint)" check-licenses vet lint',
+            'GOTOOLCHAIN=local make --no-print-directory GO=go HAWKEYE="$(command -v hawkeye)" GOLANGCI_LINT="$(command -v golangci-lint)" check-licenses vet lint && GOTOOLCHAIN=local go list -mod=vendor ./... >/dev/null',
             'make,go,golangci-lint,hawkeye', '.', 'commit,describe'],
         ['containerization', 'containerization-source', 'source', params.sourceTimeoutSeconds as Integer,
-            'mkdir -p .local/bin && ln -s "$(command -v hawkeye)" .local/bin/hawkeye && HAWKEYE_AUTO_INSTALL=0 make --no-print-directory SWIFT=/usr/bin/swift check',
+            'HAWKEYE_AUTO_INSTALL=0 make --no-print-directory SWIFT=/usr/bin/swift HAWKEYE="$(command -v hawkeye)" check',
             'make,apple-swift,hawkeye', '.', 'commit'],
         ['container', 'container-source', 'source', params.sourceTimeoutSeconds as Integer,
-            'mkdir -p .local/bin && ln -s "$(command -v hawkeye)" .local/bin/hawkeye && HAWKEYE_AUTO_INSTALL=0 make --no-print-directory PYTHON3=python3 check',
+            'HAWKEYE_AUTO_INSTALL=0 make --no-print-directory PYTHON3=python3 HAWKEYE="$(command -v hawkeye)" check',
             'make,apple-swift,python3,hawkeye', '.', 'commit,describe'],
         ['container-engine-api', 'engine-api-source', 'source', params.sourceTimeoutSeconds as Integer,
             'python3 Tools/generate_route_ledger.py --check && python3 -m py_compile Tools/performance/*.py && python3 -B Tools/performance/check_engine_streaming_performance.py --self-test && /bin/bash -n Tools/ci/*.sh && swiftformat --lint Package.swift Sources Tests Tools/ContainerEngineStreamingPerformanceFixture && markdownlint README.md docs',
@@ -118,61 +118,41 @@ def sourceStageSpecs() {
 
 def functionalStageSpecs() {
     [
-        ['container-compose', 'compose-swift-test', 'test', params.functionalTimeoutSeconds as Integer,
-            'CONTAINER_COMPOSE_RUN_RUNTIME_TESTS=0 make --no-print-directory SWIFT=/usr/bin/swift PYTHON=python3 swift-test',
-            'make,apple-swift,go,python3',
+        ['container-compose', 'compose-swift-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'CONTAINER_COMPOSE_RUN_RUNTIME_TESTS=0 make --no-print-directory SWIFT=/usr/bin/swift PYTHON=python3 swift-test build cli-smoke-built',
+            'make,apple-swift,go,python3,otool,codesign',
             'Package.swift Package.resolved Sources Tests Tools scripts Makefile config.toml docs/project/STATUS.md examples/logging/compose.yml',
             'none'],
-        ['container-compose', 'compose-go-test', 'test', params.functionalTimeoutSeconds as Integer,
-            'GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org make --no-print-directory GO=go go-test',
-            'make,go', 'Tools/compose-normalizer Makefile', 'none'],
-        ['container-compose', 'compose-cli-smoke', 'test', params.functionalTimeoutSeconds as Integer,
-            'GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org make --no-print-directory SWIFT=/usr/bin/swift PYTHON=python3 GO=go build go-build cli-smoke-built',
-            'make,apple-swift,go,python3,otool,codesign',
-            'Package.swift Package.resolved Sources Tests Tools scripts Makefile config.toml docs/images/container-compose-icon-octopus.png',
-            'none'],
-        ['container-builder-shim', 'builder-test', 'test', params.functionalTimeoutSeconds as Integer,
-            'GOTOOLCHAIN=local GIT_TAG="$PIPELINE_ORIGINAL_DESCRIBE" make --no-print-directory GO=go coverage',
+        ['container-compose', 'compose-go-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org make --no-print-directory GO=go go-test go-build',
+            'make,go,otool', 'Tools/compose-normalizer Makefile', 'none'],
+        ['container-builder-shim', 'builder-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'GOTOOLCHAIN=local GIT_TAG="$PIPELINE_ORIGINAL_DESCRIBE" make --no-print-directory GO=go coverage build',
             'make,go',
             'go.mod go.sum main.go main_test.go pkg vendor Makefile Protobuf.Makefile',
             'describe'],
-        ['container-builder-shim', 'builder-build', 'build', params.functionalTimeoutSeconds as Integer,
-            'GOTOOLCHAIN=local GIT_TAG="$PIPELINE_ORIGINAL_DESCRIBE" make --no-print-directory GO=go build',
-            'make,go',
-            'go.mod go.sum main.go pkg vendor Makefile Protobuf.Makefile',
-            'describe'],
-        ['containerization', 'containerization-test', 'test', params.functionalTimeoutSeconds as Integer,
-            'CI=1 make --no-print-directory ROOT_DIR="$PWD" SWIFT=/usr/bin/swift test',
-            'make,apple-swift',
-            'Package.swift Package.resolved Sources Tests vminitd/Sources vminitd/Makefile Makefile Protobuf.Makefile .swift-version',
-            'none'],
-        ['containerization', 'containerization-build', 'build', params.functionalTimeoutSeconds as Integer,
-            'CI=1 make --no-print-directory ROOT_DIR="$PWD" SWIFT=/usr/bin/swift containerization',
+        ['containerization', 'containerization-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'CI=1 make --no-print-directory ROOT_DIR="$PWD" SWIFT=/usr/bin/swift test containerization',
             'make,apple-swift,codesign',
             'Package.swift Package.resolved Sources Tests vminitd/Sources vminitd/Makefile Makefile Protobuf.Makefile .swift-version signing',
             'none'],
-        ['container', 'container-build', 'build', params.functionalTimeoutSeconds as Integer,
-            'CI=1 CONTAINER_SEMANTIC_HELPER_TOOLCHAIN_CACHE="$PIPELINE_INTERNAL_CACHE_ROOT/container-semantic-helper" make --no-print-directory ROOT_DIR="$PWD" PYTHON3=python3 GIT_COMMIT="$PIPELINE_ORIGINAL_COMMIT" RELEASE_VERSION="$PIPELINE_ORIGINAL_DESCRIBE" build',
+        ['container', 'container-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'CI=1 CONTAINER_SEMANTIC_HELPER_TOOLCHAIN_CACHE="$PIPELINE_INTERNAL_CACHE_ROOT/container-semantic-helper" make --no-print-directory ROOT_DIR="$PWD" PYTHON3=python3 GIT_COMMIT="$PIPELINE_ORIGINAL_COMMIT" RELEASE_VERSION="$PIPELINE_ORIGINAL_DESCRIBE" test build',
             'make,apple-swift,codesign,python3',
             'Package.swift Package.resolved Sources Tests Tools scripts Makefile Protobuf.Makefile signing',
             'commit,describe'],
-        ['container-engine-api', 'engine-api-build', 'build', params.functionalTimeoutSeconds as Integer,
-            '/usr/bin/swift build --disable-automatic-resolution -Xswiftc -warnings-as-errors --build-tests && /usr/bin/swift build --disable-automatic-resolution -Xswiftc -warnings-as-errors --target ContainerEngineStreamingPerformanceFixture',
+        ['container-engine-api', 'engine-api-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            '/usr/bin/swift build --disable-automatic-resolution -Xswiftc -warnings-as-errors --build-tests && /usr/bin/swift test --disable-automatic-resolution --skip-build && /usr/bin/swift build --disable-automatic-resolution -Xswiftc -warnings-as-errors --target ContainerEngineStreamingPerformanceFixture',
             'apple-swift',
             'Package.swift Package.resolved Sources Tests Tools/ContainerEngineStreamingPerformanceFixture',
             'none'],
-        ['devcontainer', 'devcontainer-build', 'build', params.functionalTimeoutSeconds as Integer,
-            'make --no-print-directory SWIFT=/usr/bin/swift build',
+        ['devcontainer', 'devcontainer-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'make --no-print-directory SWIFT=/usr/bin/swift test build',
             'make,apple-swift',
             'Package.swift Package.resolved Sources Tests Plugins Tools/version-generator Makefile',
             'commit'],
-        ['container-k8s', 'k8s-test', 'test', params.functionalTimeoutSeconds as Integer,
-            '/usr/bin/swift test --disable-automatic-resolution',
-            'apple-swift',
-            'Package.swift Package.resolved Sources Tests Makefile APPLE_CONTAINER_REF',
-            'none'],
-        ['container-k8s', 'k8s-build-smoke', 'test', params.functionalTimeoutSeconds as Integer,
-            '/usr/bin/swift build --disable-automatic-resolution --product k8s && make --no-print-directory cli-smoke-built',
+        ['container-k8s', 'k8s-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'make --no-print-directory SWIFT=/usr/bin/swift test build cli-smoke-built',
             'make,apple-swift',
             'Package.swift Package.resolved Sources Tests Makefile APPLE_CONTAINER_REF',
             'none'],
@@ -282,8 +262,8 @@ def pipelineSelection() {
             params.stageSelector.toString().split(',')
                 .collect { stageName -> stageName.trim() }
                 .findAll { stageName -> stageName } :
-            ['compose-source', 'compose-swift-test', 'compose-go-test',
-                'compose-cli-smoke']
+            ['compose-source', 'compose-swift-validation',
+                'compose-go-validation']
         def knownStages = (sourceStages + functionalStages).collect { stage -> stage[1] }
         def unknownStages = requestedStages.findAll { stageName ->
             !knownStages.contains(stageName)
@@ -1726,11 +1706,13 @@ workflow PIPELINE {
     ]
     swiftFunctionalInputs = functionalInputs.filter { item ->
         validationStageNames.contains(item[0]) &&
-            swiftRepositoryNames.contains(item[1])
+            swiftRepositoryNames.contains(item[1]) &&
+            item[0] != 'compose-go-validation'
     }
     lightweightFunctionalInputs = functionalInputs.filter { item ->
         validationStageNames.contains(item[0]) &&
-            !swiftRepositoryNames.contains(item[1])
+            (!swiftRepositoryNames.contains(item[1]) ||
+                item[0] == 'compose-go-validation')
     }
     RUN_SWIFT_STAGE(
         swiftFunctionalInputs,

--- a/main.nf
+++ b/main.nf
@@ -121,7 +121,7 @@ def functionalStageSpecs() {
         ['container-compose', 'compose-swift-validation', 'test', params.functionalTimeoutSeconds as Integer,
             'CONTAINER_COMPOSE_RUN_RUNTIME_TESTS=0 make --no-print-directory SWIFT=/usr/bin/swift PYTHON=python3 swift-test build cli-smoke-built',
             'make,apple-swift,go,python3,otool,codesign',
-            'Package.swift Package.resolved Sources Tests Tools scripts Makefile config.toml docs/project/STATUS.md examples/logging/compose.yml',
+            'Package.swift Package.resolved Sources Tests Tools scripts Makefile config.toml docs/project/STATUS.md docs/images/container-compose-icon-octopus.png examples/logging/compose.yml',
             'none'],
         ['container-compose', 'compose-go-validation', 'test', params.functionalTimeoutSeconds as Integer,
             'GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org make --no-print-directory GO=go go-test go-build',


### PR DESCRIPTION
## Summary

- consolidate related per-repository test/build/smoke commands into one recoverable stage so compiler caches are reused
- execute Container, Engine API, and devcontainer tests that the stack graph previously omitted
- fail fast on builder vendor drift and reuse verified Hawkeye installations
- record observed workflow defects, timings, and the next reliability refinements

## Validation

- `make pipeline-lint`
- `make pipeline-self-test` (exact-session resume and evidence restoration passed)
- `CONTAINER_FAMILY_SOURCE_ROOT=/Users/sclarke/github PIPELINE_PROFILE=stack PIPELINE_ATTEMPT_ID=plan-consolidated-20260905 make pipeline-plan` (8 source + 8 functional stages)
- `markdownlint docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-REVIEW-2026-09-05.md`

This reduces the normal functional graph from 12 isolated tasks to 8 while adding the missing test execution. Runtime, parity, release mutation, and documentation publication remain intentionally outside this non-release graph.

@codex review