### PR TITLE
fix(release): refresh pristine retained transactions

### DIFF
--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -30,6 +30,7 @@ import subprocess
 import tempfile
 import urllib.error
 import urllib.request
+import uuid
 from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
@@ -43,6 +44,10 @@ BUILD_MARKER = ".container-compose-release-root.json"
 WORKSPACE_MARKER = ".container-compose-release-workspace.json"
 BUILD_LOCK = ".container-compose-release.lock"
 DEFAULT_GIT_TIMEOUT_SECONDS = 300
+MUTABLE_TAGS_BY_COMPONENT = {
+    "container": frozenset({"homebrew-main"}),
+    "container-compose": frozenset({"current"}),
+}
 
 
 @dataclass(frozen=True)
@@ -138,6 +143,127 @@ def resolve_remote(component: Component, remote_root: Path | None = None) -> str
     return str(remote_root / f"{component.name}.git")
 
 
+def parse_remote_semantic_tags(output: str) -> dict[str, str]:
+    component_tags: dict[str, str] = {}
+    for line in output.splitlines():
+        reference_sha, reference = line.split(maxsplit=1)
+        name = reference.removeprefix("refs/tags/")
+        if SEMVER.fullmatch(name):
+            component_tags[name] = reference_sha
+    return component_tags
+
+
+def remote_semantic_tags(url: str) -> dict[str, str]:
+    return parse_remote_semantic_tags(run_git("ls-remote", "--tags", url))
+
+
+def mutable_tags(component_name: str) -> frozenset[str]:
+    return MUTABLE_TAGS_BY_COMPONENT.get(component_name, frozenset())
+
+
+def remote_immutable_tag_refs(url: str, component_name: str) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    for line in run_git("ls-remote", "--tags", "--refs", url).splitlines():
+        reference_sha, reference = line.split(maxsplit=1)
+        name = reference.removeprefix("refs/tags/")
+        if name not in mutable_tags(component_name):
+            refs[name] = reference_sha
+    return refs
+
+
+def local_immutable_tag_refs(path: Path, component_name: str) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    lines = run_git(
+        "for-each-ref",
+        "--format=%(refname:strip=2) %(objectname)",
+        "refs/tags",
+        cwd=path,
+    ).splitlines()
+    for line in lines:
+        fields = line.split()
+        if len(fields) != 2 or not SHA.fullmatch(fields[1]):
+            raise WorkspaceError(f"could not inspect tags in {path}")
+        if fields[0] not in mutable_tags(component_name):
+            refs[fields[0]] = fields[1]
+    return refs
+
+
+def local_semantic_tag_targets(path: Path) -> dict[str, str]:
+    targets: dict[str, str] = {}
+    for name in run_git(
+        "tag", "--list", "[0-9]*.[0-9]*.[0-9]*", cwd=path
+    ).splitlines():
+        if not SEMVER.fullmatch(name):
+            continue
+        target = run_git("rev-parse", f"refs/tags/{name}", cwd=path).strip()
+        if not SHA.fullmatch(target):
+            raise WorkspaceError(f"could not inspect semantic tag {name} in {path}")
+        targets[name] = target
+    return targets
+
+
+def local_remote_tracking_refs(path: Path) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    lines = run_git(
+        "for-each-ref",
+        "--format=%(refname) %(objectname)",
+        "refs/remotes",
+        cwd=path,
+    ).splitlines()
+    for line in lines:
+        fields = line.split()
+        if (
+            len(fields) != 2
+            or not fields[0].startswith("refs/remotes/")
+            or not SHA.fullmatch(fields[1])
+        ):
+            raise WorkspaceError(f"could not inspect remote refs in {path}")
+        refs[fields[0]] = fields[1]
+    return refs
+
+
+def local_recovery_objects(path: Path) -> list[str]:
+    """Return objects protected by reflogs or Git recovery pseudorefs."""
+
+    objects = {
+        value
+        for value in run_git("reflog", "show", "--all", "--format=%H", cwd=path)
+        .splitlines()
+        if value
+    }
+    git_directory = Path(run_git("rev-parse", "--absolute-git-dir", cwd=path).strip())
+    fetch_head = git_directory / "FETCH_HEAD"
+    if fetch_head.is_symlink():
+        raise WorkspaceError(f"Git recovery state is unsafe in {path}")
+    if fetch_head.is_file():
+        for line in fetch_head.read_text(encoding="utf-8").splitlines():
+            fields = line.split(maxsplit=1)
+            if not fields or not SHA.fullmatch(fields[0]):
+                raise WorkspaceError(f"could not inspect Git recovery state in {path}")
+            objects.add(fields[0])
+    for name in ("AUTO_MERGE", "BISECT_HEAD", "MERGE_AUTOSTASH", "ORIG_HEAD"):
+        pseudoref = git_directory / name
+        if pseudoref.is_symlink():
+            raise WorkspaceError(f"Git recovery state is unsafe in {path}")
+        if not pseudoref.is_file():
+            continue
+        value = pseudoref.read_text(encoding="utf-8").strip()
+        if not SHA.fullmatch(value):
+            raise WorkspaceError(f"could not inspect Git recovery state in {path}")
+        objects.add(value)
+    return sorted(objects)
+
+
+def remote_reachable_objects(url: str) -> set[str]:
+    objects: set[str] = set()
+    for line in run_git("ls-remote", url).splitlines():
+        fields = line.split()
+        if len(fields) != 2 or not SHA.fullmatch(fields[0]):
+            raise WorkspaceError(f"could not inspect remote refs at {url}")
+        objects.add(fields[0])
+    return objects
+
+
 def remote_snapshot(
     remote_root: Path | None = None,
 ) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
@@ -150,19 +276,7 @@ def remote_snapshot(
         if len(main_lines) != 1 or not SHA.fullmatch(main_lines[0][0]):
             raise WorkspaceError(f"could not resolve {component.name} main")
 
-        tag_output = run_git("ls-remote", "--tags", url)
-        component_tags: dict[str, str] = {}
-        peeled: dict[str, str] = {}
-        for line in tag_output.splitlines():
-            reference_sha, reference = line.split(maxsplit=1)
-            name = reference.removeprefix("refs/tags/")
-            if name.endswith("^{}"):
-                peeled[name[:-3]] = reference_sha
-            elif SEMVER.fullmatch(name):
-                component_tags[name] = reference_sha
-        component_tags.update(
-            {name: value for name, value in peeled.items() if SEMVER.fullmatch(name)}
-        )
+        component_tags = remote_semantic_tags(url)
         return component.name, main_lines[0][0], component_tags
 
     main_refs: dict[str, str] = {}
@@ -327,6 +441,10 @@ def verify_workspace(root: Path, build_root: Path) -> dict[str, object]:
     version = marker.get("version")
     refs = marker.get("mainRefs")
     remotes = marker.get("remoteUrls")
+    immutable_tags = marker.get("immutableTagRefs")
+    remote_refs = marker.get("remoteTrackingRefs")
+    recovery_objects = marker.get("recoveryObjects")
+    semantic_tags = marker.get("semanticTagTargets")
     if not isinstance(version, str) or not SEMVER.fullmatch(version):
         raise WorkspaceError("release workspace version is invalid")
     if resolved.name != version:
@@ -335,6 +453,60 @@ def verify_workspace(root: Path, build_root: Path) -> dict[str, object]:
         raise WorkspaceError("release workspace refs are invalid")
     if not isinstance(remotes, dict):
         raise WorkspaceError("release workspace remotes are invalid")
+    if immutable_tags is not None:
+        if not isinstance(immutable_tags, dict) or set(immutable_tags) != {
+            component.name for component in COMPONENTS
+        }:
+            raise WorkspaceError("release workspace tag refs are invalid")
+        for component_name, component_tags in immutable_tags.items():
+            if not isinstance(component_tags, dict) or any(
+                not isinstance(name, str)
+                or not name
+                or name in mutable_tags(component_name)
+                or not isinstance(value, str)
+                or not SHA.fullmatch(value)
+                for name, value in component_tags.items()
+            ):
+                raise WorkspaceError("release workspace tag refs are invalid")
+    if remote_refs is not None:
+        if not isinstance(remote_refs, dict) or set(remote_refs) != {
+            component.name for component in COMPONENTS
+        }:
+            raise WorkspaceError("release workspace remote refs are invalid")
+        for component_refs in remote_refs.values():
+            if not isinstance(component_refs, dict) or any(
+                not isinstance(name, str)
+                or not name.startswith("refs/remotes/")
+                or not isinstance(value, str)
+                or not SHA.fullmatch(value)
+                for name, value in component_refs.items()
+            ):
+                raise WorkspaceError("release workspace remote refs are invalid")
+    if recovery_objects is not None:
+        if not isinstance(recovery_objects, dict) or set(recovery_objects) != {
+            component.name for component in COMPONENTS
+        }:
+            raise WorkspaceError("release workspace recovery objects are invalid")
+        for component_objects in recovery_objects.values():
+            if not isinstance(component_objects, list) or any(
+                not isinstance(value, str) or not SHA.fullmatch(value)
+                for value in component_objects
+            ) or component_objects != sorted(set(component_objects)):
+                raise WorkspaceError("release workspace recovery objects are invalid")
+    if semantic_tags is not None:
+        if not isinstance(semantic_tags, dict) or set(semantic_tags) != {
+            component.name for component in COMPONENTS
+        }:
+            raise WorkspaceError("release workspace semantic tags are invalid")
+        for component_tags in semantic_tags.values():
+            if not isinstance(component_tags, dict) or any(
+                not isinstance(name, str)
+                or not SEMVER.fullmatch(name)
+                or not isinstance(value, str)
+                or not SHA.fullmatch(value)
+                for name, value in component_tags.items()
+            ):
+                raise WorkspaceError("release workspace semantic tags are invalid")
 
     for component in COMPONENTS:
         path = resolved / component.name
@@ -425,6 +597,7 @@ def refresh_mutable_current_tag(root: Path) -> None:
         raise WorkspaceError("could not resolve container-compose current tag")
     run_git(
         "fetch",
+        "--no-write-fetch-head",
         "origin",
         "+refs/tags/current:refs/tags/current",
         cwd=compose,
@@ -432,6 +605,176 @@ def refresh_mutable_current_tag(root: Path) -> None:
     local_current = run_git("rev-parse", "refs/tags/current", cwd=compose).strip()
     if local_current != fields[0]:
         raise WorkspaceError("container-compose current tag changed while refreshing")
+
+
+def workspace_matches_initial_checkpoint(
+    root: Path,
+    marker: dict[str, object],
+) -> bool:
+    """Return whether a retained transaction is still safe to replace."""
+
+    refs = marker["mainRefs"]
+    remotes = marker["remoteUrls"]
+    recorded_tags = marker.get("immutableTagRefs")
+    recorded_remote_refs = marker.get("remoteTrackingRefs")
+    recorded_recovery_objects = marker.get("recoveryObjects")
+    assert isinstance(refs, dict)
+    assert isinstance(remotes, dict)
+    assert recorded_tags is None or isinstance(recorded_tags, dict)
+    assert recorded_remote_refs is None or isinstance(recorded_remote_refs, dict)
+    assert recorded_recovery_objects is None or isinstance(
+        recorded_recovery_objects, dict
+    )
+    for component in COMPONENTS:
+        path = root / component.name
+        expected = refs[component.name]
+        if run_git("branch", "--show-current", cwd=path).strip() != "main":
+            return False
+        if run_git("rev-parse", "HEAD", cwd=path).strip() != expected:
+            return False
+        worktrees = run_git(
+            "worktree", "list", "--porcelain", "-z", cwd=path
+        ).split("\0")
+        if sum(field.startswith("worktree ") for field in worktrees) != 1:
+            return False
+        index_entries = run_git("ls-files", "-v", cwd=path).splitlines()
+        if any(
+            entry.startswith("S ") or (entry and entry[0].islower())
+            for entry in index_entries
+        ):
+            return False
+        local_remote_refs = local_remote_tracking_refs(path)
+        if recorded_remote_refs is not None:
+            initial_remote_refs = recorded_remote_refs[component.name]
+            assert isinstance(initial_remote_refs, dict)
+            if local_remote_refs != initial_remote_refs:
+                return False
+        else:
+            recoverable = remote_reachable_objects(str(remotes[component.name]))
+            recoverable.add(str(expected))
+            if any(value not in recoverable for value in local_remote_refs.values()):
+                return False
+        recovery_objects = set(local_recovery_objects(path))
+        if recorded_recovery_objects is not None:
+            initial_recovery_objects = recorded_recovery_objects[component.name]
+            assert isinstance(initial_recovery_objects, list)
+            new_recovery_objects = recovery_objects - set(initial_recovery_objects)
+        else:
+            new_recovery_objects = recovery_objects
+        if new_recovery_objects:
+            recoverable = remote_reachable_objects(str(remotes[component.name]))
+            recoverable.add(str(expected))
+            if new_recovery_objects - recoverable:
+                return False
+        repository_refs = run_git(
+            "for-each-ref", "--format=%(refname)", cwd=path
+        ).splitlines()
+        if any(
+            ref != "refs/heads/main"
+            and not ref.startswith("refs/remotes/")
+            and not ref.startswith("refs/tags/")
+            for ref in repository_refs
+        ):
+            return False
+        local_tags = local_immutable_tag_refs(path, component.name)
+        if recorded_tags is not None:
+            initial_tags = recorded_tags[component.name]
+            assert isinstance(initial_tags, dict)
+            if local_tags != initial_tags:
+                return False
+        else:
+            remote_tags = remote_immutable_tag_refs(
+                str(remotes[component.name]), component.name
+            )
+            if any(
+                remote_tags.get(name) != value for name, value in local_tags.items()
+            ):
+                return False
+        git_state_paths = (
+            "BISECT_START",
+            "CHERRY_PICK_HEAD",
+            "MERGE_HEAD",
+            "REVERT_HEAD",
+            "rebase-apply",
+            "rebase-merge",
+            "sequencer",
+        )
+        git_directory = Path(
+            run_git("rev-parse", "--absolute-git-dir", cwd=path).strip()
+        )
+        if any(
+            (git_directory / state_name).exists()
+            or (git_directory / state_name).is_symlink()
+            for state_name in git_state_paths
+        ):
+            return False
+        release_evidence = path / ".build" / "release-evidence"
+        if release_evidence.exists() or release_evidence.is_symlink():
+            return False
+        if run_git(
+            "status",
+            "--porcelain=v1",
+            "--untracked-files=all",
+            cwd=path,
+        ).strip():
+            return False
+    return True
+
+
+def workspace_semantic_tag_targets(
+    root: Path, marker: dict[str, object]
+) -> dict[str, dict[str, str]]:
+    recorded = marker.get("semanticTagTargets")
+    if recorded is not None:
+        assert isinstance(recorded, dict)
+        return recorded
+    return {
+        component.name: local_semantic_tag_targets(root / component.name)
+        for component in COMPONENTS
+    }
+
+
+def workspace_baseline_state(root: Path) -> dict[str, object]:
+    """Capture the local Git state recorded by a fresh checkpoint."""
+
+    return {
+        "immutableTagRefs": {
+            component.name: local_immutable_tag_refs(
+                root / component.name, component.name
+            )
+            for component in COMPONENTS
+        },
+        "remoteTrackingRefs": {
+            component.name: local_remote_tracking_refs(root / component.name)
+            for component in COMPONENTS
+        },
+        "recoveryObjects": {
+            component.name: local_recovery_objects(root / component.name)
+            for component in COMPONENTS
+        },
+    }
+
+
+def update_workspace_tag_state(
+    root: Path,
+    marker: dict[str, object],
+    semantic_tags: dict[str, dict[str, str]],
+    baseline: dict[str, object] | None = None,
+) -> None:
+    marker.update(baseline if baseline is not None else workspace_baseline_state(root))
+    marker["semanticTagTargets"] = semantic_tags
+    atomic_json(root / WORKSPACE_MARKER, marker)
+
+
+def selected_version(
+    selector: str,
+    refs: dict[str, str],
+    tags: dict[str, dict[str, str]],
+    remote_root: Path | None,
+) -> str:
+    latest = latest_tag(tags["container-compose"])
+    base = latest or compose_version(refs["container-compose"], remote_root)
+    return resolve_selector(selector, base)
 
 
 def configure_remotes(path: Path, component: Component) -> None:
@@ -524,6 +867,240 @@ def cleanup_incomplete_stages(build_root: Path) -> None:
             fsync_directory(build_root)
 
 
+def cleanup_orphaned_ready_stages(build_root: Path) -> None:
+    """Remove completed clone stages that were never journaled for handover."""
+
+    referenced: set[str] = set()
+    for item in build_root.iterdir():
+        if not item.is_dir() or item.is_symlink():
+            continue
+        marker_path = item / WORKSPACE_MARKER
+        if not marker_path.is_file() or marker_path.is_symlink():
+            continue
+        replacement = read_json(marker_path).get("replacement")
+        stage = replacement.get("stage") if isinstance(replacement, dict) else None
+        if isinstance(stage, str):
+            referenced.add(stage)
+
+    for item in build_root.iterdir():
+        if (
+            not item.name.startswith(".")
+            or ".replaced." in item.name
+            or item.name in referenced
+            or not item.is_dir()
+            or item.is_symlink()
+        ):
+            continue
+        marker_path = item / WORKSPACE_MARKER
+        if not marker_path.is_file() or marker_path.is_symlink():
+            continue
+        marker = read_json(marker_path)
+        version = marker.get("version")
+        if (
+            marker.get("owner") == "container-compose"
+            and marker.get("schemaVersion") == 1
+            and marker.get("state") == "ready"
+            and isinstance(version, str)
+            and SEMVER.fullmatch(version)
+            and item.name.startswith(f".{version}.")
+        ):
+            shutil.rmtree(item)
+            fsync_directory(build_root)
+
+
+def replacement_path(build_root: Path, value: object, label: str) -> Path:
+    if not isinstance(value, str) or Path(value).name != value or value in {".", ".."}:
+        raise WorkspaceError(f"release replacement {label} is invalid")
+    return build_root / value
+
+
+def remove_replacement_stage(stage: Path | None, version: str) -> None:
+    if stage is None:
+        return
+    if not stage.exists():
+        return
+    if stage.is_symlink() or not stage.is_dir():
+        raise WorkspaceError(f"release replacement stage is unsafe: {stage}")
+    marker = workspace_marker(stage)
+    if marker.get("state") not in {"cloning", "ready"} or marker.get("version") != version:
+        raise WorkspaceError(f"release replacement stage marker is invalid: {stage}")
+    shutil.rmtree(stage)
+
+
+def retired_workspace_path(build_root: Path, version: object) -> Path:
+    """Choose a durable, process-independent name for a retired checkpoint."""
+
+    if not isinstance(version, str) or not SEMVER.fullmatch(version):
+        raise WorkspaceError(f"release workspace version is invalid: {version}")
+    return build_root / f".{version}.replaced.{uuid.uuid4().hex}"
+
+
+def retire_workspace(
+    source: Path,
+    backup: Path,
+    marker: dict[str, object],
+    build_root: Path,
+) -> Path:
+    """Atomically hide and revalidate a checkpoint before retiring it."""
+
+    if backup.exists():
+        raise WorkspaceError(f"release workspace backup already exists: {backup}")
+    os.replace(source, backup)
+    fsync_directory(build_root)
+    if workspace_matches_initial_checkpoint(backup, marker):
+        return backup
+    if source.exists():
+        raise WorkspaceError(
+            f"release workspace changed while being retired; preserved at {backup}"
+        )
+    os.replace(backup, source)
+    fsync_directory(build_root)
+    restored = marker.copy()
+    restored.pop("replacement", None)
+    atomic_json(source / WORKSPACE_MARKER, restored)
+    raise WorkspaceError(f"release workspace changed while being retired: {source}")
+
+
+def finalize_retired_workspace(path: Path, build_root: Path) -> None:
+    """Retain a superseded checkpoint without leaving an active handover journal."""
+
+    marker = workspace_marker(path)
+    marker.pop("replacement", None)
+    marker["state"] = "retired"
+    atomic_json(path / WORKSPACE_MARKER, marker)
+    fsync_directory(build_root)
+
+
+def recover_interrupted_replacements(build_root: Path) -> None:
+    """Finish or roll back marker-journaled checkpoint handovers."""
+
+    for item in list(build_root.iterdir()):
+        if not item.is_dir() or item.is_symlink():
+            continue
+        marker_path = item / WORKSPACE_MARKER
+        if not marker_path.is_file() or marker_path.is_symlink():
+            continue
+        marker = read_json(marker_path)
+        replacement = marker.get("replacement")
+        if replacement is None:
+            continue
+        if (
+            marker.get("owner") != "container-compose"
+            or marker.get("schemaVersion") != 1
+            or marker.get("state") != "ready"
+            or not isinstance(replacement, dict)
+        ):
+            raise WorkspaceError(f"release replacement marker is invalid: {item}")
+        version = replacement.get("version")
+        selector = replacement.get("selector")
+        refs = replacement.get("mainRefs")
+        semantic_tags = replacement.get("semanticTagTargets")
+        if (
+            not isinstance(version, str)
+            or not SEMVER.fullmatch(version)
+            or not isinstance(selector, str)
+            or not isinstance(refs, dict)
+            or set(refs) != {component.name for component in COMPONENTS}
+            or any(
+                not isinstance(value, str) or not SHA.fullmatch(value)
+                for value in refs.values()
+            )
+            or not isinstance(semantic_tags, dict)
+            or set(semantic_tags) != {component.name for component in COMPONENTS}
+            or any(
+                not isinstance(component_tags, dict)
+                or any(
+                    not isinstance(name, str)
+                    or not SEMVER.fullmatch(name)
+                    or not isinstance(value, str)
+                    or not SHA.fullmatch(value)
+                    for name, value in component_tags.items()
+                )
+                for component_tags in semantic_tags.values()
+            )
+        ):
+            raise WorkspaceError(f"release replacement record is invalid: {item}")
+        destination = replacement_path(
+            build_root, replacement.get("destination"), "destination"
+        )
+        source_value = replacement.get("source", marker.get("version"))
+        source = replacement_path(build_root, source_value, "source")
+        stage_value = replacement.get("stage")
+        stage = (
+            replacement_path(build_root, stage_value, "stage")
+            if stage_value is not None
+            else None
+        )
+        if (
+            destination.name != version
+            or source.name != marker.get("version")
+            or (
+                stage is not None
+                and not stage.name.startswith(f".{version}.")
+            )
+        ):
+            raise WorkspaceError(f"release replacement paths are inconsistent: {item}")
+        ensure_workspace_is_idle(marker)
+
+        installed = False
+        if destination.exists() and destination != item:
+            destination_marker = verify_workspace(destination, build_root)
+            ensure_workspace_is_idle(destination_marker)
+            destination_matches = (
+                destination_marker.get("version") == version
+                and destination_marker.get("mainRefs") == refs
+                and destination_marker.get("semanticTagTargets") == semantic_tags
+            )
+            if destination_matches:
+                installed = True
+
+        if installed:
+            if not item.name.startswith("."):
+                if item != source:
+                    raise WorkspaceError(
+                        f"release replacement source path is inconsistent: {item}"
+                    )
+                if not workspace_matches_initial_checkpoint(item, marker):
+                    if destination_marker.get("selector") != version:
+                        destination_marker["selector"] = version
+                        atomic_json(
+                            destination / WORKSPACE_MARKER, destination_marker
+                        )
+                    restored = marker.copy()
+                    restored.pop("replacement")
+                    atomic_json(item / WORKSPACE_MARKER, restored)
+                    remove_replacement_stage(stage, version)
+                    fsync_directory(build_root)
+                    continue
+                backup = retired_workspace_path(build_root, marker["version"])
+                item = retire_workspace(item, backup, marker, build_root)
+            if destination_marker.get("selector") != selector:
+                destination_marker["selector"] = selector
+                atomic_json(destination / WORKSPACE_MARKER, destination_marker)
+            finalize_retired_workspace(item, build_root)
+            remove_replacement_stage(stage, version)
+            fsync_directory(build_root)
+            continue
+
+        if item.name.startswith("."):
+            if source.exists():
+                raise WorkspaceError(
+                    f"release replacement rollback source exists: {source}"
+                )
+            os.replace(item, source)
+            fsync_directory(build_root)
+            item = source
+        elif item != source:
+            raise WorkspaceError(
+                f"release replacement source path is inconsistent: {item}"
+            )
+        restored = marker.copy()
+        restored.pop("replacement")
+        atomic_json(item / WORKSPACE_MARKER, restored)
+        remove_replacement_stage(stage, version)
+        fsync_directory(build_root)
+
+
 def process_is_alive(pid: int) -> bool:
     if pid < 1:
         return False
@@ -542,23 +1119,130 @@ def _materialize_locked(
     remote_root: Path | None = None,
 ) -> Path:
     cleanup_incomplete_stages(safe_root)
+    recover_interrupted_replacements(safe_root)
+    cleanup_orphaned_ready_stages(safe_root)
+    snapshot: tuple[dict[str, str], dict[str, dict[str, str]]] | None = None
+    stale_retained: Path | None = None
     retained = retained_workspace(safe_root, selector)
     if retained is not None:
         marker = verify_workspace(retained, safe_root)
         ensure_workspace_is_idle(marker)
-        refresh_mutable_current_tag(retained)
-        return retained
+        retained_needs_baseline = any(
+            marker.get(field) is None
+            for field in (
+                "immutableTagRefs",
+                "recoveryObjects",
+                "remoteTrackingRefs",
+                "semanticTagTargets",
+            )
+        )
+        retained_baseline = (
+            workspace_baseline_state(retained) if retained_needs_baseline else None
+        )
+        if workspace_matches_initial_checkpoint(retained, marker):
+            snapshot = remote_snapshot(remote_root)
+            refs, tags = snapshot
+            if (
+                refs != marker["mainRefs"]
+                or workspace_semantic_tag_targets(retained, marker) != tags
+                or selected_version(selector, refs, tags, remote_root)
+                != marker["version"]
+            ):
+                stale_retained = retained
+            else:
+                refresh_mutable_current_tag(retained)
+                if retained_baseline is not None and (
+                    workspace_baseline_state(retained) == retained_baseline
+                    and workspace_matches_initial_checkpoint(retained, marker)
+                ):
+                    update_workspace_tag_state(
+                        retained, marker, tags, retained_baseline
+                    )
+                return retained
+        else:
+            refresh_mutable_current_tag(retained)
+            return retained
 
-    refs, tags = remote_snapshot(remote_root)
-    latest = latest_tag(tags["container-compose"])
-    base = latest or compose_version(refs["container-compose"], remote_root)
-    version = resolve_selector(selector, base)
+    if snapshot is None:
+        snapshot = remote_snapshot(remote_root)
+    refs, tags = snapshot
+    version = selected_version(selector, refs, tags, remote_root)
     destination = safe_root / version
+    stale_destination: Path | None = None
     if destination.exists():
         marker = verify_workspace(destination, safe_root)
         ensure_workspace_is_idle(marker)
-        refresh_mutable_current_tag(destination)
-        return destination
+        destination_needs_baseline = any(
+            marker.get(field) is None
+            for field in (
+                "immutableTagRefs",
+                "recoveryObjects",
+                "remoteTrackingRefs",
+                "semanticTagTargets",
+            )
+        )
+        destination_baseline = (
+            workspace_baseline_state(destination)
+            if destination_needs_baseline
+            else None
+        )
+        destination_matches_initial = workspace_matches_initial_checkpoint(
+            destination, marker
+        )
+        if (
+            destination_matches_initial
+            and (
+                marker["mainRefs"] != refs
+                or marker["version"] != version
+                or workspace_semantic_tag_targets(destination, marker) != tags
+            )
+        ):
+            stale_destination = destination
+        elif destination != stale_retained:
+            refresh_mutable_current_tag(destination)
+            destination_tags = workspace_semantic_tag_targets(destination, marker)
+            retired: Path | None = None
+            if stale_retained is not None:
+                stale_marker = verify_workspace(stale_retained, safe_root)
+                ensure_workspace_is_idle(stale_marker)
+                if not workspace_matches_initial_checkpoint(
+                    stale_retained, stale_marker
+                ):
+                    raise WorkspaceError(
+                        "release workspace changed before destination reuse"
+                    )
+                backup = retired_workspace_path(safe_root, stale_retained.name)
+                replacement = {
+                    "destination": destination.name,
+                    "mainRefs": marker["mainRefs"],
+                    "selector": selector,
+                    "semanticTagTargets": destination_tags,
+                    "source": stale_retained.name,
+                    "stage": None,
+                    "version": marker["version"],
+                }
+                stale_marker["replacement"] = replacement
+                atomic_json(stale_retained / WORKSPACE_MARKER, stale_marker)
+                retired = retire_workspace(
+                    stale_retained, backup, stale_marker, safe_root
+                )
+            marker = workspace_marker(destination)
+            marker["selector"] = selector
+            if (
+                destination_baseline is not None
+                and workspace_baseline_state(destination) == destination_baseline
+                and workspace_matches_initial_checkpoint(destination, marker)
+            ):
+                update_workspace_tag_state(
+                    destination, marker, tags, destination_baseline
+                )
+            else:
+                atomic_json(destination / WORKSPACE_MARKER, marker)
+            if retired is not None:
+                finalize_retired_workspace(retired, safe_root)
+            return destination
+        else:
+            stale_destination = destination
 
     stage = Path(tempfile.mkdtemp(prefix=f".{version}.", dir=safe_root))
     try:
@@ -572,6 +1256,7 @@ def _materialize_locked(
             "remoteUrls": remote_urls,
             "schemaVersion": 1,
             "selector": selector,
+            "semanticTagTargets": tags,
             "stageHost": socket.gethostname(),
             "stagePid": os.getpid(),
             "state": "cloning",
@@ -579,16 +1264,61 @@ def _materialize_locked(
         }
         atomic_json(stage / WORKSPACE_MARKER, marker)
         clone_workspace(stage, refs, remote_root)
+        marker.update(workspace_baseline_state(stage))
         fresh_refs, fresh_tags = remote_snapshot(remote_root)
         if fresh_refs != refs or fresh_tags != tags:
             raise WorkspaceError(
                 "a component main or semantic tag moved while the workspace was cloned"
             )
+        stale_workspaces: list[Path] = []
+        for path in (stale_destination, stale_retained):
+            if path is not None and path not in stale_workspaces:
+                stale_workspaces.append(path)
+        for stale in stale_workspaces:
+            stale_marker = verify_workspace(stale, safe_root)
+            ensure_workspace_is_idle(stale_marker)
+            if not workspace_matches_initial_checkpoint(stale, stale_marker):
+                raise WorkspaceError(
+                    f"release workspace changed while its replacement was cloned: {stale}"
+                )
         marker["state"] = "ready"
         marker.pop("stageHost")
         marker.pop("stagePid")
         atomic_json(stage / WORKSPACE_MARKER, marker)
-        os.replace(stage, destination)
+        replacement = {
+            "destination": destination.name,
+            "mainRefs": refs,
+            "selector": selector,
+            "semanticTagTargets": tags,
+            "stage": stage.name,
+            "version": version,
+        }
+        for stale in stale_workspaces:
+            stale_marker = workspace_marker(stale)
+            stale_replacement = replacement.copy()
+            stale_replacement["source"] = stale.name
+            stale_marker["replacement"] = stale_replacement
+            atomic_json(stale / WORKSPACE_MARKER, stale_marker)
+        retired_workspaces: list[Path] = []
+        try:
+            for stale in stale_workspaces:
+                backup_path = retired_workspace_path(safe_root, stale.name)
+                stale_marker = workspace_marker(stale)
+                retired_workspaces.append(
+                    retire_workspace(
+                        stale,
+                        backup_path,
+                        stale_marker,
+                        safe_root,
+                    )
+                )
+            os.replace(stage, destination)
+            fsync_directory(safe_root)
+        except BaseException:
+            recover_interrupted_replacements(safe_root)
+            raise
+        for retired in retired_workspaces:
+            finalize_retired_workspace(retired, safe_root)
         fsync_directory(safe_root)
     except BaseException:
         shutil.rmtree(stage, ignore_errors=True)

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -79,6 +79,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             (source / "Makefile").write_text(
                 "COMPOSE_VERSION ?= 0.14.2\n", encoding="utf-8"
             )
+            (source / ".gitignore").write_text(".build/\n", encoding="utf-8")
         self.git("add", ".", cwd=source)
         self.git("commit", "-m", "initial", cwd=source)
         self.git("tag", "0.14.2", cwd=source)
@@ -133,6 +134,16 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         self.git("commit", "-m", "release candidate", cwd=compose)
         candidate = self.git("rev-parse", "HEAD", cwd=compose).strip()
         (compose / "retained.log").write_text("interrupted\n", encoding="utf-8")
+        source = self.root / "sources" / "container-compose"
+        (source / "README.md").write_text("# newer main\n", encoding="utf-8")
+        self.git("add", "README.md", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
 
         resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
 
@@ -142,6 +153,1417 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             (compose / "retained.log").read_text(encoding="utf-8"),
             "interrupted\n",
         )
+
+    def test_resume_preserves_stashed_release_work_when_main_moves(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        stashed = compose / "operator-work.txt"
+        stashed.write_text("preserve me\n", encoding="utf-8")
+        self.git(
+            "stash",
+            "push",
+            "--include-untracked",
+            "--message",
+            "operator work",
+            cwd=compose,
+        )
+        stash = self.git("rev-parse", "refs/stash", cwd=compose).strip()
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(self.git("rev-parse", "refs/stash", cwd=compose).strip(), stash)
+        self.assertIn(
+            "operator-work.txt",
+            self.git(
+                "stash",
+                "show",
+                "--include-untracked",
+                "--name-only",
+                cwd=compose,
+            ),
+        )
+
+    def test_resume_preserves_an_unpushed_release_tag_when_main_moves(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        self.git(
+            "tag",
+            "--annotate",
+            "--message",
+            f"Release {release_root.name}",
+            release_root.name,
+            cwd=compose,
+        )
+        tag = self.git(
+            "rev-parse", f"refs/tags/{release_root.name}", cwd=compose
+        ).strip()
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git(
+                "rev-parse", f"refs/tags/{release_root.name}", cwd=compose
+            ).strip(),
+            tag,
+        )
+
+    def test_resume_preserves_an_unpushed_authority_tag_when_main_moves(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        authority_tag = f"stable-init-image-authority/{release_root.name}"
+        self.git(
+            "tag",
+            "--annotate",
+            "--message",
+            f"Authority {release_root.name}",
+            authority_tag,
+            cwd=compose,
+        )
+        tag = self.git("rev-parse", f"refs/tags/{authority_tag}", cwd=compose).strip()
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("rev-parse", f"refs/tags/{authority_tag}", cwd=compose).strip(),
+            tag,
+        )
+
+    def test_mutable_tag_names_are_scoped_to_their_owning_repositories(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        containerization = release_root / "containerization"
+        self.git("tag", "homebrew-main", cwd=compose)
+        self.git(
+            "tag",
+            "--force",
+            "--annotate",
+            "--message",
+            "local current",
+            "current",
+            cwd=containerization,
+        )
+        compose_tag = self.git("rev-parse", "refs/tags/homebrew-main", cwd=compose)
+        containerization_tag = self.git(
+            "rev-parse", "refs/tags/current", cwd=containerization
+        )
+        source = self.root / "sources" / "container-builder-shim"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-builder-shim.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("rev-parse", "refs/tags/homebrew-main", cwd=compose),
+            compose_tag,
+        )
+        self.assertEqual(
+            self.git("rev-parse", "refs/tags/current", cwd=containerization),
+            containerization_tag,
+        )
+
+    def test_resume_replaces_a_pristine_checkpoint_when_main_moves(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        original = checkpoint["mainRefs"]
+        checkpoint.pop("immutableTagRefs")
+        checkpoint.pop("remoteTrackingRefs")
+        checkpoint.pop("recoveryObjects")
+        checkpoint.pop("semanticTagTargets")
+        WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        current = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        marker = WORKSPACE.workspace_marker(resumed)
+        self.assertEqual(resumed, release_root)
+        self.assertNotEqual(marker["mainRefs"], original)
+        self.assertEqual(marker["mainRefs"]["containerization"], current)
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=resumed / "containerization").strip(),
+            current,
+        )
+        self.assertTrue((resumed / "containerization" / "new-runtime.txt").is_file())
+
+    def test_legacy_baseline_upgrade_does_not_capture_concurrent_state(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        for field in (
+            "immutableTagRefs",
+            "recoveryObjects",
+            "remoteTrackingRefs",
+            "semanticTagTargets",
+        ):
+            checkpoint.pop(field)
+        WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
+        refresh = WORKSPACE.refresh_mutable_current_tag
+
+        def add_operator_tag(root: Path) -> None:
+            refresh(root)
+            self.git("tag", "operator-after-check", cwd=root / "container-compose")
+
+        with mock.patch.object(
+            WORKSPACE,
+            "refresh_mutable_current_tag",
+            side_effect=add_operator_tag,
+        ):
+            resumed = WORKSPACE.materialize(
+                self.build_root, "-+-", self.remote_root
+            )
+
+        self.assertEqual(resumed, release_root)
+        marker = WORKSPACE.workspace_marker(resumed)
+        self.assertNotIn("immutableTagRefs", marker)
+        self.assertNotIn("recoveryObjects", marker)
+        self.assertNotIn("remoteTrackingRefs", marker)
+        self.assertNotIn("semanticTagTargets", marker)
+        self.assertEqual(
+            self.git(
+                "rev-parse",
+                "refs/tags/operator-after-check",
+                cwd=resumed / "container-compose",
+            ).strip(),
+            self.git("rev-parse", "HEAD", cwd=resumed / "container-compose").strip(),
+        )
+
+    def test_failed_replacement_clone_preserves_the_pristine_checkpoint(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        original = WORKSPACE.workspace_marker(release_root)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        with mock.patch.object(
+            WORKSPACE,
+            "clone_workspace",
+            side_effect=WORKSPACE.WorkspaceError("replacement clone failed"),
+        ):
+            with self.assertRaisesRegex(
+                WORKSPACE.WorkspaceError, "replacement clone failed"
+            ):
+                WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertTrue(release_root.is_dir())
+        self.assertEqual(WORKSPACE.workspace_marker(release_root), original)
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=release_root / "containerization").strip(),
+            original["mainRefs"]["containerization"],
+        )
+
+    def test_resume_removes_an_unjournaled_ready_clone_stage(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        orphan = self.build_root / f".{release_root.name}.orphan"
+        shutil.copytree(release_root, orphan)
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertFalse(orphan.exists())
+
+    def test_replacement_rejects_checkpoint_changes_during_clone(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        clone_workspace = WORKSPACE.clone_workspace
+
+        def clone_then_change_checkpoint(
+            stage: Path,
+            refs: dict[str, str],
+            remote_root: Path | None,
+        ) -> None:
+            clone_workspace(stage, refs, remote_root)
+            self.git(
+                "switch",
+                "-c",
+                "release/operator-change",
+                cwd=release_root / "container-compose",
+            )
+
+        with mock.patch.object(
+            WORKSPACE,
+            "clone_workspace",
+            side_effect=clone_then_change_checkpoint,
+        ):
+            with self.assertRaisesRegex(
+                WORKSPACE.WorkspaceError,
+                "changed while its replacement was cloned",
+            ):
+                WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertTrue(release_root.is_dir())
+        self.assertEqual(
+            self.git(
+                "branch",
+                "--show-current",
+                cwd=release_root / "container-compose",
+            ).strip(),
+            "release/operator-change",
+        )
+
+    def test_failed_replacement_install_restores_the_previous_checkpoint(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        original = WORKSPACE.workspace_marker(release_root)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        replace = WORKSPACE.os.replace
+        failed = False
+
+        def fail_replacement_install(source: Path, destination: Path) -> None:
+            nonlocal failed
+            source_path = Path(source)
+            destination_path = Path(destination)
+            if (
+                not failed
+                and destination_path == release_root
+                and source_path.is_dir()
+                and ".replaced." not in source_path.name
+            ):
+                failed = True
+                raise OSError("replacement install failed")
+            replace(source, destination)
+
+        with mock.patch.object(
+            WORKSPACE.os,
+            "replace",
+            side_effect=fail_replacement_install,
+        ):
+            with self.assertRaisesRegex(OSError, "replacement install failed"):
+                WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertTrue(failed)
+        self.assertTrue(release_root.is_dir())
+        self.assertEqual(WORKSPACE.workspace_marker(release_root), original)
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=release_root / "containerization").strip(),
+            original["mainRefs"]["containerization"],
+        )
+
+    def test_interrupted_same_version_swap_restores_the_previous_checkpoint(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        original = WORKSPACE.workspace_marker(release_root)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        replace = WORKSPACE.os.replace
+        recover = WORKSPACE.recover_interrupted_replacements
+        recovery_calls = 0
+
+        class SimulatedProcessExit(BaseException):
+            pass
+
+        def stop_after_backup(source: Path, destination: Path) -> None:
+            source_path = Path(source)
+            destination_path = Path(destination)
+            if (
+                destination_path == release_root
+                and source_path.is_dir()
+                and ".replaced." not in source_path.name
+            ):
+                raise SimulatedProcessExit()
+            replace(source, destination)
+
+        def stop_recovery(build_root: Path) -> None:
+            nonlocal recovery_calls
+            recovery_calls += 1
+            if recovery_calls == 1:
+                recover(build_root)
+                return
+            raise SimulatedProcessExit()
+
+        with mock.patch.object(WORKSPACE.os, "replace", side_effect=stop_after_backup):
+            with mock.patch.object(
+                WORKSPACE,
+                "recover_interrupted_replacements",
+                side_effect=stop_recovery,
+            ):
+                with self.assertRaises(SimulatedProcessExit):
+                    WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertFalse(release_root.exists())
+        backup = next(self.build_root.glob(f".{release_root.name}.replaced.*"))
+        self.assertIn("replacement", WORKSPACE.workspace_marker(backup))
+
+        atomic_json = WORKSPACE.atomic_json
+        interrupted = False
+
+        def stop_before_journal_cleanup(
+            path: Path, value: dict[str, object]
+        ) -> None:
+            nonlocal interrupted
+            if (
+                not interrupted
+                and "replacement" not in value
+            ):
+                interrupted = True
+                raise SimulatedProcessExit()
+            atomic_json(path, value)
+
+        with mock.patch.object(
+            WORKSPACE,
+            "atomic_json",
+            side_effect=stop_before_journal_cleanup,
+        ):
+            with self.assertRaises(SimulatedProcessExit):
+                WORKSPACE.recover_interrupted_replacements(self.build_root)
+
+        self.assertTrue(interrupted)
+        self.assertTrue(release_root.is_dir())
+        self.assertFalse(backup.exists())
+        self.assertIn("replacement", WORKSPACE.workspace_marker(release_root))
+
+        WORKSPACE.recover_interrupted_replacements(self.build_root)
+
+        self.assertEqual(WORKSPACE.workspace_marker(release_root), original)
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertNotEqual(WORKSPACE.workspace_marker(resumed), original)
+
+    def test_resume_replaces_ignored_preflight_artifacts_when_main_moves(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        artifact = compose / ".build" / "release-product"
+        artifact.parent.mkdir()
+        artifact.write_text("preserve me\n", encoding="utf-8")
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertFalse(artifact.exists())
+        marker = WORKSPACE.workspace_marker(resumed)
+        self.assertEqual(
+            marker["mainRefs"]["containerization"],
+            self.git("rev-parse", "HEAD", cwd=source).strip(),
+        )
+
+    def test_resume_preserves_ignored_release_evidence_when_main_moves(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        evidence = compose / ".build" / "release-evidence" / "authority.json"
+        evidence.parent.mkdir(parents=True)
+        evidence.write_text('{"status":"passed"}\n', encoding="utf-8")
+        original = WORKSPACE.workspace_marker(release_root)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(evidence.read_text(encoding="utf-8"), '{"status":"passed"}\n')
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["mainRefs"], original["mainRefs"]
+        )
+
+    def test_resume_preserves_changed_branch_state_when_main_moves(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        self.git("switch", "-c", "release/recovery", cwd=compose)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("branch", "--show-current", cwd=compose).strip(),
+            "release/recovery",
+        )
+        marker = WORKSPACE.workspace_marker(resumed)
+        self.assertNotEqual(
+            marker["mainRefs"]["containerization"],
+            self.git("rev-parse", "HEAD", cwd=source).strip(),
+        )
+
+    def test_resume_preserves_a_detached_linked_worktree_when_main_moves(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        linked = self.root / "linked-compose"
+        self.git("worktree", "add", "--detach", str(linked), "HEAD", cwd=compose)
+        (linked / "operator-work.txt").write_text("operator work\n", encoding="utf-8")
+        self.git("add", "operator-work.txt", cwd=linked)
+        self.git("commit", "-m", "operator work", cwd=linked)
+        operator_commit = self.git("rev-parse", "HEAD", cwd=linked).strip()
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(self.git("rev-parse", "HEAD", cwd=linked).strip(), operator_commit)
+        self.assertEqual(
+            (linked / "operator-work.txt").read_text(encoding="utf-8"),
+            "operator work\n",
+        )
+
+    def test_resume_preserves_edits_hidden_by_index_flags_when_main_moves(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        container = release_root / "container"
+        self.git("update-index", "--skip-worktree", "README.md", cwd=compose)
+        self.git("update-index", "--assume-unchanged", "README.md", cwd=container)
+        (compose / "README.md").write_text("skip worktree edit\n", encoding="utf-8")
+        (container / "README.md").write_text("assumed edit\n", encoding="utf-8")
+        self.assertEqual(self.git("status", "--porcelain=v1", cwd=compose), "")
+        self.assertEqual(self.git("status", "--porcelain=v1", cwd=container), "")
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            (compose / "README.md").read_text(encoding="utf-8"),
+            "skip worktree edit\n",
+        )
+        self.assertEqual(
+            (container / "README.md").read_text(encoding="utf-8"),
+            "assumed edit\n",
+        )
+
+    def test_resume_preserves_a_commit_reachable_only_from_recovery_state(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        initial = self.git("rev-parse", "HEAD", cwd=compose).strip()
+        (compose / "operator-work.txt").write_text("operator work\n", encoding="utf-8")
+        self.git("add", "operator-work.txt", cwd=compose)
+        self.git("commit", "-m", "operator work", cwd=compose)
+        operator_commit = self.git("rev-parse", "HEAD", cwd=compose).strip()
+        self.git("reset", "--hard", initial, cwd=compose)
+        self.assertEqual(self.git("status", "--porcelain=v1", cwd=compose), "")
+        self.assertEqual(self.git("branch", "--show-current", cwd=compose), "main\n")
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("rev-parse", "ORIG_HEAD", cwd=compose).strip(), operator_commit
+        )
+        self.git("cat-file", "-e", f"{operator_commit}^{{commit}}", cwd=compose)
+
+    def test_resume_preserves_a_commit_reachable_only_from_fetch_head(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        source = self.root / "sources" / "container-compose"
+        (source / "operator-work.txt").write_text("operator work\n", encoding="utf-8")
+        self.git("add", "operator-work.txt", cwd=source)
+        self.git("commit", "-m", "operator work", cwd=source)
+        operator_commit = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git("fetch", str(source), operator_commit, cwd=compose)
+        self.assertEqual(
+            self.git("rev-parse", "FETCH_HEAD", cwd=compose).strip(), operator_commit
+        )
+        dependency = self.root / "sources" / "containerization"
+        (dependency / "new-runtime.txt").write_text(
+            "new runtime\n", encoding="utf-8"
+        )
+        self.git("add", "new-runtime.txt", cwd=dependency)
+        self.git("commit", "-m", "advance main", cwd=dependency)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=dependency,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("rev-parse", "FETCH_HEAD", cwd=compose).strip(), operator_commit
+        )
+        self.git("cat-file", "-e", f"{operator_commit}^{{commit}}", cwd=compose)
+
+    def test_resume_preserves_a_custom_local_remote_ref_when_main_moves(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        operator_commit = self.git(
+            "commit-tree",
+            "HEAD^{tree}",
+            "-m",
+            "operator remote ref",
+            cwd=compose,
+        ).strip()
+        operator_ref = "refs/remotes/origin/operator-work"
+        self.git("update-ref", operator_ref, operator_commit, cwd=compose)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("rev-parse", operator_ref, cwd=compose).strip(),
+            operator_commit,
+        )
+
+    def test_pristine_symbolic_selector_advances_after_a_new_release_tag(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        self.assertEqual(release_root.name, "0.14.3")
+        source = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertEqual(resumed.name, "0.14.4")
+        self.assertFalse(release_root.exists())
+
+    def test_explicit_checkpoint_refreshes_after_a_remote_tag_change(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        original = WORKSPACE.workspace_marker(release_root)
+        source = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+
+        self.assertEqual(resumed, release_root)
+        marker = WORKSPACE.workspace_marker(resumed)
+        self.assertNotEqual(marker["semanticTagTargets"], original["semanticTagTargets"])
+        self.assertEqual(
+            marker["semanticTagTargets"]["container-compose"]["0.14.3"],
+            self.git("rev-parse", "refs/tags/0.14.3^{}", cwd=source).strip(),
+        )
+
+    def test_checkpoint_refreshes_after_an_annotated_tag_object_changes(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        source = self.root / "sources" / "container-compose"
+        self.git("tag", "--annotate", "--message", "first", "0.14.3", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=source,
+        )
+        first = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        first_object = self.git("rev-parse", "refs/tags/0.14.3", cwd=source).strip()
+        self.assertEqual(
+            WORKSPACE.workspace_marker(first)["semanticTagTargets"][
+                "container-compose"
+            ]["0.14.3"],
+            first_object,
+        )
+        self.git(
+            "tag",
+            "--force",
+            "--annotate",
+            "--message",
+            "replacement",
+            "0.14.3",
+            cwd=source,
+        )
+        second_object = self.git("rev-parse", "refs/tags/0.14.3", cwd=source).strip()
+        self.assertNotEqual(second_object, first_object)
+        self.git(
+            "push",
+            "--force",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["semanticTagTargets"][
+                "container-compose"
+            ]["0.14.3"],
+            second_object,
+        )
+        self.assertEqual(
+            self.git(
+                "rev-parse", "refs/tags/0.14.3", cwd=resumed / "container-compose"
+            ).strip(),
+            second_object,
+        )
+
+    def test_symbolic_selector_revalidates_an_existing_destination(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        current = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertEqual(resumed, existing)
+        self.assertFalse(old_symbolic.exists())
+        marker = WORKSPACE.workspace_marker(resumed)
+        self.assertEqual(marker["mainRefs"]["containerization"], current)
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=resumed / "containerization").strip(),
+            current,
+        )
+
+    def test_reused_destination_resumes_under_the_symbolic_selector(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        source = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=source,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertEqual(resumed, existing)
+        self.assertFalse(old_symbolic.exists())
+        self.assertEqual(WORKSPACE.workspace_marker(resumed)["selector"], "--+")
+        retained = existing / "container-compose" / "retained.log"
+        retained.write_text("operator work\n", encoding="utf-8")
+        self.git("tag", "0.14.4", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.4",
+            cwd=source,
+        )
+
+        resumed_again = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+
+        self.assertEqual(resumed_again, existing)
+        self.assertEqual(retained.read_text(encoding="utf-8"), "operator work\n")
+
+    def test_reused_destination_does_not_rebaseline_an_unpushed_tag(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        source = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=source,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        compose = existing / "container-compose"
+        authority_tag = f"stable-init-image-authority/{existing.name}"
+        self.git("tag", authority_tag, cwd=compose)
+
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertEqual(resumed, existing)
+        self.assertFalse(old_symbolic.exists())
+        marker = WORKSPACE.workspace_marker(resumed)
+        self.assertNotIn(
+            authority_tag,
+            marker["immutableTagRefs"]["container-compose"],
+        )
+        dependency = self.root / "sources" / "containerization"
+        (dependency / "new-runtime.txt").write_text(
+            "new runtime\n", encoding="utf-8"
+        )
+        self.git("add", "new-runtime.txt", cwd=dependency)
+        self.git("commit", "-m", "advance main", cwd=dependency)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=dependency,
+        )
+
+        resumed_again = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+
+        self.assertEqual(resumed_again, existing)
+        self.assertEqual(
+            self.git("rev-parse", f"refs/tags/{authority_tag}", cwd=compose).strip(),
+            self.git("rev-parse", "HEAD", cwd=compose).strip(),
+        )
+
+    def test_interrupted_tag_refresh_rejects_a_stale_destination(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        replace = WORKSPACE.os.replace
+        recover = WORKSPACE.recover_interrupted_replacements
+        recovery_calls = 0
+
+        class SimulatedProcessExit(BaseException):
+            pass
+
+        def stop_before_destination_backup(source: Path, destination: Path) -> None:
+            if (
+                Path(source).resolve() == existing.resolve()
+                and ".replaced." in Path(destination).name
+            ):
+                raise SimulatedProcessExit()
+            replace(source, destination)
+
+        def stop_recovery(build_root: Path) -> None:
+            nonlocal recovery_calls
+            recovery_calls += 1
+            if recovery_calls == 1:
+                recover(build_root)
+                return
+            raise SimulatedProcessExit()
+
+        remove = WORKSPACE.shutil.rmtree
+
+        def preserve_interrupted_stage(
+            path: Path, *args: object, **kwargs: object
+        ) -> None:
+            candidate = Path(path)
+            if (
+                candidate.parent.resolve() == self.build_root.resolve()
+                and candidate.name.startswith(f".{existing.name}.")
+                and ".replaced." not in candidate.name
+            ):
+                return
+            remove(path, *args, **kwargs)
+
+        with mock.patch.object(
+            WORKSPACE.os, "replace", side_effect=stop_before_destination_backup
+        ):
+            with mock.patch.object(
+                WORKSPACE.shutil,
+                "rmtree",
+                side_effect=preserve_interrupted_stage,
+            ):
+                with mock.patch.object(
+                    WORKSPACE,
+                    "recover_interrupted_replacements",
+                    side_effect=stop_recovery,
+                ):
+                    with self.assertRaises(SimulatedProcessExit):
+                        WORKSPACE.materialize(
+                            self.build_root, "--+", self.remote_root
+                        )
+
+        old_marker = WORKSPACE.workspace_marker(old_symbolic)
+        replacement = old_marker["replacement"]
+        self.assertIn(
+            "0.14.3",
+            replacement["semanticTagTargets"]["container-compose"],
+        )
+        stage = self.build_root / replacement["stage"]
+        self.assertTrue(stage.is_dir())
+
+        WORKSPACE.recover_interrupted_replacements(self.build_root.resolve())
+
+        self.assertTrue(old_symbolic.is_dir())
+        self.assertTrue(existing.is_dir())
+        self.assertFalse(stage.exists())
+        self.assertNotIn("replacement", WORKSPACE.workspace_marker(old_symbolic))
+        self.assertNotIn("replacement", WORKSPACE.workspace_marker(existing))
+
+        resumed = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+
+        self.assertEqual(resumed, existing)
+        self.assertFalse(old_symbolic.exists())
+        self.assertIn(
+            "0.14.3",
+            WORKSPACE.workspace_marker(resumed)["semanticTagTargets"][
+                "container-compose"
+            ],
+        )
+
+    def test_existing_destination_reuse_retires_the_old_checkpoint(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertFalse(old_symbolic.exists())
+        backup = next(self.build_root.glob(f".{old_symbolic.name}.replaced.*"))
+        retired_marker = WORKSPACE.workspace_marker(backup)
+
+        self.assertEqual(resumed, existing)
+        self.assertTrue(backup.is_dir())
+        self.assertEqual(retired_marker["state"], "retired")
+        self.assertNotIn("replacement", retired_marker)
+
+    def test_interrupted_destination_rebind_is_completed_from_the_journal(
+        self,
+    ) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        write_marker = WORKSPACE.atomic_json
+        interrupted = False
+
+        def stop_destination_rebind(path: Path, value: object) -> None:
+            nonlocal interrupted
+            if (
+                not interrupted
+                and path == existing / WORKSPACE.WORKSPACE_MARKER
+                and isinstance(value, dict)
+                and value.get("selector") == "--+"
+            ):
+                interrupted = True
+                raise OSError("destination rebind failed")
+            write_marker(path, value)
+
+        with mock.patch.object(
+            WORKSPACE,
+            "atomic_json",
+            side_effect=stop_destination_rebind,
+        ):
+            with self.assertRaisesRegex(OSError, "destination rebind failed"):
+                WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertTrue(interrupted)
+        self.assertFalse(old_symbolic.exists())
+        backup = next(self.build_root.glob(f".{old_symbolic.name}.replaced.*"))
+        self.assertIn("replacement", WORKSPACE.workspace_marker(backup))
+        self.assertEqual(WORKSPACE.workspace_marker(existing)["selector"], "0.14.4")
+
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertEqual(resumed, existing)
+        self.assertTrue(backup.is_dir())
+        self.assertEqual(WORKSPACE.workspace_marker(backup)["state"], "retired")
+        self.assertNotIn("replacement", WORKSPACE.workspace_marker(backup))
+        self.assertEqual(WORKSPACE.workspace_marker(existing)["selector"], "--+")
+
+    def test_interrupted_destination_reuse_rolls_back_a_changed_source(
+        self,
+    ) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        replace = WORKSPACE.os.replace
+
+        class SimulatedProcessExit(BaseException):
+            pass
+
+        def stop_before_source_retirement(source: Path, destination: Path) -> None:
+            if (
+                Path(source).resolve() == old_symbolic.resolve()
+                and ".replaced." in Path(destination).name
+            ):
+                raise SimulatedProcessExit()
+            replace(source, destination)
+
+        with mock.patch.object(
+            WORKSPACE.os, "replace", side_effect=stop_before_source_retirement
+        ):
+            with self.assertRaises(SimulatedProcessExit):
+                WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertIn("replacement", WORKSPACE.workspace_marker(old_symbolic))
+        source_file = old_symbolic / "container-compose" / "README.md"
+        source_file.write_text("operator work after interruption\n", encoding="utf-8")
+
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertEqual(resumed.resolve(), old_symbolic.resolve())
+        self.assertEqual(
+            source_file.read_text(encoding="utf-8"),
+            "operator work after interruption\n",
+        )
+        self.assertNotIn("replacement", WORKSPACE.workspace_marker(old_symbolic))
+        self.assertEqual(WORKSPACE.workspace_marker(old_symbolic)["selector"], "--+")
+        self.assertEqual(WORKSPACE.workspace_marker(existing)["selector"], "0.14.4")
+
+    def test_destination_reuse_preserves_a_concurrent_source_edit(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        replace = WORKSPACE.os.replace
+        changed = False
+
+        def edit_after_retirement(source: Path, destination: Path) -> None:
+            nonlocal changed
+            replace(source, destination)
+            candidate = Path(destination)
+            if (
+                not changed
+                and Path(source).resolve() == old_symbolic.resolve()
+                and ".replaced." in candidate.name
+            ):
+                changed = True
+                (candidate / "container-compose" / "README.md").write_text(
+                    "operator work\n", encoding="utf-8"
+                )
+
+        with mock.patch.object(
+            WORKSPACE.os, "replace", side_effect=edit_after_retirement
+        ):
+            with self.assertRaisesRegex(
+                WORKSPACE.WorkspaceError, "changed while being retired"
+            ):
+                WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertTrue(changed)
+        self.assertTrue(old_symbolic.is_dir())
+        self.assertEqual(
+            (old_symbolic / "container-compose" / "README.md").read_text(
+                encoding="utf-8"
+            ),
+            "operator work\n",
+        )
+        self.assertNotIn("replacement", WORKSPACE.workspace_marker(old_symbolic))
+        self.assertEqual(WORKSPACE.workspace_marker(existing)["selector"], "0.14.4")
+
+    def test_new_destination_is_not_installed_when_source_retirement_changes(
+        self,
+    ) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        replace = WORKSPACE.os.replace
+        changed = False
+
+        def edit_after_retirement(source: Path, destination: Path) -> None:
+            nonlocal changed
+            replace(source, destination)
+            candidate = Path(destination)
+            if (
+                not changed
+                and Path(source).resolve() == old_symbolic.resolve()
+                and ".replaced." in candidate.name
+            ):
+                changed = True
+                (candidate / "container-compose" / "README.md").write_text(
+                    "operator work\n", encoding="utf-8"
+                )
+
+        with mock.patch.object(
+            WORKSPACE.os, "replace", side_effect=edit_after_retirement
+        ):
+            with self.assertRaisesRegex(
+                WORKSPACE.WorkspaceError, "changed while being retired"
+            ):
+                WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertTrue(changed)
+        self.assertTrue(old_symbolic.is_dir())
+        self.assertFalse((self.build_root / "0.14.4").exists())
+        self.assertEqual(
+            (old_symbolic / "container-compose" / "README.md").read_text(
+                encoding="utf-8"
+            ),
+            "operator work\n",
+        )
+        self.assertNotIn("replacement", WORKSPACE.workspace_marker(old_symbolic))
+        retained = WORKSPACE.retained_workspace(self.build_root, "--+")
+        self.assertIsNotNone(retained)
+        assert retained is not None
+        self.assertEqual(retained.resolve(), old_symbolic.resolve())
+
+    def test_interrupted_reuse_recovers_a_modified_destination(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        destination_file = existing / "container-compose" / "README.md"
+        destination_file.write_text("modified destination\n", encoding="utf-8")
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        write_marker = WORKSPACE.atomic_json
+        interrupted = False
+
+        def stop_destination_rebind(path: Path, value: object) -> None:
+            nonlocal interrupted
+            if (
+                not interrupted
+                and path == existing / WORKSPACE.WORKSPACE_MARKER
+                and isinstance(value, dict)
+                and value.get("selector") == "--+"
+            ):
+                interrupted = True
+                raise OSError("modified destination rebind failed")
+            write_marker(path, value)
+
+        with mock.patch.object(
+            WORKSPACE,
+            "atomic_json",
+            side_effect=stop_destination_rebind,
+        ):
+            with self.assertRaisesRegex(
+                OSError, "modified destination rebind failed"
+            ):
+                WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertTrue(interrupted)
+        self.assertFalse(old_symbolic.exists())
+        backup = next(self.build_root.glob(f".{old_symbolic.name}.replaced.*"))
+        self.assertEqual(WORKSPACE.workspace_marker(existing)["selector"], "0.14.4")
+
+        resumed = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+
+        self.assertEqual(resumed, existing)
+        self.assertTrue(backup.is_dir())
+        self.assertEqual(WORKSPACE.workspace_marker(backup)["state"], "retired")
+        self.assertNotIn("replacement", WORKSPACE.workspace_marker(backup))
+        self.assertEqual(
+            destination_file.read_text(encoding="utf-8"),
+            "modified destination\n",
+        )
+        self.assertEqual(WORKSPACE.workspace_marker(existing)["selector"], "--+")
+
+    def test_retirement_preserves_writes_after_validation(self) -> None:
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        compose = self.root / "sources" / "container-compose"
+        self.git("tag", "0.14.3", cwd=compose)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        matches_checkpoint = WORKSPACE.workspace_matches_initial_checkpoint
+        written = False
+
+        def write_after_validation(path: Path, marker: dict[str, object]) -> bool:
+            nonlocal written
+            matches = matches_checkpoint(path, marker)
+            if matches and not written and ".replaced." in path.name:
+                written = True
+                (path / "container-compose" / "late-writer.txt").write_text(
+                    "operator work after validation\n", encoding="utf-8"
+                )
+            return matches
+
+        with mock.patch.object(
+            WORKSPACE,
+            "workspace_matches_initial_checkpoint",
+            side_effect=write_after_validation,
+        ):
+            resumed = WORKSPACE.materialize(
+                self.build_root, "--+", self.remote_root
+            )
+
+        backup = next(self.build_root.glob(f".{old_symbolic.name}.replaced.*"))
+        retired_marker = WORKSPACE.workspace_marker(backup)
+        self.assertTrue(written)
+        self.assertEqual(resumed, existing)
+        self.assertEqual(
+            (backup / "container-compose" / "late-writer.txt").read_text(
+                encoding="utf-8"
+            ),
+            "operator work after validation\n",
+        )
+        self.assertEqual(retired_marker["state"], "retired")
+        self.assertNotIn("replacement", retired_marker)
 
     def test_resume_refreshes_the_mutable_current_tag(self) -> None:
         release_root = WORKSPACE.materialize(


### PR DESCRIPTION
## Summary

- refresh a retained release transaction when every source checkout is still clean at its recorded initial main ref and that remote snapshot has moved
- preserve stashes, additional local refs, in-progress Git operations, and every unpushed immutable tag instead of classifying their repositories as pristine
- treat `current` as mutable only in Compose and `homebrew-main` as mutable only in Container
- record exact local immutable tag objects plus advertised remote semantic tag objects in new checkpoints, while safely revalidating legacy checkpoints against their authoritative remotes
- refresh pristine explicit-version checkpoints when the remote semantic tag snapshot changes
- fully clone and validate the replacement before swapping out the retained checkpoint, with rollback if the install step fails
- journal each stale checkpoint with its original source path and retire every stale source before installing the replacement, so a rejected late source edit cannot leave competing symbolic checkpoints
- roll back interrupted existing-destination handovers when the not-yet-retired source was edited, leaving the edited symbolic checkpoint resumable and the destination explicit
- revalidate an already-existing destination before symbolic selectors reuse it, atomically rebind its selector marker, and journal retirement of the superseded symbolic checkpoint
- journal same-version and cross-version checkpoint handovers so startup can finish or roll them back after process or host interruption
- move superseded semantic checkpoints into a hidden replacement namespace, revalidate them, and retain them with an inert `retired` marker so late writers cannot lose data
- use unique retired-checkpoint names so repeated handovers in one controller process cannot collide
- remove completed clone stages that were interrupted before their handover was journaled
- preserve exact recovery when a checkout has moved, become dirty, changed branch, acquired a stash, entered an in-progress Git operation, or gained a local tag
- discard ignored preflight/build output only when no durable source progress exists
- re-evaluate symbolic release selectors when a newer semantic release tag appears

Fixes #535.

## Evidence

- `python3 Tools/release/test_release_workspace.py` — 48 tests passed in 85.217 seconds
- `python3 -m py_compile Tools/release/release-workspace.py Tools/release/test_release_workspace.py`
- `git diff --check`

The regressions cover the exact 0.14.3 failure mode: stale Compose/Containerization main refs plus ignored upstream-divergence reports, with no release-source mutation. They also prove preservation of stashed operator work, unpushed annotated release and init-image-authority tags, remote-only tag rollover for symbolic and explicit selectors, symbolic-selector rebinding after destination reuse, clone-failure retention, install rollback, source-aware rollback, existing-destination revalidation, concurrent checkpoint-change rejection, rejection before a new destination is installed, recovery after a pre-retirement crash followed by a source edit, interrupted same-version swap rollback across two consecutive process exits, orphaned completed-stage cleanup, retained existing-destination handovers, late writes after retirement validation, and exact preservation of genuinely mutated transactions.