### PR TITLE
fix(build): isolate stable release transactions

### DIFF
--- a/.github/workflows/scheduled-stable-release.yml
+++ b/.github/workflows/scheduled-stable-release.yml
@@ -148,51 +148,14 @@ jobs:
       - name: Checkout container-compose release controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          path: release-stack/container-compose
+          path: release-controls/container-compose
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Checkout builder-shim source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: stephenlclarke/container-builder-shim
-          ref: main
-          path: release-stack/container-builder-shim
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Checkout containerization source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: stephenlclarke/containerization
-          ref: main
-          path: release-stack/containerization
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Checkout container runtime source
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: stephenlclarke/container
-          ref: main
-          path: release-stack/container
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Checkout Homebrew tap
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-        with:
-          repository: stephenlclarke/homebrew-tap
-          ref: main
-          path: release-stack/homebrew-tap
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Configure isolated release stack
+      - name: Configure isolated release controller
         shell: bash
         run: |
           set -euo pipefail
-          release_root="${GITHUB_WORKSPACE}/release-stack"
           automation_token="$(
             unset GH_TOKEN GITHUB_TOKEN
             gh auth token
@@ -207,27 +170,7 @@ jobs:
             exit 1
           fi
 
-          own_url() {
-            local repository="$1"
-            printf 'https://x-access-token:%s@github.com/%s.git' "${automation_token}" "${repository}"
-          }
-          configure_apple_fork() {
-            local path="$1" fork_repository="$2" upstream_repository="$3"
-            git -C "${path}" remote rename origin fork
-            git -C "${path}" remote set-url fork "$(own_url "${fork_repository}")"
-            git -C "${path}" remote add origin "https://github.com/${upstream_repository}.git"
-            git -C "${path}" remote set-url --push origin no_push
-          }
-
-          configure_apple_fork "${release_root}/container-builder-shim" \
-            stephenlclarke/container-builder-shim apple/container-builder-shim
-          configure_apple_fork "${release_root}/container" \
-            stephenlclarke/container apple/container
-          git -C "${release_root}/containerization" remote set-url origin "$(own_url stephenlclarke/containerization)"
-          git -C "${release_root}/containerization" remote add upstream https://github.com/apple/containerization.git
-          git -C "${release_root}/containerization" remote set-url --push upstream no_push
-          git -C "${release_root}/container-compose" remote set-url origin "$(own_url stephenlclarke/container-compose)"
-          git -C "${release_root}/homebrew-tap" remote set-url origin "$(own_url stephenlclarke/homebrew-tap)"
+          gh auth setup-git
 
           for command_name in docker gh git go make node npm python3 swift; do
             command -v "${command_name}" >/dev/null 2>&1 || {
@@ -244,15 +187,12 @@ jobs:
           [[ -n "${signing_key}" && -r "${signing_key}" ]]
           signing_private_key="${signing_key%.pub}"
           ssh-keygen -y -P '' -f "${signing_private_key}" >/dev/null
-          git -C "${release_root}/container-compose" config gpg.format ssh
-          git -C "${release_root}/container-compose" config commit.gpgsign true
-          git -C "${release_root}/container-compose" config user.signingkey "${signing_key}"
 
       - name: Promote the selected stable release
         shell: bash
-        working-directory: release-stack/container-compose
+        working-directory: release-controls/container-compose
         env:
-          CONTAINER_STACK_RELEASE_ROOT: ${{ github.workspace }}/release-stack
+          CONTAINER_STACK_RELEASE_BUILD_ROOT: /Volumes/SSD/github/container-compose-release-transactions
           CONTAINER_STACK_RELEASE_INTENT: milestone
           VERSION_SELECTOR: ${{ needs.preflight.outputs.selector }}
         run: |

--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -1,0 +1,745 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Create and recover exact, isolated Container-family release workspaces."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import os
+import re
+import shutil
+import socket
+import subprocess
+import tempfile
+import urllib.error
+import urllib.request
+from collections.abc import Iterable, Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+
+SEMVER = re.compile(r"^[0-9]+[.][0-9]+[.][0-9]+$")
+SHA = re.compile(r"^[0-9a-f]{40}$")
+BUILD_MARKER = ".container-compose-release-root.json"
+WORKSPACE_MARKER = ".container-compose-release-workspace.json"
+BUILD_LOCK = ".container-compose-release.lock"
+DEFAULT_GIT_TIMEOUT_SECONDS = 300
+
+
+@dataclass(frozen=True)
+class Component:
+    name: str
+    repository: str
+    clone_remote: str = "origin"
+    upstream: str | None = None
+
+    @property
+    def url(self) -> str:
+        return f"https://github.com/{self.repository}.git"
+
+
+COMPONENTS = (
+    Component(
+        "container-builder-shim",
+        "stephenlclarke/container-builder-shim",
+        clone_remote="fork",
+        upstream="apple/container-builder-shim",
+    ),
+    Component(
+        "containerization",
+        "stephenlclarke/containerization",
+        upstream="apple/containerization",
+    ),
+    Component(
+        "container",
+        "stephenlclarke/container",
+        clone_remote="fork",
+        upstream="apple/container",
+    ),
+    Component("container-compose", "stephenlclarke/container-compose"),
+    Component("homebrew-tap", "stephenlclarke/homebrew-tap"),
+)
+SOURCE_COMPONENTS = COMPONENTS[:-1]
+
+
+class WorkspaceError(RuntimeError):
+    """Raised when an isolated workspace cannot be proven safe or exact."""
+
+
+def run_git(*arguments: str, cwd: Path | None = None) -> str:
+    """Run Git without inheriting checkout-selection environment variables."""
+
+    environment = os.environ.copy()
+    for name in (
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+        "GIT_COMMON_DIR",
+        "GIT_DIR",
+        "GIT_OBJECT_DIRECTORY",
+        "GIT_WORK_TREE",
+    ):
+        environment.pop(name, None)
+    try:
+        timeout = int(
+            os.environ.get(
+                "CONTAINER_STACK_RELEASE_GIT_TIMEOUT_SECONDS",
+                str(DEFAULT_GIT_TIMEOUT_SECONDS),
+            )
+        )
+    except ValueError as error:
+        raise WorkspaceError(
+            "CONTAINER_STACK_RELEASE_GIT_TIMEOUT_SECONDS is not an integer"
+        ) from error
+    if timeout < 1 or timeout > 1800:
+        raise WorkspaceError(
+            "CONTAINER_STACK_RELEASE_GIT_TIMEOUT_SECONDS is outside 1..1800"
+        )
+    try:
+        completed = subprocess.run(
+            ["git", *arguments],
+            cwd=cwd,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise WorkspaceError(
+            f"git {' '.join(arguments)} exceeded {timeout} seconds"
+        ) from error
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip()
+        raise WorkspaceError(f"git {' '.join(arguments)} failed: {detail}")
+    return completed.stdout
+
+
+def resolve_remote(component: Component, remote_root: Path | None = None) -> str:
+    if remote_root is None:
+        return component.url
+    return str(remote_root / f"{component.name}.git")
+
+
+def remote_snapshot(
+    remote_root: Path | None = None,
+) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
+    """Read exact main and semantic-tag refs without touching a checkout."""
+
+    def inspect(component: Component) -> tuple[str, str, dict[str, str]]:
+        url = resolve_remote(component, remote_root)
+        main_output = run_git("ls-remote", "--heads", url, "refs/heads/main")
+        main_lines = [line.split() for line in main_output.splitlines() if line]
+        if len(main_lines) != 1 or not SHA.fullmatch(main_lines[0][0]):
+            raise WorkspaceError(f"could not resolve {component.name} main")
+
+        tag_output = run_git("ls-remote", "--tags", url)
+        component_tags: dict[str, str] = {}
+        peeled: dict[str, str] = {}
+        for line in tag_output.splitlines():
+            reference_sha, reference = line.split(maxsplit=1)
+            name = reference.removeprefix("refs/tags/")
+            if name.endswith("^{}"):
+                peeled[name[:-3]] = reference_sha
+            elif SEMVER.fullmatch(name):
+                component_tags[name] = reference_sha
+        component_tags.update(
+            {name: value for name, value in peeled.items() if SEMVER.fullmatch(name)}
+        )
+        return component.name, main_lines[0][0], component_tags
+
+    main_refs: dict[str, str] = {}
+    tags: dict[str, dict[str, str]] = {}
+    with ThreadPoolExecutor(max_workers=len(COMPONENTS)) as executor:
+        for name, main_ref, component_tags in executor.map(inspect, COMPONENTS):
+            main_refs[name] = main_ref
+            tags[name] = component_tags
+    return main_refs, tags
+
+
+def semantic_key(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    return int(parts[0]), int(parts[1]), int(parts[2])
+
+
+def latest_tag(tags: dict[str, str]) -> str:
+    return max(tags, key=semantic_key) if tags else ""
+
+
+def resolve_selector(selector: str, base: str) -> str:
+    if not SEMVER.fullmatch(base):
+        raise WorkspaceError(f"base version is not semantic: {base}")
+    if SEMVER.fullmatch(selector):
+        return selector
+    if selector not in {"--+", "-+-", "+--"}:
+        raise WorkspaceError(f"invalid version selector: {selector}")
+    major, minor, patch = semantic_key(base)
+    if selector == "+--":
+        return f"{major + 1}.0.0"
+    if selector == "-+-":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def compose_version(main_sha: str, remote_root: Path | None = None) -> str:
+    if remote_root is not None:
+        makefile = run_git(
+            f"--git-dir={remote_root / 'container-compose.git'}",
+            "show",
+            f"{main_sha}:Makefile",
+        )
+    else:
+        url = (
+            "https://raw.githubusercontent.com/stephenlclarke/"
+            f"container-compose/{main_sha}/Makefile"
+        )
+        try:
+            with urllib.request.urlopen(url, timeout=30) as response:  # noqa: S310
+                makefile = response.read().decode("utf-8")
+        except (OSError, UnicodeError, urllib.error.URLError) as error:
+            raise WorkspaceError(f"could not read remote compose version: {error}") from error
+    match = re.search(
+        r"^COMPOSE_VERSION[ ]*[?]=[ ]*([0-9]+[.][0-9]+[.][0-9]+)$",
+        makefile,
+        re.MULTILINE,
+    )
+    if match is None or not SEMVER.fullmatch(match.group(1)):
+        raise WorkspaceError("remote container-compose version is missing or invalid")
+    return match.group(1)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise WorkspaceError(f"invalid marker {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise WorkspaceError(f"invalid marker object: {path}")
+    return value
+
+
+def fsync_directory(path: Path) -> None:
+    """Persist a directory entry update before reporting checkpoint success."""
+
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def atomic_json(path: Path, value: dict[str, object]) -> None:
+    stage = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    contents = (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(stage, flags, 0o600)
+        try:
+            offset = 0
+            while offset < len(contents):
+                offset += os.write(descriptor, contents[offset:])
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.replace(stage, path)
+        fsync_directory(path.parent)
+    except BaseException:
+        stage.unlink(missing_ok=True)
+        raise
+
+
+@contextmanager
+def build_lock(build_root: Path) -> Iterator[None]:
+    """Serialize transaction creation, recovery claims, and cleanup."""
+
+    descriptor = os.open(build_root / BUILD_LOCK, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        yield
+    finally:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+        os.close(descriptor)
+
+
+def safe_build_root(configured: Path) -> Path:
+    expanded = configured.expanduser()
+    if expanded.is_symlink():
+        raise WorkspaceError(f"release build root must not use symlinks: {configured}")
+    absolute = expanded.resolve(strict=False)
+    external_volume = Path("/Volumes/SSD")
+    if absolute.is_relative_to(external_volume) and not external_volume.is_mount():
+        raise WorkspaceError("/Volumes/SSD is not mounted; refusing a system-disk fallback")
+    absolute.mkdir(parents=True, exist_ok=True)
+    marker = absolute / BUILD_MARKER
+    if marker.is_symlink():
+        raise WorkspaceError(f"release build root marker is unsafe: {marker}")
+    if marker.exists():
+        value = read_json(marker)
+        if value != {"owner": "container-compose", "schemaVersion": 1}:
+            raise WorkspaceError(f"release build root marker is invalid: {marker}")
+    else:
+        unexpected = [item for item in absolute.iterdir() if item.name != marker.name]
+        if unexpected:
+            raise WorkspaceError(
+                f"unmarked release build root is not empty: {absolute}"
+            )
+        atomic_json(marker, {"owner": "container-compose", "schemaVersion": 1})
+    return absolute
+
+
+def workspace_marker(root: Path) -> dict[str, object]:
+    marker = root / WORKSPACE_MARKER
+    if marker.is_symlink():
+        raise WorkspaceError(f"release workspace marker is unsafe: {marker}")
+    value = read_json(marker)
+    if value.get("schemaVersion") != 1 or value.get("owner") != "container-compose":
+        raise WorkspaceError(f"release workspace marker is invalid: {marker}")
+    return value
+
+
+def verify_workspace(root: Path, build_root: Path) -> dict[str, object]:
+    safe_root = safe_build_root(build_root)
+    resolved = root.absolute()
+    if root.is_symlink() or resolved.parent != safe_root or not resolved.is_dir():
+        raise WorkspaceError(f"release workspace escaped its build root: {root}")
+    marker = workspace_marker(resolved)
+    if marker.get("state") != "ready":
+        raise WorkspaceError("release workspace is not a completed checkpoint")
+    version = marker.get("version")
+    refs = marker.get("mainRefs")
+    remotes = marker.get("remoteUrls")
+    if not isinstance(version, str) or not SEMVER.fullmatch(version):
+        raise WorkspaceError("release workspace version is invalid")
+    if resolved.name != version:
+        raise WorkspaceError("release workspace directory does not match its version")
+    if not isinstance(refs, dict):
+        raise WorkspaceError("release workspace refs are invalid")
+    if not isinstance(remotes, dict):
+        raise WorkspaceError("release workspace remotes are invalid")
+
+    for component in COMPONENTS:
+        path = resolved / component.name
+        expected = refs.get(component.name)
+        git_directory = path / ".git"
+        if path.is_symlink() or git_directory.is_symlink() or not git_directory.is_dir():
+            raise WorkspaceError(f"release checkout is missing or unsafe: {path}")
+        if not isinstance(expected, str) or not SHA.fullmatch(expected):
+            raise WorkspaceError(f"release ref is invalid for {component.name}")
+        expected_remote = remotes.get(component.name)
+        if not isinstance(expected_remote, str):
+            raise WorkspaceError(f"release remote is invalid for {component.name}")
+        actual_remote = run_git(
+            "remote", "get-url", component.clone_remote, cwd=path
+        ).strip()
+        if actual_remote != expected_remote:
+            raise WorkspaceError(
+                f"release remote changed for {component.name}: {actual_remote}"
+            )
+        push_remote = run_git(
+            "remote", "get-url", "--push", component.clone_remote, cwd=path
+        ).strip()
+        if push_remote != expected_remote:
+            raise WorkspaceError(
+                f"release push remote changed for {component.name}: {push_remote}"
+            )
+        if component.upstream is not None:
+            upstream_url = f"https://github.com/{component.upstream}.git"
+            upstream_fetch = run_git("remote", "get-url", "upstream", cwd=path).strip()
+            upstream_push = run_git(
+                "remote", "get-url", "--push", "upstream", cwd=path
+            ).strip()
+            if upstream_fetch != upstream_url or upstream_push != "no_push":
+                raise WorkspaceError(
+                    f"Apple upstream boundary changed for {component.name}"
+                )
+            if component.clone_remote == "fork":
+                origin_fetch = run_git("remote", "get-url", "origin", cwd=path).strip()
+                origin_push = run_git(
+                    "remote", "get-url", "--push", "origin", cwd=path
+                ).strip()
+                if origin_fetch != upstream_url or origin_push != "no_push":
+                    raise WorkspaceError(
+                        f"Apple origin boundary changed for {component.name}"
+                    )
+        try:
+            run_git("cat-file", "-e", f"{expected}^{{commit}}", cwd=path)
+        except WorkspaceError:
+            run_git("fetch", component.clone_remote, expected, cwd=path)
+            run_git("cat-file", "-e", f"{expected}^{{commit}}", cwd=path)
+    return marker
+
+
+def ensure_workspace_is_idle(marker: dict[str, object]) -> None:
+    lease_host = marker.get("leaseHost")
+    lease_pid = marker.get("leasePid")
+    if lease_host is None and lease_pid is None:
+        return
+    if (
+        lease_host == socket.gethostname()
+        and isinstance(lease_pid, int)
+        and not process_is_alive(lease_pid)
+    ):
+        return
+    if lease_host == socket.gethostname() and isinstance(lease_pid, int):
+        raise WorkspaceError(
+            f"release transaction is already active in process {lease_pid}"
+        )
+    raise WorkspaceError("release transaction lease belongs to another host")
+
+
+def refresh_mutable_current_tag(root: Path) -> None:
+    """Refresh the one mutable release pointer before resuming a checkpoint."""
+
+    compose = root / "container-compose"
+    output = run_git(
+        "ls-remote",
+        "--tags",
+        "--refs",
+        "origin",
+        "refs/tags/current",
+        cwd=compose,
+    )
+    if not output.strip():
+        raise WorkspaceError("container-compose current tag is missing from origin")
+    fields = output.split()
+    if len(fields) != 2 or not SHA.fullmatch(fields[0]):
+        raise WorkspaceError("could not resolve container-compose current tag")
+    run_git(
+        "fetch",
+        "origin",
+        "+refs/tags/current:refs/tags/current",
+        cwd=compose,
+    )
+    local_current = run_git("rev-parse", "refs/tags/current", cwd=compose).strip()
+    if local_current != fields[0]:
+        raise WorkspaceError("container-compose current tag changed while refreshing")
+
+
+def configure_remotes(path: Path, component: Component) -> None:
+    if component.upstream is None:
+        return
+    upstream_url = f"https://github.com/{component.upstream}.git"
+    if component.clone_remote == "fork":
+        run_git("remote", "add", "origin", upstream_url, cwd=path)
+        run_git("remote", "set-url", "--push", "origin", "no_push", cwd=path)
+        run_git("remote", "add", "upstream", upstream_url, cwd=path)
+        run_git("remote", "set-url", "--push", "upstream", "no_push", cwd=path)
+    else:
+        run_git("remote", "add", "upstream", upstream_url, cwd=path)
+        run_git("remote", "set-url", "--push", "upstream", "no_push", cwd=path)
+
+
+def clone_workspace(
+    stage: Path,
+    refs: dict[str, str],
+    remote_root: Path | None = None,
+) -> None:
+    def clone(component: Component) -> None:
+        path = stage / component.name
+        run_git(
+            "clone",
+            "--filter=blob:none",
+            "--no-checkout",
+            "--origin",
+            component.clone_remote,
+            resolve_remote(component, remote_root),
+            str(path),
+        )
+        run_git("checkout", "-B", "main", refs[component.name], cwd=path)
+        configure_remotes(path, component)
+
+    try:
+        clone_workers = int(
+            os.environ.get("CONTAINER_STACK_RELEASE_CLONE_JOBS", "4")
+        )
+    except ValueError as error:
+        raise WorkspaceError(
+            "CONTAINER_STACK_RELEASE_CLONE_JOBS is not an integer"
+        ) from error
+    if clone_workers < 1 or clone_workers > len(COMPONENTS):
+        raise WorkspaceError("CONTAINER_STACK_RELEASE_CLONE_JOBS is outside 1..5")
+    with ThreadPoolExecutor(max_workers=clone_workers) as executor:
+        list(executor.map(clone, COMPONENTS))
+
+
+def retained_workspace(build_root: Path, selector: str) -> Path | None:
+    matches: list[Path] = []
+    for item in build_root.iterdir():
+        if not item.is_dir() or item.is_symlink() or not SEMVER.fullmatch(item.name):
+            continue
+        marker_path = item / WORKSPACE_MARKER
+        if not marker_path.is_file() or marker_path.is_symlink():
+            continue
+        marker = read_json(marker_path)
+        if marker.get("selector") == selector or marker.get("version") == selector:
+            matches.append(item)
+    if len(matches) > 1:
+        raise WorkspaceError(f"multiple retained release workspaces match {selector}")
+    return matches[0] if matches else None
+
+
+def cleanup_incomplete_stages(build_root: Path) -> None:
+    """Remove only marker-proven clone attempts that never became checkpoints."""
+
+    for item in build_root.iterdir():
+        if not item.name.startswith(".") or not item.is_dir() or item.is_symlink():
+            continue
+        marker_path = item / WORKSPACE_MARKER
+        if not marker_path.is_file() or marker_path.is_symlink():
+            continue
+        marker = read_json(marker_path)
+        if (
+            marker.get("owner") == "container-compose"
+            and marker.get("schemaVersion") == 1
+            and marker.get("state") == "cloning"
+        ):
+            stage_host = marker.get("stageHost")
+            stage_pid = marker.get("stagePid")
+            if stage_host != socket.gethostname():
+                raise WorkspaceError(
+                    f"incomplete release clone belongs to another host: {item}"
+                )
+            if isinstance(stage_pid, int) and process_is_alive(stage_pid):
+                raise WorkspaceError(f"release workspace clone is still active: {item}")
+            shutil.rmtree(item)
+            fsync_directory(build_root)
+
+
+def process_is_alive(pid: int) -> bool:
+    if pid < 1:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _materialize_locked(
+    safe_root: Path,
+    selector: str,
+    remote_root: Path | None = None,
+) -> Path:
+    cleanup_incomplete_stages(safe_root)
+    retained = retained_workspace(safe_root, selector)
+    if retained is not None:
+        marker = verify_workspace(retained, safe_root)
+        ensure_workspace_is_idle(marker)
+        refresh_mutable_current_tag(retained)
+        return retained
+
+    refs, tags = remote_snapshot(remote_root)
+    latest = latest_tag(tags["container-compose"])
+    base = latest or compose_version(refs["container-compose"], remote_root)
+    version = resolve_selector(selector, base)
+    destination = safe_root / version
+    if destination.exists():
+        marker = verify_workspace(destination, safe_root)
+        ensure_workspace_is_idle(marker)
+        refresh_mutable_current_tag(destination)
+        return destination
+
+    stage = Path(tempfile.mkdtemp(prefix=f".{version}.", dir=safe_root))
+    try:
+        remote_urls = {
+            component.name: resolve_remote(component, remote_root)
+            for component in COMPONENTS
+        }
+        marker = {
+            "mainRefs": refs,
+            "owner": "container-compose",
+            "remoteUrls": remote_urls,
+            "schemaVersion": 1,
+            "selector": selector,
+            "stageHost": socket.gethostname(),
+            "stagePid": os.getpid(),
+            "state": "cloning",
+            "version": version,
+        }
+        atomic_json(stage / WORKSPACE_MARKER, marker)
+        clone_workspace(stage, refs, remote_root)
+        fresh_refs, fresh_tags = remote_snapshot(remote_root)
+        if fresh_refs != refs or fresh_tags != tags:
+            raise WorkspaceError(
+                "a component main or semantic tag moved while the workspace was cloned"
+            )
+        marker["state"] = "ready"
+        marker.pop("stageHost")
+        marker.pop("stagePid")
+        atomic_json(stage / WORKSPACE_MARKER, marker)
+        os.replace(stage, destination)
+        fsync_directory(safe_root)
+    except BaseException:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise
+    verify_workspace(destination, safe_root)
+    refresh_mutable_current_tag(destination)
+    return destination
+
+
+def materialize(
+    build_root: Path,
+    selector: str,
+    remote_root: Path | None = None,
+) -> Path:
+    safe_root = safe_build_root(build_root)
+    with build_lock(safe_root):
+        return _materialize_locked(safe_root, selector, remote_root)
+
+
+def claim(root: Path, build_root: Path, pid: int) -> None:
+    if not process_is_alive(pid):
+        raise WorkspaceError(f"release transaction claimant is not alive: {pid}")
+    safe_root = safe_build_root(build_root)
+    with build_lock(safe_root):
+        marker = verify_workspace(root, safe_root)
+        ensure_workspace_is_idle(marker)
+        marker["leaseHost"] = socket.gethostname()
+        marker["leasePid"] = pid
+        atomic_json(root / WORKSPACE_MARKER, marker)
+
+
+def release_claim(root: Path, build_root: Path, pid: int) -> None:
+    safe_root = safe_build_root(build_root)
+    with build_lock(safe_root):
+        marker = verify_workspace(root, safe_root)
+        if (
+            marker.get("leaseHost") != socket.gethostname()
+            or marker.get("leasePid") != pid
+        ):
+            raise WorkspaceError("release transaction lease identity changed")
+        marker.pop("leaseHost")
+        marker.pop("leasePid")
+        atomic_json(root / WORKSPACE_MARKER, marker)
+
+
+def execute(root: Path, build_root: Path, arguments: list[str]) -> None:
+    """Claim a transaction, then preserve that lease PID in the release child."""
+
+    if not arguments or not arguments[0]:
+        raise WorkspaceError("release transaction command is empty")
+    claim(root, build_root, os.getpid())
+    try:
+        os.execvpe(arguments[0], arguments, os.environ)
+    except OSError as error:
+        raise WorkspaceError(
+            f"could not execute release transaction command: {error}"
+        ) from error
+
+
+def cleanup(root: Path, build_root: Path) -> None:
+    safe_root = safe_build_root(build_root)
+    with build_lock(safe_root):
+        marker = verify_workspace(root, safe_root)
+        if marker.get("leaseHost") is not None or marker.get("leasePid") is not None:
+            raise WorkspaceError("release transaction is still claimed")
+        shutil.rmtree(root)
+        fsync_directory(safe_root)
+
+
+def format_plan(remote_root: Path | None = None) -> str:
+    refs, tags = remote_snapshot(remote_root)
+    current = compose_version(refs["container-compose"], remote_root)
+    latest = latest_tag(tags["container-compose"]) or current
+    lines = [
+        "current COMPOSE_VERSION: " + current,
+        "latest semantic tag:     " + latest,
+        "next patch release:      " + resolve_selector("--+", latest),
+        "next minor release:      " + resolve_selector("-+-", latest),
+        "next major release:      " + resolve_selector("+--", latest),
+        "",
+        f"{'component':26} {'main-sha':40} {'changed-since-tag':18}",
+    ]
+    for component in SOURCE_COMPONENTS:
+        last = latest_tag(tags[component.name])
+        changed = "yes"
+        if last and tags[component.name][last] == refs[component.name]:
+            changed = "no"
+        lines.append(f"{component.name:26} {refs[component.name]:40} {changed:18}")
+    return "\n".join(lines)
+
+
+def default_build_root() -> Path:
+    configured = os.environ.get("CONTAINER_STACK_RELEASE_BUILD_ROOT")
+    if configured:
+        return Path(configured)
+    return Path("/Volumes/SSD/github/container-compose-release-transactions")
+
+
+def parse_arguments(arguments: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--remote-root", type=Path)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("plan")
+    materialize_parser = subparsers.add_parser("materialize")
+    materialize_parser.add_argument("selector")
+    materialize_parser.add_argument("--build-root", type=Path, default=default_build_root())
+    verify_parser = subparsers.add_parser("verify")
+    verify_parser.add_argument("root", type=Path)
+    verify_parser.add_argument("--build-root", type=Path, default=default_build_root())
+    cleanup_parser = subparsers.add_parser("cleanup")
+    cleanup_parser.add_argument("root", type=Path)
+    cleanup_parser.add_argument("--build-root", type=Path, default=default_build_root())
+    claim_parser = subparsers.add_parser("claim")
+    claim_parser.add_argument("root", type=Path)
+    claim_parser.add_argument("--pid", type=int, required=True)
+    claim_parser.add_argument("--build-root", type=Path, default=default_build_root())
+    release_claim_parser = subparsers.add_parser("release-claim")
+    release_claim_parser.add_argument("root", type=Path)
+    release_claim_parser.add_argument("--pid", type=int, required=True)
+    release_claim_parser.add_argument(
+        "--build-root", type=Path, default=default_build_root()
+    )
+    execute_parser = subparsers.add_parser("execute")
+    execute_parser.add_argument("root", type=Path)
+    execute_parser.add_argument("--build-root", type=Path, default=default_build_root())
+    execute_parser.add_argument("arguments", nargs=argparse.REMAINDER)
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Iterable[str] | None = None) -> int:
+    options = parse_arguments(arguments)
+    if options.command == "plan":
+        print(format_plan(options.remote_root))
+    elif options.command == "materialize":
+        print(materialize(options.build_root, options.selector, options.remote_root))
+    elif options.command == "verify":
+        verify_workspace(options.root, options.build_root)
+        print(options.root.absolute())
+    elif options.command == "cleanup":
+        cleanup(options.root, options.build_root)
+    elif options.command == "claim":
+        claim(options.root, options.build_root, options.pid)
+    elif options.command == "release-claim":
+        release_claim(options.root, options.build_root, options.pid)
+    elif options.command == "execute":
+        execute(options.root, options.build_root, options.arguments)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except WorkspaceError as error:
+        raise SystemExit(str(error)) from error

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -94,9 +94,38 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('verify_github_stable_tag_signature "${version}"', self.script)
         self.assertIn("GitHub did not verify stable tag", self.script)
 
-    def test_release_helper_supports_an_isolated_stack_root(self) -> None:
-        self.assertIn('ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"', self.script)
-        self.assertIn("CONTAINER_STACK_RELEASE_ROOT", self.script)
+    def test_release_helper_owns_an_isolated_transaction_root(self) -> None:
+        self.assertIn("run_isolated_release() {", self.script)
+        self.assertIn("CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE=1", self.script)
+        self.assertIn("release transaction retained for exact recovery", self.script)
+        self.assertIn('RELEASE_BUILD_ROOT="${CONTAINER_STACK_RELEASE_BUILD_ROOT:', self.script)
+        self.assertIn('"${RELEASE_WORKSPACE_TOOL}" execute', self.script)
+        self.assertIn('child_pid=$!', self.script)
+        self.assertIn('wait "${child_pid}"', self.script)
+        self.assertIn('--pid "${child_pid}"', self.script)
+        self.assertNotIn('--pid "$$"', self.script)
+        self.assertNotIn("Local source checkout layout expected", self.script)
+        active = self.script.split(
+            'elif [[ "${CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE:-0}" == "1" ]]',
+            1,
+        )[1].split("      else", 1)[0]
+        self.assertLess(
+            active.index('"${RELEASE_WORKSPACE_TOOL}" verify'),
+            active.index("release_current_stack"),
+        )
+
+    def test_scheduled_release_delegates_checkout_ownership_to_controller(self) -> None:
+        workflow = SCHEDULED_STABLE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        release = workflow.split("  release:", 1)[1]
+
+        self.assertIn("path: release-controls/container-compose", release)
+        self.assertIn("gh auth setup-git", release)
+        self.assertIn("CONTAINER_STACK_RELEASE_BUILD_ROOT:", release)
+        self.assertNotIn("CONTAINER_STACK_RELEASE_ROOT:", release)
+        self.assertNotIn("Checkout builder-shim source", release)
+        self.assertNotIn("Checkout containerization source", release)
+        self.assertNotIn("Checkout container runtime source", release)
+        self.assertNotIn("Checkout Homebrew tap", release)
 
     def test_local_release_gate_uses_a_stable_noninteractive_path(self) -> None:
         completed = subprocess.run(
@@ -1054,6 +1083,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("documented milestone soak override", plan)
         self.assertIn("maintenance with --+", plan)
         self.assertIn("documented operational", plan)
+        self.assertIn('python3 "${RELEASE_WORKSPACE_TOOL}" plan', plan)
+        self.assertNotIn("prepare_all_main", plan)
 
     def test_internal_dependency_pins_do_not_become_release_highlights(self) -> None:
         pin_commit = self.script[
@@ -7154,21 +7185,23 @@ esac
             self.assertEqual(result.returncode, 2)
             self.assertIn("direct container-compose main promotion is retired", result.stderr)
 
-            prepare_marker = root / "prepare-called"
+            release_marker = root / "release-called"
             result = self.run_release_function(
                 root,
                 "main release --+ --execute",
                 shell_setup="\n".join(
                     [
                         "COMPOSE_MAIN_PROMOTION_MODE=direct",
-                        f"prepare_all_main() {{ : > {shlex.quote(str(prepare_marker))}; }}",
-                        "release_current_stack() { return 0; }",
+                        (
+                            "release_current_stack() { "
+                            f": > {shlex.quote(str(release_marker))}; }}"
+                        ),
                     ]
                 ),
             )
 
             self.assertEqual(result.returncode, 2)
-            self.assertFalse(prepare_marker.exists())
+            self.assertFalse(release_marker.exists())
 
             release_marker = root / "release-read-called"
             result = self.run_release_function(

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Focused tests for exact, isolated release workspaces."""
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from unittest import mock
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("release-workspace.py")
+RELEASE_SCRIPT = MODULE_PATH.parents[2] / "scripts" / "CONTAINER_STACK_RELEASE.sh"
+SPEC = importlib.util.spec_from_file_location("release_workspace", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+WORKSPACE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = WORKSPACE
+SPEC.loader.exec_module(WORKSPACE)
+
+
+class ReleaseWorkspaceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        self.remote_root = self.root / "remotes"
+        self.remote_root.mkdir()
+        self.build_root = self.root / "build"
+        for component in WORKSPACE.COMPONENTS:
+            self.create_remote(component.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def git(self, *arguments: str, cwd: Path | None = None) -> str:
+        environment = {
+            "GIT_AUTHOR_EMAIL": "release-tests@example.com",
+            "GIT_AUTHOR_NAME": "Release Tests",
+            "GIT_COMMITTER_EMAIL": "release-tests@example.com",
+            "GIT_COMMITTER_NAME": "Release Tests",
+        }
+        completed = subprocess.run(
+            ["git", *arguments],
+            cwd=cwd,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return completed.stdout
+
+    def create_remote(self, name: str) -> None:
+        source = self.root / "sources" / name
+        source.mkdir(parents=True)
+        self.git("init", "--initial-branch=main", cwd=source)
+        (source / "README.md").write_text(f"# {name}\n", encoding="utf-8")
+        if name == "container-compose":
+            (source / "Makefile").write_text(
+                "COMPOSE_VERSION ?= 0.14.2\n", encoding="utf-8"
+            )
+        self.git("add", ".", cwd=source)
+        self.git("commit", "-m", "initial", cwd=source)
+        self.git("tag", "0.14.2", cwd=source)
+        self.git("tag", "current", cwd=source)
+        self.git(
+            "clone",
+            "--bare",
+            str(source),
+            str(self.remote_root / f"{name}.git"),
+        )
+
+    def checkout_state(self, path: Path) -> tuple[str, str, str]:
+        return (
+            self.git("branch", "--show-current", cwd=path).strip(),
+            self.git("rev-parse", "HEAD", cwd=path).strip(),
+            self.git("status", "--porcelain=v1", "--untracked-files=all", cwd=path),
+        )
+
+    def test_plan_does_not_mutate_dirty_detached_or_non_main_checkouts(self) -> None:
+        primary = self.root / "primary"
+        dirty = primary / "container-compose"
+        detached = primary / "container"
+        clean = primary / "containerization"
+        for name, path in (
+            ("container-compose", dirty),
+            ("container", detached),
+            ("containerization", clean),
+        ):
+            self.git("clone", str(self.remote_root / f"{name}.git"), str(path))
+        self.git("switch", "-c", "feature/keep-me", cwd=dirty)
+        (dirty / "README.md").write_text("modified\n", encoding="utf-8")
+        (dirty / "untracked.txt").write_text("keep\n", encoding="utf-8")
+        self.git("checkout", "--detach", cwd=detached)
+        before = {path: self.checkout_state(path) for path in (dirty, detached, clean)}
+
+        plan = WORKSPACE.format_plan(self.remote_root)
+
+        self.assertIn("next minor release:      0.15.0", plan)
+        self.assertIn("container-compose", plan)
+        self.assertEqual(
+            before,
+            {path: self.checkout_state(path) for path in (dirty, detached, clean)},
+        )
+
+    def test_materialize_resumes_the_same_mutated_transaction(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        (compose / "candidate.txt").write_text("candidate\n", encoding="utf-8")
+        self.git("add", "candidate.txt", cwd=compose)
+        self.git("commit", "-m", "release candidate", cwd=compose)
+        candidate = self.git("rev-parse", "HEAD", cwd=compose).strip()
+        (compose / "retained.log").write_text("interrupted\n", encoding="utf-8")
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(self.git("rev-parse", "HEAD", cwd=compose).strip(), candidate)
+        self.assertEqual(
+            (compose / "retained.log").read_text(encoding="utf-8"),
+            "interrupted\n",
+        )
+
+    def test_resume_refreshes_the_mutable_current_tag(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        source = self.root / "sources" / "container-compose"
+        (source / "README.md").write_text("# promoted current\n", encoding="utf-8")
+        self.git("add", "README.md", cwd=source)
+        self.git("commit", "-m", "promote current", cwd=source)
+        promoted = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git(
+            "push",
+            "--force",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/tags/current",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git(
+                "rev-parse",
+                "refs/tags/current",
+                cwd=resumed / "container-compose",
+            ).strip(),
+            promoted,
+        )
+
+    def test_resume_rejects_a_missing_remote_current_tag(self) -> None:
+        WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+        source = self.root / "sources" / "container-compose"
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            ":refs/tags/current",
+            cwd=source,
+        )
+
+        with self.assertRaisesRegex(
+            WORKSPACE.WorkspaceError, "current tag is missing"
+        ):
+            WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+    def test_missing_baseline_object_is_fetched_into_retained_workspace(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        container = release_root / "container"
+        marker = WORKSPACE.workspace_marker(release_root)
+        expected = marker["mainRefs"]["container"]
+        objects = container / ".git" / "objects"
+        shutil.rmtree(objects)
+        (objects / "info").mkdir(parents=True)
+        (objects / "pack").mkdir()
+
+        WORKSPACE.verify_workspace(release_root, self.build_root)
+
+        self.git("cat-file", "-e", f"{expected}^{{commit}}", cwd=container)
+
+    def test_incomplete_clone_is_cleaned_before_retry(self) -> None:
+        WORKSPACE.safe_build_root(self.build_root)
+        stage = self.build_root / ".0.15.0.interrupted"
+        stage.mkdir()
+        WORKSPACE.atomic_json(
+            stage / WORKSPACE.WORKSPACE_MARKER,
+            {
+                "owner": "container-compose",
+                "schemaVersion": 1,
+                "stageHost": WORKSPACE.socket.gethostname(),
+                "stagePid": 99_999_999,
+                "state": "cloning",
+            },
+        )
+
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+
+        self.assertFalse(stage.exists())
+        self.assertEqual(release_root.name, "0.15.0")
+
+    def test_semantic_tag_change_during_clone_rejects_the_snapshot(self) -> None:
+        clone_workspace = WORKSPACE.clone_workspace
+
+        def clone_then_publish_tag(
+            stage: Path,
+            refs: dict[str, str],
+            remote_root: Path | None,
+        ) -> None:
+            clone_workspace(stage, refs, remote_root)
+            source = self.root / "sources" / "container-compose"
+            self.git("tag", "0.15.0", cwd=source)
+            self.git(
+                "push",
+                str(self.remote_root / "container-compose.git"),
+                "refs/tags/0.15.0",
+                cwd=source,
+            )
+
+        with mock.patch.object(
+            WORKSPACE,
+            "clone_workspace",
+            side_effect=clone_then_publish_tag,
+        ):
+            with self.assertRaisesRegex(
+                WORKSPACE.WorkspaceError, "semantic tag moved"
+            ):
+                WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertFalse((self.build_root / "0.15.0").exists())
+        self.assertEqual(
+            [path for path in self.build_root.iterdir() if path.is_dir()],
+            [],
+        )
+
+    def test_cleanup_requires_both_markers_and_exact_parent(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        marker_path = release_root / WORKSPACE.WORKSPACE_MARKER
+        marker = json.loads(marker_path.read_text(encoding="utf-8"))
+        marker["owner"] = "someone-else"
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+
+        with self.assertRaisesRegex(WORKSPACE.WorkspaceError, "marker is invalid"):
+            WORKSPACE.cleanup(release_root, self.build_root)
+        self.assertTrue(release_root.exists())
+
+        marker["owner"] = "container-compose"
+        marker_path.write_text(json.dumps(marker), encoding="utf-8")
+        WORKSPACE.cleanup(release_root, self.build_root)
+        self.assertFalse(release_root.exists())
+
+    def test_live_claim_blocks_concurrent_release_and_can_be_cleared(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        WORKSPACE.claim(release_root, self.build_root, os.getpid())
+
+        with self.assertRaisesRegex(WORKSPACE.WorkspaceError, "already active"):
+            WORKSPACE.claim(release_root, self.build_root, os.getpid())
+        with self.assertRaisesRegex(WORKSPACE.WorkspaceError, "already active"):
+            WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+        with self.assertRaisesRegex(WORKSPACE.WorkspaceError, "still claimed"):
+            WORKSPACE.cleanup(release_root, self.build_root)
+
+        WORKSPACE.release_claim(release_root, self.build_root, os.getpid())
+        WORKSPACE.cleanup(release_root, self.build_root)
+
+    def test_dead_same_host_claim_is_recovered(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        marker_path = release_root / WORKSPACE.WORKSPACE_MARKER
+        marker = WORKSPACE.workspace_marker(release_root)
+        marker["leaseHost"] = WORKSPACE.socket.gethostname()
+        marker["leasePid"] = 99_999_999
+        WORKSPACE.atomic_json(marker_path, marker)
+
+        WORKSPACE.claim(release_root, self.build_root, os.getpid())
+
+        recovered = WORKSPACE.workspace_marker(release_root)
+        self.assertEqual(recovered["leaseHost"], WORKSPACE.socket.gethostname())
+        self.assertEqual(recovered["leasePid"], os.getpid())
+
+    def test_execute_lease_belongs_to_the_running_release_child(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        ready = self.root / "release-child-ready"
+        child = subprocess.Popen(
+            [
+                sys.executable,
+                str(MODULE_PATH),
+                "execute",
+                "--build-root",
+                str(self.build_root),
+                str(release_root),
+                sys.executable,
+                "-c",
+                "import pathlib, sys, time; "
+                "pathlib.Path(sys.argv[1]).touch(); time.sleep(30)",
+                str(ready),
+            ]
+        )
+        try:
+            for _ in range(100):
+                if ready.exists():
+                    break
+                if child.poll() is not None:
+                    self.fail(f"release child exited early with {child.returncode}")
+                time.sleep(0.01)
+            else:
+                self.fail("release child did not become ready")
+
+            marker = WORKSPACE.workspace_marker(release_root)
+            self.assertEqual(marker["leasePid"], child.pid)
+            with self.assertRaisesRegex(WORKSPACE.WorkspaceError, "already active"):
+                WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+        finally:
+            if child.poll() is None:
+                child.terminate()
+            child.wait(timeout=5)
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+        self.assertEqual(resumed, release_root)
+
+    def test_git_operations_have_a_bounded_deadline(self) -> None:
+        timeout = subprocess.TimeoutExpired(["git", "status"], 300)
+        with mock.patch.object(WORKSPACE.subprocess, "run", side_effect=timeout):
+            with self.assertRaisesRegex(
+                WORKSPACE.WorkspaceError, "git status exceeded 300 seconds"
+            ):
+                WORKSPACE.run_git("status")
+
+    def test_remote_retargeting_is_rejected(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        self.git("remote", "set-url", "origin", "https://example.com/wrong.git", cwd=compose)
+
+        with self.assertRaisesRegex(WORKSPACE.WorkspaceError, "remote changed"):
+            WORKSPACE.verify_workspace(release_root, self.build_root)
+
+    def test_cli_accepts_symbolic_selector_after_option_separator(self) -> None:
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(MODULE_PATH),
+                "--remote-root",
+                str(self.remote_root),
+                "materialize",
+                "--build-root",
+                str(self.build_root),
+                "--",
+                "-+-",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertEqual(Path(completed.stdout.strip()).name, "0.15.0")
+
+    def test_active_release_rejects_an_unmarked_checkout_before_work(self) -> None:
+        unmarked = self.root / "unmarked" / "0.15.0"
+        unmarked.mkdir(parents=True)
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "CONTAINER_STACK_RELEASE_BUILD_ROOT": str(self.build_root),
+                "CONTAINER_STACK_RELEASE_ROOT": str(unmarked),
+                "CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE": "1",
+            }
+        )
+
+        completed = subprocess.run(
+            ["/bin/bash", str(RELEASE_SCRIPT), "release", "0.15.0", "--execute"],
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("escaped its build root", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -24,6 +24,7 @@ readonly COMPOSE_PROMOTION_REVIEW_TOOL="${SELF_DIRECTORY}/../Tools/release/compo
 readonly HOMEBREW_PREFLIGHT_TOOL="${SELF_DIRECTORY}/../Tools/release/homebrew-preflight.py"
 readonly OCI_IMAGE_LAYOUT_VALIDATOR="${SELF_DIRECTORY}/../Tools/release/validate-oci-image-layout.py"
 readonly RELEASE_COMMAND_DEADLINE_RUNNER="${SELF_DIRECTORY}/../Tools/ci/run-command-with-deadline.py"
+readonly RELEASE_WORKSPACE_TOOL="${SELF_DIRECTORY}/../Tools/release/release-workspace.py"
 readonly STABLE_RELEASE_LANE_CLASSIFIER="${SELF_DIRECTORY}/../Tools/release/stable-release-default-lane.py"
 # shellcheck disable=SC1091
 source "${SELF_DIRECTORY}/../Tools/ci/container-runtime-lock.sh"
@@ -38,13 +39,14 @@ Usage:
   ${SCRIPT_USAGE} release VERSION_SELECTOR [--execute]
 
 Purpose:
-  Coordinate releases for the four local stephenlclarke source repositories
-  and the Homebrew tap without touching Apple upstream repositories.
+  Coordinate releases for the four stephenlclarke source repositories and the
+  Homebrew tap without touching Apple upstream repositories or primary local
+  checkouts.
 
 Modes:
   plan
-      Inspect the four local source main branches and print the next release
-      plan, including the Homebrew tap workflow boundary.
+      Inspect the four canonical remote main branches and print the next
+      release plan, including the Homebrew tap workflow boundary.
       This mode never mutates repositories.
 
   release VERSION_SELECTOR
@@ -77,16 +79,17 @@ Options:
   --execute
       Run mutating git commands. Without this flag the script is a dry run.
 
-Local source checkout layout expected:
-  ~/github/container-builder-shim
-  ~/github/containerization
-  ~/github/container
-  ~/github/container-compose
+Release checkout layout:
+  Exact release transactions are created below
+  /Volumes/SSD/github/container-compose-release-transactions by default.
+  Failed or interrupted transactions are retained and resumed in place.
+  Successful transactions are removed after publication completes.
 
 Rules enforced:
   - Apple remotes are read-only and must not be push targets.
   - stephenlclarke-owned remotes are the only push targets.
-  - Worktrees must be clean before release changes.
+  - Primary developer checkouts are never inspected or changed.
+  - Fresh release workspaces start at exact canonical remote main revisions.
   - Stable container-compose release tags are SSH-signed and point at the validated main commit.
   - GitHub must verify each stable tag signature before the release gate starts.
   - The hosted Stable Release Gate runs after the signed tag and before stable package publication.
@@ -190,9 +193,12 @@ Environment:
       registry or host login.
 
   CONTAINER_STACK_RELEASE_ROOT
-      Override the parent directory containing the four source checkouts and
-      the Homebrew tap. Defaults to ~/github. Use an isolated stack root for
-      release validation without touching another local workspace.
+      Internal path of an active marker-protected release transaction. Normal
+      callers must not set this; the controller sets it for its child process.
+
+  CONTAINER_STACK_RELEASE_BUILD_ROOT
+      Override the marker-protected transaction parent. Defaults to
+      /Volumes/SSD/github/container-compose-release-transactions.
 USAGE
 }
 
@@ -244,6 +250,7 @@ parse_arguments() {
 }
 
 ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"
+RELEASE_BUILD_ROOT="${CONTAINER_STACK_RELEASE_BUILD_ROOT:-/Volumes/SSD/github/container-compose-release-transactions}"
 COMPOSE_REPO="container-compose"
 CONTAINER_REPO="container"
 COMPOSE_PACKAGE_WAIT_SECONDS="${CONTAINER_STACK_COMPOSE_PACKAGE_WAIT_SECONDS:-3600}"
@@ -1233,16 +1240,6 @@ PY
 # Emit a visible section header.
 print_header() {
   printf '\n== %s ==\n' "$1"
-}
-
-# Verify that a checkout exists.
-ensure_repo_exists() {
-  local repo="$1" path
-  path="$(repo_path "${repo}")"
-  if [[ ! -d "${path}/.git" ]]; then
-    printf 'missing checkout: %s\n' "${path}" >&2
-    exit 1
-  fi
 }
 
 # Refuse to operate on dirty working trees.
@@ -3292,28 +3289,6 @@ ensure_push_boundary() {
       exit 1
     fi
   fi
-}
-
-# Fetch and align the local main branch.
-prepare_repo_main() {
-  local repo="$1" path remote
-  path="$(repo_path "${repo}")"
-  remote="$(push_remote "${repo}")"
-  ensure_repo_exists "${repo}"
-  ensure_clean "${repo}"
-  ensure_push_boundary "${repo}"
-  fetch_release_remote "${repo}"
-  run git -C "${path}" switch main
-  run git -C "${path}" pull --rebase --autostash "${remote}" main
-  ensure_clean "${repo}"
-}
-
-# Prepare every stack participant in release order.
-prepare_all_main() {
-  local repo
-  for repo in "${REPOS[@]}"; do
-    prepare_repo_main "${repo}"
-  done
 }
 
 # Read the compose plugin version from the Makefile.
@@ -5862,32 +5837,10 @@ PY
 
 # Print current stack release status.
 plan() {
-  local repo current latest next_patch next_minor next_major changed
-  prepare_all_main
-  current="$(current_compose_version)"
-  latest="$(latest_local_semver_tag "${COMPOSE_REPO}")"
-  if [[ -z "${latest}" ]]; then
-    latest="${current}"
-  fi
-  next_patch="$(resolve_version_selector '--+' "${latest}")"
-  next_minor="$(resolve_version_selector '-+-' "${latest}")"
-  next_major="$(resolve_version_selector '+--' "${latest}")"
-
   print_header "simplified stack release plan"
-  printf 'current COMPOSE_VERSION: %s\n' "${current}"
-  printf 'latest semantic tag:     %s\n' "${latest}"
-  printf 'next patch release:      %s\n' "${next_patch}"
-  printf 'next minor release:      %s\n' "${next_minor}"
-  printf 'next major release:      %s\n\n' "${next_major}"
+  python3 "${RELEASE_WORKSPACE_TOOL}" plan
+  printf '\n'
   printf 'stable release intent:   %s\n\n' "${RELEASE_INTENT:-required for release}"
-  printf '%-26s %-40s %-18s\n' "component" "main-sha" "changed-since-tag"
-  for repo in "${REPOS[@]}"; do
-    changed="yes"
-    if ! repo_changed_since_latest_tag "${repo}"; then
-      changed="no"
-    fi
-    printf '%-26s %-40s %-18s\n' "${repo}" "$(git -C "$(repo_path "${repo}")" rev-parse main)" "${changed}"
-  done
 
   cat <<'EOF'
 
@@ -5907,6 +5860,49 @@ Process:
 EOF
 }
 
+# Run a stable release only inside the exact marker-protected transaction
+# created by the release workspace controller. A failed child is retained for
+# the next invocation; only a completely successful publication is removed.
+run_isolated_release() {
+  local workspace child child_pid status claim_status
+  if [[ "${EXECUTE}" != "1" ]]; then
+    python3 "${RELEASE_WORKSPACE_TOOL}" plan
+    printf 'would materialize and retain an exact isolated release workspace for %s\n' \
+      "${VERSION_SELECTOR}"
+    return 0
+  fi
+
+  workspace="$(python3 "${RELEASE_WORKSPACE_TOOL}" materialize \
+    --build-root "${RELEASE_BUILD_ROOT}" -- "${VERSION_SELECTOR}")"
+  child="${workspace}/container-compose/scripts/${SCRIPT_NAME}"
+  if [[ ! -f "${child}" || -L "${child}" ]]; then
+    printf 'isolated release controller is missing or unsafe: %s\n' "${child}" >&2
+    return 1
+  fi
+  status=0
+  CONTAINER_STACK_RELEASE_ROOT="${workspace}" \
+  CONTAINER_STACK_RELEASE_BUILD_ROOT="${RELEASE_BUILD_ROOT}" \
+  CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE=1 \
+    python3 "${RELEASE_WORKSPACE_TOOL}" execute \
+      --build-root "${RELEASE_BUILD_ROOT}" "${workspace}" \
+      /bin/bash "${child}" release "${VERSION_SELECTOR}" --execute &
+  child_pid=$!
+  wait "${child_pid}" || status=$?
+  claim_status=0
+  python3 "${RELEASE_WORKSPACE_TOOL}" release-claim \
+    --build-root "${RELEASE_BUILD_ROOT}" --pid "${child_pid}" "${workspace}" || claim_status=$?
+  if ((claim_status != 0)); then
+    printf 'release transaction lease could not be cleared: %s\n' "${workspace}" >&2
+    return "${claim_status}"
+  fi
+  if ((status != 0)); then
+    printf 'release transaction retained for exact recovery: %s\n' "${workspace}" >&2
+    return "${status}"
+  fi
+  python3 "${RELEASE_WORKSPACE_TOOL}" cleanup \
+    --build-root "${RELEASE_BUILD_ROOT}" "${workspace}"
+}
+
 main() {
   parse_arguments "$@"
   case "${MODE}" in
@@ -5916,8 +5912,18 @@ main() {
     release)
       trap cleanup_current_init_image_authority EXIT
       ensure_compose_promotion_mode
-      prepare_all_main
-      release_current_stack
+      if [[ "${CONTAINER_STACK_RELEASE_LIBRARY:-0}" == "1" ]]; then
+        release_current_stack
+      elif [[ "${CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE:-0}" == "1" ]]; then
+        python3 "${RELEASE_WORKSPACE_TOOL}" verify \
+          --build-root "${RELEASE_BUILD_ROOT}" "${ROOT}" >/dev/null
+        for repo in "${REPOS[@]}"; do
+          ensure_push_boundary "${repo}"
+        done
+        release_current_stack
+      else
+        run_isolated_release
+      fi
       CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=1
       ;;
   esac


### PR DESCRIPTION
## Summary

- resolve stable release plans from canonical remote refs without inspecting or changing primary checkouts
- clone one exact five-repository snapshot into a marker-protected SSD transaction with verified remotes and push boundaries
- revalidate both main refs and semantic-tag maps before committing the cloned snapshot
- retain failed or interrupted transactions for exact resume, serialize claims and cleanup, and remove only successful transactions
- bind the durable transaction lease to the actual release child PID so a dead launcher cannot admit a concurrent retry
- give every Git network operation a bounded unattended deadline
- refresh the mutable Current authority on every materialization and fail closed when it is unavailable
- simplify the scheduled release job to one controller checkout and repository-owned materialization

## Evidence

- 15 focused workspace tests pass in 11.77s, covering dirty/non-main/detached checkout preservation, exact resume, mutable Current refresh and deletion, semantic-tag movement, missing-object recovery, interrupted clone cleanup, live/dead/child-owned claims, remote retarget rejection, CLI parsing, bounded Git operations, and marker-safe cleanup
- 4 existing release-policy tests pass in 0.27s
- `bash -n`, ShellCheck, `actionlint`, and patch hygiene pass
- remote planning improved from 5.81s serial to 0.87s parallel in the measured live proof, with primary checkout branch, HEAD, index, worktree, and untracked state unchanged
- the merged CI classifier reports `tools=true` and `runtime=false` for this exact change set, providing the controller-only acceptance proof for #509

Closes #507
Refs #509