### PR TITLE
fix(build): synchronize corrected builder artifact

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad"
+        "revision" : "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let containerDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/container.git",
-    revision: "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad",
+    revision: "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a",
 )
 
 let containerizationDependency: Package.Dependency = .package(

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,16 +1,16 @@
 {
   "components": {
     "container": {
-      "ref": "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad",
+      "ref": "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
       "image": {
-        "digest": "sha256:7398845b67e6d5c5e610e9f1c6bf4ce84e4c7242a8f8002ff2e5e917437cfdf7",
+        "digest": "sha256:5598b550fe76ad4992de94a3f80811326e2f7bd85147a5343bc1edd2205402dd",
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
-        "tag": "current-33970281067-287f2ea3276e"
+        "tag": "current-34122911062-f99e66b89402"
       },
-      "ref": "287f2ea3276eca73cd3781ff59b4c9c82d5f3d32",
+      "ref": "f99e66b8940242d6ea8bed448619ba61f3f6f1a5",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {


### PR DESCRIPTION
## Summary

- pin Container to the merge that adopts the corrected builder artifact
- pin the corrected immutable builder source, image tag, and digest in the Compose stack authority
- keep the Swift package manifest and lockfile on the same exact Container identity

## Why

The retained 0.14.3 release correctly rejected a partially updated stack: Compose named the new builder artifact while its Container dependency still compiled the previous builder identity. Container PR #217 now provides one reviewed main commit that reports the corrected builder identity.

## Validation

- 10 stack-consistency regression tests passed
- live stack consistency passed against Container main d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a
- focused stable-release sibling-main policy test passed
- git diff --check passed
- commit signature verified

## Related

- Closes #555
- stephenlclarke/container#217
- stephenlclarke/container-builder-shim#19