### PR TITLE
fix(build): preflight Compose oracle before parity build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ CONTAINERIZATION_INIT_SOURCE_PATH ?= $(if $(wildcard $(CONTAINERIZATION_STACK_RE
 # their scripts verbatim, so selecting it here keeps every documented `make
 # docker-compose-…-parity` invocation runnable on either installation layout.
 DOCKER_COMPOSE_REFERENCE ?= $(shell if docker compose version >/dev/null 2>&1; then printf '%s' 'docker compose'; elif command -v docker-compose >/dev/null 2>&1 && docker-compose version >/dev/null 2>&1; then printf '%s' docker-compose; else printf '%s' 'docker compose'; fi)
-DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.4.0
+DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.5.1
 DOCKER_COMPOSE_E2E_REF ?= f32009d4a2c687dd405398cc7975d12dccaf8dff
 DOCKER_TERMINAL_CANDIDATE_SOCKET ?= /tmp/container-engine-$(shell id -u)/docker.sock
 DOCKER_REST_LOGGING_CANDIDATE_SOCKET ?= $(DOCKER_TERMINAL_CANDIDATE_SOCKET)
@@ -2407,7 +2407,8 @@ docker-compose-reference:
 docker-compose-e2e-fixtures:
 	DOCKER_COMPOSE_E2E_REF="$(DOCKER_COMPOSE_E2E_REF)" ./Tools/parity/sync-docker-compose-e2e-fixtures.sh --strict
 
-docker-compose-parity: build-release release-parity-build-info container-stack-build-if-needed docker-compose-reference
+docker-compose-parity: docker-compose-reference
+	$(MAKE) --no-print-directory build-release release-parity-build-info container-stack-build-if-needed
 	container_binary="$(CONTAINER_COMPOSE_CONTAINER)"; \
 	if [[ "$$container_binary" == "container" ]]; then \
 		for candidate in "$(LOCAL_CONTAINER_BINARY)" "$(LOCAL_CONTAINER_PACKAGE_BINARY)"; do \

--- a/Tools/ci/test_build_release_local_stack.py
+++ b/Tools/ci/test_build_release_local_stack.py
@@ -122,10 +122,12 @@ class BuildReleaseLocalStackTests(unittest.TestCase):
         ]
 
         self.assertTrue(
-            parity.startswith(
-                "docker-compose-parity: build-release release-parity-build-info "
-                "container-stack-build-if-needed docker-compose-reference"
-            ),
+            parity.startswith("docker-compose-parity: docker-compose-reference"),
+            parity,
+        )
+        self.assertIn(
+            "$(MAKE) --no-print-directory build-release "
+            "release-parity-build-info container-stack-build-if-needed",
             parity,
         )
         self.assertIn(

--- a/Tools/parity/check-docker-compose-reference.sh
+++ b/Tools/parity/check-docker-compose-reference.sh
@@ -23,7 +23,7 @@
 #   DOCKER_COMPOSE                    Docker Compose command to validate.
 #                                     Defaults to "docker compose".
 #   DOCKER_COMPOSE_REFERENCE_VERSION  Required Docker Compose version.
-#                                     Defaults to 5.4.0.
+#                                     Defaults to 5.5.1.
 #
 # This preflight makes every parity target use the documented Docker Compose
 # oracle version rather than whichever version happens to be installed.
@@ -34,7 +34,7 @@ readonly SELF_PATH="${BASH_SOURCE[0]:-$0}"
 readonly SCRIPT_NAME="$(basename "$SELF_PATH")"
 
 DOCKER_COMPOSE_VALUE="${DOCKER_COMPOSE:-docker compose}"
-REQUIRED_VERSION="${DOCKER_COMPOSE_REFERENCE_VERSION:-5.4.0}"
+REQUIRED_VERSION="${DOCKER_COMPOSE_REFERENCE_VERSION:-5.5.1}"
 DOCKER_COMPOSE_COMMAND=()
 
 # Print an error message to stderr.

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3562,11 +3562,7 @@ github_cli() {{
         for stage in ("sibling-stack", "compose-ci", "swift-runtime", "compose-parity"):
             self.assertIn(f"--stage {stage}", makefile)
         self.assertIn("docker-compose-parity-stages:", makefile)
-        self.assertIn(
-            "docker-compose-parity: build-release release-parity-build-info "
-            "container-stack-build-if-needed docker-compose-reference",
-            makefile,
-        )
+        self.assertIn("docker-compose-parity: docker-compose-reference", makefile)
         self.assertIn(
             "swift-runtime-test: container-stack-build-if-needed build "
             "swift-runtime-test-build",
@@ -3644,11 +3640,24 @@ github_cli() {{
             makefile.count("env -u CONTAINER_BIN -u CONTAINER_COMPOSE_CONTAINER"),
             2,
         )
-        self.assertIn("DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.4.0", makefile)
+        self.assertIn("DOCKER_COMPOSE_REFERENCE_VERSION ?= 5.5.1", makefile)
         self.assertIn(
-            'REQUIRED_VERSION="${DOCKER_COMPOSE_REFERENCE_VERSION:-5.4.0}"',
+            'REQUIRED_VERSION="${DOCKER_COMPOSE_REFERENCE_VERSION:-5.5.1}"',
             reference_check,
         )
+        parity_target = makefile.index(
+            "docker-compose-parity: docker-compose-reference"
+        )
+        parity_build = makefile.index(
+            "$(MAKE) --no-print-directory build-release "
+            "release-parity-build-info container-stack-build-if-needed",
+            parity_target,
+        )
+        parity_runtime = makefile.index(
+            'container_binary="$(CONTAINER_COMPOSE_CONTAINER)"', parity_build
+        )
+        self.assertLess(parity_target, parity_build)
+        self.assertLess(parity_build, parity_runtime)
         self.assertIn("DOCKER_COMPOSE_E2E_REF ?= f32009d4a2c687dd405398cc7975d12dccaf8dff", makefile)
         self.assertNotIn("repackage-release", makefile)
 


### PR DESCRIPTION
Closes #518.

## What changed

- update the maintained Docker Compose parity oracle from 5.4.0 to 5.5.1;
- make the strict oracle-version check the only prerequisite of `docker-compose-parity`;
- invoke candidate compilation only after that preflight passes;
- add focused regression coverage for the version pin and execution order.

## Evidence

- focused release-policy regression passes;
- shell syntax check passes;
- strict local oracle check reports Docker Compose 5.5.1;
- dry-run ordering shows the oracle preflight before the recursive release build.

This fixes the failure observed on main `9960335f`: a 153.98-second release compilation completed before the stale 5.4.0 oracle pin was rejected. Existing build/checkpoint output remains reusable.