### PR TITLE
fix(release): align runtime stack contract

### DIFF
--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "a252482bbacbd15742845764893585131e2c4825",
+      "ref": "228897171d71975988ccdc690f1982e7433952af",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

- align the checked-in stack contract with Container `228897171d71975988ccdc690f1982e7433952af`
- keep release metadata consistent with Package.swift and Package.resolved
- restore fail-fast source validation for the current matched stack

## Validation

- stack consistency against the current Container checkout: 0.04s
- stack-consistency unit suite: 10 tests passed in 0.10s
- `git diff --check`

This mismatch was found by the recoverable pipeline before expensive functional testing; session `98ed23b8-01e6-4446-9048-c4cba4c86e74` remains resumable.