### PR TITLE
[Parity] Implement Compose use_api_socket

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,2 @@
+--swiftversion 6.2
+--disable trailingCommas,swiftTestingTestCaseNames,hoistTry,hoistAwait,blankLinesAtEndOfScope

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "184fd6d017ec4788629568f5a0fc047a7f5d814fbafc20a8d8b532bb97fdf5da",
+  "originHash" : "fba8ab3ca21467494cd4e7a81d067b5bb9339e88d538bb28870ae964b73c6e03",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "228897171d71975988ccdc690f1982e7433952af"
+        "revision" : "40ab92d74a02bbd6b7436a50d47c38898a4bc294"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "228897171d71975988ccdc690f1982e7433952af",
+        revision: "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
     )
 }()
 

--- a/Sources/ComposeCore/ComposeAPISocketCredentials.swift
+++ b/Sources/ComposeCore/ComposeAPISocketCredentials.swift
@@ -1,0 +1,389 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 container-compose project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Resolves the Docker credentials copied into the generated `#apisocket`
+/// config. Implementations return a complete Docker config containing only
+/// the resolved `auths` object.
+public protocol ComposeAPISocketCredentialResolving: Sendable {
+    func resolvedCredentialConfig() async throws -> Data
+}
+
+/// Reads Docker CLI credentials and resolves configured native helpers without
+/// invoking a shell. Helper processes receive EOF on stdin, a minimal
+/// environment, bounded execution time, and no access to Compose output.
+public struct DockerAPISocketCredentialResolver:
+    ComposeAPISocketCredentialResolving
+{
+    private static let maximumConfigBytes = 1_048_576
+    private static let helperTimeout = Duration.seconds(10)
+    private static let tokenUsername = "<token>"
+
+    private let runner: any CommandRunning
+    private let environment: [String: String]
+
+    public init(
+        runner: any CommandRunning = ProcessRunner(),
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+    ) {
+        self.runner = runner
+        self.environment = environment
+    }
+
+    public func resolvedCredentialConfig() async throws -> Data {
+        let source = try loadConfiguration()
+        var credentials = source.credentials
+
+        if let store = nonEmpty(source.credentialStore) {
+            credentials = try await credentialsFromDefaultStore(
+                store,
+                fileCredentials: credentials,
+            )
+        }
+        for (server, helper) in source.credentialHelpers.sorted(by: {
+            $0.key < $1.key
+        }) {
+            do {
+                credentials[server] = try await credential(
+                    server: server,
+                    helper: helper,
+                    sourceCredential: source.credentials[server],
+                )
+            } catch {
+                // Docker CLI deliberately keeps the default-store result when
+                // one registry-specific helper cannot be read.
+                continue
+            }
+        }
+
+        let output = DockerCredentialOutput(auths: credentials)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(output)
+    }
+
+    private func loadConfiguration() throws -> DockerCredentialSource {
+        if let environmentConfig = environment["DOCKER_AUTH_CONFIG"] {
+            return try decodeConfiguration(Data(environmentConfig.utf8))
+        }
+
+        let root: URL
+        if let configured = nonEmpty(environment["DOCKER_CONFIG"]) {
+            root = URL(fileURLWithPath: configured, isDirectory: true)
+        } else {
+            let home = environment["HOME"] ?? NSHomeDirectory()
+            root = URL(fileURLWithPath: home, isDirectory: true)
+                .appendingPathComponent(".docker", isDirectory: true)
+        }
+        let file = root.appendingPathComponent("config.json", isDirectory: false)
+        guard FileManager.default.fileExists(atPath: file.path) else {
+            return DockerCredentialSource()
+        }
+        let handle = try FileHandle(forReadingFrom: file)
+        defer { try? handle.close() }
+        let data = try handle.read(upToCount: Self.maximumConfigBytes + 1) ?? Data()
+        return try decodeConfiguration(data)
+    }
+
+    private func decodeConfiguration(_ data: Data) throws
+        -> DockerCredentialSource
+    {
+        guard data.count <= Self.maximumConfigBytes else {
+            throw ComposeError.invalidProject(
+                "Docker credential config exceeds the 1048576-byte limit",
+            )
+        }
+        do {
+            return try JSONDecoder().decode(DockerCredentialSource.self, from: data)
+        } catch {
+            throw ComposeError.invalidProject(
+                "Docker credential config is invalid: \(error.localizedDescription)",
+            )
+        }
+    }
+
+    private func credentialsFromDefaultStore(
+        _ helper: String,
+        fileCredentials: [String: DockerResolvedCredential],
+    ) async throws -> [String: DockerResolvedCredential] {
+        let listed = try await runHelper(
+            helper,
+            operation: "list",
+            input: Data("unused".utf8),
+        )
+        let servers: [String: String]
+        do {
+            servers = try JSONDecoder().decode([String: String].self, from: listed)
+        } catch {
+            throw helperError(helper, operation: "list")
+        }
+        var credentials: [String: DockerResolvedCredential] = [:]
+        for server in servers.keys.sorted() {
+            credentials[server] = try await credential(
+                server: server,
+                helper: helper,
+                sourceCredential: fileCredentials[server],
+            )
+        }
+        return credentials
+    }
+
+    private func credential(
+        server: String,
+        helper: String,
+        sourceCredential: DockerResolvedCredential?,
+    ) async throws -> DockerResolvedCredential {
+        let data: Data
+        do {
+            data = try await runHelper(
+                helper,
+                operation: "get",
+                input: Data(server.utf8),
+            )
+        } catch DockerCredentialHelperError.credentialsNotFound {
+            return DockerResolvedCredential(
+                registryToken: sourceCredential?.registryToken,
+            )
+        }
+        let value: DockerHelperCredential
+        do {
+            value = try JSONDecoder().decode(DockerHelperCredential.self, from: data)
+        } catch {
+            throw helperError(helper, operation: "get")
+        }
+        if value.username == Self.tokenUsername {
+            return DockerResolvedCredential(
+                identityToken: value.secret,
+                registryToken: sourceCredential?.registryToken,
+            )
+        }
+        return DockerResolvedCredential(
+            auth: Data("\(value.username):\(value.secret)".utf8)
+                .base64EncodedString(),
+            registryToken: sourceCredential?.registryToken,
+        )
+    }
+
+    private func runHelper(
+        _ suffix: String,
+        operation: String,
+        input: Data,
+    ) async throws -> Data {
+        let executable = try helperExecutable(suffix)
+        let result: CommandResult
+        do {
+            result = try await executeHelper(
+                executable,
+                operation: operation,
+                input: input,
+            )
+        } catch let error as ComposeError {
+            throw error
+        } catch {
+            throw helperError(suffix, operation: operation)
+        }
+        guard result.stdoutOmittedByteCount == 0,
+              result.stderrOmittedByteCount == 0
+        else {
+            throw helperError(suffix, operation: operation)
+        }
+        guard result.succeeded else {
+            if operation == "get",
+               String(bytes: result.stdoutData, encoding: .utf8)?
+               .trimmingCharacters(in: .whitespacesAndNewlines)
+               == "credentials not found in native keychain"
+            {
+                throw DockerCredentialHelperError.credentialsNotFound
+            }
+            throw helperError(suffix, operation: operation)
+        }
+        return result.stdoutData
+    }
+
+    private func helperExecutable(_ suffix: String) throws -> String {
+        guard !suffix.isEmpty,
+              suffix.unicodeScalars.allSatisfy({
+                  CharacterSet.alphanumerics.contains($0)
+                      || ".-_".unicodeScalars.contains($0)
+              })
+        else {
+            throw ComposeError.invalidProject(
+                "Docker credential helper name is invalid",
+            )
+        }
+        return "docker-credential-\(suffix)"
+    }
+
+    private func executeHelper(
+        _ executable: String,
+        operation: String,
+        input: Data,
+    ) async throws -> CommandResult {
+        let path = environment["PATH"] ?? "/usr/local/bin:/usr/bin:/bin"
+        let home = environment["HOME"] ?? NSHomeDirectory()
+        let arguments = [
+            "-i", "HOME=\(home)", "PATH=\(path)", executable, operation,
+        ]
+        return try await withThrowingTaskGroup(
+            of: CommandResult.self,
+        ) { group in
+            group.addTask {
+                try await runner.runCapturingOutputPrefix(
+                    ComposeExecutionOptions.defaultEnvironmentLauncher,
+                    arguments,
+                    input: input,
+                    maximumOutputBytes: Self.maximumConfigBytes,
+                )
+            }
+            group.addTask {
+                try await Task.sleep(for: Self.helperTimeout)
+                throw ComposeError.invalidProject(
+                    "Docker credential helper '\(executable)' timed out",
+                )
+            }
+            let first = try await group.next()!
+            group.cancelAll()
+            return first
+        }
+    }
+
+    private func helperError(
+        _ helper: String,
+        operation: String,
+    ) -> ComposeError {
+        .invalidProject(
+            "Docker credential helper 'docker-credential-\(helper)' failed during \(operation)",
+        )
+    }
+}
+
+private struct DockerCredentialSource: Decodable {
+    var credentials: [String: DockerResolvedCredential]
+    var credentialStore: String?
+    var credentialHelpers: [String: String]
+
+    init() {
+        credentials = [:]
+        credentialStore = nil
+        credentialHelpers = [:]
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case credentials = "auths"
+        case credentialStore = "credsStore"
+        case credentialHelpers = "credHelpers"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        credentials =
+            try container.decodeIfPresent(
+                [String: DockerResolvedCredential].self,
+                forKey: .credentials,
+            ) ?? [:]
+        credentialStore = try container.decodeIfPresent(
+            String.self,
+            forKey: .credentialStore,
+        )
+        credentialHelpers =
+            try container.decodeIfPresent(
+                [String: String].self,
+                forKey: .credentialHelpers,
+            ) ?? [:]
+    }
+}
+
+private struct DockerCredentialOutput: Encodable {
+    let auths: [String: DockerResolvedCredential]
+}
+
+private struct DockerResolvedCredential: Codable {
+    var auth: String?
+    var identityToken: String?
+    var registryToken: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case auth
+        case password
+        case username
+        case identityToken = "identitytoken"
+        case registryToken = "registrytoken"
+    }
+
+    init(
+        auth: String? = nil,
+        identityToken: String? = nil,
+        registryToken: String? = nil,
+    ) {
+        self.auth = auth
+        self.identityToken = identityToken
+        self.registryToken = registryToken
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        identityToken = try container.decodeIfPresent(
+            String.self,
+            forKey: .identityToken,
+        )
+        registryToken = try container.decodeIfPresent(
+            String.self,
+            forKey: .registryToken,
+        )
+        if let encoded = try container.decodeIfPresent(String.self, forKey: .auth),
+           !encoded.isEmpty
+        {
+            guard let decoded = Data(base64Encoded: encoded),
+                  decoded.contains(UInt8(ascii: ":"))
+            else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .auth,
+                    in: container,
+                    debugDescription: "Docker auth is not base64-encoded username:password data",
+                )
+            }
+            auth = decoded.base64EncodedString()
+        } else {
+            let username = try container.decodeIfPresent(String.self, forKey: .username) ?? ""
+            let password = try container.decodeIfPresent(String.self, forKey: .password) ?? ""
+            auth = username.isEmpty && password.isEmpty
+                ? nil
+                : Data("\(username):\(password)".utf8).base64EncodedString()
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(auth, forKey: .auth)
+        try container.encodeIfPresent(identityToken, forKey: .identityToken)
+        try container.encodeIfPresent(registryToken, forKey: .registryToken)
+    }
+}
+
+private struct DockerHelperCredential: Decodable {
+    let username: String
+    let secret: String
+
+    private enum CodingKeys: String, CodingKey {
+        case username = "Username"
+        case secret = "Secret"
+    }
+}
+
+private enum DockerCredentialHelperError: Error {
+    case credentialsNotFound
+}

--- a/Sources/ComposeCore/ComposeAPISocketTransform.swift
+++ b/Sources/ComposeCore/ComposeAPISocketTransform.swift
@@ -1,0 +1,94 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 container-compose project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension ComposeOrchestrator {
+    static let apiSocketConfigName = "#apisocket"
+    static let apiSocketConfigDirectory = "/run/secrets/docker"
+    static let apiSocketConfigTarget = "/run/secrets/docker/config.json"
+
+    /// Applies Docker Compose's invocation-local `use_api_socket` transform.
+    /// The normalized source project remains unchanged for `config` output;
+    /// only the effective create/run project receives the credential snapshot.
+    func projectByApplyingAPISocket(_ project: ComposeProject) async throws
+        -> ComposeProject
+    {
+        guard
+            project.services.values.contains(where: {
+                $0.useAPISocket == true
+            })
+        else {
+            return project
+        }
+
+        let data = try await apiSocketCredentialData()
+        guard let contents = String(data: data, encoding: .utf8) else {
+            throw ComposeError.invalidProject(
+                "resolved credentials for use_api_socket are not UTF-8 JSON",
+            )
+        }
+
+        var transformed = project
+        var configs = transformed.configs ?? [:]
+        configs[Self.apiSocketConfigName] = .object([
+            "content": .string(contents),
+        ])
+        transformed.configs = configs
+
+        for name in transformed.services.keys.sorted() {
+            guard var service = transformed.services[name],
+                  service.useAPISocket == true
+            else {
+                continue
+            }
+            var environment = service.environment ?? [:]
+            if !environment.keys.contains("DOCKER_CONFIG") {
+                environment["DOCKER_CONFIG"] = Self.apiSocketConfigDirectory
+            }
+            service.environment = environment
+            var serviceConfigs = service.configs ?? []
+            serviceConfigs.append(
+                .object([
+                    "source": .string(Self.apiSocketConfigName),
+                    "target": .string(Self.apiSocketConfigTarget),
+                ]),
+            )
+            service.configs = serviceConfigs
+            transformed.services[name] = service
+        }
+        return transformed
+    }
+
+    private func apiSocketCredentialData() async throws -> Data {
+        if options.dryRun {
+            // A dry run must remain side-effect free. In particular it must
+            // not invoke a native Docker credential helper, which can prompt
+            // for Keychain access on macOS.
+            return Data("{\"auths\":{}}".utf8)
+        }
+        do {
+            return try await apiSocketCredentialResolver
+                .resolvedCredentialConfig()
+        } catch let error as ComposeError {
+            throw error
+        } catch {
+            throw ComposeError.invalidProject(
+                "resolving credentials for use_api_socket failed: \(error.localizedDescription)",
+            )
+        }
+    }
+}

--- a/Sources/ComposeCore/ComposeOrchestrator.swift
+++ b/Sources/ComposeCore/ComposeOrchestrator.swift
@@ -26,6 +26,7 @@ import Foundation
 public final class ComposeOrchestrator: @unchecked Sendable {
     let runner: CommandRunning
     let options: ComposeExecutionOptions
+    let apiSocketCredentialResolver: any ComposeAPISocketCredentialResolving
     let archiveManager: ComposeArchiveManaging
     let attachManager: ComposeRuntimeAttachManaging
     let copier: ComposeRuntimeCopying
@@ -55,6 +56,7 @@ public final class ComposeOrchestrator: @unchecked Sendable {
         let dependencies = dependencies ?? ComposeOrchestratorDependencies(runner: runner, options: options)
         self.runner = runner
         self.options = options
+        apiSocketCredentialResolver = dependencies.apiSocketCredentialResolver
         archiveManager = dependencies.archiveManager
         attachManager = dependencies.attachManager
         copier = dependencies.copier

--- a/Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift
@@ -34,7 +34,7 @@ public extension ComposeOrchestrator {
         let selectedServiceReferences = try create.noDeps && !create.services.isEmpty
             ? selectedServices(project: project, selected: create.services)
             : orderedServices(project: project, selected: create.services)
-        let workingProject = try projectByValidatingLinks(project: project, activeServiceNames: Set(selectedServiceReferences.map(\.name)))
+        var workingProject = try projectByValidatingLinks(project: project, activeServiceNames: Set(selectedServiceReferences.map(\.name)))
         let services = try selectedServiceReferences.map { service in
             guard let activeService = workingProject.services[service.name] else {
                 throw ComposeError.invalidProject("unknown service '\(service.name)'")
@@ -66,6 +66,7 @@ public extension ComposeOrchestrator {
             pullPolicy: create.pullPolicy,
         )
 
+        workingProject = try await projectByApplyingAPISocket(workingProject)
         try await ensureResources(
             project: projectBySelectingResources(project: workingProject, services: services)
         )

--- a/Sources/ComposeCore/ComposeOrchestratorDependencies.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorDependencies.swift
@@ -135,6 +135,7 @@ public struct ComposeOrchestratorRuntimeDependencies: Sendable {
 public struct ComposeOrchestratorDependencies: Sendable {
     public var commands: ComposeOrchestratorCommandDependencies
     public var runtime: ComposeOrchestratorRuntimeDependencies
+    public var apiSocketCredentialResolver: any ComposeAPISocketCredentialResolving
     public var imageManager: ComposeRuntimeImageManaging
     public var pullMetadataStore: ComposePullMetadataStoring
 
@@ -143,11 +144,14 @@ public struct ComposeOrchestratorDependencies: Sendable {
         options: ComposeExecutionOptions = ComposeExecutionOptions(),
         commands: ComposeOrchestratorCommandDependencies = ComposeOrchestratorCommandDependencies(),
         runtime: ComposeOrchestratorRuntimeDependencies? = nil,
+        apiSocketCredentialResolver: (any ComposeAPISocketCredentialResolving)? = nil,
         imageManager: ComposeRuntimeImageManaging = ComposeRuntimeProviderDefaults.images(),
         pullMetadataStore: ComposePullMetadataStoring = FileComposePullMetadataStore(),
     ) {
         self.commands = commands
         self.runtime = runtime ?? ComposeOrchestratorRuntimeDependencies(runner: runner, options: options)
+        self.apiSocketCredentialResolver = apiSocketCredentialResolver
+            ?? DockerAPISocketCredentialResolver(runner: runner)
         self.imageManager = imageManager
         self.pullMetadataStore = pullMetadataStore
     }

--- a/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorLogsRunDown.swift
@@ -789,6 +789,9 @@ public extension ComposeOrchestrator {
         dependencies: [ComposeService],
         options run: ComposeRunOptions,
     ) async throws -> ComposeRunServicePreparation {
+        let project = try await projectByApplyingAPISocket(project)
+        let service = project.services[service.name] ?? service
+        let dependencies = dependencies.map { project.services[$0.name] ?? $0 }
         let cache = ComposeImageHealthCheckCache()
         let services = dependencies + [service]
         let externalVolumeMounts = try await resolveExternalVolumeMounts(

--- a/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift
@@ -76,6 +76,9 @@ extension ComposeOrchestrator {
         if run.remove {
             args.append("--rm")
         }
+        if service.useAPISocket == true {
+            args.append("--engine-api-socket")
+        }
 
         for label in try serviceLabels(
             project: project,

--- a/Sources/ComposeCore/ComposeOrchestratorUp.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorUp.swift
@@ -237,6 +237,7 @@ extension ComposeOrchestrator {
             externalVolumeMounts: externalVolumeMounts,
             pullPolicy: up.pullPolicy,
         )
+        workingProject = try await projectByApplyingAPISocket(workingProject)
         try await ensureResources(
             project: projectBySelectingResources(project: workingProject, services: services)
         )

--- a/Sources/ComposeCore/ComposeOrchestratorValidation.swift
+++ b/Sources/ComposeCore/ComposeOrchestratorValidation.swift
@@ -117,9 +117,6 @@ extension ComposeOrchestrator {
             let fieldList = fields.joined(separator: ", ")
             throw ComposeError.unsupported("service '\(service.name)' uses unsupported volume fields \(fieldList); advanced service volume options need an apple/container mount primitive gap PR")
         }
-        if service.useAPISocket == true {
-            throw ComposeError.unsupported("service '\(service.name)' uses use_api_socket; Docker-compatible API socket and credential handoff need an apple/container runtime boundary")
-        }
     }
 
     /// Validates dependency conditions in the same order as runtime orchestration.

--- a/Sources/ComposeCore/ProcessRunner.swift
+++ b/Sources/ComposeCore/ProcessRunner.swift
@@ -172,8 +172,8 @@ public struct CommandResult: Equatable, Sendable {
     public var status: Int32
     package var stdoutData: Data
     package var stderrData: Data
-    package var stdoutOmittedByteCount: Int
-    package var stderrOmittedByteCount: Int
+    public private(set) var stdoutOmittedByteCount: Int
+    public private(set) var stderrOmittedByteCount: Int
 
     public var stdout: String {
         get { processOutputString(stdoutData) }
@@ -242,6 +242,14 @@ public protocol CommandRunning: Sendable {
         environment: [String: String]?,
         io: CommandIO,
     ) async throws -> CommandResult
+
+    /// Runs a captured command while retaining at most one prefix per output stream.
+    func runCapturingOutputPrefix(
+        _ executable: String,
+        _ arguments: [String],
+        input: Data?,
+        maximumOutputBytes: Int,
+    ) async throws -> CommandResult
 }
 
 public extension CommandRunning {
@@ -259,6 +267,35 @@ public extension CommandRunning {
             workingDirectory: workingDirectory,
             environment: environment,
             io: .captured(input: input),
+        )
+    }
+
+    /// Provides bounded result semantics for custom runners. `ProcessRunner`
+    /// overrides this method so child output is bounded while it is drained.
+    func runCapturingOutputPrefix(
+        _ executable: String,
+        _ arguments: [String],
+        input: Data? = nil,
+        maximumOutputBytes: Int,
+    ) async throws -> CommandResult {
+        precondition(maximumOutputBytes >= 0)
+        let result = try await run(
+            executable,
+            arguments,
+            workingDirectory: nil,
+            environment: nil,
+            input: input,
+        )
+        let stdoutPrefix = result.stdoutData.prefix(maximumOutputBytes)
+        let stderrPrefix = result.stderrData.prefix(maximumOutputBytes)
+        return CommandResult(
+            status: result.status,
+            stdoutData: Data(stdoutPrefix),
+            stderrData: Data(stderrPrefix),
+            stdoutOmittedByteCount: result.stdoutOmittedByteCount
+                + result.stdoutData.count - stdoutPrefix.count,
+            stderrOmittedByteCount: result.stderrOmittedByteCount
+                + result.stderrData.count - stderrPrefix.count,
         )
     }
 }
@@ -328,11 +365,9 @@ public struct ProcessRunner: CommandRunning {
     }
 
     /// Runs a captured command while retaining at most one prefix per output stream.
-    package func runCapturingOutputPrefix(
+    public func runCapturingOutputPrefix(
         _ executable: String,
         _ arguments: [String],
-        workingDirectory: URL? = nil,
-        environment: [String: String]? = nil,
         input: Data? = nil,
         maximumOutputBytes: Int,
     ) async throws -> CommandResult {
@@ -340,8 +375,8 @@ public struct ProcessRunner: CommandRunning {
         return try await runCaptured(
             executable,
             arguments,
-            workingDirectory: workingDirectory,
-            environment: environment,
+            workingDirectory: nil,
+            environment: nil,
             options: CapturedProcessOptions(
                 input: input,
                 maximumOutputBytes: maximumOutputBytes,
@@ -897,73 +932,5 @@ private extension ProcessRunState {
                 stderrOmittedByteCount: stderrOmittedByteCount,
             )),
         )
-    }
-}
-
-/// Command invocation recorded by `RecordingRunner`.
-public struct RecordedCommand: Equatable, Sendable {
-    public var executable: String
-    public var arguments: [String]
-    public var workingDirectory: URL?
-    public var environment: [String: String]?
-    public var io: CommandIO
-
-    public var input: Data? {
-        if case let .captured(input) = io {
-            return input
-        }
-        return nil
-    }
-}
-
-/// Test runner that records invocations and returns queued responses.
-public final class RecordingRunner: CommandRunning, @unchecked Sendable {
-    private let lock = NSLock()
-    private var commandStorage: [RecordedCommand] = []
-    private var responseStorage: [CommandResult]
-
-    public var commands: [RecordedCommand] {
-        lock.lock()
-        defer { lock.unlock() }
-        return commandStorage
-    }
-
-    public var responses: [CommandResult] {
-        get {
-            lock.lock()
-            defer { lock.unlock() }
-            return responseStorage
-        }
-        set {
-            lock.lock()
-            defer { lock.unlock() }
-            responseStorage = newValue
-        }
-    }
-
-    public init(responses: [CommandResult] = []) {
-        responseStorage = responses
-    }
-
-    /// Records a command and returns the next queued response, or success.
-    public func run(
-        _ executable: String,
-        _ arguments: [String],
-        workingDirectory: URL?,
-        environment: [String: String]?,
-        io: CommandIO,
-    ) async throws -> CommandResult {
-        lock.withLock {
-            commandStorage.append(RecordedCommand(
-                executable: executable,
-                arguments: arguments,
-                workingDirectory: workingDirectory,
-                environment: environment,
-                io: io,
-            ))
-            return responseStorage.isEmpty
-                ? CommandResult(status: 0, stdout: "", stderr: "")
-                : responseStorage.removeFirst()
-        }
     }
 }

--- a/Sources/ComposeCore/RecordingRunner.swift
+++ b/Sources/ComposeCore/RecordingRunner.swift
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 container-compose project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Command invocation recorded by `RecordingRunner`.
+public struct RecordedCommand: Equatable, Sendable {
+    public var executable: String
+    public var arguments: [String]
+    public var workingDirectory: URL?
+    public var environment: [String: String]?
+    public var io: CommandIO
+
+    public var input: Data? {
+        if case let .captured(input) = io {
+            return input
+        }
+        return nil
+    }
+}
+
+/// Test runner that records invocations and returns queued responses.
+public final class RecordingRunner: CommandRunning, @unchecked Sendable {
+    private let lock = NSLock()
+    private var commandStorage: [RecordedCommand] = []
+    private var responseStorage: [CommandResult]
+
+    public var commands: [RecordedCommand] {
+        lock.lock()
+        defer { lock.unlock() }
+        return commandStorage
+    }
+
+    public var responses: [CommandResult] {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return responseStorage
+        }
+        set {
+            lock.lock()
+            defer { lock.unlock() }
+            responseStorage = newValue
+        }
+    }
+
+    public init(responses: [CommandResult] = []) {
+        responseStorage = responses
+    }
+
+    /// Records a command and returns the next queued response, or success.
+    public func run(
+        _ executable: String,
+        _ arguments: [String],
+        workingDirectory: URL?,
+        environment: [String: String]?,
+        io: CommandIO,
+    ) async throws -> CommandResult {
+        lock.withLock {
+            commandStorage.append(RecordedCommand(
+                executable: executable,
+                arguments: arguments,
+                workingDirectory: workingDirectory,
+                environment: environment,
+                io: io,
+            ))
+            return responseStorage.isEmpty
+                ? CommandResult(status: 0, stdout: "", stderr: "")
+                : responseStorage.removeFirst()
+        }
+    }
+}

--- a/Tests/ComposeCoreTests/ComposeAPISocketTests.swift
+++ b/Tests/ComposeCoreTests/ComposeAPISocketTests.swift
@@ -1,0 +1,479 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 container-compose project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+@testable import ComposeCore
+import Foundation
+import Testing
+
+@Suite("Compose API socket")
+struct ComposeAPISocketTests {
+    @Test
+    func `disabled projects remain byte-for-byte unchanged and do not resolve credentials`() async throws {
+        let resolver = StaticAPISocketCredentialResolver(
+            data: Data(), failure: TestFailure.unexpectedCall,
+        )
+        let orchestrator = ComposeOrchestrator(
+            dependencies: orchestratorDependencies {
+                $0.apiSocketCredentialResolver = resolver
+            },
+        )
+        let source = composeProject(
+            name: "demo",
+            services: ["worker": composeService(name: "worker", image: "example/worker")],
+        )
+
+        let transformed = try await orchestrator.projectByApplyingAPISocket(source)
+
+        #expect(transformed == source)
+        #expect(await resolver.callCount() == 0)
+    }
+
+    @Test
+    func `transform adds the generated credential config only to enabled services`() async throws {
+        let credentials = Data(#"{"auths":{"registry.example":{"auth":"dXNlcjpwYXNz"}}}"#.utf8)
+        let resolver = StaticAPISocketCredentialResolver(data: credentials)
+        let orchestrator = ComposeOrchestrator(
+            dependencies: orchestratorDependencies {
+                $0.apiSocketCredentialResolver = resolver
+            },
+        )
+        let source = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.useAPISocket = true
+                },
+                "worker": composeService(name: "worker", image: "example/worker"),
+            ],
+        )
+
+        let transformed = try await orchestrator.projectByApplyingAPISocket(source)
+        let credentialContents = try #require(
+            String(bytes: credentials, encoding: .utf8),
+        )
+
+        #expect(source.configs == nil)
+        #expect(source.services["api"]?.environment == nil)
+        #expect(source.services["api"]?.configs == nil)
+        #expect(
+            transformed.configs?[ComposeOrchestrator.apiSocketConfigName]
+                == .object(["content": .string(credentialContents)]),
+        )
+        #expect(
+            transformed.services["api"]?.environment?["DOCKER_CONFIG"]
+                == ComposeOrchestrator.apiSocketConfigDirectory,
+        )
+        #expect(
+            transformed.services["api"]?.configs
+                == [
+                    .object([
+                        "source": .string(ComposeOrchestrator.apiSocketConfigName),
+                        "target": .string(ComposeOrchestrator.apiSocketConfigTarget),
+                    ]),
+                ],
+        )
+        #expect(transformed.services["worker"]?.environment == nil)
+        #expect(transformed.services["worker"]?.configs == nil)
+        #expect(await resolver.callCount() == 1)
+    }
+
+    @Test
+    func `transform preserves an explicitly supplied Docker config environment key`() async throws {
+        let resolver = StaticAPISocketCredentialResolver(data: Data(#"{"auths":{}}"#.utf8))
+        let orchestrator = ComposeOrchestrator(
+            dependencies: orchestratorDependencies {
+                $0.apiSocketCredentialResolver = resolver
+            },
+        )
+        let source = composeProject(
+            name: "demo",
+            services: [
+                "empty": composeService(name: "empty", image: "example/empty") {
+                    $0.useAPISocket = true
+                    $0.environment = ["DOCKER_CONFIG": ""]
+                },
+                "inherited": composeService(name: "inherited", image: "example/inherited") {
+                    $0.useAPISocket = true
+                    $0.environment = ["DOCKER_CONFIG": nil]
+                },
+            ],
+        )
+
+        let transformed = try await orchestrator.projectByApplyingAPISocket(source)
+
+        #expect(transformed.services["empty"]?.environment?["DOCKER_CONFIG"] == "")
+        let inheritedEnvironment = try #require(transformed.services["inherited"]?.environment)
+        switch inheritedEnvironment["DOCKER_CONFIG"] {
+        case .some(.none):
+            break
+        default:
+            Issue.record("Expected an explicit nil DOCKER_CONFIG value")
+        }
+    }
+
+    @Test
+    func `dry run does not invoke a Docker credential resolver`() async throws {
+        let resolver = StaticAPISocketCredentialResolver(
+            data: Data(), failure: TestFailure.unexpectedCall,
+        )
+        let orchestrator = ComposeOrchestrator(
+            options: ComposeExecutionOptions(dryRun: true),
+            dependencies: orchestratorDependencies {
+                $0.apiSocketCredentialResolver = resolver
+            },
+        )
+        let source = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.useAPISocket = true
+                },
+            ],
+        )
+
+        let transformed = try await orchestrator.projectByApplyingAPISocket(source)
+
+        #expect(transformed.configs?[ComposeOrchestrator.apiSocketConfigName] != nil)
+        #expect(await resolver.callCount() == 0)
+    }
+
+    @Test
+    func `credential failure happens before project resource mutation`() async throws {
+        let runner = RecordingRunner()
+        let resourceManager = RecordingContainerResourceManager()
+        let resolver = StaticAPISocketCredentialResolver(
+            data: Data(), failure: TestFailure.credentialFailure,
+        )
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            dependencies: orchestratorDependencies {
+                $0.apiSocketCredentialResolver = resolver
+                $0.resourceManager = resourceManager
+            },
+        )
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.useAPISocket = true
+                    $0.networks = ["backend"]
+                    $0.volumes = [
+                        ComposeMount(type: "volume", source: "cache", target: "/cache"),
+                    ]
+                },
+            ],
+        ) {
+            $0.networks = ["backend": ComposeNetwork(name: "demo_backend")]
+            $0.volumes = ["cache": ComposeVolume(name: "demo_cache")]
+        }
+
+        await #expect(throws: ComposeError.self) {
+            try await orchestrator.up(project: project, options: ComposeUpOptions())
+        }
+        #expect(await resourceManager.requests.isEmpty)
+    }
+}
+
+@Suite("Compose API socket credentials")
+struct ComposeAPISocketCredentialTests {
+    @Test
+    func `resolver emits only file credentials when no helper is configured`() async throws {
+        let runner = RecordingRunner()
+        let authConfig =
+            #"{"auths":{"registry.example":{"auth":"dXNlcjpwYXNz","email":"user@example.com"}},"#
+                + #""currentContext":"desktop-linux"}"#
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: runner,
+            environment: [
+                "DOCKER_AUTH_CONFIG": authConfig,
+            ],
+        )
+
+        let data = try await resolver.resolvedCredentialConfig()
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(Set(object.keys) == ["auths"])
+        let auths = try #require(object["auths"] as? [String: Any])
+        let registry = try #require(auths["registry.example"] as? [String: Any])
+        #expect(registry["auth"] as? String == "dXNlcjpwYXNz")
+        #expect(registry["email"] == nil)
+        #expect(runner.commands.isEmpty)
+    }
+
+    @Test
+    func `file username and password become canonical auth`() async throws {
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: RecordingRunner(),
+            environment: [
+                "DOCKER_AUTH_CONFIG":
+                    #"{"auths":{"registry.example":{"username":"alice","password":"secret"}}}"#,
+            ],
+        )
+
+        let data = try await resolver.resolvedCredentialConfig()
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let auths = try #require(object["auths"] as? [String: Any])
+        let registry = try #require(auths["registry.example"] as? [String: Any])
+
+        #expect(registry["auth"] as? String == Data("alice:secret".utf8).base64EncodedString())
+        #expect(registry["username"] == nil)
+        #expect(registry["password"] == nil)
+    }
+
+    @Test
+    func `malformed file auth fails before helper execution`() async throws {
+        let runner = RecordingRunner()
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: runner,
+            environment: [
+                "DOCKER_AUTH_CONFIG": #"{"auths":{"registry.example":{"auth":"not-base64"}}}"#,
+            ],
+        )
+
+        await #expect(throws: ComposeError.self) {
+            try await resolver.resolvedCredentialConfig()
+        }
+        #expect(runner.commands.isEmpty)
+    }
+
+    @Test
+    func `default credential helper replaces file credentials without a shell`() async throws {
+        let runner = RecordingRunner(responses: [
+            CommandResult(status: 0, stdout: #"{"registry.example":"alice"}"#, stderr: ""),
+            CommandResult(status: 0, stdout: #"{"Username":"alice","Secret":"secret"}"#, stderr: ""),
+        ])
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: runner,
+            environment: [
+                "DOCKER_AUTH_CONFIG":
+                    #"{"auths":{"file.example":{"auth":"ZmlsZTpvbmx5"}},"credsStore":"test"}"#,
+                "HOME": "/private/empty-home",
+                "PATH": "/usr/bin:/bin",
+            ],
+        )
+
+        let data = try await resolver.resolvedCredentialConfig()
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let auths = try #require(object["auths"] as? [String: Any])
+        let registry = try #require(auths["registry.example"] as? [String: Any])
+
+        #expect(auths["file.example"] == nil)
+        #expect(registry["auth"] as? String == Data("alice:secret".utf8).base64EncodedString())
+        #expect(runner.commands.map(\.executable) == ["/usr/bin/env", "/usr/bin/env"])
+        #expect(
+            runner.commands.map(\.arguments) == [
+                ["-i", "HOME=/private/empty-home", "PATH=/usr/bin:/bin", "docker-credential-test", "list"],
+                ["-i", "HOME=/private/empty-home", "PATH=/usr/bin:/bin", "docker-credential-test", "get"],
+            ],
+        )
+        #expect(runner.commands[0].input == Data("unused".utf8))
+        #expect(runner.commands[1].input == Data("registry.example".utf8))
+    }
+
+    @Test
+    func `registry helper failure retains the file credential`() async throws {
+        let runner = RecordingRunner(responses: [
+            CommandResult(status: 1, stdout: "", stderr: "credentials not found"),
+        ])
+        let authConfig =
+            #"{"auths":{"registry.example":{"auth":"ZmlsZTpvbmx5"}},"#
+                + #""credHelpers":{"registry.example":"test"}}"#
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: runner,
+            environment: [
+                "DOCKER_AUTH_CONFIG": authConfig,
+                "HOME": "/private/empty-home",
+                "PATH": "/usr/bin:/bin",
+            ],
+        )
+
+        let data = try await resolver.resolvedCredentialConfig()
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let auths = try #require(object["auths"] as? [String: Any])
+        let registry = try #require(auths["registry.example"] as? [String: Any])
+
+        #expect(registry["auth"] as? String == "ZmlsZTpvbmx5")
+        #expect(runner.commands.count == 1)
+    }
+
+    @Test
+    func `registry helper not-found result replaces file auth with an empty credential`() async throws {
+        let runner = RecordingRunner(responses: [
+            CommandResult(
+                status: 1,
+                stdout: "credentials not found in native keychain\n",
+                stderr: "",
+            ),
+        ])
+        let authConfig =
+            #"{"auths":{"registry.example":{"auth":"ZmlsZTpvbmx5"}},"#
+                + #""credHelpers":{"registry.example":"test"}}"#
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: runner,
+            environment: [
+                "DOCKER_AUTH_CONFIG": authConfig,
+                "HOME": "/private/empty-home",
+                "PATH": "/usr/bin:/bin",
+            ],
+        )
+
+        let data = try await resolver.resolvedCredentialConfig()
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let auths = try #require(object["auths"] as? [String: Any])
+        let registry = try #require(auths["registry.example"] as? [String: Any])
+
+        #expect(registry.isEmpty)
+    }
+
+    @Test
+    func `token helper credential becomes an identity token`() async throws {
+        let runner = RecordingRunner(responses: [
+            CommandResult(status: 0, stdout: #"{"registry.example":"<token>"}"#, stderr: ""),
+            CommandResult(status: 0, stdout: #"{"Username":"<token>","Secret":"opaque-token"}"#, stderr: ""),
+        ])
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: runner,
+            environment: [
+                "DOCKER_AUTH_CONFIG": #"{"credsStore":"test"}"#,
+                "HOME": "/private/empty-home",
+                "PATH": "/usr/bin:/bin",
+            ],
+        )
+
+        let data = try await resolver.resolvedCredentialConfig()
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let auths = try #require(object["auths"] as? [String: Any])
+        let registry = try #require(auths["registry.example"] as? [String: Any])
+
+        #expect(registry["identitytoken"] as? String == "opaque-token")
+        #expect(registry["auth"] == nil)
+    }
+
+    @Test
+    func `credential helper output is bounded`() async throws {
+        let runner = RecordingRunner(responses: [
+            CommandResult(
+                status: 0,
+                stdout: String(repeating: "x", count: 1_048_577),
+                stderr: "",
+            ),
+        ])
+        let resolver = DockerAPISocketCredentialResolver(
+            runner: runner,
+            environment: [
+                "DOCKER_AUTH_CONFIG": #"{"credsStore":"test"}"#,
+                "HOME": "/private/empty-home",
+                "PATH": "/usr/bin:/bin",
+            ],
+        )
+
+        await #expect(throws: ComposeError.self) {
+            try await resolver.resolvedCredentialConfig()
+        }
+    }
+
+    @Test
+    func `up carries credentials and the typed socket grant into container create`() async throws {
+        let materializedRoot = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: materializedRoot) }
+        let credentials = Data(#"{"auths":{"registry.example":{"auth":"dXNlcjpwYXNz"}}}"#.utf8)
+        let resolver = StaticAPISocketCredentialResolver(data: credentials)
+        let runner = RecordingRunner(responses: [.success])
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions {
+                $0.materializedConfigSecretDirectory = materializedRoot
+            },
+            dependencies: orchestratorDependencies {
+                $0.apiSocketCredentialResolver = resolver
+            },
+        )
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.useAPISocket = true
+                },
+            ],
+        )
+
+        try await orchestrator.up(project: project, options: ComposeUpOptions())
+
+        let create = try #require(runner.commands.first?.arguments)
+        #expect(create.contains("--engine-api-socket"))
+        #expect(create.containsSequence(["--env", "DOCKER_CONFIG=/run/secrets/docker"]))
+        let source = try #require(
+            orchestratorReadOnlyVolumeSource(
+                target: ComposeOrchestrator.apiSocketConfigTarget,
+                in: create,
+            ),
+        )
+        #expect(try Data(contentsOf: URL(fileURLWithPath: source)) == credentials)
+        #expect(await resolver.callCount() == 1)
+    }
+
+    @Test
+    func `run arguments request the typed engine API socket grant`() async throws {
+        let orchestrator = ComposeOrchestrator(
+            options: ComposeExecutionOptions(dryRun: true),
+            dependencies: orchestratorDependencies { _ in },
+        )
+        let project = composeProject(
+            name: "demo",
+            services: [
+                "api": composeService(name: "api", image: "example/api") {
+                    $0.useAPISocket = true
+                },
+            ],
+        )
+        let service = try #require(project.services["api"])
+
+        let arguments = try await orchestrator.runArguments(project: project, service: service)
+
+        #expect(arguments.contains("--engine-api-socket"))
+        #expect(
+            !arguments.contains(where: { $0.contains("/var/run/docker.sock:/var/run/docker.sock") }),
+        )
+    }
+}
+
+private actor StaticAPISocketCredentialResolver: ComposeAPISocketCredentialResolving {
+    private let data: Data
+    private let failure: (any Error)?
+    private var calls = 0
+
+    init(data: Data, failure: (any Error)? = nil) {
+        self.data = data
+        self.failure = failure
+    }
+
+    func resolvedCredentialConfig() async throws -> Data {
+        calls += 1
+        if let failure {
+            throw failure
+        }
+        return data
+    }
+
+    func callCount() -> Int {
+        calls
+    }
+}
+
+private enum TestFailure: Error, Equatable {
+    case credentialFailure
+    case unexpectedCall
+}

--- a/Tests/ComposeCoreTests/ComposeOrchestratorResourceTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorResourceTests.swift
@@ -1090,33 +1090,6 @@ extension ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
-    @Test("up rejects unsupported API socket mounting before creating resources")
-    func upRejectsUnsupportedAPISocketBeforeCreatingResources() async throws {
-        let runner = RecordingRunner()
-        let project = composeProject(
-            name: "demo",
-            services: [
-                "api": composeService(name: "api", image: "example/api") {
-                    $0.useAPISocket = true
-                    $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
-                },
-            ]
-        ) {
-            $0.volumes = ["cache": ComposeVolume(name: "cache")]
-        }
-
-        do {
-            try await ComposeOrchestrator(runner: runner).up(project: project, options: ComposeUpOptions())
-            Issue.record("Expected unsupported API socket error")
-        } catch let error as ComposeError {
-            #expect(error == .unsupported("service 'api' uses use_api_socket; Docker-compatible API socket and credential handoff need an apple/container runtime boundary"))
-        } catch {
-            Issue.record("Unexpected error: \(error)")
-        }
-
-        #expect(runner.commands.isEmpty)
-    }
-
     @Test("up maps service MAC address to single network attachment")
     func upMapsServiceMACAddressToSingleNetworkAttachment() async throws {
         let runner = RecordingRunner(responses: [

--- a/Tests/ComposeCoreTests/ComposeOrchestratorRunTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorRunTests.swift
@@ -2831,33 +2831,6 @@ extension ComposeOrchestratorTests {
         #expect(runner.commands.isEmpty)
     }
 
-    @Test("run rejects unsupported API socket mounting before creating resources")
-    func runRejectsUnsupportedAPISocketBeforeCreatingResources() async throws {
-        let runner = RecordingRunner()
-        let project = composeProject(
-            name: "demo",
-            services: [
-                "job": composeService(name: "job", image: "alpine") {
-                    $0.useAPISocket = true
-                    $0.volumes = [ComposeMount(type: "volume", source: "cache", target: "/cache")]
-                },
-            ]
-        ) {
-            $0.volumes = ["cache": ComposeVolume(name: "cache")]
-        }
-
-        do {
-            try await ComposeOrchestrator(runner: runner).run(project: project, serviceName: "job", command: ["true"], remove: true)
-            Issue.record("Expected unsupported API socket error")
-        } catch let error as ComposeError {
-            #expect(error == .unsupported("service 'job' uses use_api_socket; Docker-compatible API socket and credential handoff need an apple/container runtime boundary"))
-        } catch {
-            Issue.record("Unexpected error: \(error)")
-        }
-
-        #expect(runner.commands.isEmpty)
-    }
-
     @Test("run maps service MAC address to single network attachment")
     func runMapsServiceMACAddressToSingleNetworkAttachment() async throws {
         let runner = RecordingRunner(responses: [

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "228897171d71975988ccdc690f1982e7433952af",
+      "ref": "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

- implement Docker Compose `use_api_socket` as an invocation-local project transform
- resolve Docker CLI file, default-store, and registry-helper credentials into the generated `#apisocket` config
- use Container's typed, durable `--engine-api-socket` grant instead of an unsafe generic host bind
- apply the transform to create, up, and one-off run while preserving `config` output
- keep dry-run helper-free and bound helper execution/output for unattended builds
- fail credential resolution before network or volume mutation
- pin the merged Container prerequisite and stack authority at `40ab92d74a02bbd6b7436a50d47c38898a4bc294`

## Evidence

- `swift test --filter ComposeAPISocket`: 15 tests passed in 8.28s against the merged Container commit
- `swift test --skip-build --filter ProcessRunnerBoundedOutputTests`: passed in 2.82s
- `make source-checks`: passed in 15.08s
- exact CI-selected SwiftLint strict and SwiftFormat lint paths: passed
- `git diff --cached --check`: passed
- reviewed against Docker Compose 5.4.0 `apiSocket.go` and Docker CLI 29.2.1 credential-store behavior

## Review fixes already folded in

- bound credential-helper capture while draining output
- resolve credentials before mutating project resources
- canonicalize file auth and reject malformed base64 credentials
- match Docker's standard credential-not-found behavior
- omit legacy email data and preserve registry tokens
- split structural boundaries surfaced by the exact CI lint policy

Closes #496
Part of #270
Requires stephenlclarke/container#213 (merged)
