### PR TITLE
fix(build): recover pruned dependency objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,22 @@ CONTAINER_ENGINE_API_STACK_REPO ?= $(abspath ../container-engine-api)
 CONTAINER_PACKAGE_PATH ?= $(if $(wildcard $(CONTAINER_STACK_REPO)/Package.swift),$(CONTAINER_STACK_REPO),)
 CONTAINERIZATION_PACKAGE_PATH ?= $(if $(wildcard $(CONTAINERIZATION_STACK_REPO)/Package.swift),$(CONTAINERIZATION_STACK_REPO),)
 CONTAINER_ENGINE_API_PACKAGE_PATH ?= $(if $(wildcard $(CONTAINER_ENGINE_API_STACK_REPO)/Package.swift),$(CONTAINER_ENGINE_API_STACK_REPO),)
+CONTAINER_PACKAGE_COMMIT ?=
+CONTAINER_PACKAGE_TREE ?=
+CONTAINERIZATION_PACKAGE_COMMIT ?=
+CONTAINERIZATION_PACKAGE_TREE ?=
+CONTAINER_ENGINE_API_PACKAGE_COMMIT ?=
+CONTAINER_ENGINE_API_PACKAGE_TREE ?=
+LOCAL_SWIFT_STACK_DEPENDENCY_ARGS = \
+	--container "$(CONTAINER_PACKAGE_PATH)" \
+	--container-commit "$(CONTAINER_PACKAGE_COMMIT)" \
+	--container-tree "$(CONTAINER_PACKAGE_TREE)" \
+	--containerization "$(CONTAINERIZATION_PACKAGE_PATH)" \
+	--containerization-commit "$(CONTAINERIZATION_PACKAGE_COMMIT)" \
+	--containerization-tree "$(CONTAINERIZATION_PACKAGE_TREE)" \
+	--engine-api "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" \
+	--engine-api-commit "$(CONTAINER_ENGINE_API_PACKAGE_COMMIT)" \
+	--engine-api-tree "$(CONTAINER_ENGINE_API_PACKAGE_TREE)"
 PARITY_CONTAINER_REF ?= $(if $(CONTAINER_PACKAGE_PATH),$(shell git -C "$(CONTAINER_PACKAGE_PATH)" rev-parse HEAD 2>/dev/null),$(CONTAINER_REF))
 PARITY_CONTAINERIZATION_REF ?= $(if $(CONTAINERIZATION_PACKAGE_PATH),$(shell git -C "$(CONTAINERIZATION_PACKAGE_PATH)" rev-parse HEAD 2>/dev/null),$(CONTAINERIZATION_REF))
 PARITY_CONTAINER_ENGINE_API_REF ?= $(if $(CONTAINER_ENGINE_API_PACKAGE_PATH),$(shell git -C "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" rev-parse HEAD 2>/dev/null),unspecified)
@@ -1169,9 +1185,7 @@ build:
 		$(PARITY_ENV) $(PYTHON) Tools/ci/run-with-local-swift-stack.py \
 			--swift "$(SWIFT)" \
 			--retain-edits \
-			--container "$(CONTAINER_PACKAGE_PATH)" \
-			--containerization "$(CONTAINERIZATION_PACKAGE_PATH)" \
-			--engine-api "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" \
+			$(LOCAL_SWIFT_STACK_DEPENDENCY_ARGS) \
 			-- $(SWIFT) build --product compose; \
 	else \
 		$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" -- \
@@ -1183,9 +1197,7 @@ build-release:
 		$(PARITY_ENV) $(PYTHON) Tools/ci/run-with-local-swift-stack.py \
 			--swift "$(SWIFT)" \
 			--retain-edits \
-			--container "$(CONTAINER_PACKAGE_PATH)" \
-			--containerization "$(CONTAINERIZATION_PACKAGE_PATH)" \
-			--engine-api "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" \
+			$(LOCAL_SWIFT_STACK_DEPENDENCY_ARGS) \
 			-- $(SWIFT) build -c release --product compose $(SWIFT_RELEASE_FLAGS); \
 	else \
 		$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" -- \
@@ -1221,9 +1233,7 @@ swift-test:
 		$(PYTHON) Tools/ci/run-with-local-swift-stack.py \
 			--swift "$(SWIFT)" \
 			--retain-edits \
-			--container "$(CONTAINER_PACKAGE_PATH)" \
-			--containerization "$(CONTAINERIZATION_PACKAGE_PATH)" \
-			--engine-api "$(CONTAINER_ENGINE_API_PACKAGE_PATH)" \
+			$(LOCAL_SWIFT_STACK_DEPENDENCY_ARGS) \
 			-- $(MAKE) --no-print-directory swift-test-direct \
 				CONTAINER_PACKAGE_PATH= CONTAINERIZATION_PACKAGE_PATH= \
 				CONTAINER_ENGINE_API_PACKAGE_PATH=; \

--- a/Tools/ci/run-with-local-swift-stack.py
+++ b/Tools/ci/run-with-local-swift-stack.py
@@ -37,11 +37,22 @@ OVERRIDE_ENVIRONMENT = (
     "CONTAINER_ENGINE_API_PACKAGE_PATH",
 )
 
+AUTHORITATIVE_SOURCES = {
+    "container": "https://github.com/stephenlclarke/container.git",
+    "containerization": "https://github.com/stephenlclarke/containerization.git",
+    "container-engine-api": (
+        "https://github.com/stephenlclarke/container-engine-api.git"
+    ),
+}
+GIT_FETCH_TIMEOUT_SECONDS = 60
+
 
 @dataclass(frozen=True)
 class Dependency:
     identity: str
     path: Path
+    commit: str | None = None
+    tree: str | None = None
 
 
 def clean_environment() -> dict[str, str]:
@@ -79,15 +90,45 @@ def active_edit_paths(workspace_state: Path) -> dict[str, Path]:
         raise SystemExit(f"could not inspect SwiftPM workspace state: {error}") from error
 
 
-def validate_dependency(identity: str, value: str | None) -> Dependency | None:
+def validate_object_id(name: str, value: str | None) -> str | None:
     if not value:
+        return None
+    if len(value) != 40 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise SystemExit(f"{name} must be a lowercase SHA-1 object ID: {value}")
+    return value
+
+
+def validate_dependency(
+    identity: str,
+    value: str | None,
+    commit: str | None = None,
+    tree: str | None = None,
+) -> Dependency | None:
+    if not value:
+        if commit or tree:
+            raise SystemExit(
+                f"{identity} package path is required with its commit and tree"
+            )
         return None
     path = Path(value)
     if not path.is_absolute():
         raise SystemExit(f"{identity} package path must be absolute: {path}")
     if path.is_symlink() or not (path / "Package.swift").is_file():
         raise SystemExit(f"{identity} package path is invalid: {path}")
-    return Dependency(identity=identity, path=path.resolve())
+    commit = validate_object_id(f"{identity} package commit", commit)
+    tree = validate_object_id(f"{identity} package tree", tree)
+    if (commit is None) != (tree is None):
+        raise SystemExit(
+            f"{identity} package commit and tree must be supplied together"
+        )
+    return Dependency(
+        identity=identity,
+        path=path.resolve(),
+        commit=commit,
+        tree=tree,
+    )
 
 
 def git_output(path: Path, *arguments: str) -> str:
@@ -105,15 +146,97 @@ def git_output(path: Path, *arguments: str) -> str:
     return result.stdout
 
 
+def git_object_exists(path: Path, object_name: str) -> bool:
+    return subprocess.run(
+        ["/usr/bin/git", "-C", str(path), "cat-file", "-e", object_name],
+        check=False,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    ).returncode == 0
+
+
+def fetch_dependency_object(
+    dependency: Dependency, authority: str
+) -> subprocess.CompletedProcess[str]:
+    assert dependency.commit is not None
+    environment = clean_environment()
+    environment.update(
+        {
+            "GCM_INTERACTIVE": "never",
+            "GIT_ASKPASS": "/usr/bin/false",
+            "GIT_TERMINAL_PROMPT": "0",
+        }
+    )
+    return subprocess.run(
+        [
+            "/usr/bin/git",
+            "-C",
+            str(dependency.path),
+            "fetch",
+            "--no-tags",
+            "--no-write-fetch-head",
+            authority,
+            dependency.commit,
+        ],
+        check=False,
+        env=environment,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=GIT_FETCH_TIMEOUT_SECONDS,
+    )
+
+
+def recover_dependency_object(dependency: Dependency) -> None:
+    if dependency.commit is None or dependency.tree is None:
+        return
+    commit_object = f"{dependency.commit}^{{commit}}"
+    if not git_object_exists(dependency.path, commit_object):
+        authority = AUTHORITATIVE_SOURCES[dependency.identity]
+        try:
+            result = fetch_dependency_object(dependency, authority)
+        except subprocess.TimeoutExpired as error:
+            raise SystemExit(
+                f"timed out recovering {dependency.identity} package commit "
+                f"{dependency.commit} from {authority}"
+            ) from error
+        if result.returncode != 0 or not git_object_exists(
+            dependency.path, commit_object
+        ):
+            diagnostic = result.stderr.strip() or f"exit {result.returncode}"
+            raise SystemExit(
+                f"could not recover {dependency.identity} package commit "
+                f"{dependency.commit} from {authority}: {diagnostic}"
+            )
+    recovered_tree = git_output(
+        dependency.path, "rev-parse", f"{dependency.commit}^{{tree}}"
+    ).strip()
+    if recovered_tree != dependency.tree:
+        raise SystemExit(
+            f"{dependency.identity} package commit {dependency.commit} has tree "
+            f"{recovered_tree}, expected {dependency.tree}"
+        )
+
+
 def dependency_record(dependency: Dependency) -> dict[str, str]:
     if git_output(dependency.path, "status", "--porcelain"):
         raise SystemExit(
             f"{dependency.identity} package must be clean: {dependency.path}"
         )
+    recover_dependency_object(dependency)
     tree = git_output(dependency.path, "rev-parse", "HEAD^{tree}").strip()
-    if len(tree) != 40 or any(character not in "0123456789abcdef" for character in tree):
+    if len(tree) != 40 or any(
+        character not in "0123456789abcdef" for character in tree
+    ):
         raise SystemExit(
             f"{dependency.identity} package has an invalid Git tree: {tree}"
+        )
+    if dependency.tree is not None and tree != dependency.tree:
+        raise SystemExit(
+            f"{dependency.identity} package checkout has tree {tree}, "
+            f"expected {dependency.tree}"
         )
     return {
         "identity": dependency.identity,
@@ -332,9 +455,24 @@ def run(arguments: argparse.Namespace) -> int:
     dependencies = tuple(
         dependency
         for dependency in (
-            validate_dependency("container", arguments.container),
-            validate_dependency("containerization", arguments.containerization),
-            validate_dependency("container-engine-api", arguments.engine_api),
+            validate_dependency(
+                "container",
+                arguments.container,
+                arguments.container_commit,
+                arguments.container_tree,
+            ),
+            validate_dependency(
+                "containerization",
+                arguments.containerization,
+                arguments.containerization_commit,
+                arguments.containerization_tree,
+            ),
+            validate_dependency(
+                "container-engine-api",
+                arguments.engine_api,
+                arguments.engine_api_commit,
+                arguments.engine_api_tree,
+            ),
         )
         if dependency is not None
     )
@@ -479,8 +617,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--swift", default="swift")
     parser.add_argument("--container")
+    parser.add_argument("--container-commit")
+    parser.add_argument("--container-tree")
     parser.add_argument("--containerization")
+    parser.add_argument("--containerization-commit")
+    parser.add_argument("--containerization-tree")
     parser.add_argument("--engine-api")
+    parser.add_argument("--engine-api-commit")
+    parser.add_argument("--engine-api-tree")
     parser.add_argument("--retain-edits", action="store_true")
     parser.add_argument("--cleanup", action="store_true")
     parser.add_argument("command", nargs=argparse.REMAINDER)

--- a/Tools/ci/test_build_release_local_stack.py
+++ b/Tools/ci/test_build_release_local_stack.py
@@ -37,12 +37,16 @@ class BuildReleaseLocalStackTests(unittest.TestCase):
             container = temporary_root / "container"
             containerization = temporary_root / "containerization"
             engine_api = temporary_root / "container-engine-api"
+            container_commit = "a" * 40
+            container_tree = "b" * 40
 
             result = subprocess.run(
                 [
                     "make",
                     "-n",
                     f"CONTAINER_PACKAGE_PATH={container}",
+                    f"CONTAINER_PACKAGE_COMMIT={container_commit}",
+                    f"CONTAINER_PACKAGE_TREE={container_tree}",
                     f"CONTAINERIZATION_PACKAGE_PATH={containerization}",
                     f"CONTAINER_ENGINE_API_PACKAGE_PATH={engine_api}",
                     "build-release",
@@ -54,6 +58,10 @@ class BuildReleaseLocalStackTests(unittest.TestCase):
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn(f'--container "{container}"', result.stdout)
+            self.assertIn(
+                f'--container-commit "{container_commit}"', result.stdout
+            )
+            self.assertIn(f'--container-tree "{container_tree}"', result.stdout)
             self.assertIn(
                 f'--containerization "{containerization}"', result.stdout
             )

--- a/Tools/ci/test_run_with_local_swift_stack.py
+++ b/Tools/ci/test_run_with_local_swift_stack.py
@@ -52,6 +52,20 @@ class LocalSwiftStackTests(unittest.TestCase):
         for name in STACK.OVERRIDE_ENVIRONMENT:
             self.assertNotIn(name, environment)
 
+    def test_authoritative_sources_match_the_resolved_graph(self) -> None:
+        resolved = json.loads(
+            (MODULE_PATH.parents[2] / "Package.resolved").read_text(
+                encoding="utf-8"
+            )
+        )
+        locations = {
+            pin["identity"]: pin["location"]
+            for pin in resolved["pins"]
+        }
+
+        for identity, source in STACK.AUTHORITATIVE_SOURCES.items():
+            self.assertEqual(source, locations[identity])
+
     def test_lockfile_is_not_rewritten_when_contents_match(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             lockfile = Path(temporary) / "Package.resolved"
@@ -103,6 +117,160 @@ class LocalSwiftStackTests(unittest.TestCase):
     def test_dependency_paths_must_be_absolute_packages(self) -> None:
         with self.assertRaisesRegex(SystemExit, "must be absolute"):
             STACK.validate_dependency("container", "../container")
+
+    def test_expected_object_requires_path_commit_and_tree(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "path is required"):
+            STACK.validate_dependency(
+                "container", None, "a" * 40, "b" * 40
+            )
+        with tempfile.TemporaryDirectory() as temporary:
+            package = Path(temporary)
+            (package / "Package.swift").write_text(
+                "// swift-tools-version: 6.2\n", encoding="utf-8"
+            )
+            with self.assertRaisesRegex(SystemExit, "supplied together"):
+                STACK.validate_dependency(
+                    "container", str(package), "a" * 40, None
+                )
+
+    @staticmethod
+    def create_git_dependency(root: Path) -> tuple[Path, Path, str, str]:
+        authority = root / "authority"
+        checkout = root / "checkout"
+        authority.mkdir()
+        (authority / "Package.swift").write_text(
+            "// swift-tools-version: 6.2\n", encoding="utf-8"
+        )
+        subprocess.run(["git", "init", "-q", authority], check=True)
+        subprocess.run(
+            ["git", "-C", authority, "add", "Package.swift"], check=True
+        )
+        commit = [
+            "git",
+            "-C",
+            authority,
+            "-c",
+            "user.name=Fixture",
+            "-c",
+            "user.email=fixture@example.invalid",
+            "commit",
+            "-q",
+        ]
+        subprocess.run([*commit, "-m", "initial"], check=True)
+        subprocess.run(
+            ["git", "clone", "--no-local", "-q", authority, checkout], check=True
+        )
+        subprocess.run([*commit, "--allow-empty", "-m", "promoted"], check=True)
+        promoted = subprocess.run(
+            ["git", "-C", authority, "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        tree = subprocess.run(
+            ["git", "-C", authority, "rev-parse", "HEAD^{tree}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        return authority, checkout, promoted, tree
+
+    def test_present_expected_commit_does_not_fetch(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            authority, checkout, promoted, tree = self.create_git_dependency(root)
+            subprocess.run(
+                ["git", "-C", checkout, "fetch", "-q", str(authority), promoted],
+                check=True,
+            )
+            dependency = STACK.Dependency("container", checkout, promoted, tree)
+
+            with mock.patch.object(STACK, "fetch_dependency_object") as fetch:
+                STACK.recover_dependency_object(dependency)
+
+            fetch.assert_not_called()
+
+    def test_missing_expected_commit_is_recovered_from_fixed_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            authority, checkout, promoted, tree = self.create_git_dependency(root)
+            dependency = STACK.Dependency("container", checkout, promoted, tree)
+
+            with mock.patch.dict(
+                STACK.AUTHORITATIVE_SOURCES, {"container": str(authority)}
+            ):
+                record = STACK.dependency_record(dependency)
+
+            self.assertEqual(record["tree"], tree)
+            self.assertTrue(
+                STACK.git_object_exists(checkout, f"{promoted}^{{commit}}")
+            )
+
+    def test_recovered_commit_with_wrong_tree_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            authority, checkout, promoted, _ = self.create_git_dependency(root)
+            dependency = STACK.Dependency("container", checkout, promoted, "0" * 40)
+
+            with mock.patch.dict(
+                STACK.AUTHORITATIVE_SOURCES, {"container": str(authority)}
+            ):
+                with self.assertRaisesRegex(SystemExit, "expected 0000"):
+                    STACK.recover_dependency_object(dependency)
+
+    def test_unavailable_expected_commit_fails_without_prompting(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            authority, checkout, _, tree = self.create_git_dependency(root)
+            unavailable = "f" * 40
+            dependency = STACK.Dependency("container", checkout, unavailable, tree)
+
+            with mock.patch.dict(
+                STACK.AUTHORITATIVE_SOURCES, {"container": str(authority)}
+            ):
+                with self.assertRaisesRegex(SystemExit, "could not recover"):
+                    STACK.recover_dependency_object(dependency)
+
+    def test_expected_commit_fetch_has_a_bounded_failure(self) -> None:
+        dependency = STACK.Dependency(
+            "container", Path("/tmp/container"), "f" * 40, "e" * 40
+        )
+
+        with mock.patch.object(STACK, "git_object_exists", return_value=False):
+            with mock.patch.object(
+                STACK,
+                "fetch_dependency_object",
+                side_effect=subprocess.TimeoutExpired("git fetch", 60),
+            ):
+                with self.assertRaisesRegex(SystemExit, "timed out recovering"):
+                    STACK.recover_dependency_object(dependency)
+
+    def test_configured_clone_remote_cannot_replace_fixed_authority(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            authority, checkout, promoted, tree = self.create_git_dependency(root)
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    checkout,
+                    "remote",
+                    "set-url",
+                    "origin",
+                    str(root / "untrusted"),
+                ],
+                check=True,
+            )
+            dependency = STACK.Dependency("container", checkout, promoted, tree)
+
+            with mock.patch.dict(
+                STACK.AUTHORITATIVE_SOURCES, {"container": str(authority)}
+            ):
+                STACK.recover_dependency_object(dependency)
+
+            self.assertTrue(
+                STACK.git_object_exists(checkout, f"{promoted}^{{commit}}")
+            )
 
     def test_session_resumes_when_commit_changes_but_tree_does_not(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
Closes #501.

## What changed

- declare the immutable GitHub source for every supported local Swift stack dependency
- optionally bind each local checkout to an expected commit and tree before SwiftPM edits or compilation begin
- recover only a missing exact commit from that fixed source without changing a branch or `FETCH_HEAD`
- disable terminal and credential-manager interaction and bound recovery fetches to 60 seconds
- reject malformed object IDs, incomplete commit/tree pairs, wrong trees, dirty or mismatched checkouts, unavailable objects, and source drift
- share the complete dependency arguments across local debug, release, and test builds

Tree-identical promotion remains reusable: the recovery journal is still keyed by the verified source tree rather than a rewritten commit label, but the requested promoted commit must exist and resolve to that tree before the retained checkpoint can resume.

## Proof

- Python compile: 0.02s
- 19 focused transaction and Make contract tests: 1.07s
- patch check: under 0.01s

The fixtures cover an already-present object, a real missing-object fetch from a fixed authority, wrong-tree rejection, an unavailable commit, a bounded fetch timeout, an untrusted configured clone remote, resolved-source drift, argument validation, and the existing interrupted-edit recovery paths.

No product build, broad test suite, documentation job, CodeQL analysis, parity run, or release packaging was needed for this pre-build controller change.
