### PR TITLE
fix(build): declare nested Ruby dependency

### DIFF
--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -44,6 +44,15 @@ RECOVERY_PROOF = (
 class ReleaseStageGitHistoryTests(unittest.TestCase):
     """Keep history-sensitive validation on verified Git bundles."""
 
+    def test_stage_tools_include_nested_process_dependencies(self) -> None:
+        devcontainer_stage = PIPELINE_SOURCE.split(
+            "['devcontainer', 'devcontainer-source'", 1
+        )[1].split("['container-k8s'", 1)[0]
+        self.assertIn(
+            "'make,python3,ruby,swiftformat,swiftlint,shellcheck,markdownlint,actionlint'",
+            devcontainer_stage,
+        )
+
     def test_history_sensitive_release_stages_request_commit_metadata(self) -> None:
         expected_declarations = (
             "'make,go,hawkeye', '.', 'commit,describe'",

--- a/main.nf
+++ b/main.nf
@@ -107,7 +107,7 @@ def sourceStageSpecs() {
             'python3,swiftformat,markdownlint', '.', 'commit'],
         ['devcontainer', 'devcontainer-source', 'source', params.sourceTimeoutSeconds as Integer,
             'make --no-print-directory PYTHON=python3 MARKDOWNLINT=markdownlint SWIFTLINT=swiftlint SWIFTFORMAT=swiftformat ACTIONLINT=actionlint format-check lint parity-manifest',
-            'make,python3,swiftformat,swiftlint,shellcheck,markdownlint,actionlint', '.', 'commit'],
+            'make,python3,ruby,swiftformat,swiftlint,shellcheck,markdownlint,actionlint', '.', 'commit'],
         ['container-k8s', 'k8s-source', 'source', params.sourceTimeoutSeconds as Integer,
             'make --no-print-directory PYTHON=python3 MARKDOWNLINT=markdownlint check',
             'make,python3,markdownlint,ruby', '.', 'commit'],


### PR DESCRIPTION
## Summary

- declare Ruby in the devcontainer source-stage tool closure
- ensure the sealed pipeline selects and hashes the supported Homebrew Ruby rather than falling back to macOS Ruby 2.6
- add a focused regression for nested subprocess tool declarations

## Failure evidence

Recoverable stack session `98ed23b8-01e6-4446-9048-c4cba4c86e74` failed in `devcontainer-source` because its Python workflow tests launch Ruby and use `Enumerable#filter_map`, but Ruby was omitted from the stage manifest. The sealed PATH therefore fell back to `/usr/bin/ruby` 2.6, where `filter_map` is unavailable.

## Validation

- focused pipeline declaration regression
- `make pipeline-lint` (no errors; seven pre-existing deprecation/style warnings)
- `git diff --check`

After merge, the same failed pipeline session will be resumed so successful captures/stages are reused.
