### PR TITLE
fix(release): recover earlier fetched refs

### DIFF
--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -1417,6 +1417,7 @@ def _materialize_locked(
                 "immutableTagRefs",
                 "recoveryObjects",
                 "remoteTrackingRefs",
+                "remoteSymbolicRefs",
                 "semanticTagTargets",
             )
         )

--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -693,6 +693,54 @@ def workspace_matches_initial_checkpoint(
         advertised_ref = "HEAD" if remote_ref == "HEAD" else f"refs/heads/{remote_ref}"
         return expected_remotes[remote_name], advertised_ref
 
+    def tracked_ref_was_fetched(
+        path: Path,
+        git_directory: Path,
+        ref: str,
+        value: str,
+        target: tuple[str, str],
+    ) -> bool:
+        remote_url, advertised_ref = target
+        if not advertised_ref.startswith("refs/heads/"):
+            return False
+        remote_name = ref.removeprefix("refs/remotes/").partition("/")[0]
+        reflog_path = git_directory / "logs" / ref
+        if reflog_path.is_symlink() or not reflog_path.is_file():
+            return False
+        reflog = run_git(
+            "reflog",
+            "show",
+            "-1",
+            "--format=%H%x00%gs",
+            ref,
+            cwd=path,
+        ).rstrip("\n")
+        if "\0" not in reflog:
+            return False
+        reflog_value, message = reflog.split("\0", maxsplit=1)
+        action, separator, _outcome = message.partition(":")
+        if (
+            reflog_value != value
+            or not separator
+            or not action.startswith("fetch ")
+            or remote_name not in action.split()[1:]
+        ):
+            return False
+
+        fetch_head = git_directory / "FETCH_HEAD"
+        if fetch_head.is_symlink() or not fetch_head.is_file():
+            return False
+        branch = advertised_ref.removeprefix("refs/heads/")
+        expected_notes = {
+            f"branch '{branch}' of {url}"
+            for url in (remote_url, remote_url.removesuffix(".git"))
+        }
+        for line in fetch_head.read_text(encoding="utf-8").splitlines():
+            fields = line.split("\t", maxsplit=2)
+            if len(fields) == 3 and fields[0] == value and fields[2] in expected_notes:
+                return True
+        return False
+
     for component in COMPONENTS:
         path = root / component.name
         expected = refs[component.name]
@@ -728,18 +776,41 @@ def workspace_matches_initial_checkpoint(
         if grafts.exists() or grafts.is_symlink():
             return False
         local_remote_refs = local_remote_tracking_refs(path)
+        trusted_fetched_objects: set[str] = set()
         if recorded_remote_refs is not None:
             initial_remote_refs = recorded_remote_refs[component.name]
             assert isinstance(initial_remote_refs, dict)
             # A failed child may already have fetched before it stopped. Treat
             # only the exact tracking-ref value currently advertised by that
-            # configured remote as disposable controller state.
+            # configured remote, or an exact value its last recorded fetch
+            # obtained there, as disposable controller state.
             for name, value in local_remote_refs.items():
                 if initial_remote_refs.get(name) == value:
                     continue
+                symbolic_target = run_git(
+                    "for-each-ref",
+                    "--format=%(symref)",
+                    name,
+                    cwd=path,
+                ).strip()
+                if symbolic_target:
+                    if (
+                        local_remote_refs.get(symbolic_target) != value
+                        or initial_remote_refs.get(symbolic_target)
+                        != initial_remote_refs.get(name)
+                    ):
+                        return False
+                    continue
                 target = tracked_ref_target(name, expected_remotes)
-                if target is None or advertised_refs(target[0]).get(target[1]) != value:
+                if target is None:
                     return False
+                if advertised_refs(target[0]).get(target[1]) == value:
+                    continue
+                if not tracked_ref_was_fetched(
+                    path, git_directory, name, value, target
+                ):
+                    return False
+                trusted_fetched_objects.add(value)
             for name in initial_remote_refs.keys() - local_remote_refs.keys():
                 target = tracked_ref_target(name, expected_remotes)
                 if target is None or target[1] in advertised_refs(target[0]):
@@ -773,9 +844,8 @@ def workspace_matches_initial_checkpoint(
             missing = {
                 value
                 for value in new_recovery_objects
-                if not object_reachable_from_advertised_refs(
-                    path, value, advertised
-                )
+                if value not in trusted_fetched_objects
+                and not object_reachable_from_advertised_refs(path, value, advertised)
             }
             for name, url in expected_remotes.items():
                 if not missing or name == component.clone_remote:

--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -501,6 +501,7 @@ def verify_workspace(root: Path, build_root: Path) -> dict[str, object]:
     remotes = marker.get("remoteUrls")
     immutable_tags = marker.get("immutableTagRefs")
     remote_refs = marker.get("remoteTrackingRefs")
+    remote_symbolic_refs = marker.get("remoteSymbolicRefs")
     recovery_objects = marker.get("recoveryObjects")
     semantic_tags = marker.get("semanticTagTargets")
     if not isinstance(version, str) or not SEMVER.fullmatch(version):
@@ -540,6 +541,24 @@ def verify_workspace(root: Path, build_root: Path) -> dict[str, object]:
                 for name, value in component_refs.items()
             ):
                 raise WorkspaceError("release workspace remote refs are invalid")
+    if remote_symbolic_refs is not None:
+        if not isinstance(remote_symbolic_refs, dict) or set(
+            remote_symbolic_refs
+        ) != {component.name for component in COMPONENTS}:
+            raise WorkspaceError(
+                "release workspace remote symbolic refs are invalid"
+            )
+        for component_refs in remote_symbolic_refs.values():
+            if not isinstance(component_refs, dict) or any(
+                not isinstance(name, str)
+                or not name.startswith("refs/remotes/")
+                or not isinstance(target, str)
+                or not target.startswith("refs/remotes/")
+                for name, target in component_refs.items()
+            ):
+                raise WorkspaceError(
+                    "release workspace remote symbolic refs are invalid"
+                )
     if recovery_objects is not None:
         if not isinstance(recovery_objects, dict) or set(recovery_objects) != {
             component.name for component in COMPONENTS

--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -222,6 +222,28 @@ def local_remote_tracking_refs(path: Path) -> dict[str, str]:
     return refs
 
 
+def local_remote_symbolic_refs(path: Path) -> dict[str, str]:
+    refs: dict[str, str] = {}
+    lines = run_git(
+        "for-each-ref",
+        "--format=%(refname) %(symref)",
+        "refs/remotes",
+        cwd=path,
+    ).splitlines()
+    for line in lines:
+        fields = line.split()
+        if len(fields) == 1:
+            continue
+        if (
+            len(fields) != 2
+            or not fields[0].startswith("refs/remotes/")
+            or not fields[1].startswith("refs/remotes/")
+        ):
+            raise WorkspaceError(f"could not inspect remote symbolic refs in {path}")
+        refs[fields[0]] = fields[1]
+    return refs
+
+
 def local_recovery_objects(path: Path) -> list[str]:
     """Return objects protected by reflogs or Git recovery pseudorefs."""
 
@@ -653,11 +675,15 @@ def workspace_matches_initial_checkpoint(
     remotes = marker["remoteUrls"]
     recorded_tags = marker.get("immutableTagRefs")
     recorded_remote_refs = marker.get("remoteTrackingRefs")
+    recorded_remote_symbolic_refs = marker.get("remoteSymbolicRefs")
     recorded_recovery_objects = marker.get("recoveryObjects")
     assert isinstance(refs, dict)
     assert isinstance(remotes, dict)
     assert recorded_tags is None or isinstance(recorded_tags, dict)
     assert recorded_remote_refs is None or isinstance(recorded_remote_refs, dict)
+    assert recorded_remote_symbolic_refs is None or isinstance(
+        recorded_remote_symbolic_refs, dict
+    )
     assert recorded_recovery_objects is None or isinstance(
         recorded_recovery_objects, dict
     )
@@ -776,10 +802,18 @@ def workspace_matches_initial_checkpoint(
         if grafts.exists() or grafts.is_symlink():
             return False
         local_remote_refs = local_remote_tracking_refs(path)
+        local_symbolic_refs = local_remote_symbolic_refs(path)
         trusted_fetched_objects: set[str] = set()
         if recorded_remote_refs is not None:
             initial_remote_refs = recorded_remote_refs[component.name]
             assert isinstance(initial_remote_refs, dict)
+            if recorded_remote_symbolic_refs is not None:
+                initial_remote_symbolic_refs = recorded_remote_symbolic_refs[
+                    component.name
+                ]
+                assert isinstance(initial_remote_symbolic_refs, dict)
+                if local_symbolic_refs != initial_remote_symbolic_refs:
+                    return False
             # A failed child may already have fetched before it stopped. Treat
             # only the exact tracking-ref value currently advertised by that
             # configured remote, or an exact value its last recorded fetch
@@ -787,18 +821,8 @@ def workspace_matches_initial_checkpoint(
             for name, value in local_remote_refs.items():
                 if initial_remote_refs.get(name) == value:
                     continue
-                symbolic_target = run_git(
-                    "for-each-ref",
-                    "--format=%(symref)",
-                    name,
-                    cwd=path,
-                ).strip()
-                if symbolic_target:
-                    if (
-                        local_remote_refs.get(symbolic_target) != value
-                        or initial_remote_refs.get(symbolic_target)
-                        != initial_remote_refs.get(name)
-                    ):
+                if name in local_symbolic_refs:
+                    if recorded_remote_symbolic_refs is None:
                         return False
                     continue
                 target = tracked_ref_target(name, expected_remotes)
@@ -937,6 +961,10 @@ def workspace_baseline_state(root: Path) -> dict[str, object]:
         },
         "remoteTrackingRefs": {
             component.name: local_remote_tracking_refs(root / component.name)
+            for component in COMPONENTS
+        },
+        "remoteSymbolicRefs": {
+            component.name: local_remote_symbolic_refs(root / component.name)
             for component in COMPONENTS
         },
         "recoveryObjects": {
@@ -1324,6 +1352,7 @@ def _materialize_locked(
                 "immutableTagRefs",
                 "recoveryObjects",
                 "remoteTrackingRefs",
+                "remoteSymbolicRefs",
                 "semanticTagTargets",
             )
         )

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -384,6 +384,54 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             current,
         )
 
+    def test_resume_replaces_a_checkpoint_after_fetched_main_advances_again(
+        self,
+    ) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        compose = release_root / "container-compose"
+        source = self.root / "sources" / "container-compose"
+        (source / "first.txt").write_text("first\n", encoding="utf-8")
+        self.git("add", "first.txt", cwd=source)
+        self.git("commit", "-m", "first advance", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        self.git("fetch", "--prune", "--tags", "origin", cwd=compose)
+        fetched = self.git("rev-parse", "origin/main", cwd=compose).strip()
+
+        (source / "second.txt").write_text("second\n", encoding="utf-8")
+        self.git("add", "second.txt", cwd=source)
+        self.git("commit", "-m", "second advance", cwd=source)
+        current = self.git("rev-parse", "HEAD", cwd=source).strip()
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/main",
+            cwd=source,
+        )
+        self.assertNotEqual(fetched, current)
+        self.assertEqual(
+            self.git("rev-parse", "origin/main", cwd=compose).strip(),
+            fetched,
+        )
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git("rev-parse", "HEAD", cwd=resumed / "container-compose").strip(),
+            current,
+        )
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["mainRefs"]["container-compose"],
+            current,
+        )
+
     def test_checkpoint_rejects_an_unadvertised_remote_tracking_alias(self) -> None:
         release_root = WORKSPACE.materialize(
             self.build_root, "-+-", self.remote_root

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -2086,6 +2086,48 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         WORKSPACE.cleanup(release_root, self.build_root)
         self.assertFalse(release_root.exists())
 
+    def test_malformed_remote_symbolic_ref_baselines_are_rejected(self) -> None:
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        marker_path = release_root / WORKSPACE.WORKSPACE_MARKER
+        marker = WORKSPACE.workspace_marker(release_root)
+        components = [component.name for component in WORKSPACE.COMPONENTS]
+        valid = {component: {} for component in components}
+        malformed = {
+            "non-object": [],
+            "missing-component": {
+                component: {} for component in components[1:]
+            },
+            "non-object-component": {
+                **valid,
+                components[0]: [],
+            },
+            "invalid-ref-name": {
+                **valid,
+                components[0]: {"origin/HEAD": "refs/remotes/origin/main"},
+            },
+            "invalid-symbolic-target": {
+                **valid,
+                components[0]: {
+                    "refs/remotes/origin/HEAD": "refs/heads/main"
+                },
+            },
+        }
+
+        for name, remote_symbolic_refs in malformed.items():
+            with self.subTest(name=name):
+                damaged = dict(marker)
+                damaged["remoteSymbolicRefs"] = remote_symbolic_refs
+                WORKSPACE.atomic_json(marker_path, damaged)
+                with self.assertRaisesRegex(
+                    WORKSPACE.WorkspaceError,
+                    "remote symbolic refs are invalid",
+                ):
+                    WORKSPACE.verify_workspace(release_root, self.build_root)
+
+        WORKSPACE.atomic_json(marker_path, marker)
+
     def test_live_claim_blocks_concurrent_release_and_can_be_cleared(self) -> None:
         release_root = WORKSPACE.materialize(
             self.build_root, "-+-", self.remote_root

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -322,6 +322,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         original = checkpoint["mainRefs"]
         checkpoint.pop("immutableTagRefs")
         checkpoint.pop("remoteTrackingRefs")
+        checkpoint.pop("remoteSymbolicRefs")
         checkpoint.pop("recoveryObjects")
         checkpoint.pop("semanticTagTargets")
         WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
@@ -452,6 +453,61 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             )
         )
 
+    def test_resume_preserves_a_retargeted_remote_head(self) -> None:
+        source = self.root / "sources" / "container-compose"
+        self.git("branch", "release", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "release:refs/heads/release",
+            cwd=source,
+        )
+        release_root = WORKSPACE.materialize(
+            self.build_root, "-+-", self.remote_root
+        )
+        checkpoint = WORKSPACE.workspace_marker(release_root)
+        compose = release_root / "container-compose"
+        self.assertEqual(
+            checkpoint["remoteSymbolicRefs"]["container-compose"][
+                "refs/remotes/origin/HEAD"
+            ],
+            "refs/remotes/origin/main",
+        )
+
+        self.git("switch", "release", cwd=source)
+        (source / "release.txt").write_text("release\n", encoding="utf-8")
+        self.git("add", "release.txt", cwd=source)
+        self.git("commit", "-m", "advance release", cwd=source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/release",
+            cwd=source,
+        )
+        self.git(
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/release",
+            cwd=compose,
+        )
+        self.git("fetch", "origin", "release", cwd=compose)
+
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
+        self.assertEqual(
+            self.git(
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                cwd=resumed / "container-compose",
+            ).strip(),
+            "refs/remotes/origin/release",
+        )
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["mainRefs"],
+            checkpoint["mainRefs"],
+        )
+
     def test_legacy_checkpoint_accepts_state_advertised_by_its_own_remote(
         self,
     ) -> None:
@@ -463,6 +519,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             "immutableTagRefs",
             "recoveryObjects",
             "remoteTrackingRefs",
+            "remoteSymbolicRefs",
             "semanticTagTargets",
         ):
             checkpoint.pop(field)
@@ -528,6 +585,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             "immutableTagRefs",
             "recoveryObjects",
             "remoteTrackingRefs",
+            "remoteSymbolicRefs",
             "semanticTagTargets",
         ):
             checkpoint.pop(field)
@@ -588,6 +646,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             "immutableTagRefs",
             "recoveryObjects",
             "remoteTrackingRefs",
+            "remoteSymbolicRefs",
             "semanticTagTargets",
         ):
             checkpoint.pop(field)
@@ -621,6 +680,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             "immutableTagRefs",
             "recoveryObjects",
             "remoteTrackingRefs",
+            "remoteSymbolicRefs",
             "semanticTagTargets",
         ):
             checkpoint.pop(field)
@@ -683,6 +743,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             "immutableTagRefs",
             "recoveryObjects",
             "remoteTrackingRefs",
+            "remoteSymbolicRefs",
             "semanticTagTargets",
         ):
             checkpoint.pop(field)
@@ -707,6 +768,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         self.assertNotIn("immutableTagRefs", marker)
         self.assertNotIn("recoveryObjects", marker)
         self.assertNotIn("remoteTrackingRefs", marker)
+        self.assertNotIn("remoteSymbolicRefs", marker)
         self.assertNotIn("semanticTagTargets", marker)
         self.assertEqual(
             self.git(

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -1454,6 +1454,93 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         self.assertEqual(resumed_again, existing)
         self.assertEqual(retained.read_text(encoding="utf-8"), "operator work\n")
 
+    def test_reused_legacy_destination_preserves_a_retargeted_remote_head(
+        self,
+    ) -> None:
+        compose_source = self.root / "sources" / "container-compose"
+        self.git("branch", "release", cwd=compose_source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "release:refs/heads/release",
+            cwd=compose_source,
+        )
+        old_symbolic = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+        self.git("tag", "0.14.3", cwd=compose_source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "refs/tags/0.14.3",
+            cwd=compose_source,
+        )
+        existing = WORKSPACE.materialize(
+            self.build_root, "0.14.4", self.remote_root
+        )
+        marker_path = existing / WORKSPACE.WORKSPACE_MARKER
+        marker = WORKSPACE.workspace_marker(existing)
+        marker.pop("remoteSymbolicRefs")
+        WORKSPACE.atomic_json(marker_path, marker)
+
+        resumed = WORKSPACE.materialize(self.build_root, "--+", self.remote_root)
+
+        self.assertEqual(resumed, existing)
+        self.assertFalse(old_symbolic.exists())
+        self.assertEqual(
+            WORKSPACE.workspace_marker(resumed)["remoteSymbolicRefs"][
+                "container-compose"
+            ]["refs/remotes/origin/HEAD"],
+            "refs/remotes/origin/main",
+        )
+
+        compose = resumed / "container-compose"
+        self.git("switch", "release", cwd=compose_source)
+        (compose_source / "release.txt").write_text(
+            "release\n", encoding="utf-8"
+        )
+        self.git("add", "release.txt", cwd=compose_source)
+        self.git("commit", "-m", "advance release", cwd=compose_source)
+        self.git(
+            "push",
+            str(self.remote_root / "container-compose.git"),
+            "HEAD:refs/heads/release",
+            cwd=compose_source,
+        )
+        self.git(
+            "symbolic-ref",
+            "refs/remotes/origin/HEAD",
+            "refs/remotes/origin/release",
+            cwd=compose,
+        )
+        self.git("fetch", "origin", "release", cwd=compose)
+        dependency = self.root / "sources" / "containerization"
+        (dependency / "new-runtime.txt").write_text(
+            "new runtime\n", encoding="utf-8"
+        )
+        self.git("add", "new-runtime.txt", cwd=dependency)
+        self.git("commit", "-m", "advance main", cwd=dependency)
+        self.git(
+            "push",
+            str(self.remote_root / "containerization.git"),
+            "HEAD:refs/heads/main",
+            cwd=dependency,
+        )
+
+        resumed_again = WORKSPACE.materialize(
+            self.build_root, "--+", self.remote_root
+        )
+
+        self.assertEqual(resumed_again, existing)
+        self.assertEqual(
+            self.git(
+                "symbolic-ref",
+                "refs/remotes/origin/HEAD",
+                cwd=resumed_again / "container-compose",
+            ).strip(),
+            "refs/remotes/origin/release",
+        )
+
     def test_reused_destination_does_not_rebaseline_an_unpushed_tag(self) -> None:
         old_symbolic = WORKSPACE.materialize(
             self.build_root, "--+", self.remote_root


### PR DESCRIPTION
Fixes #546.

Follow-up to #547. The retained production checkpoint exposed a second exact state after that pull request merged: the child had fetched the then-current `origin/main`, then main advanced again before materialization. The fetched tracking value was consequently no longer the live advertised tip, so the verifier still preserved the stale checkout.

This change accepts that earlier value only when both Git records agree it came from the configured remote: the exact ref’s latest reflog entry must be a fetch through that configured remote, and `FETCH_HEAD` must record the same commit, branch, and remote URL. Symbolic remote `HEAD` is accepted only when it still follows the corresponding recorded tracking ref. The trusted fetched tip is then included only for recovery-object validation. Operator-created aliases and unrelated recovery state remain protected.

Validation:
- complete workspace-controller suite: 56 tests passed
- focused two-advance, single-advance, symbolic-ref, operator-alias, custom-ref, and FETCH_HEAD preservation regressions
- Python bytecode compilation
- `git diff --check`
- signed commit verification
- real retained 0.14.3 transaction refreshed from stale `394b0c4c` to exact canonical `e73e23b3` without manual Git repair