### PR TITLE
fix(deps): consume unattended runtime stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "a252482bbacbd15742845764893585131e2c4825"
+        "revision" : "228897171d71975988ccdc690f1982e7433952af"
       }
     },
     {
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container-engine-api.git",
       "state" : {
-        "revision" : "d713f12cb362c6646d083537f16e6595d3743c74"
+        "revision" : "84830606abf971110071248e087a80ff4abb86d4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "a252482bbacbd15742845764893585131e2c4825",
+        revision: "228897171d71975988ccdc690f1982e7433952af",
     )
 }()
 


### PR DESCRIPTION
## Summary

- update Compose to Container `228897171d71975988ccdc690f1982e7433952af`
- align the resolved Engine API revision with `84830606abf971110071248e087a80ff4abb86d4`
- consume the reviewed per-query Keychain fix throughout the Compose runtime

## Validation

- `swift package dump-package` (1.11s)
- exact manifest/resolution-pin assertions
- `git diff --check`

The existing recoverable family session will provide the one authoritative stack build/test result after this pin merges. Broad PR runtime lanes would duplicate that work.