### PR TITLE
fix(build): run DocC only for stable releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,100 +15,163 @@
 #===----------------------------------------------------------------------===#
 
 name: Documentation
+run-name: Documentation · ${{ inputs.ref }}
 
 on:
-  schedule:
-    - cron: '17 3 * * *'
-  push:
-    branches: [main]
-    paths:
-      - .github/workflows/docs.yml
-      - Tools/ci/classify-documentation-changes.py
-      - docs/**
-      - Package.resolved
-      - Package.swift
-      - README.md
-      - Sources/**
-      - scripts/make-docs.sh
-  pull_request:
-    branches: [main]
-    paths:
-      - .github/workflows/docs.yml
-      - Tools/ci/classify-documentation-changes.py
-      - docs/**
-      - Package.resolved
-      - Package.swift
-      - README.md
-      - Sources/**
-      - scripts/make-docs.sh
   workflow_dispatch:
+    inputs:
+      ref:
+        description: "Published stable semantic tag"
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: documentation-${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
-  cancel-in-progress: true
+  group: documentation-${{ inputs.ref }}
+  cancel-in-progress: false
 
 jobs:
-  classify-changes:
-    name: Classify Documentation Changes
+  resolve-release:
+    name: Resolve Released Documentation Inputs
+    if: github.repository == 'stephenlclarke/container-compose'
     runs-on: ubuntu-24.04
     outputs:
-      build_docc: ${{ steps.classify.outputs.build_docc }}
+      compose_ref: ${{ steps.release.outputs.compose_ref }}
+      container_ref: ${{ steps.stack.outputs.container_ref }}
+      containerization_ref: ${{ steps.stack.outputs.containerization_ref }}
+      k8s_ref: ${{ steps.stack.outputs.k8s_ref }}
     steps:
-      - name: Checkout documentation controls
+      - name: Require exact published release inputs
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.ref }}
+        shell: bash
+        run: |
+          # shellcheck disable=SC2016 # awk programs intentionally use single quotes.
+          set -euo pipefail
+          if [[ ! "${RELEASE_TAG}" =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]; then
+            printf 'stable release ref must be a bare semantic tag: %s\n' \
+              "${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          compose_remote="https://github.com/${GITHUB_REPOSITORY}.git"
+          compose_ref="$(
+            git ls-remote --tags "${compose_remote}" \
+              "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" \
+              | awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+          )"
+          if [[ ! "${compose_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'could not resolve published stable tag %s\n' "${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_REF}" != "refs/heads/main" ]] || \
+            [[ ! "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'documentation control must be dispatched from an immutable main revision, got %s at %s\n' \
+              "${GITHUB_SHA}" "${GITHUB_REF}" >&2
+            exit 1
+          fi
+          release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
+          if [[ "$(jq -r '.draft or .prerelease' <<<"${release}")" != "false" ]]; then
+            printf 'documentation requires a published stable release: %s\n' \
+              "${RELEASE_TAG}" >&2
+            exit 1
+          fi
+          printf 'compose_ref=%s\n' "${compose_ref}" >> "${GITHUB_OUTPUT}"
+          printf 'Released documentation input: %s at %s.\n' \
+            "${RELEASE_TAG}" "${compose_ref}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Checkout tagged container-compose source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
+          path: release-source
+          ref: ${{ steps.release.outputs.compose_ref }}
 
-      - name: Classify documented API and site inputs
-        id: classify
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
-          HEAD_SHA: ${{ github.sha }}
-          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      - name: Resolve exact released stack refs
+        id: stack
+        working-directory: release-source
         shell: bash
         run: |
           set -euo pipefail
-          case "${EVENT_NAME}" in
-            pull_request)
-              base="${PR_BASE_SHA}"
-              head="${PR_HEAD_SHA}"
-              ;;
-            push)
-              base="${BEFORE_SHA}"
-              head="${HEAD_SHA}"
-              if [[ "${base}" == 0000000000000000000000000000000000000000 ]]; then
-                printf 'build_docc=true\n' >> "${GITHUB_OUTPUT}"
-                exit 0
-              fi
-              ;;
-            *)
-              printf 'build_docc=true\n' >> "${GITHUB_OUTPUT}"
-              exit 0
-              ;;
-          esac
-          classification="$(
-            python3 Tools/ci/classify-documentation-changes.py \
-              --repository . \
-              --base "${base}" \
-              --head "${head}" \
-              --github-output "${GITHUB_OUTPUT}"
+          python3 - <<'PY' >> "${GITHUB_OUTPUT}"
+          import json
+          import re
+          from pathlib import Path
+
+          manifest = json.loads(
+              Path("Tools/release/stack-refs.json").read_text(encoding="utf-8")
+          )
+          if manifest.get("schemaVersion") != 1:
+              raise SystemExit("unsupported released stack manifest")
+          components = manifest.get("components", {})
+          expected = {
+              "container": "stephenlclarke/container",
+              "containerization": "stephenlclarke/containerization",
+          }
+          for name, repository in expected.items():
+              component = components.get(name, {})
+              ref = component.get("ref", "")
+              if component.get("repository") != repository:
+                  raise SystemExit(f"released {name} repository changed")
+              if re.fullmatch(r"[0-9a-f]{40}", ref) is None:
+                  raise SystemExit(f"released {name} ref is not immutable: {ref}")
+              print(f"{name}_ref={ref}")
+
+          documentation = json.loads(
+              Path("Tools/release/documentation-refs.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          if documentation.get("schemaVersion") != 1:
+              raise SystemExit("unsupported released documentation manifest")
+          k8s = documentation.get("sites", {}).get("k8s", {})
+          k8s_ref = k8s.get("ref", "")
+          k8s_release_tag = k8s.get("releaseTag", "")
+          if k8s.get("repository") != "stephenlclarke/container-k8s":
+              raise SystemExit("released container-k8s repository changed")
+          if re.fullmatch(r"[0-9a-f]{40}", k8s_ref) is None:
+              raise SystemExit(
+                  f"released container-k8s ref is not immutable: {k8s_ref}"
+              )
+          if not k8s_release_tag:
+              raise SystemExit("released container-k8s tag is missing")
+          print(f"k8s_ref={k8s_ref}")
+          print(f"k8s_release_tag={k8s_release_tag}")
+          PY
+
+      - name: Verify released container-k8s authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+          K8S_REF: ${{ steps.stack.outputs.k8s_ref }}
+          K8S_RELEASE_TAG: ${{ steps.stack.outputs.k8s_release_tag }}
+        shell: bash
+        run: |
+          # shellcheck disable=SC2016 # awk programs intentionally use single quotes.
+          set -euo pipefail
+          k8s_remote="https://github.com/stephenlclarke/container-k8s.git"
+          k8s_tag_ref="$(
+            git ls-remote --tags "${k8s_remote}" \
+              "refs/tags/${K8S_RELEASE_TAG}" \
+              "refs/tags/${K8S_RELEASE_TAG}^{}" \
+              | awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
           )"
-          reason="$(jq -r .reason <<<"${classification}")"
-          build_docc="$(jq -r .build_docc <<<"${classification}")"
-          printf "DocC build: \`%s\` — %s.\n" "${build_docc}" "${reason}" \
-            >> "${GITHUB_STEP_SUMMARY}"
+          k8s_release="$(
+            gh api \
+              "repos/stephenlclarke/container-k8s/releases/tags/${K8S_RELEASE_TAG}"
+          )"
+          if [[ "$(jq -r '.draft' <<<"${k8s_release}")" != "false" ]] || \
+            [[ "${k8s_tag_ref}" != "${K8S_REF}" ]]; then
+            printf 'container-k8s ref is not attached to a published release: %s at %s\n' \
+              "${K8S_RELEASE_TAG}" "${K8S_REF}" >&2
+            exit 1
+          fi
 
   build-sites:
     name: Build ${{ matrix.site }} DocC Site
-    needs: classify-changes
-    # Pull requests validate documentation classification and workflow syntax,
-    # but product documentation is generated only by the post-merge authority.
-    if: github.event_name != 'pull_request' && needs.classify-changes.outputs.build_docc == 'true'
+    needs: resolve-release
     runs-on: macos-26
     timeout-minutes: 60
     strategy:
@@ -117,22 +180,35 @@ jobs:
         include:
           - site: compose
             repository: stephenlclarke/container-compose
+            ref: ${{ needs.resolve-release.outputs.compose_ref }}
           - site: container
             repository: stephenlclarke/container
+            ref: ${{ needs.resolve-release.outputs.container_ref }}
           - site: containerization
             repository: stephenlclarke/containerization
+            ref: ${{ needs.resolve-release.outputs.containerization_ref }}
           - site: k8s
             repository: stephenlclarke/container-k8s
+            ref: ${{ needs.resolve-release.outputs.k8s_ref }}
     steps:
       - name: Checkout ${{ matrix.site }} source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: ${{ matrix.repository }}
-          ref: ${{ matrix.site == 'compose' && github.sha || 'main' }}
+          ref: ${{ matrix.ref }}
           path: source
+
+      - name: Verify exact documentation source
+        env:
+          EXPECTED_REF: ${{ matrix.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C source rev-parse HEAD)" == "${EXPECTED_REF}" ]]
 
       - name: Build static API documentation
         env:
+          DOCS_SOURCE_REFERENCE: ${{ matrix.ref }}
           SITE: ${{ matrix.site }}
         shell: bash
         run: |
@@ -167,7 +243,7 @@ jobs:
                   --enable-experimental-combined-documentation \
                   --hosting-base-path container-compose/k8s \
                   --source-service github \
-                  --source-service-base-url https://github.com/stephenlclarke/container-k8s/blob/main \
+                  --source-service-base-url "https://github.com/stephenlclarke/container-k8s/blob/${DOCS_SOURCE_REFERENCE}" \
                   --checkout-path "$GITHUB_WORKSPACE/source"
               )
               printf '{}\n' > "${output}/theme-settings.json"
@@ -192,23 +268,20 @@ jobs:
           esac
 
       - name: Archive DocC site
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && github.repository == 'stephenlclarke/container-compose'
         env:
           SITE: ${{ matrix.site }}
         run: tar -czf "${SITE}.tgz" -C _site .
 
       - name: Save DocC site
-        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && github.repository == 'stephenlclarke/container-compose'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: api-docs-${{ matrix.site }}
+          name: api-docs-${{ inputs.ref }}-${{ matrix.site }}-${{ matrix.ref }}
           path: ${{ matrix.site }}.tgz
-          retention-days: 1
+          retention-days: 30
 
   upload-pages-artifact:
     name: Assemble and Upload GitHub Pages Artifact
     needs: build-sites
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && github.repository == 'stephenlclarke/container-compose'
     runs-on: ubuntu-24.04
     permissions:
       pages: write
@@ -219,7 +292,7 @@ jobs:
       - name: Download DocC sites
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          pattern: api-docs-*
+          pattern: api-docs-${{ inputs.ref }}-*
           path: downloads
           merge-multiple: true
 
@@ -241,7 +314,6 @@ jobs:
   deploy:
     name: Deploy GitHub Pages
     needs: upload-pages-artifact
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && github.repository == 'stephenlclarke/container-compose'
     runs-on: ubuntu-24.04
     permissions:
       id-token: write

--- a/Tools/ci/test_documentation_workflow.py
+++ b/Tools/ci/test_documentation_workflow.py
@@ -36,17 +36,26 @@ class DocumentationWorkflowTests(unittest.TestCase):
         self.assertIn("    timeout-minutes: 60\n", build_job)
         self.assertNotIn("    timeout-minutes: 45\n", build_job)
 
-    def test_documentation_classification_is_api_aware_and_fail_fast(self) -> None:
+    def test_documentation_is_release_only_and_fans_out_fail_fast(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        classify_job = workflow[
-            workflow.index("  classify-changes:\n") : workflow.index("  build-sites:\n")
+        triggers = workflow[
+            workflow.index("on:\n") : workflow.index("permissions:\n")
+        ]
+        resolve_job = workflow[
+            workflow.index("  resolve-release:\n") : workflow.index("  build-sites:\n")
         ]
         build_job = workflow[
             workflow.index("  build-sites:\n") : workflow.index("  upload-pages-artifact:\n")
         ]
 
-        self.assertIn("classify-documentation-changes.py", classify_job)
-        self.assertIn("--github-output \"${GITHUB_OUTPUT}\"", classify_job)
+        self.assertIn("  workflow_dispatch:\n", triggers)
+        self.assertIn("        required: true\n", triggers)
+        self.assertNotIn("  schedule:\n", triggers)
+        self.assertNotIn("  push:\n", triggers)
+        self.assertNotIn("  pull_request:\n", triggers)
+        self.assertIn("Require exact published release inputs", resolve_job)
+        self.assertIn("Checkout tagged container-compose source", resolve_job)
+        self.assertIn("    needs: resolve-release\n", build_job)
         self.assertIn("      fail-fast: true\n", build_job)
 
 

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -1027,11 +1027,17 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
             workflow,
         )
 
-    def test_benchmark_report_only_change_skips_docc_builds(self) -> None:
+    def test_benchmark_report_changes_cannot_trigger_docc_builds(self) -> None:
         workflow = DOCUMENTATION_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("Classify documented API and site inputs", workflow)
-        self.assertIn("classify-documentation-changes.py", workflow)
-        self.assertIn("needs.classify-changes.outputs.build_docc == 'true'", workflow)
+        triggers = workflow[
+            workflow.index("on:\n") : workflow.index("permissions:\n")
+        ]
+
+        self.assertIn("  workflow_dispatch:\n", triggers)
+        self.assertNotIn("  schedule:\n", triggers)
+        self.assertNotIn("  push:\n", triggers)
+        self.assertNotIn("  pull_request:\n", triggers)
+        self.assertNotIn("classify-documentation-changes.py", workflow)
 
     def test_documentation_pr_dispatches_only_lightweight_protected_checks(self) -> None:
         benchmark = WORKFLOW.read_text(encoding="utf-8")

--- a/Tools/release/documentation-refs.json
+++ b/Tools/release/documentation-refs.json
@@ -1,0 +1,10 @@
+{
+  "schemaVersion": 1,
+  "sites": {
+    "k8s": {
+      "ref": "21b4325d2d169aab4c4ff9090720f2f141e99860",
+      "releaseTag": "homebrew-main-17-21b4325d2d16",
+      "repository": "stephenlclarke/container-k8s"
+    }
+  }
+}

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2012,6 +2012,124 @@ github_cli() {{
         self.assertIn("--json databaseId,displayTitle", self.script)
         self.assertIn('latest_compose_package_dispatch_run "${version}"', self.script)
 
+    def test_release_helper_runs_released_docc_last_from_a_durable_manifest(
+        self,
+    ) -> None:
+        publish = self.script[
+            self.script.index("publish_stable_release() {") : self.script.index(
+                "tag_stable_version() {"
+            )
+        ]
+        self.assertLess(
+            publish.index('dispatch_stable_release_gate "${version}"'),
+            publish.index('dispatch_compose_stable_package "${version}"'),
+        )
+        self.assertLess(
+            publish.index('dispatch_compose_stable_package "${version}"'),
+            publish.index('dispatch_stable_documentation "${version}"'),
+        )
+        self.assertIn("write_release_documentation_manifest", self.script)
+        self.assertIn("Tools/release/documentation-refs.json", self.script)
+        self.assertIn("released_k8s_documentation_authority", self.script)
+        self.assertIn("repos/stephenlclarke/container-k8s/releases", self.script)
+        self.assertIn("workflow run docs.yml", self.script)
+        self.assertNotIn('-f "k8s_ref=', self.script)
+        self.assertIn(
+            "stable documentation already passed for the exact released inputs",
+            self.script,
+        )
+
+    def test_release_helper_recovers_from_an_exact_successful_docc_checkpoint(
+        self,
+    ) -> None:
+        completed = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            "dispatch_stable_documentation 0.15.0",
+            shell_setup="\n".join(
+                [
+                    (
+                        "latest_stable_documentation_dispatch() { "
+                        "printf '731\\tcompleted\\tsuccess\\n'; }"
+                    ),
+                    "github_cli() { exit 99; }",
+                ]
+            ),
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn(
+            "stable documentation already passed for the exact released inputs: "
+            "0.15.0 (run 731)",
+            completed.stdout,
+        )
+
+    def test_release_helper_waits_for_an_active_exact_docc_checkpoint(self) -> None:
+        active = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            "dispatch_stable_documentation 0.15.0",
+            shell_setup="\n".join(
+                [
+                    (
+                        "latest_stable_documentation_dispatch() { "
+                        "printf '812\\tin_progress\\t\\n'; }"
+                    ),
+                    (
+                        "wait_for_github_run_success() { "
+                        "printf 'wait %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }"
+                    ),
+                    "github_cli() { exit 99; }",
+                ]
+            ),
+        )
+
+        self.assertEqual(active.returncode, 0, active.stderr)
+        self.assertIn("stable documentation is already running", active.stdout)
+        self.assertIn("wait 812 stable documentation and Pages deployment", active.stdout)
+
+    def test_release_helper_writes_the_published_k8s_documentation_authority(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "container-compose" / "Tools" / "release").mkdir(
+                parents=True
+            )
+            k8s_ref = "b" * 40
+            written = self.run_release_function(
+                root,
+                "write_release_documentation_manifest",
+                shell_setup="\n".join(
+                    [
+                        "need_command() { :; }",
+                        (
+                            "released_k8s_documentation_authority() { "
+                            "printf '%s\\n%s\\n' homebrew-main-19-deadbeef "
+                            f"{k8s_ref}; }}"
+                        ),
+                    ]
+                ),
+            )
+
+            self.assertEqual(written.returncode, 0, written.stderr)
+            manifest = json.loads(
+                (
+                    root
+                    / "container-compose"
+                    / "Tools"
+                    / "release"
+                    / "documentation-refs.json"
+                ).read_text(encoding="utf-8")
+            )
+            self.assertEqual(manifest["schemaVersion"], 1)
+            self.assertEqual(
+                manifest["sites"]["k8s"],
+                {
+                    "ref": k8s_ref,
+                    "releaseTag": "homebrew-main-19-deadbeef",
+                    "repository": "stephenlclarke/container-k8s",
+                },
+            )
+
     def test_current_formulae_use_the_matched_runtime_in_the_single_prerelease(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn('runtime_asset="container-current-${PUBLISH_SHA:0:12}-arm64.tar.gz"', workflow)
@@ -2500,15 +2618,39 @@ github_cli() {{
     def test_documentation_sites_build_in_parallel_before_pages_assembly(self) -> None:
         workflow = DOCS_WORKFLOW.read_text(encoding="utf-8")
 
+        self.assertIn(
+            "run-name: Documentation · ${{ inputs.ref }}",
+            workflow,
+        )
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertNotIn("\n  schedule:", workflow)
+        self.assertNotIn("\n  push:", workflow)
+        self.assertNotIn("\n  pull_request:", workflow)
+        self.assertIn(
+            'ref:\n        description: "Published stable semantic tag"', workflow
+        )
+        trigger = workflow[workflow.index("\non:") : workflow.index("\npermissions:")]
+        self.assertNotIn("k8s_ref:", trigger)
         concurrency = workflow[
             workflow.index("concurrency:") : workflow.index("\njobs:")
         ]
         self.assertIn(
-            "group: documentation-${{ github.workflow }}-${{ github.ref }}-"
-            "${{ github.event_name }}",
+            "group: documentation-${{ inputs.ref }}",
             concurrency,
         )
-        self.assertIn("cancel-in-progress: true", concurrency)
+        self.assertIn("cancel-in-progress: false", concurrency)
+        self.assertIn("name: Resolve Released Documentation Inputs", workflow)
+        self.assertIn("stable release ref must be a bare semantic tag", workflow)
+        self.assertIn(
+            "container-k8s ref is not attached to a published release", workflow
+        )
+        self.assertIn("Tools/release/stack-refs.json", workflow)
+        self.assertIn("Tools/release/documentation-refs.json", workflow)
+        self.assertIn("ref: ${{ matrix.ref }}", workflow)
+        self.assertIn(
+            '[[ "$(git -C source rev-parse HEAD)" == "${EXPECTED_REF}" ]]',
+            workflow,
+        )
         self.assertIn("strategy:", workflow)
         self.assertIn("fail-fast: true", workflow)
         self.assertEqual(workflow.count("- site:"), 4)
@@ -2517,11 +2659,7 @@ github_cli() {{
         self.assertIn("downloads/compose.tgz", workflow)
         self.assertIn('downloads/${site}.tgz', workflow)
         self.assertIn("name: Build ${{ matrix.site }} DocC Site", workflow)
-        self.assertIn(
-            "if: github.event_name != 'pull_request' && "
-            "needs.classify-changes.outputs.build_docc == 'true'",
-            workflow,
-        )
+        self.assertIn("DOCS_SOURCE_REFERENCE: ${{ matrix.ref }}", workflow)
         self.assertIn("runs-on: macos-26", workflow)
         self.assertIn("needs: build-sites", workflow)
         self.assertIn("merge-multiple: true", workflow)
@@ -7175,6 +7313,7 @@ esac
                         "stable_release_is_published() { return 0; }",
                         "ensure_stable_release_is_unpublished() { exit 71; }",
                         "dispatch_compose_stable_tap_repair() { printf 'repair %s\\n' \"$1\"; }",
+                        "dispatch_stable_documentation() { printf 'docs %s\\n' \"$1\"; }",
                         "publish_stable_release() { exit 72; }",
                         "print_stable_release_point() { printf 'point %s %s\\n' \"$1\" \"$2\"; }",
                     ]
@@ -7182,6 +7321,7 @@ esac
             )
             self.assertEqual(published.returncode, 0, published.stderr)
             self.assertIn("repair 0.6.70", published.stdout)
+            self.assertIn("docs 0.6.70", published.stdout)
             self.assertIn("formula-only recovery from immutable release assets", published.stdout)
 
             unpublished = self.run_release_function(
@@ -7225,6 +7365,7 @@ esac
                         "homebrew_stable_formula_identities() { printf '%s\\n' formulae-before; }",
                         "prepare_stable_init_image_authority() { exit 76; }",
                         "dispatch_compose_stable_tap_repair() { exit 71; }",
+                        "dispatch_stable_documentation() { printf 'docs %s\\n' \"$1\"; }",
                         "publish_stable_init_image_asset() { printf 'init %s %s\\n' \"$1\" \"$2\"; }",
                         "verify_compose_stable_package() { printf 'verify %s %s %s %s\\n' \"$1\" \"$2\" \"$3\" \"$4\"; }",
                         "require_stable_init_image_authority_unchanged() { printf 'authority %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }",
@@ -7235,6 +7376,7 @@ esac
 
             self.assertEqual(recovered.returncode, 0, recovered.stderr)
             self.assertIn(f"init 0.13.1 {'a' * 64}", recovered.stdout)
+            self.assertIn("docs 0.13.1", recovered.stdout)
             self.assertIn(
                 f"verify 0.13.1 false formulae-before {'a' * 64}",
                 recovered.stdout,

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -144,6 +144,10 @@ Environment:
   CONTAINER_STACK_COMPOSE_PACKAGE_POLL_SECONDS
       Override the default one-hour package workflow wait and 30-second poll.
 
+  CONTAINER_STACK_DOCUMENTATION_WAIT_SECONDS
+      Override the default two-hour wait for the four parallel, release-only
+      DocC sites and their GitHub Pages deployment.
+
   CONTAINER_STACK_RELEASE_CANDIDATE_STOP_TIMEOUT_SECONDS
       Override the default 30-second bound for stopping the exact candidate
       runtime namespace during local release-gate cleanup.
@@ -244,6 +248,7 @@ COMPOSE_REPO="container-compose"
 CONTAINER_REPO="container"
 COMPOSE_PACKAGE_WAIT_SECONDS="${CONTAINER_STACK_COMPOSE_PACKAGE_WAIT_SECONDS:-3600}"
 COMPOSE_PACKAGE_POLL_SECONDS="${CONTAINER_STACK_COMPOSE_PACKAGE_POLL_SECONDS:-30}"
+DOCUMENTATION_WAIT_SECONDS="${CONTAINER_STACK_DOCUMENTATION_WAIT_SECONDS:-7200}"
 STABLE_RELEASE_GATE_WAIT_SECONDS="${CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS:-24000}"
 PROMOTION_WAIT_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_WAIT_SECONDS:-3600}"
 PROMOTION_POLL_SECONDS="${CONTAINER_STACK_RELEASE_PROMOTION_POLL_SECONDS:-30}"
@@ -654,7 +659,7 @@ validate_unpublished_release_commit() {
     IFS=',' read -r -a release_files <<<"${files}"
     for file in "${release_files[@]}"; do
       case "${file}" in
-        Makefile|Sources/ComposePlugin/ComposePlugin.swift|Tools/release/stack-refs.json) ;;
+        Makefile|Sources/ComposePlugin/ComposePlugin.swift|Tools/release/stack-refs.json|Tools/release/documentation-refs.json) ;;
         *)
           printf 'release preparation commit changes an unexpected file: %s %s\n' \
             "${commit}" "${file}" >&2
@@ -4341,6 +4346,51 @@ manifest.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding=
 PY
 }
 
+# Bind the only documentation-only repository to one published release. The
+# stable source tag then contains every ref needed to rebuild Pages exactly,
+# even after Actions run history expires.
+write_release_documentation_manifest() {
+  local path manifest authority k8s_release_tag k8s_ref
+  path="$(repo_path "${COMPOSE_REPO}")"
+  manifest="${path}/Tools/release/documentation-refs.json"
+
+  if [[ "${EXECUTE}" != "1" ]]; then
+    printf 'would update: %s with one exact published container-k8s ref\n' \
+      "${manifest}"
+    return 0
+  fi
+
+  need_command gh
+  authority="$(released_k8s_documentation_authority)"
+  k8s_release_tag="$(sed -n '1p' <<<"${authority}")"
+  k8s_ref="$(sed -n '2p' <<<"${authority}")"
+  if [[ ! "${k8s_release_tag}" =~ ^[A-Za-z0-9._-]+$ ]] || \
+    [[ ! "${k8s_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'published container-k8s documentation authority is malformed: %s at %s\n' \
+      "${k8s_release_tag:-missing}" "${k8s_ref:-missing}" >&2
+    return 1
+  fi
+
+  python3 - "${manifest}" "${k8s_release_tag}" "${k8s_ref}" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+manifest = Path(sys.argv[1])
+data = {
+    "schemaVersion": 1,
+    "sites": {
+        "k8s": {
+            "repository": "stephenlclarke/container-k8s",
+            "releaseTag": sys.argv[2],
+            "ref": sys.argv[3],
+        }
+    },
+}
+manifest.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+PY
+}
+
 remote_main_commit() {
   local repo="$1" path remote
   path="$(repo_path "${repo}")"
@@ -4991,6 +5041,45 @@ latest_stable_release_gate_dispatch_run() {
     --jq '.[0].databaseId // ""'
 }
 
+# Return the newest run for one immutable stable documentation manifest.
+latest_stable_documentation_dispatch() {
+  local version="$1" title
+  title="Documentation · ${version}"
+  github_cli run list \
+    --repo "$(github_repo "${COMPOSE_REPO}")" \
+    --workflow Documentation \
+    --event workflow_dispatch \
+    --limit 100 \
+    --json databaseId,displayTitle,status,conclusion \
+    --jq "map(select(.displayTitle == \"${title}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
+}
+
+# Resolve the newest published (draft-free) container-k8s release tag and its
+# exact Git object. The pair is committed into the stable source candidate,
+# so documentation recovery never relies on retained workflow history.
+released_k8s_documentation_authority() {
+  local tag ref remote
+  remote="https://github.com/stephenlclarke/container-k8s.git"
+  tag="$(
+    github_cli api --paginate --slurp \
+      'repos/stephenlclarke/container-k8s/releases?per_page=100' \
+      | jq -r '[.[][] | select(.draft == false and .published_at != null)] | sort_by(.published_at) | last | .tag_name // ""'
+  )"
+  if [[ -z "${tag}" ]]; then
+    printf 'container-k8s has no published release for stable documentation\n' >&2
+    return 1
+  fi
+  ref="$(
+    git ls-remote --tags "${remote}" "refs/tags/${tag}" "refs/tags/${tag}^{}" \
+      | awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+  )"
+  if [[ ! "${ref}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'could not resolve published container-k8s release %s\n' "${tag}" >&2
+    return 1
+  fi
+  printf '%s\n%s\n' "${tag}" "${ref}"
+}
+
 # Wait for a GitHub Actions run to complete successfully.
 wait_for_github_run_success() {
   local run_id="$1" label="$2" wait_seconds="${3:-${COMPOSE_PACKAGE_WAIT_SECONDS}}"
@@ -5530,6 +5619,70 @@ dispatch_stable_release_gate() {
   done
 }
 
+# Build and publish DocC only after the stable package, Homebrew pair, and all
+# earlier release gates have succeeded. A successful exact-input run is the
+# recovery checkpoint; every retry reads the same refs from the immutable
+# stable source tag.
+dispatch_stable_documentation() {
+  local version="$1" details previous_run run_id status conclusion deadline now
+  print_header "publish released documentation for ${version}"
+
+  if [[ "${EXECUTE}" != "1" ]]; then
+    printf 'would use the exact documentation refs committed in the stable source tag\n'
+    printf 'would run: gh workflow run docs.yml --repo %s --ref main -f ref=%s\n' \
+      "$(github_repo "${COMPOSE_REPO}")" "${version}"
+    printf 'would build the four DocC sites in parallel and deploy Pages as the final release operation\n'
+    return 0
+  fi
+
+  need_command gh
+  details="$(latest_stable_documentation_dispatch "${version}")"
+  IFS=$'\t' read -r previous_run status conclusion <<<"${details}"
+  if [[ -n "${previous_run}" && "${status}" == "completed" && \
+    "${conclusion}" == "success" ]]; then
+    printf 'stable documentation already passed for the exact released inputs: %s (run %s)\n' \
+      "${version}" "${previous_run}"
+    return 0
+  fi
+  if [[ -n "${previous_run}" && "${status}" != "completed" ]]; then
+    printf 'stable documentation is already running for the exact released inputs: %s\n' \
+      "${previous_run}"
+    wait_for_github_run_success \
+      "${previous_run}" "stable documentation and Pages deployment" \
+      "${DOCUMENTATION_WAIT_SECONDS}"
+    return 0
+  fi
+
+  run github_cli workflow run docs.yml \
+    --repo "$(github_repo "${COMPOSE_REPO}")" \
+    --ref main \
+    -f "ref=${version}"
+
+  deadline=$((SECONDS + DOCUMENTATION_WAIT_SECONDS))
+  while true; do
+    details="$(latest_stable_documentation_dispatch "${version}")"
+    IFS=$'\t' read -r run_id status conclusion <<<"${details}"
+    if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
+      printf 'stable documentation started: %s\n' "${run_id}"
+      wait_for_github_run_success \
+        "${run_id}" "stable documentation and Pages deployment" \
+        "${DOCUMENTATION_WAIT_SECONDS}"
+      return 0
+    fi
+
+    now="${SECONDS}"
+    if (( now >= deadline )); then
+      printf 'timed out waiting for stable documentation dispatch for %s\n' \
+        "${version}" >&2
+      exit 1
+    fi
+
+    printf 'waiting for stable documentation dispatch for %s; next check in %ss\n' \
+      "${version}" "${COMPOSE_PACKAGE_POLL_SECONDS}"
+    sleep "${COMPOSE_PACKAGE_POLL_SECONDS}"
+  done
+}
+
 # Print the verified boundary for a stable release or its formula-only recovery.
 print_stable_release_point() {
   local version="$1" generation="$2" latest label tap_update
@@ -5562,6 +5715,7 @@ publish_stable_release() {
   local version="$1"
   dispatch_stable_release_gate "${version}"
   dispatch_compose_stable_package "${version}"
+  dispatch_stable_documentation "${version}"
   print_stable_release_point "${version}" "container-compose stable package workflow dispatch"
 }
 
@@ -5584,6 +5738,7 @@ resume_stable_release() {
     if [[ "${promote_default_lane}" == "true" ]]; then
       ensure_latest_stable_retry "${version}"
       dispatch_compose_stable_tap_repair "${version}"
+      dispatch_stable_documentation "${version}"
       print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
     else
       authority_record="$(ensure_published_stable_recovery_authority "${version}")"
@@ -5595,6 +5750,7 @@ resume_stable_release() {
         "${stable_formula_identities_before}" "${authority_init_digest}"
       require_stable_init_image_authority_unchanged \
         "${version}" "${authority_object}" "${authority_init_digest}"
+      dispatch_stable_documentation "${version}"
       print_stable_release_point "${version}" "maintenance backfill asset recovery"
     fi
     return 0
@@ -5654,17 +5810,18 @@ release_current_stack() {
   sync_containerization_package_pins
   sync_container_package_pin
   write_release_stack_manifest
+  write_release_documentation_manifest
   prepare_stable_init_image_authority
 
   if [[ "${EXECUTE}" == "1" ]]; then
-    git -C "${path}" add Makefile Sources/ComposePlugin/ComposePlugin.swift Tools/release/stack-refs.json
-    if ! git -C "${path}" diff --cached --quiet -- Makefile Sources/ComposePlugin/ComposePlugin.swift Tools/release/stack-refs.json; then
+    git -C "${path}" add Makefile Sources/ComposePlugin/ComposePlugin.swift Tools/release/stack-refs.json Tools/release/documentation-refs.json
+    if ! git -C "${path}" diff --cached --quiet -- Makefile Sources/ComposePlugin/ComposePlugin.swift Tools/release/stack-refs.json Tools/release/documentation-refs.json; then
       run git -C "${path}" commit -S -m "chore(release): prepare ${version}"
     else
       printf 'release prep files already match %s\n' "${version}"
     fi
   else
-    run git -C "${path}" add Makefile Sources/ComposePlugin/ComposePlugin.swift Tools/release/stack-refs.json
+    run git -C "${path}" add Makefile Sources/ComposePlugin/ComposePlugin.swift Tools/release/stack-refs.json Tools/release/documentation-refs.json
     run git -C "${path}" commit -S -m "chore(release): prepare ${version}"
   fi
 


### PR DESCRIPTION
## What changed

- remove scheduled, pull-request, and ordinary main-push DocC compilation
- dispatch documentation only after stable package and Homebrew verification
- build the four sites in parallel from immutable released refs
- commit the published container-k8s documentation authority into the stable source tag
- make retries wait for an active run and reuse a successful exact-release checkpoint
- retain a manual stable-tag recovery path that does not rebuild the product

## Why

A non-release SwiftPM graph change started four DocC builds. Three sites consumed roughly 2, 1, and 7 minutes, while Container was still running after 30 minutes when the run was cancelled. None of that work could publish stable documentation.

The release tag is now the durable documentation authority. Compose, Container, and Containerization refs come from its stack manifest; the documentation-only k8s ref and published tag come from `Tools/release/documentation-refs.json`. The workflow verifies every checkout before building and never follows a moving main branch.

## Focused validation

- `actionlint .github/workflows/docs.yml`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- nine focused release/workflow recovery contracts
- JSON and patch validation
- live k8s authority resolution: `homebrew-main-17-21b4325d2d16` -> `21b4325d2d169aab4c4ff9090720f2f141e99860`

The non-release skip can be observed as soon as this PR runs without a Documentation workflow. The real stable release will provide the exact-ref Pages rehearsal, so #506 remains open until that proof exists.

Refs #506
