### PR TITLE
fix(build): scope CI validation by changed inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,11 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       heavy: ${{ steps.filter.outputs.heavy }}
+      tools: ${{ steps.filter.outputs.tools }}
+      runtime: ${{ steps.filter.outputs.runtime }}
       handoff: ${{ steps.filter.outputs.handoff }}
     steps:
-      - name: Checkout for push diff
-        if: github.event_name == 'push'
+      - name: Checkout change classifier
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
@@ -75,7 +76,7 @@ jobs:
           # validation transaction instead of inferring their scope from a
           # synthetic tag-push diff (whose before SHA is all zeroes).
           if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
-            printf 'heavy=true\nhandoff=false\n' >> "$GITHUB_OUTPUT"
+            python3 Tools/ci/classify-ci-changes.py --full >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -83,15 +84,15 @@ jobs:
             pull_request)
               gh api "repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files" \
                 --paginate \
-                --jq '.[].filename' > "$changed_files"
+                --jq '.[] | .filename, (.previous_filename // empty)' > "$changed_files"
               ;;
             push)
               before="${{ github.event.before }}"
               after="${GITHUB_SHA}"
               if [[ "$before" =~ ^0+$ ]] || ! git cat-file -e "$before^{commit}" 2>/dev/null; then
-                git diff-tree --no-commit-id --name-only -r "$after" > "$changed_files"
+                git diff-tree --no-commit-id --name-only --no-renames -r "$after" > "$changed_files"
               else
-                git diff --name-only "$before" "$after" > "$changed_files"
+                git diff --name-only --no-renames "$before" "$after" > "$changed_files"
               fi
               ;;
             workflow_dispatch)
@@ -106,36 +107,18 @@ jobs:
                 [[ "$(jq -r '.base.ref' <<<"${pr_metadata}")" == "main" ]]
                 gh api "repos/${GITHUB_REPOSITORY}/pulls/${DOCUMENTATION_PR}/files" \
                   --paginate \
-                  --jq '.[].filename' > "$changed_files"
+                  --jq '.[] | .filename, (.previous_filename // empty)' > "$changed_files"
               else
-                printf 'heavy=true\nhandoff=false\n' >> "$GITHUB_OUTPUT"
+                python3 Tools/ci/classify-ci-changes.py --full >> "$GITHUB_OUTPUT"
                 exit 0
               fi
               ;;
             *)
-              printf 'heavy=true\nhandoff=false\n' >> "$GITHUB_OUTPUT"
+              python3 Tools/ci/classify-ci-changes.py --full >> "$GITHUB_OUTPUT"
               exit 0
               ;;
           esac
-
-          heavy=false
-          handoff=false
-          while IFS= read -r path; do
-            case "$path" in
-              docs/upstream/*)
-                handoff=true
-                ;;
-              *.md|docs/*|Formula/*)
-                ;;
-              *)
-                heavy=true
-                break
-                ;;
-            esac
-          done < "$changed_files"
-
-          printf 'heavy=%s\n' "$heavy" >> "$GITHUB_OUTPUT"
-          printf 'handoff=%s\n' "$handoff" >> "$GITHUB_OUTPUT"
+          python3 Tools/ci/classify-ci-changes.py "$changed_files" >> "$GITHUB_OUTPUT"
 
   source_checks:
     name: Source Checks
@@ -223,7 +206,7 @@ jobs:
   tool_tests:
     name: Tool Tests (${{ matrix.suite }})
     needs: changes
-    if: needs.changes.outputs.heavy == 'true'
+    if: needs.changes.outputs.tools == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
@@ -254,7 +237,7 @@ jobs:
       - changes
       - resolve-canonical-main
     if: >
-      needs.changes.outputs.heavy == 'true' &&
+      (needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main') &&
       needs.resolve-canonical-main.result == 'success'
     # This lane compiles and exercises unit/CLI coverage only. Keep VM-backed
     # integration in the recoverable release graph and use a managed runner
@@ -781,6 +764,8 @@ jobs:
 
   resolve-canonical-main:
     name: Resolve Canonical Main
+    needs: changes
+    if: needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     outputs:
       artifact_run_id: ${{ steps.main.outputs.artifact_run_id }}
@@ -916,7 +901,9 @@ jobs:
       - name: Check parallel validation jobs
         env:
           RESOLVE_CANONICAL_MAIN_RESULT: ${{ needs.resolve-canonical-main.result }}
+          RUNTIME_SELECTED: ${{ needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main' }}
           SOURCE_CHECKS_RESULT: ${{ needs.source_checks.result }}
+          TOOLS_SELECTED: ${{ needs.changes.outputs.tools }}
           TOOL_TESTS_RESULT: ${{ needs.tool_tests.result }}
           VALIDATE_RUNTIME_RESULT: ${{ needs.validate_runtime.result }}
         run: |
@@ -925,19 +912,31 @@ jobs:
             printf 'Source Checks concluded %s\n' "${SOURCE_CHECKS_RESULT}" >&2
             exit 1
           fi
-          if [[ "${TOOL_TESTS_RESULT}" != "success" ]]; then
+          if [[ "${TOOLS_SELECTED}" == "true" && "${TOOL_TESTS_RESULT}" != "success" ]]; then
             printf 'Tool Tests concluded %s\n' "${TOOL_TESTS_RESULT}" >&2
             exit 1
           fi
-          if [[ "${VALIDATE_RUNTIME_RESULT}" != "success" ]]; then
+          if [[ "${TOOLS_SELECTED}" != "true" && "${TOOL_TESTS_RESULT}" != "skipped" ]]; then
+            printf 'Unselected Tool Tests concluded %s\n' "${TOOL_TESTS_RESULT}" >&2
+            exit 1
+          fi
+          if [[ "${RUNTIME_SELECTED}" == "true" && "${VALIDATE_RUNTIME_RESULT}" != "success" ]]; then
             printf 'Validate Runtime concluded %s\n' "${VALIDATE_RUNTIME_RESULT}" >&2
             exit 1
           fi
-          if [[ "${RESOLVE_CANONICAL_MAIN_RESULT}" != "success" && "${RESOLVE_CANONICAL_MAIN_RESULT}" != "skipped" ]]; then
+          if [[ "${RUNTIME_SELECTED}" != "true" && "${VALIDATE_RUNTIME_RESULT}" != "skipped" ]]; then
+            printf 'Unselected Validate Runtime concluded %s\n' "${VALIDATE_RUNTIME_RESULT}" >&2
+            exit 1
+          fi
+          if [[ "${RUNTIME_SELECTED}" == "true" && "${RESOLVE_CANONICAL_MAIN_RESULT}" != "success" ]]; then
             printf 'Resolve Canonical Main concluded %s\n' "${RESOLVE_CANONICAL_MAIN_RESULT}" >&2
             exit 1
           fi
-          printf 'Source Checks, Tool Tests, and Validate Runtime passed, including any required atomic Sonar restoration.\n'
+          if [[ "${RUNTIME_SELECTED}" != "true" && "${RESOLVE_CANONICAL_MAIN_RESULT}" != "skipped" ]]; then
+            printf 'Unselected Resolve Canonical Main concluded %s\n' "${RESOLVE_CANONICAL_MAIN_RESULT}" >&2
+            exit 1
+          fi
+          printf 'All selected validation scopes passed, including any required atomic Sonar restoration.\n'
 
   validate-lightweight:
     # Branch protection requires one stable aggregate context for both the

--- a/Tools/ci/classify-ci-changes.py
+++ b/Tools/ci/classify-ci-changes.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Classify repository changes into independent CI validation scopes."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+
+RUNTIME_DRIVER_PATHS = {
+    "Tools/ci/run-swift-test.sh",
+    "Tools/ci/run-with-local-swift-stack.py",
+    "Tools/ci/summarize-swift-testing.py",
+    "Tools/ci/use-stack-container.sh",
+    "Tools/ci/use-stack-containerization.sh",
+}
+
+
+@dataclass(frozen=True)
+class ValidationScope:
+    """The CI work required for one changed-file set."""
+
+    heavy: bool
+    tools: bool
+    runtime: bool
+    handoff: bool
+
+
+def _under(path: PurePosixPath, directory: str) -> bool:
+    return path.parts[:1] == (directory,)
+
+
+def classify(paths: list[str], *, full: bool = False) -> ValidationScope:
+    """Return the smallest safe validation scope for ``paths``."""
+
+    if full or not paths:
+        return ValidationScope(heavy=True, tools=True, runtime=True, handoff=False)
+
+    tools = False
+    runtime = False
+    handoff = False
+    for value in paths:
+        path = PurePosixPath(value)
+        if path.is_absolute() or ".." in path.parts or not path.parts:
+            tools = True
+            runtime = True
+            continue
+
+        if value.startswith("docs/upstream/"):
+            handoff = True
+            continue
+        if path.suffix == ".md" or _under(path, "docs") or _under(path, "Formula"):
+            continue
+
+        if value.startswith("Tests/BuildPipeline/"):
+            tools = True
+            continue
+
+        if value in RUNTIME_DRIVER_PATHS:
+            tools = True
+            runtime = True
+            continue
+
+        if (
+            _under(path, "Sources")
+            or _under(path, "Tests")
+            or _under(path, "examples")
+            or value in {"Package.swift", "Package.resolved"}
+            or value.startswith("Tools/compose-normalizer/")
+        ):
+            runtime = True
+            continue
+
+        if value == "Makefile":
+            tools = True
+            runtime = True
+            continue
+
+        if value == ".github/workflows/ci.yml":
+            tools = True
+            runtime = True
+            continue
+
+        if (
+            _under(path, ".github")
+            or _under(path, "Tools")
+            or _under(path, "scripts")
+            or _under(path, "build-pipeline")
+            or value
+            in {
+                ".gitignore",
+                ".markdownlint.json",
+                ".swiftformat",
+                ".swiftlint.yml",
+                "LICENSE",
+                "config.toml",
+                "licenserc.toml",
+                "main.nf",
+                "nextflow.config",
+                "sonar-project.properties",
+            }
+        ):
+            tools = True
+            continue
+
+        # New top-level inputs must prove that they are safe before receiving a
+        # narrower classification.
+        tools = True
+        runtime = True
+
+    return ValidationScope(
+        heavy=tools or runtime,
+        tools=tools,
+        runtime=runtime,
+        handoff=handoff,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("changed_files", type=Path, nargs="?")
+    parser.add_argument("--full", action="store_true")
+    arguments = parser.parse_args()
+    if arguments.full:
+        paths: list[str] = []
+    elif arguments.changed_files is None:
+        parser.error("changed_files is required unless --full is used")
+    else:
+        paths = arguments.changed_files.read_text(encoding="utf-8").splitlines()
+
+    scope = classify(paths, full=arguments.full)
+    for name in ("heavy", "tools", "runtime", "handoff"):
+        print(f"{name}={str(getattr(scope, name)).lower()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/ci/test_classify_ci_changes.py
+++ b/Tools/ci/test_classify_ci_changes.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Focused tests for the CI changed-file classifier."""
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("classify-ci-changes.py")
+SPEC = importlib.util.spec_from_file_location("classify_ci_changes", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+CLASSIFIER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CLASSIFIER
+SPEC.loader.exec_module(CLASSIFIER)
+
+
+class ClassifyCIChangesTests(unittest.TestCase):
+    def test_controller_changes_select_tools_without_runtime(self) -> None:
+        scope = CLASSIFIER.classify(
+            [
+                ".github/workflows/docs.yml",
+                "Tools/release/test_container_stack_release.py",
+                "scripts/CONTAINER_STACK_RELEASE.sh",
+            ]
+        )
+
+        self.assertTrue(scope.heavy)
+        self.assertTrue(scope.tools)
+        self.assertFalse(scope.runtime)
+        self.assertFalse(scope.handoff)
+
+    def test_runtime_changes_select_runtime_without_tool_suites(self) -> None:
+        scope = CLASSIFIER.classify(
+            ["Sources/ComposeCore/Project.swift", "Tests/ComposeCoreTests/ProjectTests.swift"]
+        )
+
+        self.assertTrue(scope.heavy)
+        self.assertFalse(scope.tools)
+        self.assertTrue(scope.runtime)
+
+    def test_go_normalizer_is_runtime_work(self) -> None:
+        scope = CLASSIFIER.classify(["Tools/compose-normalizer/main.go"])
+
+        self.assertTrue(scope.runtime)
+        self.assertFalse(scope.tools)
+
+    def test_build_pipeline_fixtures_select_tool_tests(self) -> None:
+        scope = CLASSIFIER.classify(
+            [
+                "Tests/BuildPipeline/recovery-proof.nf",
+                "Tests/BuildPipeline/recovery-proof.config",
+            ]
+        )
+
+        self.assertTrue(scope.heavy)
+        self.assertTrue(scope.tools)
+        self.assertFalse(scope.runtime)
+
+    def test_swift_runtime_drivers_select_both_scopes(self) -> None:
+        for path in sorted(CLASSIFIER.RUNTIME_DRIVER_PATHS):
+            with self.subTest(path=path):
+                scope = CLASSIFIER.classify([path])
+                self.assertTrue(scope.heavy)
+                self.assertTrue(scope.tools)
+                self.assertTrue(scope.runtime)
+
+    def test_mixed_and_makefile_changes_select_both_scopes(self) -> None:
+        for paths in (
+            ["Sources/ComposePlugin/ComposePlugin.swift", "Tools/ci/tool.py"],
+            ["Makefile"],
+        ):
+            with self.subTest(paths=paths):
+                scope = CLASSIFIER.classify(paths)
+                self.assertTrue(scope.tools)
+                self.assertTrue(scope.runtime)
+
+    def test_rename_paths_retain_the_removed_runtime_scope(self) -> None:
+        scope = CLASSIFIER.classify(
+            ["Tools/ci/renamed-helper.py", "Sources/ComposeCore/OldHelper.swift"]
+        )
+
+        self.assertTrue(scope.tools)
+        self.assertTrue(scope.runtime)
+
+    def test_ci_workflow_changes_validate_the_runtime_lane_they_can_edit(self) -> None:
+        scope = CLASSIFIER.classify([".github/workflows/ci.yml"])
+
+        self.assertTrue(scope.tools)
+        self.assertTrue(scope.runtime)
+
+    def test_documentation_and_handoff_changes_stay_lightweight(self) -> None:
+        scope = CLASSIFIER.classify(
+            ["README.md", "docs/STATUS.md", "docs/upstream/apple-container/PR-1.md"]
+        )
+
+        self.assertFalse(scope.heavy)
+        self.assertFalse(scope.tools)
+        self.assertFalse(scope.runtime)
+        self.assertTrue(scope.handoff)
+
+    def test_full_and_unknown_inputs_fail_safe(self) -> None:
+        for scope in (
+            CLASSIFIER.classify([], full=True),
+            CLASSIFIER.classify([]),
+            CLASSIFIER.classify(["new-build-input.xyz"]),
+            CLASSIFIER.classify(["../outside"]),
+        ):
+            with self.subTest(scope=scope):
+                self.assertTrue(scope.heavy)
+                self.assertTrue(scope.tools)
+                self.assertTrue(scope.runtime)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -312,6 +312,7 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
         self.assertIn('run: make "${TOOL_TEST_TARGET}"', tool_tests_section)
         self.assertIn("      - tool_tests", CI_WORKFLOW)
         self.assertIn("TOOL_TESTS_RESULT", CI_WORKFLOW)
+        self.assertIn("if: needs.changes.outputs.tools == 'true'", tool_tests_section)
         self.assertIn(
             "coverage-tools-test: coverage-python-tools-test "
             "release-tools-test ci-tools-test",
@@ -322,20 +323,50 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
         classifier = CI_WORKFLOW.split("      - name: Classify changed files", 1)[
             1
         ].split("  source_checks:", 1)[0]
-        handoff_case = classifier.split("docs/upstream/*)", 1)[1].split(";;", 1)[
-            0
-        ]
         lightweight = CI_WORKFLOW.split("  validate-lightweight:", 1)[1]
 
         self.assertIn("handoff: ${{ steps.filter.outputs.handoff }}", CI_WORKFLOW)
-        self.assertIn("handoff=true", handoff_case)
-        self.assertNotIn("heavy=true", handoff_case)
+        self.assertIn("tools: ${{ steps.filter.outputs.tools }}", CI_WORKFLOW)
+        self.assertIn("runtime: ${{ steps.filter.outputs.runtime }}", CI_WORKFLOW)
+        self.assertIn(
+            'python3 Tools/ci/classify-ci-changes.py "$changed_files"',
+            classifier,
+        )
+        self.assertEqual(
+            classifier.count("(.previous_filename // empty)"),
+            2,
+        )
+        self.assertEqual(classifier.count("--no-renames"), 2)
         self.assertIn(
             "HANDOFF_CHANGE: ${{ needs.changes.outputs.handoff }}",
             lightweight,
         )
         self.assertIn("make upstream-handoff-registry-check", lightweight)
         self.assertIn("if: needs.changes.outputs.heavy == 'true'", CI_WORKFLOW)
+
+    def test_ci_skips_runtime_validation_for_controller_only_changes(self) -> None:
+        runtime_validation = CI_WORKFLOW.split("  validate_runtime:", 1)[1].split(
+            "  prebuilt_binaries:", 1
+        )[0]
+        canonical_main = CI_WORKFLOW.split("  resolve-canonical-main:", 1)[1].split(
+            "  validate:", 1
+        )[0]
+        aggregate = CI_WORKFLOW.split("  validate:", 1)[1].split(
+            "  validate-lightweight:", 1
+        )[0]
+
+        self.assertIn(
+            "needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main'",
+            runtime_validation,
+        )
+        self.assertIn(
+            "if: needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main'",
+            canonical_main,
+        )
+        self.assertIn("TOOLS_SELECTED", aggregate)
+        self.assertIn("RUNTIME_SELECTED", aggregate)
+        self.assertIn("github.ref == 'refs/heads/main'", aggregate)
+        self.assertIn("All selected validation scopes passed", aggregate)
 
     def test_runtime_validation_uses_pinned_managed_macos_toolchain(
         self,


### PR DESCRIPTION
## Summary

- classify controller/tool changes independently from Swift and Go runtime changes
- preserve full validation for stable tags, mixed changes, and unknown inputs
- keep one stable aggregate `Validate` check while requiring only the selected jobs

## Evidence

PR #508 demonstrated the defect at exact head `44f13ed`: relevant source checks completed in 54 seconds, while an unaffected managed-macOS runtime lane ran for 10m08s after controller-only changes.

Focused classifier coverage exercises controller-only, runtime-only, Go, mixed, documentation/handoff, empty, malformed, and unknown inputs. Focused workflow-policy tests and `actionlint` pass.

Refs #509