### PR TITLE
fix(release): handle empty launchd cleanup sets

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1191,6 +1191,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "stop_stable_container_validation_runtime "
                 f"{shlex.quote(str(stable))} {shlex.quote(str(app_root))} "
                 f"{shlex.quote(namespace)}",
+                shell="/bin/bash",
                 shell_setup=f"export STOP_LOG={shlex.quote(str(stop_log))}",
                 environment_overrides={
                     "CONTAINER_STACK_RELEASE_LAUNCHCTL": str(launchctl)
@@ -5235,6 +5236,37 @@ esac
                     "RELEASE_QUIESCED_DEADLINES=()\n"
                     "RELEASE_QUIESCED_RESTARTED_UNREADY=()\n"
                     "RELEASE_SUSPENDED_RUNNER_PGIDS=()"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_quiesce_accepts_an_empty_worker_set_under_system_bash(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                "#!/bin/bash\n"
+                '[[ "${1:-}" == "list" ]] || exit 64\n',
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "quiesce_local_release_workers; "
+                "test ${#RELEASE_QUIESCED_LABELS[@]} -eq 0",
+                shell="/bin/bash",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(root))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_QUIESCED_LABELS=()\n"
+                    "RELEASE_QUIESCED_PLISTS=()\n"
+                    "RELEASE_QUIESCED_ACTION_STARTED=()\n"
+                    "RELEASE_QUIESCED_DEADLINES=()\n"
+                    "RELEASE_QUIESCED_RESTARTED_UNREADY=()\n"
+                    "RELEASE_SUSPENDED_RUNNER_PGIDS=()\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=1"
                 ),
             )
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -1845,6 +1845,7 @@ force_bootout_stable_container_validation_namespace() {
   local service_namespace="$1"
   local stable_container_path="$2"
   local manager domain label active_pids="" launchctl_output=""
+  local index=0
   local -a labels=()
 
   if [[ ! "${service_namespace}" =~ ^io\.github\.container\.stack-validation\.[A-Za-z0-9]+$ ]] || \
@@ -1872,7 +1873,8 @@ force_bootout_stable_container_validation_namespace() {
     [[ -n "${label}" ]] && labels+=("${label}")
   done < <(/usr/bin/awk -v prefix="${service_namespace}." \
     'index($3, prefix) == 1 { print $3 }' <<<"${launchctl_output}")
-  for label in "${labels[@]}"; do
+  for ((index = 0; index < ${#labels[@]}; index++)); do
+    label="${labels[index]}"
     if ! "${RELEASE_COMMAND_DEADLINE_RUNNER}" \
       --seconds "${CANDIDATE_STOP_TIMEOUT_SECONDS}" --grace-seconds 0 -- \
       "${RELEASE_LAUNCHCTL}" bootout "${domain}/${label}"; then
@@ -2802,6 +2804,7 @@ release_local_release_gate_host_state() {
 # loaded set is restored by the caller's EXIT path even when validation fails.
 quiesce_local_release_workers() {
   local attempt=0
+  local index=0
   local label=""
   local listed_labels=""
   local plist=""
@@ -2849,7 +2852,8 @@ quiesce_local_release_workers() {
     [[ -n "${label}" ]] && labels+=("${label}")
   done <<<"${listed_labels}"
 
-  for label in "${labels[@]}"; do
+  for ((index = 0; index < ${#labels[@]}; index++)); do
+    label="${labels[index]}"
     if ! [[ "${label}" =~ ^[A-Za-z0-9._-]+$ ]]; then
       printf 'refusing unsafe release launch-agent label: %s\n' "${label}" >&2
       restore_quiesced_release_launch_agents || true
@@ -2908,7 +2912,8 @@ quiesce_local_release_workers() {
 
   for ((attempt = 1; attempt <= RELEASE_QUIESCE_WAIT_ATTEMPTS; attempt++)); do
     local workers_stopped=1
-    for label in "${RELEASE_QUIESCED_LABELS[@]}"; do
+    for ((index = 0; index < ${#RELEASE_QUIESCED_LABELS[@]}; index++)); do
+      label="${RELEASE_QUIESCED_LABELS[index]}"
       loaded_status=0
       release_launch_agent_is_loaded "${label}" || loaded_status=$?
       case "${loaded_status}" in


### PR DESCRIPTION
## Summary

- make nested-runtime launchd cleanup portable to macOS `/bin/bash` 3.2 when no services match
- make the equivalent worker-quiescence loops safe for an empty launch-agent set
- run both zero-service paths explicitly under the supported system Bash in focused regressions

## Why

The retained 0.14.3 stable gate passed upstream and Homebrew preflights, then stopped before compilation because Bash 3.2 expands an empty array as unset under `set -u`. Bash 5 accepts the same expression, so the existing developer-shell test did not expose the release-host failure.

The implementation uses indexed loops whose bounds are derived from `${#array[@]}`, which is portable to Bash 3.2 and preserves the exact namespace and launch-agent safety checks.

Closes #563.

## Validation

- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- three focused release-controller tests, including nested cleanup and empty worker quiescence under `/bin/bash`: 3 passed in 1.842s
- `git diff --check`

No product compilation, runtime parity, documentation build, or release-only analysis was rerun for this controller-only fix.