### PR TITLE
fix(release): stage exact validation trees

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -238,7 +238,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         stack_source = '"CONTAINERIZATION_STACK_REPO=${containerization_path}"'
 
         self.assertIn("stage_local_validation_checkout() {", self.script)
-        self.assertIn("clone --no-local --no-checkout --quiet", self.script)
+        self.assertIn("fetch --quiet --no-tags", self.script)
+        self.assertIn('--depth=1 origin "${source_commit}"', self.script)
         self.assertIn("remote remove origin", self.script)
         self.assertIn("objects/info/alternates", self.script)
         self.assertIn(staging, local_gate)
@@ -405,6 +406,69 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "--full",
                 "--strict",
                 "--no-dangling",
+            )
+
+    def test_local_validation_checkout_ignores_unrelated_missing_objects(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            staged = root / "staged"
+            source.mkdir()
+            self.run_command("git", "-C", str(source), "init", "-b", "main", "--quiet")
+            self.configure_repo(source)
+            (source / "tracked.txt").write_text("tracked\n", encoding="utf-8")
+            self.run_command("git", "-C", str(source), "add", "tracked.txt")
+            self.run_command("git", "-C", str(source), "commit", "--quiet", "-m", "main")
+            source_commit = self.git(source, "rev-parse", "HEAD")
+
+            self.run_command("git", "-C", str(source), "checkout", "-b", "unrelated", "--quiet")
+            unrelated = source / "unrelated.txt"
+            unrelated.write_text("unrelated historical object\n", encoding="utf-8")
+            self.run_command("git", "-C", str(source), "add", "unrelated.txt")
+            self.run_command(
+                "git", "-C", str(source), "commit", "--quiet", "-m", "unrelated"
+            )
+            unrelated_blob = self.git(source, "rev-parse", "HEAD:unrelated.txt")
+            self.run_command("git", "-C", str(source), "checkout", "main", "--quiet")
+            object_path = source / ".git" / "objects" / unrelated_blob[:2] / unrelated_blob[2:]
+            object_path.unlink()
+            self.run_command(
+                "git", "-C", str(source), "config", "remote.origin.promisor", "true"
+            )
+            self.run_command(
+                "git", "-C", str(source), "config", "remote.origin.partialclonefilter", "blob:none"
+            )
+
+            (source / "bin").mkdir()
+            (source / "bin" / "vmlinux-arm64").write_bytes(b"kernel")
+            (source / ".local" / "bin").mkdir(parents=True)
+            source_hawkeye = source / ".local" / "bin" / "hawkeye"
+            source_hawkeye.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            source_hawkeye.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                (
+                    "stage_local_validation_checkout "
+                    f"{shlex.quote(str(source))} {shlex.quote(str(staged))}"
+                ),
+                shell="/bin/bash",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(self.git(staged, "rev-parse", "HEAD"), source_commit)
+            self.assertEqual(self.git(staged, "remote"), "")
+            self.run_command(
+                "git",
+                "-C",
+                str(staged),
+                "fsck",
+                "--full",
+                "--strict",
+                "--no-dangling",
+                source_commit,
             )
 
     def test_stable_containerization_checkout_is_marked_and_git_clean(self) -> None:
@@ -5003,6 +5067,29 @@ esac
                 log.read_text(encoding="utf-8").splitlines(),
                 [f"kickstart {label}"],
             )
+
+    def test_restore_accepts_an_empty_runner_set_under_system_bash(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            result = self.run_release_function(
+                Path(directory),
+                "restore_quiesced_release_launch_agents; "
+                "test ${#RELEASE_QUIESCED_LABELS[@]} -eq 0; "
+                "test ${#RELEASE_QUIESCED_PLISTS[@]} -eq 0; "
+                "test ${#RELEASE_QUIESCED_ACTION_STARTED[@]} -eq 0; "
+                "test ${#RELEASE_QUIESCED_DEADLINES[@]} -eq 0; "
+                "test ${#RELEASE_QUIESCED_RESTARTED_UNREADY[@]} -eq 0",
+                shell="/bin/bash",
+                shell_setup=(
+                    "RELEASE_QUIESCED_LABELS=()\n"
+                    "RELEASE_QUIESCED_PLISTS=()\n"
+                    "RELEASE_QUIESCED_ACTION_STARTED=()\n"
+                    "RELEASE_QUIESCED_DEADLINES=()\n"
+                    "RELEASE_QUIESCED_RESTARTED_UNREADY=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_runner_restore_requires_online_registration(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -953,8 +953,11 @@ stage_local_validation_checkout() {
       "${source_path}" >&2
     return 1
   fi
-  if ! "${isolated_git[@]}" clone --no-local --no-checkout --quiet \
-    "${source_path}" "${staged_path}"; then
+  if ! "${isolated_git[@]}" init --quiet "${staged_path}" || \
+    ! "${isolated_git[@]}" -C "${staged_path}" remote add origin \
+      "${source_path}" || \
+    ! "${isolated_git[@]}" -C "${staged_path}" fetch --quiet --no-tags \
+      --depth=1 origin "${source_commit}"; then
     printf 'failed to stage release validation checkout locally: %s\n' \
       "${source_path}" >&2
     return 1
@@ -2707,11 +2710,18 @@ restore_quiesced_release_launch_agents() {
     fi
   done
 
-  RELEASE_QUIESCED_LABELS=("${failed_labels[@]}")
-  RELEASE_QUIESCED_PLISTS=("${failed_plists[@]}")
-  RELEASE_QUIESCED_ACTION_STARTED=("${failed_action_started[@]}")
-  RELEASE_QUIESCED_DEADLINES=("${failed_deadlines[@]}")
-  RELEASE_QUIESCED_RESTARTED_UNREADY=("${failed_restarted_unready[@]}")
+  RELEASE_QUIESCED_LABELS=()
+  RELEASE_QUIESCED_PLISTS=()
+  RELEASE_QUIESCED_ACTION_STARTED=()
+  RELEASE_QUIESCED_DEADLINES=()
+  RELEASE_QUIESCED_RESTARTED_UNREADY=()
+  if ((${#failed_labels[@]} > 0)); then
+    RELEASE_QUIESCED_LABELS=("${failed_labels[@]}")
+    RELEASE_QUIESCED_PLISTS=("${failed_plists[@]}")
+    RELEASE_QUIESCED_ACTION_STARTED=("${failed_action_started[@]}")
+    RELEASE_QUIESCED_DEADLINES=("${failed_deadlines[@]}")
+    RELEASE_QUIESCED_RESTARTED_UNREADY=("${failed_restarted_unready[@]}")
+  fi
   return "${restore_status}"
 }
 


### PR DESCRIPTION
Fixes #551.

## What changed

- stage only the exact validation commit with a depth-one fetch instead of cloning every ref from a partial/promisor transaction checkout
- preserve exact tree, clean checkout, self-contained object, no-remote, Hawkeye, kernel, and cleanup checks
- clear empty quiesced-runner recovery arrays safely under macOS system Bash 3.2

## Focused evidence

- 5 validation-checkout controller tests passed
- 16 runner-restoration controller tests passed under the affected path
- direct staging proof passed against the retained partial Containerization checkout at `f9d57ad1c80944c43bec6fc74afe1bfac3956480`
- `bash -n`, Python byte compilation, and `git diff --check` passed

The retained 0.14.3 transaction remains unpublished and recoverable. It will be resumed only after this exact head is reviewed and merged.