### PR TITLE
chore(release): refresh 0.14.3 Container authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 7 September 2026 snapshot, the three support forks are **1144 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 7 September 2026 snapshot, the three support forks are **1146 commits ahead of Apple upstream**:
 >
 > - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 303 ahead** at [`f9d57ad1c809`](https://github.com/stephenlclarke/containerization/commit/f9d57ad1c80944c43bec6fc74afe1bfac3956480).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 788 ahead** at [`40ab92d74a02`](https://github.com/stephenlclarke/container/commit/40ab92d74a02bbd6b7436a50d47c38898a4bc294).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 790 ahead** at [`aaacb3ed973f`](https://github.com/stephenlclarke/container/commit/aaacb3ed973f9e47434fc14335f87a4a42a1f2ad).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 53 ahead** at [`287f2ea3276e`](https://github.com/stephenlclarke/container-builder-shim/commit/287f2ea3276eca73cd3781ff59b4c9c82d5f3d32).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "eee7ad097079cc3b02d5309ec10160143f2d0c6a",
-      "forkHead": "40ab92d74a02bbd6b7436a50d47c38898a4bc294",
+      "forkHead": "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -500,7 +500,8 @@
             "c676fcc0df7400f0189b6aefb8de584ea8b4a519",
             "436a7c9b4edc14a6b23440f8bf4b438e39830b81",
             "6f4c232563ba812404282471bdea4d32a143e745",
-            "228897171d71975988ccdc690f1982e7433952af"
+            "228897171d71975988ccdc690f1982e7433952af",
+            "09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `40ab92d74a02bbd6b7436a50d47c38898a4bc294` | 0 | 788 | 665 |
+| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `aaacb3ed973f9e47434fc14335f87a4a42a1f2ad` | 0 | 790 | 666 |
 | `containerization` | `847655d373a27b8b8d0c3a9747f04f16b5de1206` | `f9d57ad1c80944c43bec6fc74afe1bfac3956480` | 0 | 303 | 239 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `287f2ea3276eca73cd3781ff59b4c9c82d5f3d32` | 0 | 53 | 44 |
-| **Total** | | | **0** | **1144** | **948** |
+| **Total** | | | **0** | **1146** | **949** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 692 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 693 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 231 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -293,3 +293,8 @@ socket grant is a generic runtime primitive consumed by Compose
 `use_api_socket`. Apple's Pi agent support is upstream history after the
 reviewed synchronization merge, so it adds no fork-only classification. No
 temporary port or rejected Compose-policy disposition changed.
+
+The final 7 September 2026 release refresh advances Container through
+`aaacb3ed973f`. Its exact Containerization dependency pin at `09acdc2f1df2`
+is support maintenance and adds no new runtime behaviour. No generic runtime
+primitive, temporary port, or rejected Compose-policy disposition changed.

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -8325,6 +8325,28 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/534"
     },
     {
+      "id": "container-compose-544",
+      "owner": "stephenlclarke/container-compose",
+      "title": "chore(release): refresh 0.14.3 Container classification authority",
+      "state": "active-draft",
+      "lastVerified": "2026-09-07",
+      "commits": [
+        "09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607",
+        "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-544.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-545.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/545"
+    },
+    {
       "id": "process-list-compose-top-process-list",
       "owner": "stephenlclarke/container-compose",
       "title": "Pull request: support Docker-shaped `container compose top`",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-07
 
-Entries: 423. Document snapshots: 738. Current supporting documents: 132.
+Entries: 424. Document snapshots: 740. Current supporting documents: 134.
 
-States: `active-draft` 28, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 29, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -253,6 +253,7 @@ States: `active-draft` 28, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [Pin synchronized Container fork for 0.14.1](https://github.com/stephenlclarke/container-compose/pull/449) | `active-draft` | `2647090a8af7` | [Issue details](container-compose/ISSUE-448.md); [PR details](container-compose/PR-449.md) |
 | `stephenlclarke/container-compose` | [Make the recoverable pipeline reliable and efficient](https://github.com/stephenlclarke/container-compose/pull/489) | `active-draft` | `bdfd9cef9139`, `03a387961ee9` | [Issue details](container-compose/ISSUE-488.md); [PR details](container-compose/PR-489.md) |
 | `stephenlclarke/container-compose` | [chore(release): refresh 0.14.3 upstream authority](https://github.com/stephenlclarke/container-compose/pull/534) | `active-draft` | `228897171d71`, `40ab92d74a02`, `847655d373a2`, `f9d57ad1c809` | [Issue details](container-compose/ISSUE-533.md); [PR details](container-compose/PR-534.md) |
+| `stephenlclarke/container-compose` | [chore(release): refresh 0.14.3 Container classification authority](https://github.com/stephenlclarke/container-compose/pull/545) | `active-draft` | `09acdc2f1df2`, `aaacb3ed973f` | [Issue details](container-compose/ISSUE-544.md); [PR details](container-compose/PR-545.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-544.md
+++ b/docs/upstream/container-compose/ISSUE-544.md
@@ -1,0 +1,24 @@
+# Issue 544: refresh 0.14.3 Container classification authority
+
+## Problem
+
+The stable 0.14.3 release preflight correctly stopped before expensive testing after Container pull request #215 advanced the fork from `40ab92d74a02bbd6b7436a50d47c38898a4bc294` to `aaacb3ed973f9e47434fc14335f87a4a42a1f2ad`. The reviewed dependency-pin commit `09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607` was not yet classified, leaving the registry at 665 of 666 current fork-only commits.
+
+## Scope
+
+- Classify the new Container dependency pin in the existing support-maintenance slice.
+- Advance the exact Container fork head.
+- Refresh the README snapshot and human classification summary from the authoritative fetched repositories.
+- Leave release-version prose, release assets, CodeQL, Homebrew, DocC, and released-artifact benchmarks to the recoverable 0.14.3 release transaction.
+
+## Acceptance evidence
+
+- `make fork-classifications-check` reports all 949 patch-unique non-merge commits classified exactly once.
+- `make upstream-divergence-release-check` reports all three support forks current with Apple and cleanly mergeable.
+- `make readme-upstream-metrics-check`, `make stack-consistency`, and `make upstream-handoff-registry-check` pass.
+- Focused Markdown, JSON, and diff checks pass.
+- Exact-head review has no unresolved findings and the required pull-request checks pass.
+
+Related lower work: Container [#214](https://github.com/stephenlclarke/container/issues/214) and [#215](https://github.com/stephenlclarke/container/pull/215).
+
+Implementation: [#545](https://github.com/stephenlclarke/container-compose/pull/545).

--- a/docs/upstream/container-compose/PR-545.md
+++ b/docs/upstream/container-compose/PR-545.md
@@ -1,0 +1,24 @@
+# Pull request 545: refresh 0.14.3 Container classification authority
+
+## Change
+
+This pull request refreshes the exact upstream authority required by the recoverable 0.14.3 release transaction. It classifies Container's reviewed Containerization dependency pin `09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607` as support maintenance, advances the Container fork head to `aaacb3ed973f9e47434fc14335f87a4a42a1f2ad`, and regenerates the visible divergence totals from fetched repository heads.
+
+## Scope boundary
+
+This is release-authority metadata only. It changes no Compose or runtime behaviour and does not run or duplicate the stable release controller's dependency-pin, release-documentation, CodeQL, packaging, Homebrew, DocC, or released-artifact benchmark stages.
+
+## Validation
+
+- `make fork-classifications-check`
+- `make upstream-divergence-release-check`
+- `make readme-upstream-metrics-check`
+- `make stack-consistency`
+- `make upstream-handoff-registry-check`
+- focused Markdown and JSON validation
+- `git diff --check`
+- exact-head review and required hosted checks before merge
+
+Closes [#544](https://github.com/stephenlclarke/container-compose/issues/544).
+
+Related lower work: Container [#214](https://github.com/stephenlclarke/container/issues/214) and [#215](https://github.com/stephenlclarke/container/pull/215).


### PR DESCRIPTION
# Pull request 545: refresh 0.14.3 Container classification authority

## Change

This pull request refreshes the exact upstream authority required by the recoverable 0.14.3 release transaction. It classifies Container's reviewed Containerization dependency pin `09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607` as support maintenance, advances the Container fork head to `aaacb3ed973f9e47434fc14335f87a4a42a1f2ad`, and regenerates the visible divergence totals from fetched repository heads.

## Scope boundary

This is release-authority metadata only. It changes no Compose or runtime behaviour and does not run or duplicate the stable release controller's dependency-pin, release-documentation, CodeQL, packaging, Homebrew, DocC, or released-artifact benchmark stages.

## Validation

- `make fork-classifications-check`
- `make upstream-divergence-release-check`
- `make readme-upstream-metrics-check`
- `make stack-consistency`
- `make upstream-handoff-registry-check`
- focused Markdown and JSON validation
- `git diff --check`
- exact-head review and required hosted checks before merge

Closes [#544](https://github.com/stephenlclarke/container-compose/issues/544).

Related lower work: Container [#214](https://github.com/stephenlclarke/container/issues/214) and [#215](https://github.com/stephenlclarke/container/pull/215).
