### PR TITLE
fix(release): recover interrupted promotion alignment

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -6779,6 +6779,44 @@ esac
             self.assertNotEqual(candidate_head, remote_head)
             self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "")
 
+    def test_release_helper_recovers_after_promotion_merge_before_alignment(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            local, candidate_head, candidate_tree, promoted_head = (
+                self.create_promotion_merge(root)
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("already promoted", result.stdout)
+            self.assertEqual(self.git(local, "rev-parse", "main"), promoted_head)
+            self.assertEqual(self.git(local, "rev-parse", "main^{tree}"), candidate_tree)
+            self.assertEqual(self.git(local, "status", "--short"), "")
+            self.assertNotEqual(candidate_head, promoted_head)
+
+    def test_release_helper_rejects_changed_tree_after_promotion_merge(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            local, candidate_head, _candidate_tree, _promoted_head = (
+                self.create_promotion_merge(root, change_promoted_tree=True)
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("refusing to recover", result.stderr)
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
+            self.assertEqual(self.git(local, "status", "--short"), "")
+
     def test_release_helper_retains_the_symlinked_coverage_gate_repair(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -7813,6 +7851,56 @@ exit 64
         self.commit_file(local, "README.md", "base\n", "chore: initial stack")
         self.run_command("git", "-C", str(local), "push", "-u", "origin", "main")
         return remote, local
+
+    def create_promotion_merge(
+        self,
+        root: Path,
+        *,
+        change_promoted_tree: bool = False,
+    ) -> tuple[Path, str, str, str]:
+        remote, local = self.create_compose_checkout(root)
+        self.enable_ssh_signing(root, local)
+        self.commit_signed_files(
+            local,
+            {"Makefile": "COMPOSE_VERSION ?= 0.6.71\n"},
+            "chore(release): prepare 0.6.71",
+        )
+        candidate_head = self.git(local, "rev-parse", "main")
+        candidate_tree = self.git(local, "rev-parse", "main^{tree}")
+        self.run_command(
+            "git",
+            "-C",
+            str(local),
+            "push",
+            "origin",
+            "main:refs/heads/release/candidate",
+        )
+
+        promotion = root / "promotion"
+        self.run_command(
+            "git", "clone", "--branch", "main", str(remote), str(promotion)
+        )
+        self.configure_repo(promotion)
+        self.run_command(
+            "git",
+            "-C",
+            str(promotion),
+            "merge",
+            "--no-ff",
+            "origin/release/candidate",
+            "-m",
+            "chore: merge reviewed release candidate",
+        )
+        if change_promoted_tree:
+            self.commit_file(
+                promotion,
+                "unexpected.txt",
+                "changed\n",
+                "fix: change promoted tree",
+            )
+        self.run_command("git", "-C", str(promotion), "push", "origin", "main")
+        promoted_head = self.git(promotion, "rev-parse", "main")
+        return local, candidate_head, candidate_tree, promoted_head
 
     def create_equivalent_squash(self, root: Path) -> tuple[Path, Path, str, str]:
         remote, local = self.create_compose_checkout(root)

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -732,7 +732,7 @@ validate_unpublished_release_commit() {
 }
 
 recover_unpublished_release_candidate() {
-  local version="$1" path remote local_head remote_head commit commits
+  local version="$1" path remote local_head remote_head local_tree remote_tree commit commits
   RECOVERED_UNPUBLISHED_RELEASE_BASE=""
   path="$(repo_path "${COMPOSE_REPO}")"
   remote="$(push_remote "${COMPOSE_REPO}")"
@@ -746,12 +746,26 @@ recover_unpublished_release_candidate() {
     printf 'cannot recover an unpublished release candidate without %s/main\n' "${remote}" >&2
     exit 1
   fi
-  if ! git -C "${path}" merge-base --is-ancestor "${remote_head}" "${local_head}"; then
-    printf 'container-compose main is not based on %s/main; refusing to recover a release candidate\n' "${remote}" >&2
-    exit 1
-  fi
   if [[ -n "$(git -C "${path}" status --short)" ]]; then
     printf 'dirty worktree blocks recovery of an unpublished release candidate for container-compose\n' >&2
+    exit 1
+  fi
+  if ! git -C "${path}" merge-base --is-ancestor "${remote_head}" "${local_head}"; then
+    fetch_release_remote "${COMPOSE_REPO}"
+    remote_head="$(remote_main_commit "${COMPOSE_REPO}")"
+    if [[ -z "${remote_head}" ]] ||
+      ! git -C "${path}" cat-file -e "${remote_head}^{commit}" 2>/dev/null; then
+      printf 'cannot inspect promoted container-compose main on %s\n' "${remote}" >&2
+      exit 1
+    fi
+    local_tree="$(git -C "${path}" rev-parse "${local_head}^{tree}")"
+    remote_tree="$(git -C "${path}" rev-parse "${remote_head}^{tree}")"
+    if git -C "${path}" merge-base --is-ancestor "${local_head}" "${remote_head}" &&
+      [[ "${local_tree}" == "${remote_tree}" ]]; then
+      align_equivalent_compose_main "${path}" "${remote}" "${remote_head}" "${local_tree}"
+      return 0
+    fi
+    printf 'container-compose main is not based on %s/main; refusing to recover a release candidate\n' "${remote}" >&2
     exit 1
   fi
 


### PR DESCRIPTION
Closes #513.

## What changed

- recover a retained release transaction after GitHub has merged the exact reviewed Compose candidate but before the local transaction aligned to the rewritten main commit
- accept recovery only when remote main contains the retained candidate and has the identical tree
- keep divergence, changed-tree, and dirty-worktree cases fail-closed
- align the retained checkout to the promoted remote commit before release validation resumes

## Focused validation

- 5 promotion/recovery policy tests passed in 1.972s (2.10s wall)
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `git diff --check origin/main...HEAD`

No Swift runtime, documentation, CodeQL, or broad integration suite was run because this change is isolated to release-controller recovery.