### PR TITLE
fix(build): bind stable release authority receipt

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -846,6 +846,7 @@ jobs:
           fi
 
       - name: Require the hosted release authority
+        id: stable-authority
         env:
           GH_TOKEN: ${{ github.token }}
           PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
@@ -875,16 +876,18 @@ jobs:
               ;;
             tag)
               authority_name="Stable Release Authority (${PUBLISH_REF_NAME})"
-              authority_filter=".check_runs[] | select(.name == \"${authority_name}\""
+              authority_filter="[.[].check_runs[] | select(.name == \"${authority_name}\""
               authority_filter+=' and .status == "completed"'
               authority_filter+=' and .conclusion == "success"'
-              authority_filter+=' and .app.slug == "github-actions")'
-              authority_filter+=' | .external_id'
-              authority_run_id="$(
-                gh api --paginate "repos/${GITHUB_REPOSITORY}/commits/${PUBLISH_SHA}/check-runs?per_page=100" \
-                  --jq "${authority_filter}" \
-                  | tail -n 1
+              authority_filter+=' and .app.slug == "github-actions")]'
+              authority_filter+=' | sort_by(.completed_at) | last'
+              authority_filter+=' | [.external_id, .output.summary] | @tsv'
+              authority_record="$(
+                gh api --paginate --slurp \
+                  "repos/${GITHUB_REPOSITORY}/commits/${PUBLISH_SHA}/check-runs?per_page=100" \
+                  --jq "${authority_filter}"
               )"
+              IFS=$'\t' read -r authority_run_id authority_summary <<< "${authority_record}"
               if [[ ! "${authority_run_id}" =~ ^[0-9]+$ ]]; then
                 printf 'refusing to package %s without candidate-bound Stable Release Authority %s\n' \
                   "${PUBLISH_SHA}" "${authority_name}" >&2
@@ -900,12 +903,117 @@ jobs:
                   "${PUBLISH_SHA}" >&2
                 exit 1
               fi
+              receipt_sha256="$(
+                sed -nE 's/.* Authority receipt SHA-256: ([0-9a-f]{64})[.].*/\1/p' \
+                  <<< "${authority_summary}"
+              )"
+              artifact_id="$(
+                sed -nE 's/.* Authority artifact ID: ([0-9]+)[.].*/\1/p' \
+                  <<< "${authority_summary}"
+              )"
+              artifact_digest="$(
+                sed -nE 's/.* Authority artifact digest: ([0-9a-f]{64})[.].*/\1/p' \
+                  <<< "${authority_summary}"
+              )"
+              if [[ ! "${receipt_sha256}" =~ ^[0-9a-f]{64}$ ]] ||
+                [[ ! "${artifact_id}" =~ ^[0-9]+$ ]] ||
+                [[ ! "${artifact_digest}" =~ ^[0-9a-f]{64}$ ]]; then
+                printf 'stable release authority has no valid receipt binding\n' >&2
+                exit 1
+              fi
+              {
+                printf 'run_id=%s\n' "${authority_run_id}"
+                printf 'receipt_sha256=%s\n' "${receipt_sha256}"
+                printf 'artifact_id=%s\n' "${artifact_id}"
+                printf 'artifact_digest=%s\n' "${artifact_digest}"
+              } >> "${GITHUB_OUTPUT}"
               ;;
             *)
               printf 'unsupported publish ref type: %s\n' "${PUBLISH_REF_TYPE}" >&2
               exit 1
               ;;
           esac
+
+      - name: Verify candidate-bound authority receipt
+        id: authority-bundle
+        if: needs.resolve-publish-context.outputs.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_REF_NAME: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+          BUILDER_REF: ${{ steps.stack-refs.outputs.container_builder_shim_ref }}
+          CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
+          CONTAINER_REF: ${{ steps.stack-refs.outputs.container_ref }}
+          AUTHORITY_RUN_ID: ${{ steps.stable-authority.outputs.run_id }}
+          AUTHORITY_RECEIPT_SHA256: ${{ steps.stable-authority.outputs.receipt_sha256 }}
+          AUTHORITY_ARTIFACT_ID: ${{ steps.stable-authority.outputs.artifact_id }}
+          AUTHORITY_ARTIFACT_DIGEST: ${{ steps.stable-authority.outputs.artifact_digest }}
+        shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+        run: |
+          set -euo pipefail
+          authority_root="${RUNNER_TEMP}/stable-release-authority-${PUBLISH_REF_NAME}"
+          mkdir "${authority_root}"
+          artifact_json="${authority_root}/artifact.json"
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${AUTHORITY_ARTIFACT_ID}" \
+            > "${artifact_json}"
+          expected_name="stable-release-authority-${PUBLISH_REF_NAME}-${PUBLISH_SHA}"
+          if [[ "$(jq -r '.expired' "${artifact_json}")" != "false" ]] ||
+            [[ "$(jq -r '.name' "${artifact_json}")" != "${expected_name}" ]] ||
+            [[ "$(jq -r '.digest' "${artifact_json}")" != "sha256:${AUTHORITY_ARTIFACT_DIGEST}" ]] ||
+            [[ "$(jq -r '.workflow_run.id' "${artifact_json}")" != "${AUTHORITY_RUN_ID}" ]]; then
+            printf 'stable release authority artifact does not match its check run\n' >&2
+            exit 1
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${AUTHORITY_ARTIFACT_ID}/zip" \
+            > "${authority_root}/artifact.zip"
+          mkdir "${authority_root}/bundle"
+          /usr/bin/ditto -x -k "${authority_root}/artifact.zip" \
+            "${authority_root}/bundle"
+          receipt="${authority_root}/bundle/stable-release-authority.json"
+          if [[ "$(shasum -a 256 "${receipt}" | awk '{print $1}')" != \
+            "${AUTHORITY_RECEIPT_SHA256}" ]]; then
+            printf 'stable release authority receipt digest changed\n' >&2
+            exit 1
+          fi
+          init_authority_object="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/stable-init-image-authority/${PUBLISH_REF_NAME}" \
+              --jq '.object.sha'
+          )"
+          init_authority="$(
+            gh api "repos/${GITHUB_REPOSITORY}/git/tags/${init_authority_object}"
+          )"
+          if [[ "$(jq -r '.verification.verified' <<< "${init_authority}")" != "true" ]] ||
+            [[ "$(jq -r '.object.sha' <<< "${init_authority}")" != "${PUBLISH_SHA}" ]]; then
+            printf 'stable init-image authority no longer verifies the package source\n' >&2
+            exit 1
+          fi
+          init_image_sha256="$(
+            jq -r '.message' <<< "${init_authority}" |
+              sed -nE 's/^Guest init image SHA-256: ([0-9a-f]{64})[.]$/\1/p'
+          )"
+          homebrew_tap_ref="$(
+            git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git \
+              refs/heads/main | awk '{print $1}' | tail -n 1
+          )"
+          python3 container-compose/Tools/release/stable-release-authority.py verify \
+            --evidence-dir "${authority_root}/bundle" \
+            --receipt "${receipt}" \
+            --release-tag "${PUBLISH_REF_NAME}" \
+            --candidate-sha "${PUBLISH_SHA}" \
+            --builder-ref "${BUILDER_REF}" \
+            --containerization-ref "${CONTAINERIZATION_REF}" \
+            --container-ref "${CONTAINER_REF}" \
+            --homebrew-tap-ref "${homebrew_tap_ref}" \
+            --init-image-sha256 "${init_image_sha256}" >/dev/null
+          authority_asset="stable-release-authority.tar.gz"
+          /usr/bin/tar -C "${authority_root}/bundle" -czf \
+            "${RUNNER_TEMP}/${authority_asset}" .
+          python3 container-compose/Tools/release/write-sha256-sidecar.py \
+            "${RUNNER_TEMP}/${authority_asset}"
+          {
+            printf 'asset=%s\n' "${authority_asset}"
+            printf 'local_asset=%s\n' "${RUNNER_TEMP}/${authority_asset}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Install Developer ID application certificate
         env:
@@ -1276,6 +1384,12 @@ jobs:
         with:
           subject-path: ${{ steps.current-init-image.outputs.local_asset }}
 
+      - name: Attest stable release authority
+        if: needs.resolve-publish-context.outputs.ref_type == 'tag'
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: ${{ steps.authority-bundle.outputs.local_asset }}
+
       - name: Upload workflow artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -1371,6 +1485,12 @@ jobs:
           printf '%s\n%s\n' \
             "${{ steps.runtime-package.outputs.local_asset }}" \
             "${{ steps.runtime-package.outputs.local_asset }}.sha256" > "${extra_assets}"
+          if [[ "${PUBLISH_REF_TYPE}" == "tag" ]]; then
+            printf '%s\n%s\n' \
+              "${{ steps.authority-bundle.outputs.local_asset }}" \
+              "${{ steps.authority-bundle.outputs.local_asset }}.sha256" \
+              >> "${extra_assets}"
+          fi
           if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
             printf '%s\n%s\n' \
               "${{ steps.current-init-image.outputs.local_asset }}" \

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -278,6 +278,10 @@ jobs:
     needs: resolve-candidate
     runs-on: [self-hosted, macOS, ARM64, container-compose-release]
     timeout-minutes: 120
+    outputs:
+      authority_artifact_digest: ${{ steps.upload-authority.outputs.artifact-digest }}
+      authority_artifact_id: ${{ steps.upload-authority.outputs.artifact-id }}
+      authority_receipt_sha256: ${{ steps.authority-receipt.outputs.sha256 }}
     env:
       DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
     steps:
@@ -444,6 +448,7 @@ jobs:
           pipeline_environment=(
             "PIPELINE_PROFILE=release-hosted"
             "PIPELINE_STATE_ROOT=${RELEASE_PIPELINE_STATE_ROOT}"
+            "PIPELINE_ATTEMPT_ID=stable-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
             "PIPELINE_EXECUTION_PATH=${GITHUB_WORKSPACE}/container-compose/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
             "PIPELINE_COMPOSE_REPO=${GITHUB_WORKSPACE}/container-compose"
             "PIPELINE_COMPOSE_REF=${CANDIDATE_SHA}"
@@ -469,6 +474,55 @@ jobs:
             env "${pipeline_environment[@]}" make -C release-tools pipeline
           fi
 
+      - name: Create candidate-bound authority receipt
+        id: authority-receipt
+        env:
+          RELEASE_TAG: ${{ inputs.ref }}
+          CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
+          BUILDER_REF: ${{ steps.stack-refs.outputs.container_builder_shim_ref }}
+          CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
+          CONTAINER_REF: ${{ steps.stack-refs.outputs.container_ref }}
+          HOMEBREW_TAP_REF: ${{ needs.resolve-candidate.outputs.homebrew_tap_ref }}
+          INIT_IMAGE_SHA256: ${{ needs.resolve-candidate.outputs.init_image_sha256 }}
+        shell: /bin/bash --noprofile --norc -e -o pipefail {0}
+        run: |
+          set -euo pipefail
+          attempt_id="stable-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          evidence="${RELEASE_PIPELINE_STATE_ROOT}/evidence/${attempt_id}"
+          bundle="${RUNNER_TEMP}/stable-release-authority"
+          if [[ -e "${bundle}" || -L "${bundle}" ]]; then
+            printf 'stable release authority bundle already exists: %s\n' "${bundle}" >&2
+            exit 2
+          fi
+          mkdir "${bundle}"
+          cp "${evidence}/pipeline-summary.tsv" "${bundle}/"
+          cp "${evidence}/attempt.tsv" "${bundle}/"
+          cp "${evidence}/session.uuid" "${bundle}/"
+          cp -R "${evidence}/preflight" "${bundle}/preflight"
+          receipt_sha256="$(
+            python3 release-tools/Tools/release/stable-release-authority.py create \
+              --evidence-dir "${bundle}" \
+              --receipt "${bundle}/stable-release-authority.json" \
+              --release-tag "${RELEASE_TAG}" \
+              --candidate-sha "${CANDIDATE_SHA}" \
+              --builder-ref "${BUILDER_REF}" \
+              --containerization-ref "${CONTAINERIZATION_REF}" \
+              --container-ref "${CONTAINER_REF}" \
+              --homebrew-tap-ref "${HOMEBREW_TAP_REF}" \
+              --init-image-sha256 "${INIT_IMAGE_SHA256}"
+          )"
+          [[ "${receipt_sha256}" =~ ^[0-9a-f]{64}$ ]]
+          printf 'sha256=%s\n' "${receipt_sha256}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload candidate-bound authority receipt
+        id: upload-authority
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: stable-release-authority-${{ inputs.ref }}-${{ needs.resolve-candidate.outputs.sha }}
+          path: ${{ runner.temp }}/stable-release-authority
+          if-no-files-found: error
+          retention-days: 90
+
   record-release-authority:
     name: Record Stable Release Authority
     needs: [resolve-candidate, release-gate]
@@ -488,6 +542,9 @@ jobs:
           AUTHORITY_REF: ${{ needs.resolve-candidate.outputs.authority_ref }}
           INIT_IMAGE_SHA256: ${{ needs.resolve-candidate.outputs.init_image_sha256 }}
           INIT_IMAGE_AUTHORITY_OBJECT: ${{ needs.resolve-candidate.outputs.init_image_authority_object }}
+          AUTHORITY_ARTIFACT_DIGEST: ${{ needs.release-gate.outputs.authority_artifact_digest }}
+          AUTHORITY_ARTIFACT_ID: ${{ needs.release-gate.outputs.authority_artifact_id }}
+          AUTHORITY_RECEIPT_SHA256: ${{ needs.release-gate.outputs.authority_receipt_sha256 }}
         shell: bash
         run: |
           set -euo pipefail
@@ -540,11 +597,20 @@ jobs:
             printf 'stable init-image authority digest changed after validation\n' >&2
             exit 75
           fi
+          if [[ ! "${AUTHORITY_ARTIFACT_ID}" =~ ^[0-9]+$ ]] ||
+            [[ ! "${AUTHORITY_ARTIFACT_DIGEST}" =~ ^[0-9a-f]{64}$ ]] ||
+            [[ ! "${AUTHORITY_RECEIPT_SHA256}" =~ ^[0-9a-f]{64}$ ]]; then
+            printf 'stable release authority receipt outputs are invalid\n' >&2
+            exit 75
+          fi
           authority_name="Stable Release Authority (${RELEASE_TAG})"
           details_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           summary="Hosted Stable Release Gate passed for immutable source"
           summary+=" ${CANDIDATE_SHA}."
           summary+=" Guest init image SHA-256: ${INIT_IMAGE_SHA256}."
+          summary+=" Authority receipt SHA-256: ${AUTHORITY_RECEIPT_SHA256}."
+          summary+=" Authority artifact ID: ${AUTHORITY_ARTIFACT_ID}."
+          summary+=" Authority artifact digest: ${AUTHORITY_ARTIFACT_DIGEST}."
           gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
             -f "name=${authority_name}" \
             -f "head_sha=${CANDIDATE_SHA}" \

--- a/Tools/release/retain-release-assets.py
+++ b/Tools/release/retain-release-assets.py
@@ -33,7 +33,7 @@ RETENTION_END = "<!-- container-release-retention:end -->"
 LEGACY_PIN_HIGHLIGHT = re.compile(
     r"(?m)^- Release automation pins .+ by exact SwiftPM revision [0-9a-f]{12}\.\n?"
 )
-STABLE_BENCHMARK_ASSETS = frozenset(
+STABLE_RETAINED_ASSETS = frozenset(
     {
         "container-release-arm64.tar.gz",
         "container-release-arm64.tar.gz.sha256",
@@ -41,6 +41,8 @@ STABLE_BENCHMARK_ASSETS = frozenset(
         "container-compose-plugin-release-arm64.tar.gz.sha256",
         "container-vminit-arm64.oci.tar",
         "container-vminit-arm64.oci.tar.sha256",
+        "stable-release-authority.tar.gz",
+        "stable-release-authority.tar.gz.sha256",
     }
 )
 
@@ -204,9 +206,9 @@ def historical_source_note(
             "",
             (
                 "This release is retained as source history. Its tap-backed package "
-                "and non-benchmark release assets have been retired; any immutable "
-                "runtime, plugin, and guest assets required for a reproducible "
-                "published-version benchmark remain attached."
+                "and non-reproducibility release assets have been retired; immutable "
+                "runtime, plugin, guest, and release-authority assets required for a "
+                "reproducible published-version benchmark or release proof remain attached."
             ),
             "The public Homebrew formula intentionally follows only the newest release in each lane, so it cannot select this historical tag.",
             "Use Homebrew to bootstrap the build tools, then build this exact source tag:",
@@ -270,7 +272,7 @@ def list_releases(repo: str) -> list[dict]:
 
 
 def historical_assets_to_retire(release: dict) -> list[dict]:
-    """Return assets not needed to benchmark a historical stable release."""
+    """Return assets not needed to reproduce a historical stable release."""
 
     assets = list(release.get("assets", []))
     if release.get("prerelease"):
@@ -278,7 +280,7 @@ def historical_assets_to_retire(release: dict) -> list[dict]:
     return [
         asset
         for asset in assets
-        if asset.get("name") not in STABLE_BENCHMARK_ASSETS
+        if asset.get("name") not in STABLE_RETAINED_ASSETS
     ]
 
 

--- a/Tools/release/stable-release-authority.py
+++ b/Tools/release/stable-release-authority.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Create or verify one candidate-bound stable release authority receipt."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+
+OBJECT_ID = re.compile(r"[0-9a-f]{40}")
+DIGEST = re.compile(r"[0-9a-f]{64}")
+SEMVER = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_file(path: Path) -> Path:
+    if path.is_symlink() or not path.is_file():
+        raise SystemExit(f"stable release authority input is indirect or missing: {path}")
+    return path
+
+
+def parse_pairs(path: Path) -> list[tuple[str, ...]]:
+    rows: list[tuple[str, ...]] = []
+    for line in require_file(path).read_text(encoding="utf-8").splitlines():
+        fields = tuple(line.split("\t"))
+        if len(fields) < 2 or any(not field for field in fields):
+            raise SystemExit(f"stable release authority input is malformed: {path}")
+        rows.append(fields)
+    return rows
+
+
+def unique_value(rows: list[tuple[str, ...]], name: str, path: Path) -> str:
+    values = [row[1] for row in rows if len(row) == 2 and row[0] == name]
+    if len(values) != 1:
+        raise SystemExit(f"stable release authority input has no unique {name}: {path}")
+    return values[0]
+
+
+def validated_inputs(arguments: argparse.Namespace) -> dict[str, str]:
+    values = {
+        "releaseTag": arguments.release_tag,
+        "candidateSha": arguments.candidate_sha,
+        "containerBuilderShim": arguments.builder_ref,
+        "containerization": arguments.containerization_ref,
+        "container": arguments.container_ref,
+        "homebrewTap": arguments.homebrew_tap_ref,
+        "guestInitImageSha256": arguments.init_image_sha256,
+    }
+    if not SEMVER.fullmatch(values["releaseTag"]):
+        raise SystemExit(f"stable release tag is invalid: {values['releaseTag']}")
+    for name in (
+        "candidateSha",
+        "containerBuilderShim",
+        "containerization",
+        "container",
+        "homebrewTap",
+    ):
+        if not OBJECT_ID.fullmatch(values[name]):
+            raise SystemExit(f"stable release authority {name} is not immutable")
+    if not DIGEST.fullmatch(values["guestInitImageSha256"]):
+        raise SystemExit("stable release authority guest image digest is invalid")
+    return values
+
+
+def build_receipt(arguments: argparse.Namespace) -> dict[str, Any]:
+    values = validated_inputs(arguments)
+    evidence_input = Path(arguments.evidence_dir)
+    if evidence_input.is_symlink() or not evidence_input.is_dir():
+        raise SystemExit(
+            "stable release authority evidence is indirect or missing: "
+            f"{evidence_input}"
+        )
+    evidence = evidence_input.resolve()
+    preflight = evidence / "preflight"
+    if preflight.is_symlink() or not preflight.is_dir():
+        raise SystemExit(
+            f"stable release authority preflight is indirect or missing: {preflight}"
+        )
+    summary = evidence / "pipeline-summary.tsv"
+    attempt = evidence / "attempt.tsv"
+    session = evidence / "session.uuid"
+    summary_rows = parse_pairs(summary)
+    attempt_rows = parse_pairs(attempt)
+    session_value = require_file(session).read_text(encoding="utf-8").strip()
+    if unique_value(summary_rows, "schema", summary) != "1":
+        raise SystemExit("stable release authority pipeline summary schema is unsupported")
+    if unique_value(summary_rows, "profile", summary) != "release-hosted":
+        raise SystemExit("stable release authority pipeline profile is not release-hosted")
+    if unique_value(summary_rows, "complete", summary) != "true":
+        raise SystemExit("stable release authority pipeline summary is incomplete")
+    if unique_value(attempt_rows, "profile", attempt) != "release-hosted":
+        raise SystemExit("stable release authority attempt profile is not release-hosted")
+    for status in ("orchestrator-exit", "tee-exit", "evidence-exit", "exit"):
+        if unique_value(attempt_rows, status, attempt) != "0":
+            raise SystemExit(f"stable release authority attempt did not pass: {status}")
+    if not re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+        session_value,
+    ):
+        raise SystemExit("stable release authority session UUID is invalid")
+
+    evidence_entries: list[dict[str, str]] = []
+    for row in summary_rows:
+        if row[0] not in {
+            "repository-receipt",
+            "stage-artifact",
+            "stage-output",
+            "stage-receipt",
+        }:
+            continue
+        if len(row) != 3 or not DIGEST.fullmatch(row[2]):
+            raise SystemExit(
+                f"stable release authority pipeline evidence is malformed: {row[0]}"
+            )
+        evidence_entries.append(
+            {"kind": row[0], "name": row[1], "sha256": row[2]}
+        )
+    if not evidence_entries:
+        raise SystemExit("stable release authority pipeline evidence is empty")
+    if len({(item["kind"], item["name"]) for item in evidence_entries}) != len(
+        evidence_entries
+    ):
+        raise SystemExit("stable release authority pipeline evidence contains duplicates")
+
+    repository_digests = {
+        item["name"]: item["sha256"]
+        for item in evidence_entries
+        if item["kind"] == "repository-receipt"
+    }
+    expected_commits = {
+        "container-compose": values["candidateSha"],
+        "container-builder-shim": values["containerBuilderShim"],
+        "containerization": values["containerization"],
+        "container": values["container"],
+        "homebrew-tap": values["homebrewTap"],
+    }
+    for repository, commit in expected_commits.items():
+        for kind in ("identity", "provenance"):
+            name = f"{repository}.{kind}.tsv"
+            repository_receipt = preflight / name
+            if repository_digests.get(name) != sha256_file(
+                require_file(repository_receipt)
+            ):
+                raise SystemExit(
+                    f"stable release authority repository receipt changed: {name}"
+                )
+            repository_rows = parse_pairs(repository_receipt)
+            if unique_value(repository_rows, "repository", repository_receipt) != repository:
+                raise SystemExit(
+                    f"stable release authority repository name changed: {name}"
+                )
+            if unique_value(repository_rows, "commit", repository_receipt) != commit:
+                raise SystemExit(
+                    f"stable release authority repository commit changed: {name}"
+                )
+            if unique_value(repository_rows, "clean", repository_receipt) != "true":
+                raise SystemExit(
+                    f"stable release authority repository was not clean: {name}"
+                )
+
+    package_inputs = {
+        "candidateSha": values["candidateSha"],
+        "components": {
+            "container-builder-shim": values["containerBuilderShim"],
+            "containerization": values["containerization"],
+            "container": values["container"],
+            "homebrew-tap": values["homebrewTap"],
+        },
+        "guestInitImageSha256": values["guestInitImageSha256"],
+    }
+    package_inputs_sha256 = hashlib.sha256(
+        json.dumps(package_inputs, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    host_tools_sha256 = unique_value(summary_rows, "host-tools-sha256", summary)
+    if not DIGEST.fullmatch(host_tools_sha256):
+        raise SystemExit("stable release authority host toolchain digest is invalid")
+    return {
+        "schema": 1,
+        "result": "success",
+        "releaseTag": values["releaseTag"],
+        **package_inputs,
+        "packageInputsSha256": package_inputs_sha256,
+        "pipeline": {
+            "attemptSha256": sha256_file(attempt),
+            "evidence": evidence_entries,
+            "hostToolsSha256": host_tools_sha256,
+            "session": session_value,
+            "summarySha256": sha256_file(summary),
+        },
+    }
+
+
+def write_receipt(receipt: dict[str, Any], output: Path) -> None:
+    if output.exists() or output.is_symlink():
+        raise SystemExit(f"refusing to replace stable release authority receipt: {output}")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.{os.getpid()}.tmp")
+    if temporary.exists() or temporary.is_symlink():
+        raise SystemExit(f"stable release authority temporary output exists: {temporary}")
+    try:
+        with temporary.open("x", encoding="utf-8") as stream:
+            stream.write(json.dumps(receipt, indent=2, sort_keys=True) + "\n")
+        os.chmod(temporary, 0o444)
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def verify_receipt(expected: dict[str, Any], receipt: Path) -> str:
+    try:
+        actual = json.loads(require_file(receipt).read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise SystemExit(
+            f"stable release authority receipt is malformed: {error.msg}"
+        ) from error
+    if actual != expected:
+        raise SystemExit("stable release authority receipt does not match its evidence")
+    return sha256_file(receipt)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=("create", "verify"))
+    parser.add_argument("--evidence-dir", required=True)
+    parser.add_argument("--receipt", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--builder-ref", required=True)
+    parser.add_argument("--containerization-ref", required=True)
+    parser.add_argument("--container-ref", required=True)
+    parser.add_argument("--homebrew-tap-ref", required=True)
+    parser.add_argument("--init-image-sha256", required=True)
+    arguments = parser.parse_args()
+    expected = build_receipt(arguments)
+    receipt = Path(arguments.receipt)
+    if arguments.mode == "create":
+        write_receipt(expected, receipt)
+        print(sha256_file(receipt))
+        return
+    print(verify_receipt(expected, receipt))
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3037,8 +3037,22 @@ github_cli() {{
         self.assertIn("workflowName", tag_authority)
         self.assertIn("Stable Release Gate", tag_authority)
         self.assertIn("workflow_dispatch", tag_authority)
+        self.assertIn(".output.summary", tag_authority)
+        self.assertIn("Authority receipt SHA-256", tag_authority)
+        self.assertIn("Authority artifact ID", tag_authority)
+        self.assertIn("Authority artifact digest", tag_authority)
         self.assertNotIn('workflow="stable-release-gate.yml"', tag_authority)
         self.assertNotIn('--commit "${PUBLISH_SHA}"', tag_authority)
+
+        receipt = authority[
+            authority.index("- name: Verify candidate-bound authority receipt") :
+        ]
+        self.assertIn("actions/artifacts/${AUTHORITY_ARTIFACT_ID}", receipt)
+        self.assertIn(".workflow_run.id", receipt)
+        self.assertIn('"sha256:${AUTHORITY_ARTIFACT_DIGEST}"', receipt)
+        self.assertIn("stable-release-authority.py verify", receipt)
+        self.assertIn("--candidate-sha \"${PUBLISH_SHA}\"", receipt)
+        self.assertIn("stable-release-authority.tar.gz", receipt)
 
     def test_stable_gate_records_the_candidate_bound_guest_digest(self) -> None:
         workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
@@ -3063,6 +3077,20 @@ github_cli() {{
         )
         self.assertIn(
             'summary+=" Guest init image SHA-256: ${INIT_IMAGE_SHA256}."',
+            workflow,
+        )
+        self.assertIn("Create candidate-bound authority receipt", workflow)
+        self.assertIn("Upload candidate-bound authority receipt", workflow)
+        self.assertIn(
+            'summary+=" Authority receipt SHA-256: ${AUTHORITY_RECEIPT_SHA256}."',
+            workflow,
+        )
+        self.assertIn(
+            'summary+=" Authority artifact ID: ${AUTHORITY_ARTIFACT_ID}."',
+            workflow,
+        )
+        self.assertIn(
+            'summary+=" Authority artifact digest: ${AUTHORITY_ARTIFACT_DIGEST}."',
             workflow,
         )
         self.assertIn(
@@ -3259,6 +3287,24 @@ github_cli() {{
         self.assertTrue(
             (ROOT / "Tools" / "release" / "verify-developer-id-archive.sh").is_file()
         )
+
+    def test_stable_authority_is_attested_published_and_retained(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        retention = (
+            ROOT / "Tools" / "release" / "retain-release-assets.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("- name: Attest stable release authority", workflow)
+        self.assertIn(
+            "subject-path: ${{ steps.authority-bundle.outputs.local_asset }}",
+            workflow,
+        )
+        self.assertIn(
+            '"${{ steps.authority-bundle.outputs.local_asset }}.sha256"',
+            workflow,
+        )
+        self.assertIn('"stable-release-authority.tar.gz"', retention)
+        self.assertIn('"stable-release-authority.tar.gz.sha256"', retention)
 
     def test_package_authority_requires_a_successful_candidate_bound_gate(self) -> None:
         accepted = self.run_package_authority_step("tag", "0.6.70", "29288195238", "success")
@@ -7703,7 +7749,7 @@ exit 64
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         authority = workflow[
             workflow.index("- name: Require the hosted release authority") : workflow.index(
-                "- name: Install Developer ID application certificate"
+                "- name: Verify candidate-bound authority receipt"
             )
         ]
         run_marker = "        run: |\n"
@@ -7712,8 +7758,9 @@ exit 64
         fake_gh = """\
 gh() {
   case "$1:$2" in
-    api:*) printf '%s\\n' "${TEST_AUTHORITY_RUN_ID}" ;;
-    run:*) printf '%s\\n' "${TEST_GATE_CONCLUSION}" ;;
+    api:*) printf '%s\\t%s\\n' "${TEST_AUTHORITY_RUN_ID}" "${TEST_AUTHORITY_SUMMARY}" ;;
+    run:list) printf '%s\\n' "${TEST_GATE_CONCLUSION}" ;;
+    run:view) printf '%s\\n' "${TEST_GATE_CONCLUSION}" ;;
     *) exit 64 ;;
   esac
 }
@@ -7727,7 +7774,14 @@ gh() {
                 "GITHUB_REPOSITORY": "stephenlclarke/container-compose",
                 "GH_TOKEN": "test",
                 "TEST_AUTHORITY_RUN_ID": authority_run_id,
+                "TEST_AUTHORITY_SUMMARY": (
+                    "Hosted Stable Release Gate passed. "
+                    f"Authority receipt SHA-256: {'a' * 64}. "
+                    "Authority artifact ID: 12345. "
+                    f"Authority artifact digest: {'b' * 64}."
+                ),
                 "TEST_GATE_CONCLUSION": gate_conclusion,
+                "GITHUB_OUTPUT": os.devnull,
             }
         )
         return subprocess.run(

--- a/Tools/release/test_retain_release_assets.py
+++ b/Tools/release/test_retain_release_assets.py
@@ -155,7 +155,7 @@ class ReleaseAssetRetentionTests(unittest.TestCase):
                 {"id": index, "name": name}
                 for index, name in enumerate(
                     [
-                        *sorted(module.STABLE_BENCHMARK_ASSETS),
+                        *sorted(module.STABLE_RETAINED_ASSETS),
                         "release-highlights.md",
                         "quality-snapshot.svg",
                     ],

--- a/Tools/release/test_stable_release_authority.py
+++ b/Tools/release/test_stable_release_authority.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for candidate-bound stable release authority receipts."""
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("stable-release-authority.py")
+SPEC = importlib.util.spec_from_file_location("stable_release_authority", MODULE_PATH)
+assert SPEC and SPEC.loader
+AUTHORITY = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = AUTHORITY
+SPEC.loader.exec_module(AUTHORITY)
+
+
+class StableReleaseAuthorityTests(unittest.TestCase):
+    """A successful receipt is complete, immutable, and evidence-bound."""
+
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.evidence = self.root / "evidence"
+        self.evidence.mkdir()
+        self.refs = {
+            "container-compose": "a" * 40,
+            "container-builder-shim": "b" * 40,
+            "containerization": "c" * 40,
+            "container": "d" * 40,
+            "homebrew-tap": "e" * 40,
+        }
+        preflight = self.evidence / "preflight"
+        preflight.mkdir()
+        repository_summary = []
+        for repository, commit in self.refs.items():
+            for kind in ("identity", "provenance"):
+                receipt = preflight / f"{repository}.{kind}.tsv"
+                receipt.write_text(
+                    "\n".join(
+                        (
+                            "schema\t2",
+                            f"repository\t{repository}",
+                            f"commit\t{commit}",
+                            "clean\ttrue",
+                            "",
+                        )
+                    ),
+                    encoding="utf-8",
+                )
+                repository_summary.append(
+                    "repository-receipt\t"
+                    f"{receipt.name}\t{AUTHORITY.sha256_file(receipt)}"
+                )
+        (self.evidence / "pipeline-summary.tsv").write_text(
+            "\n".join(
+                (
+                    "schema\t1",
+                    "profile\trelease-hosted",
+                    f"host-tools-sha256\t{'1' * 64}",
+                    f"stage-receipt\tcontainer.receipt.tsv\t{'2' * 64}",
+                    f"stage-output\tcontainer.stdout.log\t{'3' * 64}",
+                    f"stage-artifact\tcontainer.artifacts.tar\t{'4' * 64}",
+                    *repository_summary,
+                    "complete\ttrue",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        (self.evidence / "attempt.tsv").write_text(
+            "\n".join(
+                (
+                    "schema\t1",
+                    "profile\trelease-hosted",
+                    "orchestrator-exit\t0",
+                    "tee-exit\t0",
+                    "evidence-exit\t0",
+                    "exit\t0",
+                    "",
+                )
+            ),
+            encoding="utf-8",
+        )
+        (self.evidence / "session.uuid").write_text(
+            "01234567-89ab-cdef-0123-456789abcdef\n", encoding="utf-8"
+        )
+        self.receipt = self.root / "receipt.json"
+
+    def arguments(self, **overrides: str) -> argparse.Namespace:
+        values = {
+            "evidence_dir": str(self.evidence),
+            "receipt": str(self.receipt),
+            "release_tag": "0.15.0",
+            "candidate_sha": self.refs["container-compose"],
+            "builder_ref": self.refs["container-builder-shim"],
+            "containerization_ref": self.refs["containerization"],
+            "container_ref": self.refs["container"],
+            "homebrew_tap_ref": self.refs["homebrew-tap"],
+            "init_image_sha256": "f" * 64,
+        }
+        values.update(overrides)
+        return argparse.Namespace(**values)
+
+    def test_receipt_binds_inputs_toolchain_and_pipeline_evidence(self) -> None:
+        expected = AUTHORITY.build_receipt(self.arguments())
+        AUTHORITY.write_receipt(expected, self.receipt)
+        actual = json.loads(self.receipt.read_text(encoding="utf-8"))
+
+        self.assertEqual(actual, expected)
+        self.assertEqual(actual["candidateSha"], "a" * 40)
+        self.assertEqual(actual["components"]["container"], "d" * 40)
+        self.assertEqual(actual["pipeline"]["hostToolsSha256"], "1" * 64)
+        self.assertEqual(len(actual["pipeline"]["evidence"]), 13)
+        self.assertRegex(actual["packageInputsSha256"], r"^[0-9a-f]{64}$")
+        self.assertEqual(self.receipt.stat().st_mode & 0o777, 0o444)
+
+    def test_receipt_changes_when_package_input_or_evidence_changes(self) -> None:
+        original = AUTHORITY.build_receipt(self.arguments())
+        changed_input = AUTHORITY.build_receipt(
+            self.arguments(init_image_sha256="0" * 64)
+        )
+        (self.evidence / "attempt.tsv").write_text(
+            (self.evidence / "attempt.tsv").read_text(encoding="utf-8")
+            + "completed-utc\t2026-09-06T10:00:00Z\n",
+            encoding="utf-8",
+        )
+        changed_evidence = AUTHORITY.build_receipt(self.arguments())
+
+        self.assertNotEqual(
+            original["packageInputsSha256"],
+            changed_input["packageInputsSha256"],
+        )
+        self.assertNotEqual(
+            original["pipeline"]["attemptSha256"],
+            changed_evidence["pipeline"]["attemptSha256"],
+        )
+
+    def test_failed_attempt_is_rejected(self) -> None:
+        attempt = self.evidence / "attempt.tsv"
+        attempt.write_text(
+            attempt.read_text(encoding="utf-8").replace("exit\t0", "exit\t1"),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(SystemExit, "attempt did not pass"):
+            AUTHORITY.build_receipt(self.arguments())
+
+    def test_duplicate_evidence_name_is_rejected(self) -> None:
+        summary = self.evidence / "pipeline-summary.tsv"
+        summary.write_text(
+            summary.read_text(encoding="utf-8")
+            + f"stage-receipt\tcontainer.receipt.tsv\t{'2' * 64}\n",
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(SystemExit, "contains duplicates"):
+            AUTHORITY.build_receipt(self.arguments())
+
+    def test_repository_receipt_tampering_is_rejected(self) -> None:
+        identity = self.evidence / "preflight" / "container.identity.tsv"
+        identity.write_text(
+            identity.read_text(encoding="utf-8").replace("clean\ttrue", "clean\tfalse"),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(SystemExit, "repository receipt changed"):
+            AUTHORITY.build_receipt(self.arguments())
+
+    def test_indirect_evidence_and_preflight_are_rejected(self) -> None:
+        indirect_evidence = self.root / "indirect-evidence"
+        indirect_evidence.symlink_to(self.evidence, target_is_directory=True)
+        with self.assertRaisesRegex(SystemExit, "evidence is indirect"):
+            AUTHORITY.build_receipt(
+                self.arguments(evidence_dir=str(indirect_evidence))
+            )
+
+        preflight = self.evidence / "preflight"
+        retained = self.root / "retained-preflight"
+        preflight.rename(retained)
+        preflight.symlink_to(retained, target_is_directory=True)
+        with self.assertRaisesRegex(SystemExit, "preflight is indirect"):
+            AUTHORITY.build_receipt(self.arguments())
+
+    def test_incomplete_input_identity_is_rejected(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "not immutable"):
+            AUTHORITY.build_receipt(self.arguments(container_ref="main"))
+
+    def test_existing_receipt_is_never_replaced(self) -> None:
+        self.receipt.write_text("retained\n", encoding="utf-8")
+
+        with self.assertRaisesRegex(SystemExit, "refusing to replace"):
+            AUTHORITY.write_receipt(
+                AUTHORITY.build_receipt(self.arguments()), self.receipt
+            )
+        self.assertEqual(self.receipt.read_text(encoding="utf-8"), "retained\n")
+
+    def test_verifier_rejects_tampered_and_malformed_receipts(self) -> None:
+        expected = AUTHORITY.build_receipt(self.arguments())
+        AUTHORITY.write_receipt(expected, self.receipt)
+        self.assertEqual(
+            AUTHORITY.verify_receipt(expected, self.receipt),
+            AUTHORITY.sha256_file(self.receipt),
+        )
+
+        self.receipt.chmod(0o644)
+        self.receipt.write_text(
+            self.receipt.read_text(encoding="utf-8").replace("a" * 40, "0" * 40),
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(SystemExit, "does not match its evidence"):
+            AUTHORITY.verify_receipt(expected, self.receipt)
+
+        self.receipt.write_text("{not-json}\n", encoding="utf-8")
+        with self.assertRaisesRegex(SystemExit, "receipt is malformed"):
+            AUTHORITY.verify_receipt(expected, self.receipt)
+
+    def test_temporary_output_is_removed_after_write_failure(self) -> None:
+        temporary = self.receipt.with_name(
+            f".{self.receipt.name}.{os.getpid()}.tmp"
+        )
+
+        with mock.patch.object(AUTHORITY.os, "replace", side_effect=OSError("failed")):
+            with self.assertRaisesRegex(OSError, "failed"):
+                AUTHORITY.write_receipt(
+                    AUTHORITY.build_receipt(self.arguments()), self.receipt
+                )
+        self.assertFalse(temporary.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- emit one immutable stable-release authority receipt from the recoverable hosted gate
- bind the receipt to the candidate, component refs, guest image, Homebrew snapshot, toolchain, result, and evidence digests
- make stable packaging verify the originating run, artifact identity, REST digest, receipt digest, and exact package inputs before signing or publishing
- attest and retain the verified authority bundle as a durable release asset

## Validation

- `actionlint .github/workflows/stable-release-gate.yml .github/workflows/prebuilt-binaries.yml`
- 28 focused receipt, release-policy, and retention tests
- Python compilation for all changed release tools and tests
- `git diff --check`

## Review findings resolved

- reject a symlinked evidence or preflight boundary before resolving it
- build the receipt from the copied immutable bundle rather than a mutable source directory
- normalize the documented bare `upload-artifact` digest against the REST API's `sha256:` representation
- choose the newest successful candidate-bound authority check deterministically

## Compatibility

Release workflow only. No Compose command behavior changes. This is part of #324; final rehearsal and measured release comparison remain on that issue.

## Related work

- #502
- #503
- #504
