### PR TITLE
chore(release): refresh corrected builder authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 7 September 2026 snapshot, the three support forks are **1146 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 7 September 2026 snapshot, the three support forks are **1150 commits ahead of Apple upstream**:
 >
 > - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 303 ahead** at [`f9d57ad1c809`](https://github.com/stephenlclarke/containerization/commit/f9d57ad1c80944c43bec6fc74afe1bfac3956480).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 790 ahead** at [`aaacb3ed973f`](https://github.com/stephenlclarke/container/commit/aaacb3ed973f9e47434fc14335f87a4a42a1f2ad).
-> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 53 ahead** at [`287f2ea3276e`](https://github.com/stephenlclarke/container-builder-shim/commit/287f2ea3276eca73cd3781ff59b4c9c82d5f3d32).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 792 ahead** at [`d8ccda0fd6f3`](https://github.com/stephenlclarke/container/commit/d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a).
+> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 55 ahead** at [`f99e66b89402`](https://github.com/stephenlclarke/container-builder-shim/commit/f99e66b8940242d6ea8bed448619ba61f3f6f1a5).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >
 > What looks like a local Compose change can therefore require coordinated conflict resolution, pin updates, builds, tests, packaging, and release validation across the entire stack. The pinned revisions must move together.

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "eee7ad097079cc3b02d5309ec10160143f2d0c6a",
-      "forkHead": "aaacb3ed973f9e47434fc14335f87a4a42a1f2ad",
+      "forkHead": "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -501,7 +501,8 @@
             "436a7c9b4edc14a6b23440f8bf4b438e39830b81",
             "6f4c232563ba812404282471bdea4d32a143e745",
             "228897171d71975988ccdc690f1982e7433952af",
-            "09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607"
+            "09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607",
+            "25399784a692d5d5933ab3db67d385e0e82b5fad"
           ]
         },
         {
@@ -1101,7 +1102,7 @@
     },
     "container-builder-shim": {
       "upstreamHead": "e18d2182fd060dbf1c68113a74e7564d563dde27",
-      "forkHead": "287f2ea3276eca73cd3781ff59b4c9c82d5f3d32",
+      "forkHead": "f99e66b8940242d6ea8bed448619ba61f3f6f1a5",
       "slices": [
         {
           "id": "container-builder-shim-support-maintenance",
@@ -1143,7 +1144,8 @@
             "723d49ff42ebb2d76ebfcadffda023f6b049b484",
             "b6990e48e4a345081d86ed04d72a355296a2d672",
             "711d64048d01c181b8c29cf9acb782da9491290b",
-            "3b0e23c02f035a4b7825a124c4d95c36c3c9019f"
+            "3b0e23c02f035a4b7825a124c4d95c36c3c9019f",
+            "8538b2e7931f41a831af66dc65381f7acc46cc64"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `aaacb3ed973f9e47434fc14335f87a4a42a1f2ad` | 0 | 790 | 666 |
+| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a` | 0 | 792 | 667 |
 | `containerization` | `847655d373a27b8b8d0c3a9747f04f16b5de1206` | `f9d57ad1c80944c43bec6fc74afe1bfac3956480` | 0 | 303 | 239 |
-| `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `287f2ea3276eca73cd3781ff59b4c9c82d5f3d32` | 0 | 53 | 44 |
-| **Total** | | | **0** | **1146** | **949** |
+| `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `f99e66b8940242d6ea8bed448619ba61f3f6f1a5` | 0 | 55 | 45 |
+| **Total** | | | **0** | **1150** | **951** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 693 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 695 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 231 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -298,3 +298,10 @@ The final 7 September 2026 release refresh advances Container through
 `aaacb3ed973f`. Its exact Containerization dependency pin at `09acdc2f1df2`
 is support maintenance and adds no new runtime behaviour. No generic runtime
 primitive, temporary port, or rejected Compose-policy disposition changed.
+
+The corrected-builder refresh advances Container through `d8ccda0fd6f3` and
+the builder shim through `f99e66b89402`. Container's immutable builder image
+pin at `25399784a692` and the builder shim's module-derived Go toolchain fix at
+`8538b2e7931f` are support maintenance. They make the matched build
+reproducible without adding runtime behaviour or changing any temporary port,
+generic primitive, or rejected Compose-policy disposition.

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -8347,6 +8347,30 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/545"
     },
     {
+      "id": "container-compose-557",
+      "owner": "stephenlclarke/container-compose",
+      "title": "chore(release): refresh corrected builder classification authority",
+      "state": "active-draft",
+      "lastVerified": "2026-09-07",
+      "commits": [
+        "25399784a692d5d5933ab3db67d385e0e82b5fad",
+        "8538b2e7931f41a831af66dc65381f7acc46cc64",
+        "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a",
+        "f99e66b8940242d6ea8bed448619ba61f3f6f1a5"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-557.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-558.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/558"
+    },
+    {
       "id": "process-list-compose-top-process-list",
       "owner": "stephenlclarke/container-compose",
       "title": "Pull request: support Docker-shaped `container compose top`",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-07
 
-Entries: 424. Document snapshots: 740. Current supporting documents: 134.
+Entries: 425. Document snapshots: 742. Current supporting documents: 136.
 
-States: `active-draft` 29, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 30, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -254,6 +254,7 @@ States: `active-draft` 29, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [Make the recoverable pipeline reliable and efficient](https://github.com/stephenlclarke/container-compose/pull/489) | `active-draft` | `bdfd9cef9139`, `03a387961ee9` | [Issue details](container-compose/ISSUE-488.md); [PR details](container-compose/PR-489.md) |
 | `stephenlclarke/container-compose` | [chore(release): refresh 0.14.3 upstream authority](https://github.com/stephenlclarke/container-compose/pull/534) | `active-draft` | `228897171d71`, `40ab92d74a02`, `847655d373a2`, `f9d57ad1c809` | [Issue details](container-compose/ISSUE-533.md); [PR details](container-compose/PR-534.md) |
 | `stephenlclarke/container-compose` | [chore(release): refresh 0.14.3 Container classification authority](https://github.com/stephenlclarke/container-compose/pull/545) | `active-draft` | `09acdc2f1df2`, `aaacb3ed973f` | [Issue details](container-compose/ISSUE-544.md); [PR details](container-compose/PR-545.md) |
+| `stephenlclarke/container-compose` | [chore(release): refresh corrected builder classification authority](https://github.com/stephenlclarke/container-compose/pull/558) | `active-draft` | `25399784a692`, `8538b2e7931f`, `d8ccda0fd6f3`, `f99e66b89402` | [Issue details](container-compose/ISSUE-557.md); [PR details](container-compose/PR-558.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-557.md
+++ b/docs/upstream/container-compose/ISSUE-557.md
@@ -1,0 +1,38 @@
+# Issue 557: refresh corrected builder classification authority
+
+## Problem
+
+The recoverable 0.14.3 release preflight stopped before testing after Container
+pull request #217 and container-builder-shim pull request #19 advanced their
+fork heads. The reviewed Container builder-image pin
+`25399784a692d5d5933ab3db67d385e0e82b5fad` and builder module-derived Go
+toolchain fix `8538b2e7931f41a831af66dc65381f7acc46cc64` were not yet classified,
+leaving both registries one commit short.
+
+## Scope
+
+- Classify both build fixes in their existing support-maintenance slices.
+- Advance the exact Container and builder-shim fork heads.
+- Refresh the README snapshot and human classification summary from the
+  authoritative fetched repositories.
+- Leave release assets, CodeQL, Homebrew, DocC, and released-artifact
+  benchmarks to the retained 0.14.3 release transaction.
+
+## Acceptance evidence
+
+- `make fork-classifications-check` reports all 951 patch-unique non-merge
+  commits classified exactly once.
+- `make upstream-divergence-release-check` reports all three support forks
+  current with Apple and cleanly mergeable.
+- `make readme-upstream-metrics-check`, `make stack-consistency`, and
+  `make upstream-handoff-registry-check` pass.
+- Focused Markdown, JSON, and diff checks pass.
+- Required pull-request checks pass on the exact head.
+
+Related lower work: Container
+[#216](https://github.com/stephenlclarke/container/issues/216) and
+[#217](https://github.com/stephenlclarke/container/pull/217), and builder shim
+[#18](https://github.com/stephenlclarke/container-builder-shim/issues/18) and
+[#19](https://github.com/stephenlclarke/container-builder-shim/pull/19).
+
+Implementation: [#558](https://github.com/stephenlclarke/container-compose/pull/558).

--- a/docs/upstream/container-compose/PR-558.md
+++ b/docs/upstream/container-compose/PR-558.md
@@ -1,0 +1,37 @@
+# Pull request 558: refresh corrected builder classification authority
+
+## Change
+
+This pull request refreshes the exact upstream authority required by the
+recoverable 0.14.3 release transaction. It classifies Container's immutable
+builder-image pin `25399784a692d5d5933ab3db67d385e0e82b5fad` and the builder
+shim's module-derived Go toolchain fix
+`8538b2e7931f41a831af66dc65381f7acc46cc64` as support maintenance, advances
+both fork heads, and regenerates the visible divergence totals from fetched
+repository heads.
+
+## Scope boundary
+
+This is release-authority metadata only. It changes no Compose or runtime
+behaviour and does not run or duplicate the stable release controller's
+release documentation, CodeQL, packaging, Homebrew, DocC, or released-artifact
+benchmark stages.
+
+## Validation
+
+- `make fork-classifications-check`
+- `make upstream-divergence-release-check`
+- `make readme-upstream-metrics-check`
+- `make stack-consistency`
+- `make upstream-handoff-registry-check`
+- focused Markdown and JSON validation
+- `git diff --check`
+- required hosted checks before merge
+
+Closes [#557](https://github.com/stephenlclarke/container-compose/issues/557).
+
+Related lower work: Container
+[#216](https://github.com/stephenlclarke/container/issues/216) and
+[#217](https://github.com/stephenlclarke/container/pull/217), and builder shim
+[#18](https://github.com/stephenlclarke/container-builder-shim/issues/18) and
+[#19](https://github.com/stephenlclarke/container-builder-shim/pull/19).


### PR DESCRIPTION
## Summary

- classify the corrected Container builder pin and builder-shim Go toolchain fix as support maintenance
- advance the reviewed Container and builder-shim fork heads
- refresh README fork metrics, the human classification view, and the upstream handoff registry

## Scope

This is release-authority metadata only. It changes no runtime behaviour and does not duplicate packaging, CodeQL, Homebrew, DocC, or released-artifact benchmarks.

## Validation

- make upstream-divergence-release-check
- make readme-upstream-metrics-check
- make stack-consistency
- make upstream-handoff-registry-check
- focused Markdown and JSON validation
- git diff --check
- commit signature verified

## Related

- Closes #557
- stephenlclarke/container#217
- stephenlclarke/container-builder-shim#19