### PR TITLE
fix(runtime): keep public parity pulls non-interactive

### DIFF
--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -707,6 +707,16 @@ exit 113
                 {"CONTAINER_RUNTIME_APP_ROOT": "/tmp/" + "x" * 80},
                 "container runtime app root exceeds the provider Unix socket path limit",
             ),
+            (
+                "space-separated anonymous registry hosts",
+                {
+                    "CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS": (
+                        "ghcr.io docker.io"
+                    ),
+                },
+                "CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS must be a "
+                "comma-separated host list",
+            ),
         ]
         for name, overrides, expected_error in cases:
             with self.subTest(name=name), tempfile.TemporaryDirectory() as temporary_directory:
@@ -1033,7 +1043,10 @@ exit 113
                         rf"^/(?:private/)?tmp/container-compose-runtime-{os.getuid()}"
                         rf"/candidate-[0-9a-f]{{16}}/bin/container$",
                     )
-                    self.assertEqual(values[3], "ghcr.io")
+                    self.assertEqual(
+                        values[3],
+                        "ghcr.io,docker.io,registry-1.docker.io,index.docker.io",
+                    )
                     staged_paths.append(values[0])
 
                 self.assertEqual(staged_paths[0], staged_paths[1])

--- a/scripts/run-with-container-runtime.sh
+++ b/scripts/run-with-container-runtime.sh
@@ -77,7 +77,7 @@ runtime_local_user_root=
 runtime_managed_candidate_root=${CONTAINER_RUNTIME_STAGED_CANDIDATE_ROOT:-}
 runtime_managed_package_sha256=${CONTAINER_RUNTIME_PACKAGE_SHA256:-}
 runtime_app_root_localized=false
-runtime_anonymous_registry_hosts=${CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS-ghcr.io}
+runtime_anonymous_registry_hosts=${CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS-ghcr.io,docker.io,registry-1.docker.io,index.docker.io}
 runtime_launchctl=${CONTAINER_RUNTIME_LAUNCHCTL:-/bin/launchctl}
 
 if [[ -z "$runtime_local_execution_root" ]]; then
@@ -464,6 +464,27 @@ validate_runtime_start_deadline_seconds() {
             "$runtime_start_deadline_seconds" >&2
         exit 2
     fi
+}
+
+# Keep the public-host policy unambiguous before it reaches launchd-managed
+# image services. The service accepts a comma-separated list; whitespace used
+# as a separator silently turns the complete value into one unmatched host and
+# can block an unattended build on a Keychain query.
+validate_runtime_anonymous_registry_hosts() {
+    [[ -n "$runtime_anonymous_registry_hosts" ]] || return 0
+
+    local hosts=()
+    local host
+    IFS=',' read -r -a hosts <<<"$runtime_anonymous_registry_hosts"
+    for host in "${hosts[@]}"; do
+        host="${host#"${host%%[![:space:]]*}"}"
+        host="${host%"${host##*[![:space:]]}"}"
+        if [[ -z "$host" || "$host" =~ [[:space:]] ]]; then
+            printf 'CONTAINER_RUNTIME_ANONYMOUS_REGISTRY_HOSTS must be a comma-separated host list: %s\n' \
+                "$runtime_anonymous_registry_hosts" >&2
+            exit 2
+        fi
+    done
 }
 
 # Validate the privacy-protection controls before inspecting caller paths.
@@ -1910,6 +1931,7 @@ install_matched_init_image() {
 }
 
 validate_runtime_start_deadline_seconds
+validate_runtime_anonymous_registry_hosts
 validate_runtime_localization_modes
 assert_no_competing_container_launch_agents
 runtime_local_user_root="$runtime_local_execution_root/container-compose-runtime-$(id -u)"


### PR DESCRIPTION
Closes #527.

Uses the complete comma-separated public fixture registry set for isolated runtime validation and rejects whitespace-separated host lists before any launchd service starts. This prevents public BuildKit and Docker Hub pulls from entering Keychain during unattended parity runs.

Focused evidence:
- runtime-wrapper default and no-side-effect validation tests passed
- Bash syntax and ShellCheck passed
- live commit parity fetched the Docker Hub fixture, built it, committed both implementations, and passed
- isolated runtime stopped cleanly with no privacy prompt