### PR TITLE
fix(release): validate legacy configured remotes

### DIFF
--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -264,6 +264,19 @@ def remote_reachable_objects(url: str) -> set[str]:
     return objects
 
 
+def expected_fetch_remotes(component: Component, clone_url: str) -> dict[str, str]:
+    """Return the exact, controller-owned fetch remotes for a component."""
+
+    remotes = {component.clone_remote: clone_url}
+    if component.upstream is None:
+        return remotes
+    upstream_url = f"https://github.com/{component.upstream}.git"
+    remotes["upstream"] = upstream_url
+    if component.clone_remote == "fork":
+        remotes["origin"] = upstream_url
+    return remotes
+
+
 def remote_snapshot(
     remote_root: Path | None = None,
 ) -> tuple[dict[str, str], dict[str, dict[str, str]]]:
@@ -625,9 +638,26 @@ def workspace_matches_initial_checkpoint(
     assert recorded_recovery_objects is None or isinstance(
         recorded_recovery_objects, dict
     )
+    advertised_by_url: dict[str, set[str]] = {}
+
+    def advertised_objects(url: str) -> set[str]:
+        if url not in advertised_by_url:
+            advertised_by_url[url] = remote_reachable_objects(url)
+        return advertised_by_url[url]
+
     for component in COMPONENTS:
         path = root / component.name
         expected = refs[component.name]
+        clone_url = str(remotes[component.name])
+        expected_remotes = expected_fetch_remotes(component, clone_url)
+        actual_remotes = set(run_git("remote", cwd=path).splitlines())
+        if actual_remotes != set(expected_remotes):
+            return False
+        if any(
+            run_git("remote", "get-url", name, cwd=path).strip() != url
+            for name, url in expected_remotes.items()
+        ):
+            return False
         if run_git("branch", "--show-current", cwd=path).strip() != "main":
             return False
         if run_git("rev-parse", "HEAD", cwd=path).strip() != expected:
@@ -650,10 +680,21 @@ def workspace_matches_initial_checkpoint(
             if local_remote_refs != initial_remote_refs:
                 return False
         else:
-            recoverable = remote_reachable_objects(str(remotes[component.name]))
-            recoverable.add(str(expected))
-            if any(value not in recoverable for value in local_remote_refs.values()):
-                return False
+            for name, value in local_remote_refs.items():
+                suffix = name.removeprefix("refs/remotes/")
+                remote_name, separator, _ = suffix.partition("/")
+                if (
+                    not separator
+                    or remote_name not in expected_remotes
+                    or (
+                        value not in advertised_objects(expected_remotes[remote_name])
+                        and not (
+                            remote_name == component.clone_remote
+                            and value == expected
+                        )
+                    )
+                ):
+                    return False
         recovery_objects = set(local_recovery_objects(path))
         if recorded_recovery_objects is not None:
             initial_recovery_objects = recorded_recovery_objects[component.name]
@@ -662,9 +703,14 @@ def workspace_matches_initial_checkpoint(
         else:
             new_recovery_objects = recovery_objects
         if new_recovery_objects:
-            recoverable = remote_reachable_objects(str(remotes[component.name]))
+            recoverable = set(advertised_objects(clone_url))
             recoverable.add(str(expected))
-            if new_recovery_objects - recoverable:
+            missing = new_recovery_objects - recoverable
+            for name, url in expected_remotes.items():
+                if not missing or name == component.clone_remote:
+                    continue
+                missing -= advertised_objects(url)
+            if missing:
                 return False
         repository_refs = run_git(
             "for-each-ref", "--format=%(refname)", cwd=path

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -349,6 +349,96 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         )
         self.assertTrue((resumed / "containerization" / "new-runtime.txt").is_file())
 
+    def test_legacy_checkpoint_accepts_state_advertised_by_its_own_remote(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        for field in (
+            "immutableTagRefs",
+            "recoveryObjects",
+            "remoteTrackingRefs",
+            "semanticTagTargets",
+        ):
+            checkpoint.pop(field)
+        WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
+        containerization = release_root / "containerization"
+        initial = self.git("rev-parse", "HEAD", cwd=containerization).strip()
+        (containerization / "upstream.txt").write_text(
+            "upstream work\n", encoding="utf-8"
+        )
+        self.git("add", "upstream.txt", cwd=containerization)
+        self.git("commit", "-m", "upstream work", cwd=containerization)
+        upstream_commit = self.git(
+            "rev-parse", "HEAD", cwd=containerization
+        ).strip()
+        self.git("reset", "--hard", initial, cwd=containerization)
+        self.git(
+            "update-ref",
+            "refs/remotes/upstream/main",
+            upstream_commit,
+            cwd=containerization,
+        )
+        source = self.root / "sources" / "container-compose"
+        (source / "new-compose.txt").write_text("new compose\n", encoding="utf-8")
+        self.git("add", "new-compose.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        current = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        reachable = WORKSPACE.remote_reachable_objects
+
+        def configured_remote_objects(url: str) -> set[str]:
+            if url == "https://github.com/apple/containerization.git":
+                return {upstream_commit}
+            return reachable(url)
+
+        with mock.patch.object(
+            WORKSPACE,
+            "remote_reachable_objects",
+            side_effect=configured_remote_objects,
+        ):
+            resumed = WORKSPACE.materialize(
+                self.build_root, "-+-", self.remote_root
+            )
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["mainRefs"]["container-compose"],
+            current,
+        )
+
+    def test_resume_preserves_an_additional_remote_when_main_moves(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        scratch = str(self.remote_root / "container-compose.git")
+        self.git("remote", "add", "scratch", scratch, cwd=compose)
+        source = self.root / "sources" / "containerization"
+        (source / "new-runtime.txt").write_text("new runtime\n", encoding="utf-8")
+        self.git("add", "new-runtime.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("remote", "get-url", "scratch", cwd=compose).strip(), scratch
+        )
+
     def test_legacy_baseline_upgrade_does_not_capture_concurrent_state(self) -> None:
         release_root = WORKSPACE.materialize(
             self.build_root, "-+-", self.remote_root


### PR DESCRIPTION
## Summary

- validate every legacy remote-tracking ref against the exact configured remote that owns it
- accept the recorded checkpoint main object when the clone remote has advanced
- validate legacy recovery objects against the union of verified controller-owned remotes
- preserve checkpoints that acquired an additional remote instead of discarding operator configuration
- cache remote advertisements within one eligibility check

Fixes #537.

## Evidence

- `python3 Tools/release/test_release_workspace.py` — 50 tests passed in 95.756 seconds
- `python3 -m py_compile Tools/release/release-workspace.py Tools/release/test_release_workspace.py`
- `git diff --check`
- the actual retained 0.14.3 transaction now evaluates as safely replaceable; its only previously rejected objects are exact Apple upstream tips still advertised by their verified remotes

The release stopped before expensive testing. No release source, tag, or durable evidence was modified.