### PR TITLE
fix(release): recover fetched remote ancestors

### DIFF
--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -264,6 +264,29 @@ def remote_reachable_objects(url: str) -> set[str]:
     return objects
 
 
+def object_reachable_from_advertised_refs(
+    path: Path, candidate: str, advertised: set[str]
+) -> bool:
+    """Return whether an object is named by, or is history of, a remote ref."""
+
+    if candidate in advertised:
+        return True
+    try:
+        containing_refs = run_git(
+            "for-each-ref",
+            "--contains",
+            candidate,
+            "--format=%(objectname)",
+            "refs/heads",
+            "refs/remotes",
+            "refs/tags",
+            cwd=path,
+        ).splitlines()
+    except WorkspaceError:
+        return False
+    return any(tip in advertised for tip in containing_refs)
+
+
 def expected_fetch_remotes(component: Component, clone_url: str) -> dict[str, str]:
     """Return the exact, controller-owned fetch remotes for a component."""
 
@@ -673,6 +696,12 @@ def workspace_matches_initial_checkpoint(
             for entry in index_entries
         ):
             return False
+        git_directory = Path(
+            run_git("rev-parse", "--absolute-git-dir", cwd=path).strip()
+        )
+        grafts = git_directory / "info" / "grafts"
+        if grafts.exists() or grafts.is_symlink():
+            return False
         local_remote_refs = local_remote_tracking_refs(path)
         if recorded_remote_refs is not None:
             initial_remote_refs = recorded_remote_refs[component.name]
@@ -703,13 +732,26 @@ def workspace_matches_initial_checkpoint(
         else:
             new_recovery_objects = recovery_objects
         if new_recovery_objects:
-            recoverable = set(advertised_objects(clone_url))
-            recoverable.add(str(expected))
-            missing = new_recovery_objects - recoverable
+            advertised = set(advertised_objects(clone_url))
+            advertised.add(str(expected))
+            missing = {
+                value
+                for value in new_recovery_objects
+                if not object_reachable_from_advertised_refs(
+                    path, value, advertised
+                )
+            }
             for name, url in expected_remotes.items():
                 if not missing or name == component.clone_remote:
                     continue
-                missing -= advertised_objects(url)
+                remote_advertised = advertised_objects(url)
+                missing = {
+                    value
+                    for value in missing
+                    if not object_reachable_from_advertised_refs(
+                        path, value, remote_advertised
+                    )
+                }
             if missing:
                 return False
         repository_refs = run_git(
@@ -744,9 +786,6 @@ def workspace_matches_initial_checkpoint(
             "rebase-apply",
             "rebase-merge",
             "sequencer",
-        )
-        git_directory = Path(
-            run_git("rev-parse", "--absolute-git-dir", cwd=path).strip()
         )
         if any(
             (git_directory / state_name).exists()

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -414,6 +414,138 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             current,
         )
 
+    def test_legacy_checkpoint_accepts_an_earlier_fetched_main_ancestor(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        for field in (
+            "immutableTagRefs",
+            "recoveryObjects",
+            "remoteTrackingRefs",
+            "semanticTagTargets",
+        ):
+            checkpoint.pop(field)
+        WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
+
+        source = self.root / "sources" / "container-compose"
+        compose = release_root / "container-compose"
+        (source / "first.txt").write_text("first\n", encoding="utf-8")
+        self.git("add", "first.txt", cwd=source)
+        self.git("commit", "-m", "first advance", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        self.git("fetch", "origin", "main", cwd=compose)
+        earlier = self.git("rev-parse", "origin/main", cwd=compose).strip()
+
+        (source / "second.txt").write_text("second\n", encoding="utf-8")
+        self.git("add", "second.txt", cwd=source)
+        self.git("commit", "-m", "second advance", cwd=source)
+        current = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        self.git("fetch", "origin", "main", cwd=compose)
+
+        self.assertIn(earlier, WORKSPACE.local_recovery_objects(compose))
+        self.assertNotIn(
+            earlier,
+            WORKSPACE.remote_reachable_objects(
+                str(self.remote_root / "container-compose.git")
+            ),
+        )
+
+        resumed = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["mainRefs"]["container-compose"],
+            current,
+        )
+
+    def test_legacy_checkpoint_does_not_query_unneeded_secondary_remotes(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        for field in (
+            "immutableTagRefs",
+            "recoveryObjects",
+            "remoteTrackingRefs",
+            "semanticTagTargets",
+        ):
+            checkpoint.pop(field)
+        WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
+
+        reachable = WORKSPACE.remote_reachable_objects
+
+        def clone_remotes_only(url: str) -> set[str]:
+            if url.startswith("https://github.com/apple/"):
+                raise AssertionError(f"unexpected secondary remote query: {url}")
+            return reachable(url)
+
+        with mock.patch.object(
+            WORKSPACE,
+            "remote_reachable_objects",
+            side_effect=clone_remotes_only,
+        ):
+            self.assertTrue(
+                WORKSPACE.workspace_matches_initial_checkpoint(
+                    release_root,
+                    checkpoint,
+                )
+            )
+
+    def test_legacy_checkpoint_rejects_grafted_recovery_history(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        for field in (
+            "immutableTagRefs",
+            "recoveryObjects",
+            "remoteTrackingRefs",
+            "semanticTagTargets",
+        ):
+            checkpoint.pop(field)
+        WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
+
+        compose = release_root / "container-compose"
+        head = self.git("rev-parse", "HEAD", cwd=compose).strip()
+        tree = self.git("rev-parse", "HEAD^{tree}", cwd=compose).strip()
+        unadvertised = self.git(
+            "commit-tree", tree, "-m", "unadvertised recovery object", cwd=compose
+        ).strip()
+        git_directory = Path(
+            self.git("rev-parse", "--absolute-git-dir", cwd=compose).strip()
+        )
+        (git_directory / "ORIG_HEAD").write_text(
+            f"{unadvertised}\n", encoding="utf-8"
+        )
+        (git_directory / "info" / "grafts").write_text(
+            f"{head} {unadvertised}\n", encoding="utf-8"
+        )
+
+        self.assertFalse(
+            WORKSPACE.workspace_matches_initial_checkpoint(
+                release_root,
+                checkpoint,
+            )
+        )
+
     def test_resume_preserves_an_additional_remote_when_main_moves(self) -> None:
         release_root = WORKSPACE.materialize(
             self.build_root, "-+-", self.remote_root


### PR DESCRIPTION
Fixes #539.

A pristine legacy checkpoint can fetch one main tip, then fetch a later tip on a subsequent retry. The earlier tip remains in FETCH_HEAD or a reflog but is no longer directly advertised, so the release controller incorrectly treated the checkpoint as user-modified and reused its stale source.

This accepts a recovery object only when a local ref containing it still targets an object advertised by one of the exact controller-owned configured remotes (or the recorded checkpoint head). Unexpected remotes, refs, worktree changes, and unrelated recovery objects remain rejected.

Evidence:

- `python3 -m unittest Tools.release.test_release_workspace` — 51 passed in 114.178s.
- The real retained 0.14.3 checkpoint is now classified as replaceable in 5.541s.
- The regression reproduces two successive main advances/fetches and proves the earlier, no-longer-advertised tip remains safely recoverable through the currently advertised descendant.