### PR TITLE
feat(bridge): confirm destructive output replacement

### DIFF
--- a/Sources/ComposeCore/ComposeBridge.swift
+++ b/Sources/ComposeCore/ComposeBridge.swift
@@ -35,15 +35,19 @@ public struct ComposeBridgeConvertOptions: Sendable, Equatable {
     public var templates: String?
     /// Transformer image references to apply.
     public var transformations: [String]
+    /// Whether an existing non-empty output directory may be replaced without prompting.
+    public var assumeYes: Bool
 
     public init(
         output: String = "out",
         templates: String? = nil,
         transformations: [String] = [],
+        assumeYes: Bool = false,
     ) {
         self.output = output
         self.templates = templates
         self.transformations = transformations
+        self.assumeYes = assumeYes
     }
 }
 
@@ -125,7 +129,7 @@ extension ComposeOrchestrator {
         defer { try? FileManager.default.removeItem(at: input) }
 
         if !convert.output.isEmpty {
-            try recreateBridgeOutputDirectory(output)
+            try await prepareBridgeOutputDirectory(output, assumeYes: convert.assumeYes)
         }
         for transformation in transformations {
             try await pullMissingImage(transformation, quiet: true)
@@ -139,6 +143,21 @@ extension ComposeOrchestrator {
                 inheritedIO: true,
             )
         }
+    }
+
+    private func prepareBridgeOutputDirectory(_ output: String, assumeYes: Bool) async throws {
+        try validateBridgeOutputDirectory(output)
+        if try bridgeOutputDirectoryNeedsConfirmation(output), !assumeYes {
+            let confirmed = try await options.confirm(
+                "Output directory '\(output)' is not empty, all its content will be permanently deleted. Continue? [yN] ",
+            )
+            guard confirmed else {
+                throw ComposeError.invalidProject(
+                    "deletion of output directory '\(output)' was not confirmed",
+                )
+            }
+        }
+        try recreateBridgeOutputDirectory(output)
     }
 
     /// Lists locally available Compose Bridge transformer images.

--- a/Sources/ComposeCore/ComposeBridgeSupport.swift
+++ b/Sources/ComposeCore/ComposeBridgeSupport.swift
@@ -71,7 +71,7 @@ func createBridgeInputDirectory(composeYAML: String) throws -> URL {
     }
 }
 
-func recreateBridgeOutputDirectory(_ output: String) throws {
+func validateBridgeOutputDirectory(_ output: String) throws {
     let url = URL(fileURLWithPath: output, isDirectory: true)
     let currentDirectory = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
         .resolvingSymlinksInPath().standardizedFileURL.path
@@ -82,6 +82,28 @@ func recreateBridgeOutputDirectory(_ output: String) throws {
                 + "or an ancestor of the current directory",
         )
     }
+}
+
+func bridgeOutputDirectoryNeedsConfirmation(_ output: String) throws -> Bool {
+    var isDirectory: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: output, isDirectory: &isDirectory) else {
+        return false
+    }
+    guard isDirectory.boolValue else {
+        throw ComposeError.invalidProject("bridge output path is not a directory: \(output)")
+    }
+    do {
+        return try !FileManager.default.contentsOfDirectory(atPath: output).isEmpty
+    } catch {
+        throw ComposeError.invalidProject(
+            "cannot read bridge output directory '\(output)': \(error.localizedDescription)",
+        )
+    }
+}
+
+func recreateBridgeOutputDirectory(_ output: String) throws {
+    try validateBridgeOutputDirectory(output)
+    let url = URL(fileURLWithPath: output, isDirectory: true)
     if FileManager.default.fileExists(atPath: output) {
         try FileManager.default.removeItem(at: url)
     }

--- a/Sources/ComposePlugin/ComposeCLIHelp.swift
+++ b/Sources/ComposePlugin/ComposeCLIHelp.swift
@@ -394,6 +394,7 @@ enum ComposeCLIHelp {
             "--output": .supported,
             "--templates": .supported,
             "--transformation": .supported,
+            "--yes": .supported,
         ],
         "bridge transformations": [
             "--dry-run": .supported,
@@ -1171,6 +1172,10 @@ enum ComposeCLIHelp {
           -t, --transformation stringArray   Transformation to apply to compose
                                              model (default:
                                              docker/compose-bridge-kubernetes)
+          -y, --yes                          Assume "yes" to the output directory
+                                             overwrite prompt. For scripts/CI,
+                                             where no interactive confirmation is
+                                             possible
         """,
         "bridge transformations": """
         Usage:  container compose bridge transformations [OPTIONS] COMMAND

--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -906,6 +906,8 @@ struct BridgeConvert: AsyncParsableCommand, ComposeProjectCommand {
     var templates: String?
     @Option(name: [.customShort("t"), .customLong("transformation")], parsing: .upToNextOption, help: "Transformation to apply to compose model.")
     var transformations: [String] = []
+    @Flag(name: [.customShort("y"), .customLong("yes")], help: "Assume yes to the output directory overwrite prompt.")
+    var yes = false
 
     /// Runs the selected Bridge transformer image or images.
     func run() async throws {
@@ -916,7 +918,8 @@ struct BridgeConvert: AsyncParsableCommand, ComposeProjectCommand {
             options: ComposeBridgeConvertOptions(
                 output: output,
                 templates: templates,
-                transformations: transformations
+                transformations: transformations,
+                assumeYes: yes,
             )
         )
     }

--- a/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
+++ b/Tests/ComposeCoreTests/ComposeOrchestratorInspectionAndConfigTests.swift
@@ -2781,6 +2781,136 @@ extension ComposeOrchestratorTests {
         #expect(emitted.messages.contains("+ container rm --force compose-bridge-abc123"))
     }
 
+    @Test("bridge convert preserves non-empty output when overwrite is declined")
+    func bridgeConvertPreservesNonEmptyOutputWhenOverwriteIsDeclined() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let output = directory.appendingPathComponent("out", isDirectory: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let guardFile = output.appendingPathComponent("README.md")
+        try "do not delete me".write(to: guardFile, atomically: true, encoding: .utf8)
+        let prompts = MessageRecorder()
+        let runner = RecordingRunner()
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(
+                runtimeHooks: .init(confirm: { prompt in
+                    prompts.append(prompt)
+                    return false
+                }),
+            ),
+            imageManager: RecordingContainerImageManager(),
+        )
+
+        await #expect(throws: ComposeError.self) {
+            try await orchestrator.bridgeConvert(
+                project: ComposeProject(name: "demo", services: [:]),
+                options: ComposeBridgeConvertOptions(
+                    output: output.path,
+                    transformations: ["example/transformer"],
+                ),
+            )
+        }
+
+        #expect(try String(contentsOf: guardFile, encoding: .utf8) == "do not delete me")
+        #expect(runner.commands.isEmpty)
+        #expect(prompts.messages == [
+            "Output directory '\(output.path)' is not empty, all its content will be permanently deleted. Continue? [yN] ",
+        ])
+    }
+
+    @Test("bridge convert yes replaces non-empty output without prompting")
+    func bridgeConvertYesReplacesNonEmptyOutputWithoutPrompting() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let output = directory.appendingPathComponent("out", isDirectory: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let guardFile = output.appendingPathComponent("stale.txt")
+        try "stale".write(to: guardFile, atomically: true, encoding: .utf8)
+        let runner = BridgeInputInspectingRunner()
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(
+                runtimeHooks: .init(confirm: { _ in
+                    throw ComposeError.invalidProject("unexpected confirmation prompt")
+                }),
+            ),
+            imageManager: RecordingContainerImageManager(),
+        )
+
+        try await orchestrator.bridgeConvert(
+            project: ComposeProject(name: "demo", services: [:]),
+            options: ComposeBridgeConvertOptions(
+                output: output.path,
+                transformations: ["example/transformer"],
+                assumeYes: true,
+            ),
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: guardFile.path))
+        #expect(runner.commands.count == 1)
+    }
+
+    @Test("bridge convert replaces non-empty output after confirmation")
+    func bridgeConvertReplacesNonEmptyOutputAfterConfirmation() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let output = directory.appendingPathComponent("out", isDirectory: true)
+        try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+        let guardFile = output.appendingPathComponent("stale.txt")
+        try "stale".write(to: guardFile, atomically: true, encoding: .utf8)
+        let prompts = MessageRecorder()
+        let runner = BridgeInputInspectingRunner()
+        let orchestrator = ComposeOrchestrator(
+            runner: runner,
+            options: ComposeExecutionOptions(
+                runtimeHooks: .init(confirm: { prompt in
+                    prompts.append(prompt)
+                    return true
+                }),
+            ),
+            imageManager: RecordingContainerImageManager(),
+        )
+
+        try await orchestrator.bridgeConvert(
+            project: ComposeProject(name: "demo", services: [:]),
+            options: ComposeBridgeConvertOptions(
+                output: output.path,
+                transformations: ["example/transformer"],
+            ),
+        )
+
+        #expect(!FileManager.default.fileExists(atPath: guardFile.path))
+        #expect(runner.commands.count == 1)
+        #expect(prompts.messages.count == 1)
+    }
+
+    @Test("bridge convert preserves an output path that is not a directory")
+    func bridgeConvertPreservesOutputPathThatIsNotDirectory() async throws {
+        let directory = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let output = directory.appendingPathComponent("out")
+        try "do not delete me".write(to: output, atomically: true, encoding: .utf8)
+        let runner = RecordingRunner()
+
+        await #expect(throws: ComposeError.self) {
+            try await ComposeOrchestrator(
+                runner: runner,
+                imageManager: RecordingContainerImageManager(),
+            ).bridgeConvert(
+                project: ComposeProject(name: "demo", services: [:]),
+                options: ComposeBridgeConvertOptions(
+                    output: output.path,
+                    transformations: ["example/transformer"],
+                    assumeYes: true,
+                ),
+            )
+        }
+
+        #expect(try String(contentsOf: output, encoding: .utf8) == "do not delete me")
+        #expect(runner.commands.isEmpty)
+    }
+
     @Test("bridge convert accepts empty output without deleting the current directory")
     func bridgeConvertAcceptsEmptyOutputWithoutDeletingCurrentDirectory() async throws {
         let runner = BridgeInputInspectingRunner()

--- a/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
+++ b/Tests/ComposePluginTests/ComposeCLIHelpTests.swift
@@ -891,19 +891,21 @@ struct ComposeCLIHelpTests {
 
                 #expect(command.global.dryRun)
             }),
-            (["bridge", "convert"], ["--dry-run", "--output", "--templates", "--transformation"], {
+            (["bridge", "convert"], ["--dry-run", "--output", "--templates", "--transformation", "--yes"], {
                 let command = try BridgeConvert.parse([
                     "--dry-run",
                     "--output", "out",
                     "--templates", "templates",
                     "--transformation", "one",
                     "--transformation", "two",
+                    "--yes",
                 ])
 
                 #expect(command.global.dryRun)
                 #expect(command.output == "out")
                 #expect(command.templates == "templates")
                 #expect(command.transformations == ["one", "two"])
+                #expect(command.yes)
             }),
             (["bridge", "transformations"], ["--dry-run"], {
                 let command = try BridgeTransformations.parse(["--dry-run"])

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -48,7 +48,7 @@ registry, terminal, TLS, EOF, and certificate parsing fixes below that runtime.
 ## At a Glance
 
 The current help surface contains 40 green commands, 6 partial commands, and 0
-unsupported commands. It contains 262 green documented long options, 1 partial
+unsupported commands. It contains 263 green documented long options, 1 partial
 long option, and 0 unsupported long options.
 
 The six partial commands are `attach`, `events`, `exec`, `logs`, `run`, and
@@ -373,7 +373,7 @@ the logging contract.
 `container compose --help` and `container compose COMMAND --help` are the
 authoritative option reference.
 
-All 262 documented long options are parsed and mapped for their current command
+All 263 documented long options are parsed and mapped for their current command
 behavior except `exec --privileged`, whose partial behavior is described above.
 Command parity remains a separate axis: a green flag does not override a deeper
 runtime boundary described by its command.


### PR DESCRIPTION
Closes #520.

## What changed

- add Docker Compose 5.5.1-compatible `bridge convert -y, --yes`;
- refuse to delete a non-empty output directory unless the user confirms;
- let scripts and CI opt into replacement with `--yes`;
- reject an output path that is not a directory;
- preserve the existing root/current-directory/ancestor/symlink protections.

## Focused evidence

- 6 targeted parser and core tests pass (decline, confirm, `--yes`, non-directory preservation, option coverage, representative parsing);
- deterministic SwiftLint/SwiftFormat check passes for newly lintable files;
- Docker Compose 5.5.1 CLI-surface parity passes with no unexpected differences;
- path-consistent incremental debug build completed in 5.83 seconds before the final focused test cycle.

Found by the first stage of the post-#516 full parity closeout after the Docker Compose oracle moved from 5.4.0 to 5.5.1.