### PR TITLE
fix(release): preserve promoted candidate base

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -6790,13 +6790,111 @@ esac
 
             result = self.run_release_function(
                 root / "github",
-                "recover_unpublished_release_candidate 0.6.71",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "ensure_current_release_source_identity",
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("already promoted", result.stdout)
+            self.assertIn("current tag targets published parent", result.stdout)
             self.assertEqual(self.git(local, "rev-parse", "main"), promoted_head)
             self.assertEqual(self.git(local, "rev-parse", "main^{tree}"), candidate_tree)
+            self.assertEqual(self.git(local, "status", "--short"), "")
+            self.assertNotEqual(candidate_head, promoted_head)
+
+    def test_release_helper_rejects_stale_current_before_promotion_merge(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, local = self.create_compose_checkout(root)
+            stale_current = self.git(local, "rev-parse", "main")
+            self.run_command(
+                "git", "-C", str(local), "tag", "--no-sign", "current", stale_current
+            )
+            self.run_command("git", "-C", str(local), "push", "origin", "current")
+            self.enable_ssh_signing(root, local)
+            self.commit_signed_files(
+                local,
+                {"Package.resolved": "published dependency pin\n"},
+                "chore(deps): pin container stack 123456789abc abcdef123456",
+            )
+            published_parent = self.git(local, "rev-parse", "main")
+            self.run_command("git", "-C", str(local), "push", "origin", "main")
+            self.commit_signed_files(
+                local,
+                {"Makefile": "COMPOSE_VERSION ?= 0.6.71\n"},
+                "chore(release): prepare 0.6.71",
+            )
+            candidate_head = self.git(local, "rev-parse", "main")
+            candidate_tree = self.git(local, "rev-parse", "main^{tree}")
+            self.run_command(
+                "git",
+                "-C",
+                str(local),
+                "push",
+                "origin",
+                "main:refs/heads/release/candidate",
+            )
+
+            promotion = root / "promotion"
+            self.run_command(
+                "git", "clone", "--branch", "main", str(remote), str(promotion)
+            )
+            self.configure_repo(promotion)
+            self.run_command(
+                "git",
+                "-C",
+                str(promotion),
+                "merge",
+                "--no-ff",
+                "origin/release/candidate",
+                "-m",
+                "chore: merge reviewed release candidate",
+            )
+            self.run_command("git", "-C", str(promotion), "push", "origin", "main")
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "ensure_current_release_source_identity",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("exact pre-promotion", result.stderr)
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
+            self.assertEqual(self.git(local, "rev-parse", "main^{tree}"), candidate_tree)
+            self.assertNotEqual(stale_current, published_parent)
+            self.assertEqual(self.git(local, "status", "--short"), "")
+
+    def test_release_helper_recovers_after_current_publishes_promotion(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            local, candidate_head, candidate_tree, promoted_head = (
+                self.create_promotion_merge(root)
+            )
+            self.run_command("git", "-C", str(local), "fetch", "origin", "main")
+            self.run_command(
+                "git", "-C", str(local), "tag", "--force", "current", promoted_head
+            )
+            self.run_command(
+                "git", "-C", str(local), "push", "--force", "origin", "current"
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "ensure_current_release_source_identity",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("already promoted", result.stdout)
+            self.assertNotIn("current tag targets published parent", result.stdout)
+            self.assertEqual(self.git(local, "rev-parse", "main"), promoted_head)
+            self.assertEqual(self.git(local, "rev-parse", "main^{tree}"), candidate_tree)
+            self.assertEqual(self.git(local, "rev-parse", "current"), promoted_head)
             self.assertEqual(self.git(local, "status", "--short"), "")
             self.assertNotEqual(candidate_head, promoted_head)
 
@@ -7859,6 +7957,11 @@ exit 64
         change_promoted_tree: bool = False,
     ) -> tuple[Path, str, str, str]:
         remote, local = self.create_compose_checkout(root)
+        published_head = self.git(local, "rev-parse", "main")
+        self.run_command(
+            "git", "-C", str(local), "tag", "--no-sign", "current", published_head
+        )
+        self.run_command("git", "-C", str(local), "push", "origin", "current")
         self.enable_ssh_signing(root, local)
         self.commit_signed_files(
             local,

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -732,7 +732,7 @@ validate_unpublished_release_commit() {
 }
 
 recover_unpublished_release_candidate() {
-  local version="$1" path remote local_head remote_head local_tree remote_tree commit commits
+  local version="$1" path remote local_head remote_head local_tree remote_tree current_head promotion_parent commit commits
   RECOVERED_UNPUBLISHED_RELEASE_BASE=""
   path="$(repo_path "${COMPOSE_REPO}")"
   remote="$(push_remote "${COMPOSE_REPO}")"
@@ -762,6 +762,30 @@ recover_unpublished_release_candidate() {
     remote_tree="$(git -C "${path}" rev-parse "${remote_head}^{tree}")"
     if git -C "${path}" merge-base --is-ancestor "${local_head}" "${remote_head}" &&
       [[ "${local_tree}" == "${remote_tree}" ]]; then
+      promotion_parent="$(git -C "${path}" rev-parse --verify -q "${remote_head}^1" || true)"
+      if [[ -z "${promotion_parent}" ]] ||
+        ! git -C "${path}" merge-base --is-ancestor "${promotion_parent}" "${local_head}" ||
+        ! git -C "${path}" rev-parse "${remote_head}^@" | grep -Fxq "${local_head}"; then
+        printf 'promoted container-compose candidate is not the reviewed direct merge parent\n' >&2
+        exit 1
+      fi
+      current_head="$(git -C "${path}" rev-parse --verify -q 'refs/tags/current^{}' || true)"
+      if [[ "${current_head}" != "${promotion_parent}" &&
+        "${current_head}" != "${remote_head}" ]]; then
+        printf 'current does not identify the exact pre-promotion container-compose main\n' >&2
+        exit 1
+      fi
+      commits="$(git -C "${path}" rev-list --reverse "${promotion_parent}..${local_head}")"
+      if [[ -z "${commits}" ]]; then
+        printf 'promoted container-compose candidate has no unpublished commits after current\n' >&2
+        exit 1
+      fi
+      while IFS= read -r commit; do
+        validate_unpublished_release_commit "${path}" "${commit}" "${version}" || exit 1
+      done <<<"${commits}"
+      if [[ "${current_head}" == "${promotion_parent}" ]]; then
+        RECOVERED_UNPUBLISHED_RELEASE_BASE="${promotion_parent}"
+      fi
       align_equivalent_compose_main "${path}" "${remote}" "${remote_head}" "${local_tree}"
       return 0
     fi


### PR DESCRIPTION
Closes #513.

Follow-up to #514 and its exact-head P1 review finding.

## What changed

- retain the previously published Current parent when recovering a candidate that GitHub has already promoted with rewritten history
- revalidate every retained candidate commit from that Current parent before alignment
- allow immediate source-identity validation without waiting for asynchronous Current publication
- keep missing, unrelated, changed-tree, divergent, dirty, and malformed candidate states fail-closed

## Focused validation

- 5 promotion/recovery policy tests passed in 2.077s (2.21s wall)
- the interrupted-promotion regression now calls `ensure_current_release_source_identity` before Current advances
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `git diff --check origin/main...HEAD`

No Swift runtime, documentation, CodeQL, or broad integration suite was run.