### PR TITLE
[Build] Advance Compose to Container 24c4726d

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "54b27945699003a9f041a9c3b557c04c35be915c680e1477371f24f735940da9",
+  "originHash" : "1bf517a669e892e339e67a2b457e47590d5176bfb0addefec90b9b75a65e4906",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a"
+        "revision" : "24c4726d104859149f9227007822dd79edbfa88d"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let containerDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/container.git",
-    revision: "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a",
+    revision: "24c4726d104859149f9227007822dd79edbfa88d",
 )
 
 let containerizationDependency: Package.Dependency = .package(

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a",
+      "ref": "24c4726d104859149f9227007822dd79edbfa88d",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

Advance the immutable Compose Container dependency from `d8ccda0fd6f3` to reviewed Container main `24c4726d1048`.

The lockfile and checked-in stack manifest move with the package declaration so Current publication sees one coherent stack. This is the manual propagation needed for the retained 0.14.3 release; #542 remains open for the durable automatic propagation workflow.

## Evidence

- `swift package resolve` completed with only the requested Container pin change
- `CONTAINER_STACK_REPO=/Users/sclarke/github/container /usr/bin/python3 Tools/ci/check-stack-consistency.py` passed in 0.05s
- `git diff --check` passed
- commit `71d76f8a1f4b` has a verified SSH signature

Refs #542