### PR TITLE
chore(release): refresh 0.14.3 upstream authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 5 September 2026 snapshot, the three support forks are **1140 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 7 September 2026 snapshot, the three support forks are **1144 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 301 ahead** at [`b404e03bb914`](https://github.com/stephenlclarke/containerization/commit/b404e03bb914904107a6a9305ba1f0e44c79a59c).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 786 ahead** at [`a252482bbacb`](https://github.com/stephenlclarke/container/commit/a252482bbacbd15742845764893585131e2c4825).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 303 ahead** at [`f9d57ad1c809`](https://github.com/stephenlclarke/containerization/commit/f9d57ad1c80944c43bec6fc74afe1bfac3956480).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 788 ahead** at [`40ab92d74a02`](https://github.com/stephenlclarke/container/commit/40ab92d74a02bbd6b7436a50d47c38898a4bc294).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 53 ahead** at [`287f2ea3276e`](https://github.com/stephenlclarke/container-builder-shim/commit/287f2ea3276eca73cd3781ff59b4c9c82d5f3d32).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-09-05",
+  "reviewedAt": "2026-09-07",
   "repositories": {
     "container": {
       "upstreamHead": "eee7ad097079cc3b02d5309ec10160143f2d0c6a",
-      "forkHead": "a252482bbacbd15742845764893585131e2c4825",
+      "forkHead": "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -499,7 +499,8 @@
             "1af892c31c70358cee23a7c591241228b663ebf3",
             "c676fcc0df7400f0189b6aefb8de584ea8b4a519",
             "436a7c9b4edc14a6b23440f8bf4b438e39830b81",
-            "6f4c232563ba812404282471bdea4d32a143e745"
+            "6f4c232563ba812404282471bdea4d32a143e745",
+            "228897171d71975988ccdc690f1982e7433952af"
           ]
         },
         {
@@ -674,7 +675,8 @@
             "f31dc1a14f8f76baac87509ec4c3f6c27262998c",
             "1f830f601deb1ebfebab70a4b448b5156ce62a07",
             "727f872cc87fc75e9272d9de9269807b948d8e44",
-            "f10d44fc7ed5de5e00a00a3f2b7a3fd29ecc3dd7"
+            "f10d44fc7ed5de5e00a00a3f2b7a3fd29ecc3dd7",
+            "40ab92d74a02bbd6b7436a50d47c38898a4bc294"
           ]
         },
         {
@@ -744,8 +746,8 @@
       ]
     },
     "containerization": {
-      "upstreamHead": "d7fc7c15a257e348000f3ed3708e84a9d33add97",
-      "forkHead": "b404e03bb914904107a6a9305ba1f0e44c79a59c",
+      "upstreamHead": "847655d373a27b8b8d0c3a9747f04f16b5de1206",
+      "forkHead": "f9d57ad1c80944c43bec6fc74afe1bfac3956480",
       "slices": [
         {
           "id": "containerization-support-maintenance",

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 5 September 2026
+Updated: 7 September 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `a252482bbacbd15742845764893585131e2c4825` | 0 | 786 | 663 |
-| `containerization` | `d7fc7c15a257e348000f3ed3708e84a9d33add97` | `b404e03bb914904107a6a9305ba1f0e44c79a59c` | 0 | 301 | 239 |
+| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `40ab92d74a02bbd6b7436a50d47c38898a4bc294` | 0 | 788 | 665 |
+| `containerization` | `847655d373a27b8b8d0c3a9747f04f16b5de1206` | `f9d57ad1c80944c43bec6fc74afe1bfac3956480` | 0 | 303 | 239 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `287f2ea3276eca73cd3781ff59b4c9c82d5f3d32` | 0 | 53 | 44 |
-| **Total** | | | **0** | **1140** | **946** |
+| **Total** | | | **0** | **1144** | **948** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,8 +32,8 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 691 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
-| `generic-runtime-primitive` | 230 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
+| `support-maintenance` | 692 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `generic-runtime-primitive` | 231 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
 
@@ -284,3 +284,12 @@ ext4 parsing, registry authentication, terminal restoration, TLS lifecycle,
 certificate parsing, dependency security updates, and reusable build tooling.
 All newly patch-unique commits are support maintenance; no generic primitive,
 temporary port, or rejected Compose-policy disposition changed.
+
+The 7 September 2026 release refresh advances Container through
+`40ab92d74a02`, Apple Containerization through `847655d373a2`, and
+Containerization through `f9d57ad1c809`. Container's unattended Engine API
+keychain dependency pin is support maintenance, while its durable Engine
+socket grant is a generic runtime primitive consumed by Compose
+`use_api_socket`. Apple's Pi agent support is upstream history after the
+reviewed synchronization merge, so it adds no fork-only classification. No
+temporary port or rejected Compose-policy disposition changed.

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "archiveCommit": "3d77ec228c7f55a04f689d5e1453752fc0c27f72",
-  "generatedAt": "2026-09-05",
+  "generatedAt": "2026-09-07",
   "entries": [
     {
       "id": "apple-container-1459",
@@ -8299,6 +8299,30 @@
         }
       ],
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/489"
+    },
+    {
+      "id": "container-compose-533",
+      "owner": "stephenlclarke/container-compose",
+      "title": "chore(release): refresh 0.14.3 upstream authority",
+      "state": "active-draft",
+      "lastVerified": "2026-09-07",
+      "commits": [
+        "228897171d71975988ccdc690f1982e7433952af",
+        "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
+        "847655d373a27b8b8d0c3a9747f04f16b5de1206",
+        "f9d57ad1c80944c43bec6fc74afe1bfac3956480"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-533.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-534.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/534"
     },
     {
       "id": "process-list-compose-top-process-list",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -6,11 +6,11 @@ This registry replaces the retired issue and pull-request handoff pairs.
 Current supporting records remain as ordinary Markdown files; every retired document
 links to an immutable Git snapshot.
 
-Last verified: 2026-09-05
+Last verified: 2026-09-07
 
-Entries: 422. Document snapshots: 736. Current supporting documents: 130.
+Entries: 423. Document snapshots: 738. Current supporting documents: 132.
 
-States: `active-draft` 27, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 28, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -252,6 +252,7 @@ States: `active-draft` 27, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [Remove undeclared gtimeout dependency from managed Sonar gates](https://github.com/stephenlclarke/container-compose/pull/447) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-446.md); [PR details](container-compose/PR-447.md) |
 | `stephenlclarke/container-compose` | [Pin synchronized Container fork for 0.14.1](https://github.com/stephenlclarke/container-compose/pull/449) | `active-draft` | `2647090a8af7` | [Issue details](container-compose/ISSUE-448.md); [PR details](container-compose/PR-449.md) |
 | `stephenlclarke/container-compose` | [Make the recoverable pipeline reliable and efficient](https://github.com/stephenlclarke/container-compose/pull/489) | `active-draft` | `bdfd9cef9139`, `03a387961ee9` | [Issue details](container-compose/ISSUE-488.md); [PR details](container-compose/PR-489.md) |
+| `stephenlclarke/container-compose` | [chore(release): refresh 0.14.3 upstream authority](https://github.com/stephenlclarke/container-compose/pull/534) | `active-draft` | `228897171d71`, `40ab92d74a02`, `847655d373a2`, `f9d57ad1c809` | [Issue details](container-compose/ISSUE-533.md); [PR details](container-compose/PR-534.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-533.md
+++ b/docs/upstream/container-compose/ISSUE-533.md
@@ -1,0 +1,24 @@
+# Issue 533: refresh 0.14.3 upstream alignment metadata
+
+## Problem
+
+The 0.14.3 stable-release preflight stopped before any build because the reviewed fork-classification authority still named the pre-`use_api_socket` Container head and the previous Apple Containerization head. The Container fork has since added its reviewed unattended Engine API dependency pin at `228897171d71975988ccdc690f1982e7433952af` and durable Engine socket grant at `40ab92d74a02bbd6b7436a50d47c38898a4bc294`. Apple Containerization added Pi agent support at `847655d373a27b8b8d0c3a9747f04f16b5de1206`, and the support fork synchronized that change unchanged at `f9d57ad1c80944c43bec6fc74afe1bfac3956480`.
+
+## Scope
+
+- Classify the two new patch-unique Container commits in their existing reviewed maintenance and generic-runtime slices.
+- Advance the exact Container and Containerization fork heads and Apple Containerization head.
+- Refresh the README snapshot and human classification summary from the authoritative fetched repositories.
+- Leave release-version prose, stack dependency pins, and generated release documents to the recoverable 0.14.3 release transaction because their focused consistency checks remain green at the current source checkpoint.
+
+## Acceptance evidence
+
+- `make fork-classifications-check` reports all 948 patch-unique non-merge commits classified exactly once.
+- `make upstream-divergence-release-check` reports all three support forks current with Apple and cleanly mergeable.
+- `make readme-upstream-metrics-check`, `make stack-consistency`, and `make upstream-handoff-registry-check` pass.
+- Focused Markdown, JSON, and diff checks pass.
+- Exact-head review has no unresolved findings and the required pull-request checks pass.
+
+Related lower work: Container [#208](https://github.com/stephenlclarke/container/pull/208) and [#213](https://github.com/stephenlclarke/container/pull/213), and Containerization [#77](https://github.com/stephenlclarke/containerization/pull/77).
+
+Implementation: [#534](https://github.com/stephenlclarke/container-compose/pull/534).

--- a/docs/upstream/container-compose/PR-534.md
+++ b/docs/upstream/container-compose/PR-534.md
@@ -1,0 +1,24 @@
+# Pull request 534: refresh 0.14.3 upstream alignment metadata
+
+## Change
+
+This pull request refreshes the exact upstream authority required by the recoverable 0.14.3 release transaction. It classifies Container's unattended Engine API dependency pin `228897171d71975988ccdc690f1982e7433952af` as support maintenance and its durable Engine socket grant `40ab92d74a02bbd6b7436a50d47c38898a4bc294` as a generic runtime primitive. It also advances Apple Containerization through `847655d373a27b8b8d0c3a9747f04f16b5de1206`, records the reviewed support-fork synchronization at `f9d57ad1c80944c43bec6fc74afe1bfac3956480`, and regenerates the visible divergence totals from fetched repository heads.
+
+## Scope boundary
+
+This is release-authority metadata only. It changes no Compose or runtime behavior and does not run or duplicate the stable release controller's dependency-pin, release-documentation, CodeQL, packaging, Homebrew, DocC, or released-artifact benchmark stages.
+
+## Validation
+
+- `make fork-classifications-check`
+- `make upstream-divergence-release-check`
+- `make readme-upstream-metrics-check`
+- `make stack-consistency`
+- `make upstream-handoff-registry-check`
+- focused Markdown and JSON validation
+- `git diff --check`
+- exact-head review and required hosted checks before merge
+
+Closes [#533](https://github.com/stephenlclarke/container-compose/issues/533).
+
+Related lower work: Container [#208](https://github.com/stephenlclarke/container/pull/208) and [#213](https://github.com/stephenlclarke/container/pull/213), and Containerization [#77](https://github.com/stephenlclarke/containerization/pull/77).


### PR DESCRIPTION
# Pull request 534: refresh 0.14.3 upstream alignment metadata

## Change

This pull request refreshes the exact upstream authority required by the recoverable 0.14.3 release transaction. It classifies Container's unattended Engine API dependency pin `228897171d71975988ccdc690f1982e7433952af` as support maintenance and its durable Engine socket grant `40ab92d74a02bbd6b7436a50d47c38898a4bc294` as a generic runtime primitive. It also advances Apple Containerization through `847655d373a27b8b8d0c3a9747f04f16b5de1206`, records the reviewed support-fork synchronization at `f9d57ad1c80944c43bec6fc74afe1bfac3956480`, and regenerates the visible divergence totals from fetched repository heads.

## Scope boundary

This is release-authority metadata only. It changes no Compose or runtime behavior and does not run or duplicate the stable release controller's dependency-pin, release-documentation, CodeQL, packaging, Homebrew, DocC, or released-artifact benchmark stages.

## Validation

- `make fork-classifications-check`
- `make upstream-divergence-release-check`
- `make readme-upstream-metrics-check`
- `make stack-consistency`
- `make upstream-handoff-registry-check`
- focused Markdown and JSON validation
- `git diff --check`
- exact-head review and required hosted checks before merge

Closes [#533](https://github.com/stephenlclarke/container-compose/issues/533).

Related lower work: Container [#208](https://github.com/stephenlclarke/container/pull/208) and [#213](https://github.com/stephenlclarke/container/pull/213), and Containerization [#77](https://github.com/stephenlclarke/containerization/pull/77).
