### PR TITLE
fix(build): make local validation deterministic

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -406,116 +406,30 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Swift style tools
-        env:
-          HOMEBREW_NO_ENV_HINTS: "1"
-        run: |
-          set -euo pipefail
-          for tap in aws/tap azure/bicep; do
-            HOMEBREW_NO_REQUIRE_TAP_TRUST=1 brew untap "$tap" >/dev/null 2>&1 || true
-          done
-          if ! command -v swiftlint >/dev/null 2>&1; then
-            HOMEBREW_REQUIRE_TAP_TRUST=1 brew install swiftlint
-          fi
-          if ! command -v swiftformat >/dev/null 2>&1; then
-            HOMEBREW_REQUIRE_TAP_TRUST=1 brew install swiftformat
-          fi
-          swiftlint version
-          swiftformat --version
-
-      - name: Collect Swift style paths
-        id: style-paths
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Run deterministic Swift style checks
         shell: bash
         run: |
           set -euo pipefail
-          changed_files="${RUNNER_TEMP}/changed-files.txt"
-          style_paths="${RUNNER_TEMP}/swift-style-paths.txt"
-
           case "${GITHUB_EVENT_NAME}" in
             pull_request)
-              gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files" \
-                --paginate \
-                --jq '.[].filename' > "$changed_files"
+              export SWIFT_STYLE_BASE="${{ github.event.pull_request.base.sha }}"
+              export SWIFT_STYLE_HEAD="${GITHUB_SHA}"
               ;;
             push)
               before="${{ github.event.before }}"
-              after="${GITHUB_SHA}"
               if [[ "$before" =~ ^0+$ ]] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
-                git diff-tree --no-commit-id --name-only -r "$after" > "$changed_files"
+                export SWIFT_STYLE_ALL=1
               else
-                git diff --name-only "$before" "$after" > "$changed_files"
+                export SWIFT_STYLE_BASE="$before"
+                export SWIFT_STYLE_HEAD="${GITHUB_SHA}"
               fi
               ;;
             workflow_dispatch)
-              {
-                if [[ -f Package.swift ]]; then
-                  printf 'Package.swift\n'
-                fi
-                find Sources Tests -type f -name '*.swift' -print
-              } > "$changed_files"
+              export SWIFT_STYLE_ALL=1
               ;;
             *)
-              : > "$changed_files"
+              printf 'Unsupported Swift style event: %s\n' "${GITHUB_EVENT_NAME}" >&2
+              exit 2
               ;;
           esac
-
-          while IFS= read -r path; do
-            [[ -f "$path" ]] || continue
-            # These legacy command and orchestrator files predate the strict changed-file style gate.
-            case "$path" in
-              Sources/ComposePlugin/ComposeCLIHelp.swift|Tests/ComposePluginTests/ComposeCLIHelpTests.swift)
-                continue
-                ;;
-              Sources/ComposePlugin/ComposePlugin.swift)
-                continue
-                ;;
-              Sources/ComposeCore/ComposeCommandOptions.swift|Sources/ComposeCore/ComposeCommitImageArchive.swift|Sources/ComposeCore/ComposeExecutionOptions.swift|Sources/ComposeCore/ComposeOrchestratorBuildAndImages.swift|Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift|Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift|Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift|Sources/ComposeCore/ComposeOrchestratorUp.swift|Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift|Sources/ComposeCore/ContainerDiscoveryAdapter.swift|Tests/ComposeCoreTests/ComposeOrchestratorTests.swift)
-                continue
-                ;;
-              Sources/ComposeContainerRuntime/ComposeCommitImageArchive.swift|Tests/ComposeCoreTests/ComposeOrchestratorBuildAndImageTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorCopyExportCommitTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorLogsWatchAttachTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorResourceTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorRunTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift|Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift|Tests/ComposeCoreTests/ComposeOrchestratorValidationTests.swift)
-                continue
-                ;;
-              Sources/ComposePlugin/ContainerPackageCompatibility.swift|Tests/ComposePluginTests/ContainerPackageCompatibilityTests.swift|Tests/ComposeCoreTests/ComposeNormalizerTests.swift|Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift)
-                continue
-                ;;
-            esac
-            case "$path" in
-              Package.swift|Sources/*.swift|Tests/*.swift)
-                printf '%s\n' "$path"
-                ;;
-            esac
-          done < "$changed_files" | sort -u > "$style_paths"
-
-          if [[ ! -s "$style_paths" ]]; then
-            printf 'No Swift style paths selected.\n'
-            printf 'has_paths=false\n' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          printf 'Selected Swift style paths:\n'
-          sed 's/^/  /' "$style_paths"
-          printf 'has_paths=true\n' >> "$GITHUB_OUTPUT"
-
-      - name: Run SwiftLint
-        if: steps.style-paths.outputs.has_paths == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          style_paths=()
-          while IFS= read -r path; do
-            style_paths+=("$path")
-          done < "${RUNNER_TEMP}/swift-style-paths.txt"
-          swiftlint lint --strict --quiet "${style_paths[@]}"
-
-      - name: Run SwiftFormat lint
-        if: steps.style-paths.outputs.has_paths == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          style_paths=()
-          while IFS= read -r path; do
-            style_paths+=("$path")
-          done < "${RUNNER_TEMP}/swift-style-paths.txt"
-          swiftformat "${style_paths[@]}" --lint --swift-version 6.2
+          make swift-style-check

--- a/Makefile
+++ b/Makefile
@@ -580,7 +580,7 @@ DOCKER_COMPOSE_PARITY_TARGETS := \
 SWIFT_TEST_FLAGS ?=
 SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -F -Xswiftc '$(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)' -Xlinker -rpath -Xlinker '$(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)' $(if $(strip $(SWIFT_TEST_RUNTIME_LIBRARY_PATH)),-Xlinker -rpath -Xlinker '$(SWIFT_TEST_RUNTIME_LIBRARY_PATH)'))
 
-.PHONY: all workflow ci ci-fast release-gate-environment-fingerprint-check release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-runtime-test-build swift-runtime-test swift-coverage go-test go-build go-release-check cli-smoke cli-smoke-built container-stack-build container-stack-build-if-needed docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-parity-stages docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-external-dockerfile-parity docker-compose-build-external-secret-parity docker-compose-build-isolation-parity docker-compose-build-no-cache-filter-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-image-volumes-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-cpu-limit-parity docker-compose-privileged-parity docker-compose-security-opt-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-memory-byte-precision-parity docker-compose-memory-swap-limit-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-service-discovery-parity docker-compose-links-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-state-status-parity docker-compose-rm-parity docker-compose-lifecycle-hooks-parity docker-compose-signal-log-reliability-parity docker-compose-restart-policy-parity docker-compose-userns-mode-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-syntax coverage-python-tools-test release-tools-test ci-tools-test coverage-tools-test source-checks lint format fmt check check-licenses update-licenses pre-commit
+.PHONY: all workflow ci ci-fast release-gate-environment-fingerprint-check release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-test-direct swift-runtime-test-build swift-runtime-test swift-coverage go-test go-build go-release-check cli-smoke cli-smoke-built container-stack-build container-stack-build-if-needed docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-parity-stages docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-external-dockerfile-parity docker-compose-build-external-secret-parity docker-compose-build-isolation-parity docker-compose-build-no-cache-filter-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-image-volumes-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-cpu-limit-parity docker-compose-privileged-parity docker-compose-security-opt-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-memory-byte-precision-parity docker-compose-memory-swap-limit-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-service-discovery-parity docker-compose-links-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-state-status-parity docker-compose-rm-parity docker-compose-lifecycle-hooks-parity docker-compose-signal-log-reliability-parity docker-compose-restart-policy-parity docker-compose-userns-mode-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-syntax coverage-python-tools-test release-tools-test ci-tools-test coverage-tools-test source-checks lint format fmt check check-licenses update-licenses pre-commit swift-style-tools swift-style-paths swift-style-check swift-style-format local-swift-stack-clean
 
 .PHONY: print-release-gate-static-fingerprint print-release-gate-fingerprint
 .PHONY: worktree-audit worktree-audit-strict
@@ -1161,28 +1161,35 @@ release-plan:
 	./scripts/CONTAINER_STACK_RELEASE.sh plan
 
 resolve:
-	$(SWIFT) package resolve
+	$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" -- \
+		$(SWIFT) package resolve
 
 build:
 	@if [[ -n "$(CONTAINER_PACKAGE_PATH)$(CONTAINERIZATION_PACKAGE_PATH)" ]]; then \
-		lock_backup="$$(mktemp "$${TMPDIR:-/tmp}/container-compose-package-resolved.XXXXXX")"; \
-		cp Package.resolved "$$lock_backup"; \
-		restore_lock() { trap - EXIT HUP INT QUIT TERM; cp "$$lock_backup" Package.resolved; rm -f "$$lock_backup"; }; \
-		trap restore_lock EXIT HUP INT QUIT TERM; \
-		$(PARITY_ENV) $(SWIFT) build --product compose; \
+		$(PARITY_ENV) $(PYTHON) Tools/ci/run-with-local-swift-stack.py \
+			--swift "$(SWIFT)" \
+			--retain-edits \
+			--container "$(CONTAINER_PACKAGE_PATH)" \
+			--containerization "$(CONTAINERIZATION_PACKAGE_PATH)" \
+			--engine-api "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" \
+			-- $(SWIFT) build --product compose; \
 	else \
-		$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) --product compose; \
+		$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" -- \
+			$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) --product compose; \
 	fi
 
 build-release:
 	@if [[ -n "$(CONTAINER_PACKAGE_PATH)$(CONTAINERIZATION_PACKAGE_PATH)" ]]; then \
-		lock_backup="$$(mktemp "$${TMPDIR:-/tmp}/container-compose-package-resolved.XXXXXX")"; \
-		cp Package.resolved "$$lock_backup"; \
-		restore_lock() { trap - EXIT HUP INT QUIT TERM; cp "$$lock_backup" Package.resolved; rm -f "$$lock_backup"; }; \
-		trap restore_lock EXIT HUP INT QUIT TERM; \
-		$(PARITY_ENV) $(SWIFT) build -c release --product compose $(SWIFT_RELEASE_FLAGS); \
+		$(PARITY_ENV) $(PYTHON) Tools/ci/run-with-local-swift-stack.py \
+			--swift "$(SWIFT)" \
+			--retain-edits \
+			--container "$(CONTAINER_PACKAGE_PATH)" \
+			--containerization "$(CONTAINERIZATION_PACKAGE_PATH)" \
+			--engine-api "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" \
+			-- $(SWIFT) build -c release --product compose $(SWIFT_RELEASE_FLAGS); \
 	else \
-		$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) -c release --product compose $(SWIFT_RELEASE_FLAGS); \
+		$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" -- \
+			$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) -c release --product compose $(SWIFT_RELEASE_FLAGS); \
 	fi
 
 .PHONY: release-parity-build-info
@@ -1209,7 +1216,26 @@ test: swift-test go-test
 swift-test-build:
 	$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) --build-tests --enable-code-coverage $(SWIFT_TEST_FLAGS)
 
-swift-test: swift-test-build
+swift-test:
+	@if [[ -n "$(CONTAINER_PACKAGE_PATH)$(CONTAINERIZATION_PACKAGE_PATH)" ]]; then \
+		$(PYTHON) Tools/ci/run-with-local-swift-stack.py \
+			--swift "$(SWIFT)" \
+			--retain-edits \
+			--container "$(CONTAINER_PACKAGE_PATH)" \
+			--containerization "$(CONTAINERIZATION_PACKAGE_PATH)" \
+			--engine-api "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" \
+			-- $(MAKE) --no-print-directory swift-test-direct \
+				CONTAINER_PACKAGE_PATH= CONTAINERIZATION_PACKAGE_PATH= \
+				CONTAINER_ENGINE_API_PACKAGE_PATH=; \
+	else \
+		$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" -- \
+			$(MAKE) --no-print-directory swift-test-direct; \
+	fi
+
+local-swift-stack-clean:
+	$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" --cleanup
+
+swift-test-direct: swift-test-build
 	@mkdir -p .build
 	@env -u CONTAINER_BIN -u CONTAINER_COMPOSE_CONTAINER \
 		PYTHON="$(PYTHON)" SWIFT_TEST_RESULT_LOG="$(SWIFT_TEST_RESULT_LOG)" SWIFT_TEST_ATTEMPTS="$(SWIFT_TEST_ATTEMPTS)" \
@@ -2785,6 +2811,18 @@ worktree-audit-strict:
 
 source-preflight: upstream-handoff-registry-check stack-consistency core-runtime-neutrality check-licenses
 
+swift-style-tools:
+	$(PYTHON) Tools/ci/swift-style.py install
+
+swift-style-paths:
+	$(PYTHON) Tools/ci/swift-style.py paths
+
+swift-style-check:
+	$(PYTHON) Tools/ci/swift-style.py lint
+
+swift-style-format:
+	$(PYTHON) Tools/ci/swift-style.py format
+
 check: source-preflight lint
 
 lint: lint-static coverage-tools-test performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test compose-events-harness-test
@@ -2811,7 +2849,7 @@ lint-static:
 
 fmt: format
 
-format: update-licenses
+format: update-licenses swift-style-format
 	cd Tools/compose-normalizer && $(GO) fmt ./...
 
 check-licenses:
@@ -2832,7 +2870,7 @@ pre-commit:
 	chmod +x "$(HOOKS_DIR)/pre-commit"
 	@./scripts/ensure-hawkeye-exists.sh
 
-clean:
+clean: local-swift-stack-clean
 	$(SWIFT) package clean
 	rm -rf "$(DIST_DIR)" "$(PLUGIN_ARCHIVE)" "$(DOCS_OUTPUT_DIR)" "$(DOCS_SERVER_DIR)" "$(DOCS_SCRATCH_PATH)" .scannerwork coverage*.lcov coverage.out coverage.report coverage*.xml
 	rm -f *.profraw Tools/compose-normalizer/coverage.out Tools/compose-normalizer/compose-normalizer

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fba8ab3ca21467494cd4e7a81d067b5bb9339e88d538bb28870ae964b73c6e03",
+  "originHash" : "54b27945699003a9f041a9c3b557c04c35be915c680e1477371f24f735940da9",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Package.swift
+++ b/Package.swift
@@ -15,32 +15,17 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import Foundation
 import PackageDescription
 
-let containerDependency: Package.Dependency = {
-    if let path = ProcessInfo.processInfo.environment["CONTAINER_PACKAGE_PATH"],
-       !path.isEmpty
-    {
-        return .package(name: "container", path: path)
-    }
-    return .package(
-        url: "https://github.com/stephenlclarke/container.git",
-        revision: "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
-    )
-}()
+let containerDependency: Package.Dependency = .package(
+    url: "https://github.com/stephenlclarke/container.git",
+    revision: "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
+)
 
-let containerizationDependency: Package.Dependency = {
-    if let path = ProcessInfo.processInfo.environment["CONTAINERIZATION_PACKAGE_PATH"],
-       !path.isEmpty
-    {
-        return .package(name: "containerization", path: path)
-    }
-    return .package(
-        url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "b404e03bb914904107a6a9305ba1f0e44c79a59c",
-    )
-}()
+let containerizationDependency: Package.Dependency = .package(
+    url: "https://github.com/stephenlclarke/containerization.git",
+    revision: "b404e03bb914904107a6a9305ba1f0e44c79a59c",
+)
 
 let nioSSLDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/swift-nio-ssl.git",

--- a/Tools/ci/run-with-local-swift-stack.py
+++ b/Tools/ci/run-with-local-swift-stack.py
@@ -1,0 +1,496 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Run one Swift command in a recoverable local dependency session."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import fcntl
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+OVERRIDE_ENVIRONMENT = (
+    "CONTAINER_PACKAGE_PATH",
+    "CONTAINERIZATION_PACKAGE_PATH",
+    "CONTAINER_ENGINE_API_PACKAGE_PATH",
+)
+
+
+@dataclass(frozen=True)
+class Dependency:
+    identity: str
+    path: Path
+
+
+def clean_environment() -> dict[str, str]:
+    environment = os.environ.copy()
+    for name in OVERRIDE_ENVIRONMENT:
+        environment.pop(name, None)
+    return environment
+
+
+def sha256(contents: bytes) -> str:
+    return hashlib.sha256(contents).hexdigest()
+
+
+def restore_lockfile(lockfile: Path, contents: bytes) -> bool:
+    if lockfile.read_bytes() == contents:
+        return False
+    lockfile.write_bytes(contents)
+    return True
+
+
+def active_edit_paths(workspace_state: Path) -> dict[str, Path]:
+    if not workspace_state.exists():
+        return {}
+    try:
+        state = json.loads(workspace_state.read_text(encoding="utf-8"))
+        dependencies = state.get("object", {}).get("dependencies", [])
+        return {
+            dependency.get("packageRef", {}).get("identity", ""): Path(
+                dependency.get("state", {}).get("path", "")
+            ).resolve()
+            for dependency in dependencies
+            if dependency.get("state", {}).get("name") == "edited"
+        }
+    except (json.JSONDecodeError, OSError, TypeError, AttributeError) as error:
+        raise SystemExit(f"could not inspect SwiftPM workspace state: {error}") from error
+
+
+def validate_dependency(identity: str, value: str | None) -> Dependency | None:
+    if not value:
+        return None
+    path = Path(value)
+    if not path.is_absolute():
+        raise SystemExit(f"{identity} package path must be absolute: {path}")
+    if path.is_symlink() or not (path / "Package.swift").is_file():
+        raise SystemExit(f"{identity} package path is invalid: {path}")
+    return Dependency(identity=identity, path=path.resolve())
+
+
+def git_output(path: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ["/usr/bin/git", "-C", str(path), *arguments],
+        check=False,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if result.returncode != 0:
+        diagnostic = result.stderr.strip() or f"exit {result.returncode}"
+        raise SystemExit(f"could not inspect local package {path}: {diagnostic}")
+    return result.stdout
+
+
+def dependency_record(dependency: Dependency) -> dict[str, str]:
+    if git_output(dependency.path, "status", "--porcelain"):
+        raise SystemExit(
+            f"{dependency.identity} package must be clean: {dependency.path}"
+        )
+    tree = git_output(dependency.path, "rev-parse", "HEAD^{tree}").strip()
+    if len(tree) != 40 or any(character not in "0123456789abcdef" for character in tree):
+        raise SystemExit(
+            f"{dependency.identity} package has an invalid Git tree: {tree}"
+        )
+    return {
+        "identity": dependency.identity,
+        "path": str(dependency.path),
+        "tree": tree,
+    }
+
+
+def dependency_records(
+    dependencies: tuple[Dependency, ...],
+) -> tuple[dict[str, str], ...]:
+    return tuple(dependency_record(dependency) for dependency in dependencies)
+
+
+def recovery_paths(root: Path) -> tuple[Path, Path]:
+    recovery_root = root / ".build" / "local-swift-stack"
+    return recovery_root / "journal.json", recovery_root / "Package.resolved.backup"
+
+
+def ensure_recovery_root(root: Path) -> Path:
+    recovery_root = root / ".build" / "local-swift-stack"
+    recovery_root.mkdir(parents=True, exist_ok=True)
+    if recovery_root.is_symlink() or not recovery_root.is_dir():
+        raise SystemExit(
+            f"local Swift stack recovery root is indirect or invalid: {recovery_root}"
+        )
+    return recovery_root
+
+
+def read_recovery_state(root: Path) -> tuple[dict[str, object], bytes] | None:
+    journal, backup = recovery_paths(root)
+    if not journal.exists() and not backup.exists():
+        return None
+    if journal.is_symlink() or not journal.is_file():
+        raise SystemExit("local Swift stack recovery state is incomplete or indirect")
+    try:
+        state = json.loads(journal.read_text(encoding="utf-8"))
+        expected_sha256 = state["package_resolved_sha256"]
+    except (json.JSONDecodeError, KeyError, TypeError, OSError) as error:
+        raise SystemExit(f"local Swift stack recovery journal is invalid: {error}") from error
+    schema = state.get("schema")
+    if schema == 3:
+        if backup.exists():
+            raise SystemExit("local Swift stack recovery state mixes journal schemas")
+        try:
+            encoded_lock = state["package_resolved_base64"]
+            if not isinstance(encoded_lock, str):
+                raise TypeError("package_resolved_base64 is not text")
+            original_lock = base64.b64decode(encoded_lock, validate=True)
+        except (KeyError, TypeError, ValueError) as error:
+            raise SystemExit(
+                f"local Swift stack recovery journal has an invalid lock: {error}"
+            ) from error
+    elif schema in (1, 2):
+        if backup.is_symlink() or not backup.is_file():
+            raise SystemExit(
+                "local Swift stack legacy recovery backup is incomplete or indirect"
+            )
+        original_lock = backup.read_bytes()
+    else:
+        raise SystemExit("local Swift stack recovery journal has an unknown schema")
+    if sha256(original_lock) != expected_sha256:
+        raise SystemExit("local Swift stack recovery journal does not match its lock backup")
+    return state, original_lock
+
+
+def can_resume(
+    root: Path,
+    lockfile: Path,
+    dependencies: tuple[Dependency, ...],
+    records: tuple[dict[str, str], ...],
+) -> bool:
+    recovery = read_recovery_state(root)
+    if recovery is None:
+        return False
+    state, original_lock = recovery
+    if state.get("schema") != 3 or state.get("dependencies") != list(records):
+        return False
+    active_edits = active_edit_paths(root / ".build" / "workspace-state.json")
+    if any(active_edits.get(item.identity) != item.path for item in dependencies):
+        return False
+    restore_lockfile(lockfile, original_lock)
+    return True
+
+
+def swift_package(swift: str, environment: dict[str, str], *arguments: str) -> int:
+    result = subprocess.run(
+        [swift, "package", *arguments],
+        check=False,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+    )
+    return result.returncode
+
+
+def edit_dependencies(
+    swift: str, dependencies: tuple[Dependency, ...], environment: dict[str, str]
+) -> tuple[bool, tuple[str, ...]]:
+    edited: list[str] = []
+    for dependency in dependencies:
+        status = swift_package(
+            swift,
+            environment,
+            "edit",
+            dependency.identity,
+            "--path",
+            str(dependency.path),
+        )
+        if status != 0:
+            return False, tuple(edited)
+        edited.append(dependency.identity)
+    return True, tuple(edited)
+
+
+def unedit_dependencies(
+    swift: str, identities: tuple[str, ...], environment: dict[str, str]
+) -> int:
+    status = 0
+    for identity in reversed(identities):
+        current = swift_package(swift, environment, "unedit", identity, "--force")
+        if current != 0:
+            status = current
+    return status
+
+
+def recover(
+    root: Path,
+    lockfile: Path,
+    swift: str,
+    environment: dict[str, str],
+) -> None:
+    recovery = read_recovery_state(root)
+    if recovery is None:
+        return
+    state, original_lock = recovery
+    try:
+        identities = tuple(state["identities"])
+    except (KeyError, TypeError) as error:
+        raise SystemExit(f"local Swift stack recovery journal is invalid: {error}") from error
+    if any(not isinstance(identity, str) or not identity for identity in identities):
+        raise SystemExit("local Swift stack recovery journal has invalid dependency identities")
+    active_edits = active_edit_paths(root / ".build" / "workspace-state.json")
+    active_identities = tuple(
+        identity for identity in identities if identity in active_edits
+    )
+    if unedit_dependencies(swift, active_identities, environment) != 0:
+        raise SystemExit(
+            "could not recover interrupted SwiftPM edits; recovery state retained"
+        )
+    restore_lockfile(lockfile, original_lock)
+    journal, backup = recovery_paths(root)
+    journal.unlink()
+    if backup.exists():
+        backup.unlink()
+    print("Recovered an interrupted local Swift stack transaction.")
+
+
+def write_recovery_journal(
+    root: Path,
+    lock_contents: bytes,
+    managed_dependencies: tuple[Dependency, ...],
+    records: tuple[dict[str, str], ...],
+) -> Path:
+    recovery_root = ensure_recovery_root(root)
+    journal = recovery_root / "journal.json"
+    _, legacy_backup = recovery_paths(root)
+    if legacy_backup.exists() or journal.exists():
+        raise SystemExit("local Swift stack recovery state was not cleared")
+    journal_temporary = recovery_root / "journal.json.pending"
+    if journal_temporary.exists() or journal_temporary.is_symlink():
+        if journal_temporary.is_symlink() or not journal_temporary.is_file():
+            raise SystemExit("local Swift stack pending journal is indirect or invalid")
+        journal_temporary.unlink()
+    journal_contents = (
+        json.dumps(
+            {
+                "schema": 3,
+                "dependencies": records,
+                "identities": [
+                    dependency.identity for dependency in managed_dependencies
+                ],
+                "package_resolved_base64": base64.b64encode(lock_contents).decode(
+                    "ascii"
+                ),
+                "package_resolved_sha256": sha256(lock_contents),
+            },
+            sort_keys=True,
+        )
+        + "\n"
+    ).encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(journal_temporary, flags, 0o600)
+    try:
+        offset = 0
+        while offset < len(journal_contents):
+            offset += os.write(descriptor, journal_contents[offset:])
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    os.replace(journal_temporary, journal)
+    directory_descriptor = os.open(recovery_root, os.O_RDONLY)
+    try:
+        os.fsync(directory_descriptor)
+    finally:
+        os.close(directory_descriptor)
+    return journal
+
+
+def run(arguments: argparse.Namespace) -> int:
+    root = Path.cwd()
+    lockfile = root / "Package.resolved"
+    if not lockfile.is_file() or lockfile.is_symlink():
+        raise SystemExit(f"tracked Package.resolved is unavailable: {lockfile}")
+    dependencies = tuple(
+        dependency
+        for dependency in (
+            validate_dependency("container", arguments.container),
+            validate_dependency("containerization", arguments.containerization),
+            validate_dependency("container-engine-api", arguments.engine_api),
+        )
+        if dependency is not None
+    )
+    environment = clean_environment()
+    recovery_root = ensure_recovery_root(root)
+    lock_path = recovery_root / "transaction.lock"
+    if lock_path.is_symlink():
+        raise SystemExit(f"local Swift stack lock must not be a symbolic link: {lock_path}")
+    lock_descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        try:
+            fcntl.flock(lock_descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as error:
+            raise SystemExit("another local Swift stack transaction is active") from error
+        if arguments.cleanup:
+            recover(root, lockfile, arguments.swift, environment)
+            return 0
+
+        records = dependency_records(dependencies)
+        resuming = (
+            arguments.retain_edits
+            and bool(dependencies)
+            and can_resume(root, lockfile, dependencies, records)
+        )
+        if not resuming:
+            recover(root, lockfile, arguments.swift, environment)
+        prior_edits = active_edit_paths(root / ".build" / "workspace-state.json")
+        expected_edits = {
+            dependency.identity: dependency.path for dependency in dependencies
+        }
+        incompatible_edits = {
+            identity: path
+            for identity, path in prior_edits.items()
+            if expected_edits.get(identity) != path
+        }
+        if incompatible_edits:
+            raise SystemExit(
+                "refusing to replace incompatible SwiftPM edits: "
+                + ", ".join(sorted(incompatible_edits))
+            )
+        managed_dependencies = tuple(
+            dependency
+            for dependency in dependencies
+            if dependency.identity not in prior_edits
+        )
+        if resuming:
+            recovery = read_recovery_state(root)
+            assert recovery is not None
+            _, original_lock = recovery
+            try:
+                return subprocess.run(
+                    arguments.command,
+                    check=False,
+                    env=environment,
+                    stdin=subprocess.DEVNULL,
+                ).returncode
+            finally:
+                restore_lockfile(lockfile, original_lock)
+        if not managed_dependencies:
+            original_lock = lockfile.read_bytes()
+            try:
+                return subprocess.run(
+                    arguments.command,
+                    check=False,
+                    env=environment,
+                    stdin=subprocess.DEVNULL,
+                ).returncode
+            finally:
+                restore_lockfile(lockfile, original_lock)
+
+        original_lock = lockfile.read_bytes()
+        journal = write_recovery_journal(
+            root,
+            original_lock,
+            managed_dependencies,
+            records,
+        )
+        edited: tuple[str, ...] = ()
+        command_status = 0
+        cleanup_status = 0
+        lock_changed = False
+        setup_failed = False
+        try:
+            edited_ok, edited = edit_dependencies(
+                arguments.swift, managed_dependencies, environment
+            )
+            if not edited_ok:
+                cleanup_status = unedit_dependencies(
+                    arguments.swift, edited, environment
+                )
+                edited = ()
+                if cleanup_status == 0 and swift_package(
+                    arguments.swift, environment, "resolve"
+                ) == 0:
+                    edited_ok, edited = edit_dependencies(
+                        arguments.swift, managed_dependencies, environment
+                    )
+                if not edited_ok:
+                    command_status = 2
+                    setup_failed = True
+            if edited_ok:
+                lock_changed = restore_lockfile(lockfile, original_lock)
+                command_status = subprocess.run(
+                    arguments.command,
+                    check=False,
+                    env=environment,
+                    stdin=subprocess.DEVNULL,
+                ).returncode
+        finally:
+            lock_changed = (
+                restore_lockfile(lockfile, original_lock) or lock_changed
+            )
+            if not arguments.retain_edits or setup_failed:
+                final_cleanup_status = unedit_dependencies(
+                    arguments.swift, edited, environment
+                )
+                if final_cleanup_status != 0:
+                    cleanup_status = final_cleanup_status
+            if cleanup_status == 0 and (not arguments.retain_edits or setup_failed):
+                journal.unlink()
+        if lock_changed:
+            print(
+                "local Swift stack changed Package.resolved; the original lock was restored",
+                file=sys.stderr,
+            )
+        if cleanup_status != 0:
+            print(
+                "could not restore SwiftPM editable dependencies; recovery state retained",
+                file=sys.stderr,
+            )
+            return cleanup_status
+        return command_status
+    finally:
+        try:
+            fcntl.flock(lock_descriptor, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        os.close(lock_descriptor)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--swift", default="swift")
+    parser.add_argument("--container")
+    parser.add_argument("--containerization")
+    parser.add_argument("--engine-api")
+    parser.add_argument("--retain-edits", action="store_true")
+    parser.add_argument("--cleanup", action="store_true")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    arguments = parser.parse_args()
+    if arguments.command and arguments.command[0] == "--":
+        arguments.command = arguments.command[1:]
+    if not arguments.command and not arguments.cleanup:
+        parser.error("a command is required after --")
+    raise SystemExit(run(arguments))
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/ci/swift-style.py
+++ b/Tools/ci/swift-style.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Install and run the repository's deterministic Swift style toolchain."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LEGACY_EXCLUSIONS = frozenset(
+    {
+        "Sources/ComposePlugin/ComposeCLIHelp.swift",
+        "Tests/ComposePluginTests/ComposeCLIHelpTests.swift",
+        "Sources/ComposePlugin/ComposePlugin.swift",
+        "Sources/ComposeCore/ComposeCommandOptions.swift",
+        "Sources/ComposeCore/ComposeCommitImageArchive.swift",
+        "Sources/ComposeCore/ComposeExecutionOptions.swift",
+        "Sources/ComposeCore/ComposeOrchestratorBuildAndImages.swift",
+        "Sources/ComposeCore/ComposeOrchestratorCreateAndLogs.swift",
+        "Sources/ComposeCore/ComposeOrchestratorMountsContainersVolumes.swift",
+        "Sources/ComposeCore/ComposeOrchestratorRunCopyStart.swift",
+        "Sources/ComposeCore/ComposeOrchestratorUp.swift",
+        "Sources/ComposeCore/ComposeOrchestratorWaitAndPorts.swift",
+        "Sources/ComposeCore/ContainerDiscoveryAdapter.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorTests.swift",
+        "Sources/ComposeContainerRuntime/ComposeCommitImageArchive.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorBuildAndImageTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorCopyExportCommitTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorLifecycleTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorLogsWatchAttachTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorResourceTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorRunTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorRuntimeAdapterTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorTestSupport.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorUpAndCreateTests.swift",
+        "Tests/ComposeCoreTests/ComposeOrchestratorValidationTests.swift",
+        "Sources/ComposePlugin/ContainerPackageCompatibility.swift",
+        "Tests/ComposePluginTests/ContainerPackageCompatibilityTests.swift",
+        "Tests/ComposeCoreTests/ComposeNormalizerTests.swift",
+        "Tests/ComposeRuntimeTests/ComposeRuntimeSmokeTests.swift",
+    }
+)
+
+
+@dataclass(frozen=True)
+class Tool:
+    name: str
+    version: str
+    url: str
+    archive_sha256: str
+    member: str
+    executable_sha256: str
+
+
+TOOLS = (
+    Tool(
+        name="swiftlint",
+        version="0.65.1",
+        url="https://github.com/realm/SwiftLint/releases/download/0.65.1/portable_swiftlint.zip",
+        archive_sha256="c1e429b0599cf1b516f369a2d9ec04eaf0e436f3c12b637df8851fa52ff694d0",
+        member="swiftlint",
+        executable_sha256="52112ece2dfa99c2442a1367f9a365d43784714cf224c3675bf8bc2f18ebd7c8",
+    ),
+    Tool(
+        name="swiftformat",
+        version="0.63.0",
+        url="https://github.com/nicklockwood/SwiftFormat/releases/download/0.63.0/swiftformat.zip",
+        archive_sha256="28c7802e11fa5ae113d903066439c6bb1be20a8ac1ad9709c42616a7e273fb0f",
+        member="swiftformat",
+        executable_sha256="4cb54c31a889282e7f2473515d498f07c71f3aa0a66bbc056837c006149a8af1",
+    ),
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def cache_root() -> Path:
+    configured = os.environ.get("SWIFT_STYLE_CACHE_ROOT")
+    root = Path(configured) if configured else ROOT / ".local" / "share" / "swift-style"
+    if not root.is_absolute():
+        raise SystemExit(f"SWIFT_STYLE_CACHE_ROOT must be absolute: {root}")
+    return root
+
+
+def download(url: str, destination: Path) -> None:
+    subprocess.run(
+        [
+            "/usr/bin/curl",
+            "--fail",
+            "--location",
+            "--silent",
+            "--show-error",
+            "--connect-timeout",
+            "20",
+            "--max-time",
+            "600",
+            "--max-filesize",
+            "67108864",
+            "--retry",
+            "3",
+            "--retry-all-errors",
+            "--output",
+            str(destination),
+            url,
+        ],
+        check=True,
+        stdin=subprocess.DEVNULL,
+    )
+
+
+def install_tool(tool: Tool, root: Path, downloader=download) -> Path:
+    destination = root / f"{tool.name}-{tool.version}" / tool.name
+    if destination.is_file() and not destination.is_symlink():
+        if sha256(destination) == tool.executable_sha256:
+            return destination
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix=f".{tool.name}-", dir=destination.parent) as temporary:
+        temporary_root = Path(temporary)
+        archive = temporary_root / "tool.zip"
+        downloader(tool.url, archive)
+        actual_archive_sha256 = sha256(archive)
+        if actual_archive_sha256 != tool.archive_sha256:
+            raise SystemExit(
+                f"{tool.name} archive digest mismatch: expected {tool.archive_sha256}, "
+                f"got {actual_archive_sha256}"
+            )
+        extracted = temporary_root / tool.name
+        with zipfile.ZipFile(archive) as bundle:
+            members = {member.filename: member for member in bundle.infolist()}
+            if tool.member not in members or members[tool.member].is_dir():
+                raise SystemExit(f"{tool.name} archive has no {tool.member} executable")
+            with bundle.open(members[tool.member]) as source, extracted.open("wb") as target:
+                shutil.copyfileobj(source, target)
+        actual_executable_sha256 = sha256(extracted)
+        if actual_executable_sha256 != tool.executable_sha256:
+            raise SystemExit(
+                f"{tool.name} executable digest mismatch: expected "
+                f"{tool.executable_sha256}, got {actual_executable_sha256}"
+            )
+        extracted.chmod(stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+        os.replace(extracted, destination)
+    return destination
+
+
+def install_tools(root: Path) -> dict[str, Path]:
+    installed = {tool.name: install_tool(tool, root) for tool in TOOLS}
+    for tool in TOOLS:
+        result = subprocess.run(
+            [str(installed[tool.name]), "version" if tool.name == "swiftlint" else "--version"],
+            check=True,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.stdout.strip() != tool.version:
+            raise SystemExit(
+                f"{tool.name} version mismatch: expected {tool.version}, "
+                f"got {result.stdout.strip() or 'missing'}"
+            )
+        print(f"{tool.name} {tool.version}: {installed[tool.name]}")
+    return installed
+
+
+def git(*arguments: str) -> str:
+    result = subprocess.run(
+        ["/usr/bin/git", "-C", str(ROOT), *arguments],
+        check=True,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout
+
+
+def changed_paths() -> tuple[str, ...]:
+    if os.environ.get("SWIFT_STYLE_ALL") == "1":
+        output = git("ls-files", "Package.swift", "Sources", "Tests")
+    elif files_from := os.environ.get("SWIFT_STYLE_FILES_FROM"):
+        path = Path(files_from)
+        if not path.is_absolute():
+            raise SystemExit(f"SWIFT_STYLE_FILES_FROM must be absolute: {path}")
+        output = path.read_text(encoding="utf-8")
+    elif os.environ.get("SWIFT_STYLE_STAGED") == "1":
+        output = git("diff", "--cached", "--name-only", "--diff-filter=ACMR")
+    else:
+        base = os.environ.get("SWIFT_STYLE_BASE", "origin/main")
+        head = os.environ.get("SWIFT_STYLE_HEAD", "HEAD")
+        output = git("diff", "--name-only", "--diff-filter=ACMR", f"{base}...{head}")
+    return tuple(line for line in output.splitlines() if line)
+
+
+def style_paths(paths: tuple[str, ...]) -> tuple[str, ...]:
+    selected = []
+    for relative in paths:
+        if relative in LEGACY_EXCLUSIONS:
+            continue
+        if relative == "Package.swift" or (
+            relative.endswith(".swift")
+            and (relative.startswith("Sources/") or relative.startswith("Tests/"))
+        ):
+            candidate = ROOT / relative
+            if candidate.is_file() and not candidate.is_symlink():
+                selected.append(relative)
+    return tuple(sorted(set(selected)))
+
+
+def run_style(action: str) -> None:
+    paths = style_paths(changed_paths())
+    if not paths:
+        print("No Swift style paths selected.")
+        return
+    print("Selected Swift style paths:")
+    for path in paths:
+        print(f"  {path}")
+    tools = install_tools(cache_root())
+    if action == "lint":
+        subprocess.run(
+            [
+                str(tools["swiftlint"]),
+                "lint",
+                "--strict",
+                "--quiet",
+                "--config",
+                str(ROOT / ".swiftlint.yml"),
+                *paths,
+            ],
+            check=True,
+            cwd=ROOT,
+            stdin=subprocess.DEVNULL,
+        )
+        subprocess.run(
+            [
+                str(tools["swiftformat"]),
+                *paths,
+                "--lint",
+                "--config",
+                str(ROOT / ".swiftformat"),
+            ],
+            check=True,
+            cwd=ROOT,
+            stdin=subprocess.DEVNULL,
+        )
+    else:
+        subprocess.run(
+            [
+                str(tools["swiftformat"]),
+                *paths,
+                "--config",
+                str(ROOT / ".swiftformat"),
+            ],
+            check=True,
+            cwd=ROOT,
+            stdin=subprocess.DEVNULL,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("install", "paths", "lint", "format"))
+    arguments = parser.parse_args()
+    if arguments.action == "install":
+        install_tools(cache_root())
+    elif arguments.action == "paths":
+        print("\n".join(style_paths(changed_paths())))
+    else:
+        run_style(arguments.action)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/ci/test_build_release_local_stack.py
+++ b/Tools/ci/test_build_release_local_stack.py
@@ -31,7 +31,7 @@ ROOT = Path(__file__).parents[2]
 class BuildReleaseLocalStackTests(unittest.TestCase):
     """`build-release` must preserve the local-stack behavior of `build`."""
 
-    def test_uses_local_overlays_and_restores_package_resolution(self) -> None:
+    def test_uses_recoverable_local_stack_session(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_root = Path(temporary_directory)
             container = temporary_root / "container"
@@ -53,15 +53,15 @@ class BuildReleaseLocalStackTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn(f'CONTAINER_PACKAGE_PATH="{container}"', result.stdout)
+            self.assertIn(f'--container "{container}"', result.stdout)
             self.assertIn(
-                f'CONTAINERIZATION_PACKAGE_PATH="{containerization}"', result.stdout
+                f'--containerization "{containerization}"', result.stdout
             )
             self.assertIn(
-                f'CONTAINER_ENGINE_API_PACKAGE_PATH="{engine_api}"', result.stdout
+                f'--engine-api "{engine_api}"', result.stdout
             )
-            self.assertIn('cp Package.resolved "$lock_backup"', result.stdout)
-            self.assertIn("trap restore_lock EXIT HUP INT QUIT TERM", result.stdout)
+            self.assertIn("Tools/ci/run-with-local-swift-stack.py", result.stdout)
+            self.assertIn("--retain-edits", result.stdout)
             branch_separator = "else " + chr(92) + "\n"
             local_branch, separator, fallback_branch = result.stdout.partition(
                 branch_separator
@@ -96,6 +96,14 @@ class BuildReleaseLocalStackTests(unittest.TestCase):
             "swift build --disable-automatic-resolution -c release --product compose",
             result.stdout,
         )
+        self.assertIn("Tools/ci/run-with-local-swift-stack.py", result.stdout)
+
+    def test_clean_restores_local_stack_before_removing_products(self) -> None:
+        makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+
+        self.assertIn("local-swift-stack-clean:\n", makefile)
+        self.assertIn("--cleanup", makefile)
+        self.assertIn("clean: local-swift-stack-clean\n", makefile)
 
     def test_full_parity_uses_the_release_compose_binary(self) -> None:
         makefile = (ROOT / "Makefile").read_text(encoding="utf-8")

--- a/Tools/ci/test_run_with_local_swift_stack.py
+++ b/Tools/ci/test_run_with_local_swift_stack.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for isolated local Swift stack execution."""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("run-with-local-swift-stack.py")
+SPEC = importlib.util.spec_from_file_location("run_with_local_swift_stack", MODULE_PATH)
+assert SPEC and SPEC.loader
+STACK = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = STACK
+SPEC.loader.exec_module(STACK)
+
+
+class LocalSwiftStackTests(unittest.TestCase):
+    """Local dependency overrides never become release graph inputs."""
+
+    def test_clean_environment_removes_manifest_overrides(self) -> None:
+        original = os.environ.copy()
+        try:
+            for name in STACK.OVERRIDE_ENVIRONMENT:
+                os.environ[name] = "/untrusted/local/path"
+            environment = STACK.clean_environment()
+        finally:
+            os.environ.clear()
+            os.environ.update(original)
+
+        for name in STACK.OVERRIDE_ENVIRONMENT:
+            self.assertNotIn(name, environment)
+
+    def test_lockfile_is_not_rewritten_when_contents_match(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            lockfile = Path(temporary) / "Package.resolved"
+            contents = b'{"pins":[]}\n'
+            lockfile.write_bytes(contents)
+            original_mtime = lockfile.stat().st_mtime_ns
+
+            self.assertFalse(STACK.restore_lockfile(lockfile, contents))
+            self.assertEqual(lockfile.stat().st_mtime_ns, original_mtime)
+
+    def test_active_edits_reports_every_edited_dependency(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            state = Path(temporary) / "workspace-state.json"
+            state.write_text(
+                json.dumps(
+                    {
+                        "object": {
+                            "dependencies": [
+                                {
+                                    "packageRef": {"identity": "container"},
+                                    "state": {"name": "edited", "path": "/tmp/container"},
+                                },
+                                {
+                                    "packageRef": {"identity": "swift-log"},
+                                    "state": {"name": "sourceControlCheckout"},
+                                },
+                                {
+                                    "packageRef": {"identity": "containerization"},
+                                    "state": {
+                                        "name": "edited",
+                                        "path": "/tmp/containerization",
+                                    },
+                                },
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                STACK.active_edit_paths(state),
+                {
+                    "container": Path("/tmp/container").resolve(),
+                    "containerization": Path("/tmp/containerization").resolve(),
+                },
+            )
+
+    def test_dependency_paths_must_be_absolute_packages(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "must be absolute"):
+            STACK.validate_dependency("container", "../container")
+
+    def test_session_resumes_when_commit_changes_but_tree_does_not(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            dependency_root = root / "container"
+            dependency_root.mkdir()
+            (dependency_root / "Package.swift").write_text(
+                "// swift-tools-version: 6.2\n", encoding="utf-8"
+            )
+            subprocess.run(["git", "init", "-q", dependency_root], check=True)
+            subprocess.run(
+                ["git", "-C", dependency_root, "add", "Package.swift"], check=True
+            )
+            commit = [
+                "git",
+                "-C",
+                dependency_root,
+                "-c",
+                "user.name=Fixture",
+                "-c",
+                "user.email=fixture@example.invalid",
+                "commit",
+                "-q",
+            ]
+            subprocess.run([*commit, "-m", "first"], check=True)
+            dependency = STACK.validate_dependency("container", str(dependency_root))
+            assert dependency is not None
+            records = STACK.dependency_records((dependency,))
+
+            lockfile = root / "Package.resolved"
+            original = b'{"pins":[]}\n'
+            lockfile.write_bytes(original)
+            STACK.write_recovery_journal(
+                root, original, (dependency,), records
+            )
+            self.assertFalse(
+                (root / ".build" / "local-swift-stack" / "Package.resolved.backup").exists()
+            )
+            workspace_state = root / ".build" / "workspace-state.json"
+            workspace_state.write_text(
+                json.dumps(
+                    {
+                        "object": {
+                            "dependencies": [
+                                {
+                                    "packageRef": {"identity": "container"},
+                                    "state": {
+                                        "name": "edited",
+                                        "path": str(dependency_root),
+                                    },
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            subprocess.run([*commit, "--allow-empty", "-m", "promoted"], check=True)
+            lockfile.write_bytes(b"edited\n")
+
+            promoted_records = STACK.dependency_records((dependency,))
+            self.assertEqual(promoted_records, records)
+            self.assertTrue(
+                STACK.can_resume(
+                    root, lockfile, (dependency,), promoted_records
+                )
+            )
+            self.assertEqual(lockfile.read_bytes(), original)
+
+    def test_recover_restores_an_interrupted_lock_transaction(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            lockfile = root / "Package.resolved"
+            original = b'{"pins":[]}\n'
+            lockfile.write_bytes(b"locally edited\n")
+            recovery = root / ".build" / "local-swift-stack"
+            recovery.mkdir(parents=True)
+            (recovery / "Package.resolved.backup").write_bytes(original)
+            (recovery / "journal.json").write_text(
+                json.dumps(
+                    {
+                        "schema": 1,
+                        "identities": [],
+                        "package_resolved_sha256": STACK.sha256(original),
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            STACK.recover(root, lockfile, "/usr/bin/true", {})
+
+            self.assertEqual(lockfile.read_bytes(), original)
+            self.assertFalse((recovery / "Package.resolved.backup").exists())
+            self.assertFalse((recovery / "journal.json").exists())
+
+    def test_recover_retains_evidence_when_unedit_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            lockfile = root / "Package.resolved"
+            original = b'{"pins":[]}\n'
+            lockfile.write_bytes(b"locally edited\n")
+            recovery = root / ".build" / "local-swift-stack"
+            recovery.mkdir(parents=True)
+            backup = recovery / "Package.resolved.backup"
+            journal = recovery / "journal.json"
+            backup.write_bytes(original)
+            journal.write_text(
+                json.dumps(
+                    {
+                        "schema": 1,
+                        "identities": ["container"],
+                        "package_resolved_sha256": STACK.sha256(original),
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (root / ".build" / "workspace-state.json").write_text(
+                json.dumps(
+                    {
+                        "object": {
+                            "dependencies": [
+                                {
+                                    "packageRef": {"identity": "container"},
+                                    "state": {"name": "edited", "path": "/tmp/container"},
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(STACK, "unedit_dependencies", return_value=1):
+                with self.assertRaisesRegex(SystemExit, "recovery state retained"):
+                    STACK.recover(root, lockfile, "/usr/bin/false", {})
+
+            self.assertEqual(lockfile.read_bytes(), b"locally edited\n")
+            self.assertTrue(backup.exists())
+            self.assertTrue(journal.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/test_swift_style.py
+++ b/Tools/ci/test_swift_style.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for the deterministic Swift style toolchain."""
+
+import hashlib
+import importlib.util
+import shutil
+import stat
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("swift-style.py")
+SPEC = importlib.util.spec_from_file_location("swift_style", MODULE_PATH)
+assert SPEC and SPEC.loader
+STYLE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = STYLE
+SPEC.loader.exec_module(STYLE)
+
+
+class SwiftStyleTests(unittest.TestCase):
+    """Selection and installation use one fail-closed policy."""
+
+    def test_style_paths_select_supported_existing_files(self) -> None:
+        selected = STYLE.style_paths(
+            (
+                "Package.swift",
+                "Sources/ComposeCore/ComposeAPISocketTransform.swift",
+                "Tests/ComposeCoreTests/ComposeAPISocketTests.swift",
+                "Sources/ComposePlugin/ComposePlugin.swift",
+                "docs/project/STATUS.md",
+                "Sources/ComposeCore/Missing.swift",
+            )
+        )
+
+        self.assertEqual(
+            selected,
+            (
+                "Package.swift",
+                "Sources/ComposeCore/ComposeAPISocketTransform.swift",
+                "Tests/ComposeCoreTests/ComposeAPISocketTests.swift",
+            ),
+        )
+
+    def test_install_tool_verifies_archive_and_executable(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source_archive = root / "source.zip"
+            payload = b"#!/bin/sh\nprintf '1.2.3\\n'\n"
+            with zipfile.ZipFile(source_archive, "w") as archive:
+                archive.writestr("fixture", payload)
+            tool = STYLE.Tool(
+                name="fixture",
+                version="1.2.3",
+                url="https://example.invalid/fixture.zip",
+                archive_sha256=hashlib.sha256(source_archive.read_bytes()).hexdigest(),
+                member="fixture",
+                executable_sha256=hashlib.sha256(payload).hexdigest(),
+            )
+
+            def copy_archive(_url: str, destination: Path) -> None:
+                shutil.copyfile(source_archive, destination)
+
+            installed = STYLE.install_tool(tool, root / "cache", copy_archive)
+
+            self.assertEqual(installed.read_bytes(), payload)
+            self.assertTrue(installed.stat().st_mode & stat.S_IXUSR)
+            self.assertEqual(STYLE.install_tool(tool, root / "cache", copy_archive), installed)
+
+    def test_install_tool_rejects_untrusted_archive(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source_archive = root / "source.zip"
+            with zipfile.ZipFile(source_archive, "w") as archive:
+                archive.writestr("fixture", b"untrusted")
+            tool = STYLE.Tool(
+                name="fixture",
+                version="1.0.0",
+                url="https://example.invalid/fixture.zip",
+                archive_sha256="0" * 64,
+                member="fixture",
+                executable_sha256="0" * 64,
+            )
+
+            def copy_archive(_url: str, destination: Path) -> None:
+                shutil.copyfile(source_archive, destination)
+
+            with self.assertRaisesRegex(SystemExit, "archive digest mismatch"):
+                STYLE.install_tool(tool, root / "cache", copy_archive)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace environment-dependent Swift manifests with immutable remote pins and a recoverable SwiftPM edit session for local stack work;
- reuse compiled products when a reviewed dependency commit is promoted to a tree-identical merged commit;
- restore the tracked lock before compilation and restore the remote graph explicitly at cleanup;
- persist the complete recovery record as one atomic, fsynced journal so interruption cannot leave a split lock/journal state;
- replace floating Homebrew style tools and duplicated changed-path logic with one repository-owned, digest-pinned entry point.

## Measured evidence

Container feature `d452778d1fc25a0a560717485696e71c127b1550` and merged commit `40ab92d74a02bbd6b7436a50d47c38898a4bc294` share Git tree `ce04f14d959c8bf25c72112a3f2bae9e98458005`.

- previous edit/unedit promoted build: 21.79s, 94 SwiftProtobuf compile actions;
- retained-session first build: 6.04s;
- tree-identical promoted build: 4.38s, zero source compile actions;
- exact remote-graph cleanup: 0.59s;
- atomic-journal create/resume/cleanup proof: 0.59s / 0.05s / 0.61s;
- pinned style check: 0.35s with no Homebrew transaction.

## Validation

- `python3 -m unittest Tools.ci.test_run_with_local_swift_stack Tools.ci.test_swift_style Tools.ci.test_build_release_local_stack` — 14 passed in 0.33s;
- `actionlint .github/workflows/quality.yml` — passed in 0.04s;
- `make swift-style-check` for `Package.swift` — passed in 0.35s;
- `make resolve` without local overrides — passed in 0.34s and retained every dependency pin;
- `git diff --cached --check` — passed.

The broad Swift suite, CodeQL, DocC, parity, and release packaging were intentionally left to their hosted/release boundaries.

Closes #494.
Closes #495.
Closes #498.
Closes #499.

Related: #324, #500, #501, stephenlclarke/container#210, stephenlclarke/container#211, and stephenlclarke/container#212.
