### PR TITLE
fix(release): reject stale Current stack pins

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -480,6 +480,29 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.sha }}
 
+      - name: Require Current stack pins to match fork mains
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        working-directory: container-compose
+        shell: bash
+        run: |
+          set -euo pipefail
+          for component in container-builder-shim containerization container; do
+            repository="$(jq -er --arg component "${component}" \
+              '.components[$component].repository' Tools/release/stack-refs.json)"
+            pinned_ref="$(jq -er --arg component "${component}" \
+              '.components[$component].ref' Tools/release/stack-refs.json)"
+            main_ref="$(gh api "repos/${repository}/commits/main" --jq '.sha')"
+            if [[ ! "${pinned_ref}" =~ ^[0-9a-f]{40}$ ||
+                  ! "${main_ref}" =~ ^[0-9a-f]{40}$ ||
+                  "${pinned_ref}" != "${main_ref}" ]]; then
+              printf 'Current stack uses %s %s, but fork main is %s; update the stack pin before packaging\n' \
+                "${component}" "${pinned_ref:-missing}" "${main_ref:-missing}" >&2
+              exit 1
+            fi
+          done
+
       - name: Require a writable Homebrew promotion token
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
@@ -1435,6 +1458,25 @@ jobs:
                 "${PUBLISH_SHA}" "${current_main:-missing}"
               publish=false
             fi
+            for component in container-builder-shim containerization container; do
+              repository="$(jq -er --arg component "${component}" \
+                '.components[$component].repository' \
+                container-compose/Tools/release/stack-refs.json)"
+              pinned_ref="$(jq -er --arg component "${component}" \
+                '.components[$component].ref' \
+                container-compose/Tools/release/stack-refs.json)"
+              main_ref="$(
+                git ls-remote --heads "https://github.com/${repository}.git" refs/heads/main \
+                  | awk '{ print $1 }' \
+                  | tail -n 1
+              )"
+              if [[ "${pinned_ref}" != "${main_ref}" ]]; then
+                printf 'Skipping stale Current stack: %s uses %s, but fork main is now %s.\n' \
+                  "${component}" "${pinned_ref:-missing}" "${main_ref:-missing}"
+                publish=false
+                break
+              fi
+            done
           fi
           printf 'publish=%s\n' "${publish}" >> "$GITHUB_OUTPUT"
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "40ab92d74a02bbd6b7436a50d47c38898a4bc294"
+        "revision" : "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "b404e03bb914904107a6a9305ba1f0e44c79a59c"
+        "revision" : "f9d57ad1c80944c43bec6fc74afe1bfac3956480"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,12 +19,12 @@ import PackageDescription
 
 let containerDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/container.git",
-    revision: "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
+    revision: "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad",
 )
 
 let containerizationDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/containerization.git",
-    revision: "b404e03bb914904107a6a9305ba1f0e44c79a59c",
+    revision: "f9d57ad1c80944c43bec6fc74afe1bfac3956480",
 )
 
 let nioSSLDependency: Package.Dependency = .package(

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
+      "ref": "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "b404e03bb914904107a6a9305ba1f0e44c79a59c",
+      "ref": "f9d57ad1c80944c43bec6fc74afe1bfac3956480",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1998,6 +1998,20 @@ github_cli() {{
         self.assertIn("name: Fail-Fast Release Configuration", workflow)
         self.assertIn("name: Checkout immutable release control tools", fail_fast)
         self.assertIn("ref: ${{ github.sha }}", fail_fast)
+        self.assertIn("name: Require Current stack pins to match fork mains", fail_fast)
+        self.assertIn(
+            "for component in container-builder-shim containerization container",
+            fail_fast,
+        )
+        self.assertIn('gh api "repos/${repository}/commits/main"', fail_fast)
+        self.assertIn(
+            "update the stack pin before packaging",
+            fail_fast,
+        )
+        self.assertLess(
+            fail_fast.index("name: Require Current stack pins to match fork mains"),
+            fail_fast.index("name: Require a writable Homebrew promotion token"),
+        )
         self.assertIn(
             "python3 release-tools/Tools/release/homebrew-preflight.py", fail_fast
         )
@@ -2012,6 +2026,18 @@ github_cli() {{
             workflow.index("name: CodeQL"),
         )
         self.assertLess(workflow.index("name: CodeQL"), workflow.index("name: Package"))
+        freshness = workflow[
+            workflow.index("- name: Verify current source is still latest") : workflow.index(
+                "- name: Checkout immutable release control tools",
+                workflow.index("- name: Verify current source is still latest"),
+            )
+        ]
+        self.assertIn(
+            "for component in container-builder-shim containerization container",
+            freshness,
+        )
+        self.assertIn("Skipping stale Current stack", freshness)
+        self.assertIn("publish=false", freshness)
         local_gate = self.script[
             self.script.index("run_local_release_gate() {") : self.script.index(
                 "sync_containerization_package_pins() {"


### PR DESCRIPTION
## Summary

- pin Compose to Container `aaacb3ed973f9e47434fc14335f87a4a42a1f2ad` and Containerization `f9d57ad1c80944c43bec6fc74afe1bfac3956480`;
- reject stale builder-shim, Containerization, or Container refs in the initial Current release preflight, before signing or compilation;
- recheck all three fork mains after packaging and skip publication if a dependency advanced during the build.

This closes the gap that allowed the `d3f798de` Current workflow to spend 14 minutes packaging a stale Containerization pin before the stable controller rejected it. Container PR #215 updates the dependent runtime first, so the graph retains one exact Containerization revision.

## Focused proof

- `swift package resolve` completed successfully.
- `Package.swift`, `Package.resolved`, and the resolved checkouts select exactly Container `aaacb3ed973f9e47434fc14335f87a4a42a1f2ad` and Containerization `f9d57ad1c80944c43bec6fc74afe1bfac3956480`.
- Focused release-workflow policy regression: 1 passed.
- `actionlint .github/workflows/prebuilt-binaries.yml` passed.
- Local fork-main comparison confirms all three recorded stack refs currently match their remote main SHAs.
- `git diff --check` passed.

## Related

Closes #541.
Automatic downstream synchronization remains tracked by #542.
Depends on stephenlclarke/container#215.