### PR TITLE
fix(release): recover fetched tracking refs

### DIFF
--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -662,11 +662,36 @@ def workspace_matches_initial_checkpoint(
         recorded_recovery_objects, dict
     )
     advertised_by_url: dict[str, set[str]] = {}
+    advertised_refs_by_url: dict[str, dict[str, str]] = {}
 
     def advertised_objects(url: str) -> set[str]:
+        if url in advertised_refs_by_url:
+            return set(advertised_refs_by_url[url].values())
         if url not in advertised_by_url:
             advertised_by_url[url] = remote_reachable_objects(url)
         return advertised_by_url[url]
+
+    def advertised_refs(url: str) -> dict[str, str]:
+        if url not in advertised_refs_by_url:
+            refs: dict[str, str] = {}
+            for line in run_git("ls-remote", url).splitlines():
+                fields = line.split()
+                if len(fields) != 2 or not SHA.fullmatch(fields[0]):
+                    raise WorkspaceError(f"could not inspect remote refs at {url}")
+                refs[fields[1]] = fields[0]
+            advertised_refs_by_url[url] = refs
+            advertised_by_url[url] = set(refs.values())
+        return advertised_refs_by_url[url]
+
+    def tracked_ref_target(
+        ref: str, expected_remotes: dict[str, str]
+    ) -> tuple[str, str] | None:
+        suffix = ref.removeprefix("refs/remotes/")
+        remote_name, separator, remote_ref = suffix.partition("/")
+        if not separator or remote_name not in expected_remotes:
+            return None
+        advertised_ref = "HEAD" if remote_ref == "HEAD" else f"refs/heads/{remote_ref}"
+        return expected_remotes[remote_name], advertised_ref
 
     for component in COMPONENTS:
         path = root / component.name
@@ -706,8 +731,19 @@ def workspace_matches_initial_checkpoint(
         if recorded_remote_refs is not None:
             initial_remote_refs = recorded_remote_refs[component.name]
             assert isinstance(initial_remote_refs, dict)
-            if local_remote_refs != initial_remote_refs:
-                return False
+            # A failed child may already have fetched before it stopped. Treat
+            # only the exact tracking-ref value currently advertised by that
+            # configured remote as disposable controller state.
+            for name, value in local_remote_refs.items():
+                if initial_remote_refs.get(name) == value:
+                    continue
+                target = tracked_ref_target(name, expected_remotes)
+                if target is None or advertised_refs(target[0]).get(target[1]) != value:
+                    return False
+            for name in initial_remote_refs.keys() - local_remote_refs.keys():
+                target = tracked_ref_target(name, expected_remotes)
+                if target is None or target[1] in advertised_refs(target[0]):
+                    return False
         else:
             for name, value in local_remote_refs.items():
                 suffix = name.removeprefix("refs/remotes/")

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -349,6 +349,61 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         )
         self.assertTrue((resumed / "containerization" / "new-runtime.txt").is_file())
 
+    def test_resume_replaces_a_checkpoint_after_its_fetch_advances_main(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        compose = release_root / "container-compose"
+        source = self.root / "sources" / "container-compose"
+        (source / "new-compose.txt").write_text("new compose\n", encoding="utf-8")
+        self.git("add", "new-compose.txt", cwd=source)
+        self.git("commit", "-m", "advance main", cwd=source)
+        current = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        self.git("fetch", "origin", "main", cwd=compose)
+        self.assertNotEqual(
+            WORKSPACE.local_remote_tracking_refs(compose),
+            checkpoint["remoteTrackingRefs"]["container-compose"],
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=resumed / "container-compose").strip(),
+            current,
+        )
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["mainRefs"]["container-compose"],
+            current,
+        )
+
+    def test_checkpoint_rejects_an_unadvertised_remote_tracking_alias(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        compose = release_root / "container-compose"
+        self.git(
+            "update-ref",
+            "refs/remotes/origin/operator-work",
+            "origin/main",
+            cwd=compose,
+        )
+
+        self.assertFalse(
+            WORKSPACE.workspace_matches_initial_checkpoint(
+                release_root,
+                checkpoint,
+            )
+        )
+
     def test_legacy_checkpoint_accepts_state_advertised_by_its_own_remote(
         self,
     ) -> None:


### PR DESCRIPTION
Fixes #546.

A retained release transaction can stop after its child has fetched `origin/main`. That fetch changes only a controller-owned remote-tracking ref, but the workspace verifier previously treated any recorded remote-ref difference as operator work. The next invocation therefore preserved a stale checkout and the release child rejected it.

This change permits only an exact tracking-ref value currently advertised under the corresponding ref by the configured remote. Unchanged recorded refs remain valid; deleted refs are accepted only when the configured remote no longer advertises them; unadvertised aliases and operator state still force preservation. The advertised-ref query is cached and reused by recovery-object validation.

Validation:
- complete `Tools.release.test_release_workspace` suite: 55 tests passed
- focused fetched-main, unadvertised-alias, and legacy-remote regressions
- Python bytecode compilation
- `git diff --check`
- signed commit verification