### PR TITLE
fix(format): match Docker invalid UTF-8 JSON

### DIFF
--- a/Sources/ComposeCore/ComposeDockerTemplateData.swift
+++ b/Sources/ComposeCore/ComposeDockerTemplateData.swift
@@ -190,7 +190,7 @@ private func structuredTemplateJSONString(bytes: [UInt8]) throws -> String {
             valid.unicodeScalars.append(scalar)
         case .error:
             content += try structuredTemplateJSONString(valid).dropQuotes
-            content += #"\ufffd"#
+            content.append("\u{FFFD}")
             valid = ""
         case .emptyInput:
             content += try structuredTemplateJSONString(valid).dropQuotes

--- a/Tests/ComposeCoreTests/ComposeDockerTemplateJSONTests.swift
+++ b/Tests/ComposeCoreTests/ComposeDockerTemplateJSONTests.swift
@@ -44,7 +44,7 @@ struct ComposeDockerTemplateJSONTests {
             try renderDockerTemplate(
                 #"{{json (truncate "aéz" 2)}}"#,
                 values: values,
-            ) == #""a\ufffd""#,
+            ) == #""a\#(replacementCharacter)""#,
         )
         #expect(
             try renderDockerTemplate(

--- a/Tools/parity/check-compose-format-template-actions.sh
+++ b/Tools/parity/check-compose-format-template-actions.sh
@@ -514,7 +514,7 @@ check_implementation() {
         "${command[@]}" --project-name "$project" -f "$FIXTURE_DIR/compose.yaml" ps \
             --format '{{json (truncate "aéz" 2)}}'
     )"
-    assert_equal "$actual" '"a\ufffd"' "$project partial UTF-8 JSON template"
+    assert_equal "$actual" '"a�"' "$project partial UTF-8 JSON template"
 
     actual="$(
         "${command[@]}" --project-name "$project" -f "$FIXTURE_DIR/compose.yaml" ps \


### PR DESCRIPTION
## Summary

- emit a literal Unicode replacement character when structured JSON repairs invalid UTF-8 bytes
- update the focused unit expectation and Docker Compose parity oracle
- preserve every other Go-compatible JSON escape

## Validation

- focused `JSON repairs only invalid UTF8 bytes` test passed
- `bash -n Tools/parity/check-compose-format-template-actions.sh`
- `shellcheck Tools/parity/check-compose-format-template-actions.sh`
- deterministic SwiftLint/SwiftFormat passed for both changed Swift files
- focused Docker Compose 5.5.1 structured format-template parity passed end-to-end with the signed isolated Container runtime

Closes #523.