### PR TITLE
fix(release): persist host restoration state

### DIFF
--- a/Tools/release/release-host-state.py
+++ b/Tools/release/release-host-state.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Persist host restoration authority across release-controller processes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+SCHEMA = 1
+ROOT_MARKER = ".container-compose-release-host-state"
+ROOT_MARKER_VALUE = "container-compose release host state v1\n"
+JOURNAL = "quiesced-launch-agents.json"
+LABEL = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+class HostStateError(RuntimeError):
+    """Raised when durable host state cannot be trusted or updated."""
+
+
+@dataclass(frozen=True)
+class LaunchAgent:
+    """One launch agent that must be restored after release validation."""
+
+    label: str
+    plist: str
+
+
+def validate_launch_agent(label: str, plist: str) -> LaunchAgent:
+    """Return a normalized launch-agent entry or reject unsafe input."""
+
+    if not LABEL.fullmatch(label):
+        raise HostStateError(f"invalid launch-agent label: {label!r}")
+    if not plist.startswith("/") or "\n" in plist or "\t" in plist:
+        raise HostStateError(f"invalid launch-agent plist path: {plist!r}")
+    if Path(plist).name != f"{label}.plist":
+        raise HostStateError(
+            f"launch-agent plist does not match label {label}: {plist}"
+        )
+    return LaunchAgent(label=label, plist=plist)
+
+
+def require_regular_private_file(path: Path, description: str) -> os.stat_result:
+    """Require one user-owned regular file with no group or other access."""
+
+    try:
+        metadata = path.lstat()
+    except FileNotFoundError as error:
+        raise HostStateError(f"missing {description}: {path}") from error
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.getuid():
+        raise HostStateError(f"untrusted {description}: {path}")
+    if stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise HostStateError(f"insecure permissions on {description}: {path}")
+    return metadata
+
+
+def path_exists_without_following_links(path: Path) -> bool:
+    """Return whether a directory entry exists, including a dangling link."""
+
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def write_new_private_file(path: Path, content: bytes) -> None:
+    """Create one private file without following an existing link."""
+
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(descriptor, "wb", closefd=False) as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+    finally:
+        os.close(descriptor)
+
+
+def fsync_directory(path: Path) -> None:
+    """Make a journal rename or removal durable in its containing directory."""
+
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def require_state_root(root: Path) -> Path:
+    """Create or validate the private marker-protected host-state root."""
+
+    if not root.is_absolute() or root == Path("/"):
+        raise HostStateError(f"host-state root must be an absolute child path: {root}")
+    try:
+        root.mkdir(mode=0o700)
+        fsync_directory(root.parent)
+    except FileExistsError:
+        pass
+    metadata = root.lstat()
+    if not stat.S_ISDIR(metadata.st_mode) or metadata.st_uid != os.getuid():
+        raise HostStateError(f"untrusted host-state root: {root}")
+    if stat.S_IMODE(metadata.st_mode) & 0o077:
+        raise HostStateError(f"insecure permissions on host-state root: {root}")
+
+    marker = root / ROOT_MARKER
+    if not path_exists_without_following_links(marker):
+        write_new_private_file(marker, ROOT_MARKER_VALUE.encode("utf-8"))
+        fsync_directory(root)
+    require_regular_private_file(marker, "host-state marker")
+    if marker.read_text(encoding="utf-8") != ROOT_MARKER_VALUE:
+        raise HostStateError(f"invalid host-state marker: {marker}")
+    return root
+
+
+def load_launch_agents(root: Path) -> list[LaunchAgent]:
+    """Read and validate the complete retained restoration journal."""
+
+    root = require_state_root(root)
+    journal = root / JOURNAL
+    if not path_exists_without_following_links(journal):
+        return []
+    require_regular_private_file(journal, "host-state journal")
+    try:
+        payload = json.loads(journal.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        raise HostStateError(f"invalid host-state journal: {journal}") from error
+    if not isinstance(payload, dict) or set(payload) != {
+        "entries",
+        "ownerUid",
+        "schema",
+    }:
+        raise HostStateError(f"invalid host-state journal structure: {journal}")
+    if payload["schema"] != SCHEMA or payload["ownerUid"] != os.getuid():
+        raise HostStateError(f"host-state journal identity does not match: {journal}")
+    if not isinstance(payload["entries"], list):
+        raise HostStateError(f"invalid host-state journal entries: {journal}")
+
+    entries: list[LaunchAgent] = []
+    for item in payload["entries"]:
+        if not isinstance(item, dict) or set(item) != {"label", "plist"}:
+            raise HostStateError(f"invalid host-state journal entry: {journal}")
+        if not isinstance(item["label"], str) or not isinstance(item["plist"], str):
+            raise HostStateError(f"invalid host-state journal value: {journal}")
+        entries.append(validate_launch_agent(item["label"], item["plist"]))
+    if len({entry.label for entry in entries}) != len(entries):
+        raise HostStateError(f"duplicate launch-agent journal entry: {journal}")
+    return entries
+
+
+def store_launch_agents(root: Path, entries: Sequence[LaunchAgent]) -> None:
+    """Atomically replace the retained restoration journal."""
+
+    root = require_state_root(root)
+    journal = root / JOURNAL
+    if not entries:
+        if path_exists_without_following_links(journal):
+            require_regular_private_file(journal, "host-state journal")
+            journal.unlink()
+            fsync_directory(root)
+        return
+
+    if path_exists_without_following_links(journal):
+        require_regular_private_file(journal, "host-state journal")
+
+    payload = {
+        "entries": [
+            {"label": entry.label, "plist": entry.plist}
+            for entry in entries
+        ],
+        "ownerUid": os.getuid(),
+        "schema": SCHEMA,
+    }
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".host-state.", dir=root)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8", closefd=False) as stream:
+            json.dump(payload, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(temporary, journal)
+        fsync_directory(root)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def record_launch_agent(root: Path, entry: LaunchAgent) -> None:
+    """Durably retain restoration authority before host mutation."""
+
+    entries = load_launch_agents(root)
+    existing = next((item for item in entries if item.label == entry.label), None)
+    if existing is not None and existing != entry:
+        raise HostStateError(
+            f"launch-agent journal already maps {entry.label} to {existing.plist}"
+        )
+    if existing is None:
+        store_launch_agents(root, [*entries, entry])
+
+
+def remove_launch_agent(root: Path, entry: LaunchAgent) -> None:
+    """Discard restoration authority only after the service is healthy."""
+
+    entries = load_launch_agents(root)
+    existing = next((item for item in entries if item.label == entry.label), None)
+    if existing is not None and existing != entry:
+        raise HostStateError(
+            f"launch-agent journal maps {entry.label} to {existing.plist}"
+        )
+    store_launch_agents(root, [item for item in entries if item != entry])
+
+
+def parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--root", type=Path, required=True)
+    commands = result.add_subparsers(dest="command", required=True)
+    commands.add_parser("list")
+    for name in ("record", "remove"):
+        command = commands.add_parser(name)
+        command.add_argument("--label", required=True)
+        command.add_argument("--plist", required=True)
+    return result
+
+
+def main(arguments: Sequence[str]) -> int:
+    """Execute one host-state journal operation."""
+
+    options = parser().parse_args(arguments)
+    try:
+        if options.command == "list":
+            for entry in load_launch_agents(options.root):
+                print(f"{entry.label}\t{entry.plist}")
+        else:
+            entry = validate_launch_agent(options.label, options.plist)
+            if options.command == "record":
+                record_launch_agent(options.root, entry)
+            else:
+                remove_launch_agent(options.root, entry)
+    except (HostStateError, OSError) as error:
+        print(str(error), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -60,6 +60,7 @@ STABLE_RELEASE_LANE_CLASSIFIER = (
 RUNNER_INSTALLER = ROOT / "scripts" / "install-scheduled-release-runner.sh"
 HAWKEYE_INSTALLER = ROOT / "scripts" / "install-hawkeye.sh"
 PIPELINE_MAIN = ROOT / "main.nf"
+HOST_STATE_TOOL = ROOT / "Tools" / "release" / "release-host-state.py"
 
 
 class ContainerStackReleasePolicyTests(unittest.TestCase):
@@ -111,6 +112,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         )[1].split("      else", 1)[0]
         self.assertLess(
             active.index('"${RELEASE_WORKSPACE_TOOL}" verify'),
+            active.index("recover_release_host_state_on_startup"),
+        )
+        self.assertLess(
+            active.index("recover_release_host_state_on_startup"),
             active.index("release_current_stack"),
         )
 
@@ -229,7 +234,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
             self.assertEqual(accepted.returncode, 0, accepted.stderr)
 
-    def test_local_release_gate_pins_hawkeye_before_runtime_work(self) -> None:
+    def test_local_release_gate_fails_fast_before_pinning_hawkeye(self) -> None:
         local_gate = self.script[
             self.script.index("run_local_release_gate() {") : self.script.index(
                 "# Verify that Apple remotes cannot be pushed"
@@ -243,7 +248,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('"HAWKEYE=${release_hawkeye}"', local_gate)
         self.assertLess(local_gate.index(selected), local_gate.index(preflight))
         self.assertLess(
-            local_gate.index(preflight), local_gate.index("require_local_virtualization")
+            local_gate.index("require_local_virtualization"), local_gate.index(selected)
         )
         self.assertLess(
             local_gate.index(preflight),
@@ -4954,6 +4959,10 @@ github_cli() {{
 
         self.assertLess(
             local_gate.index("acquire_container_runtime_lock"),
+            local_gate.index("recover_retained_release_launch_agents"),
+        )
+        self.assertLess(
+            local_gate.index("recover_retained_release_launch_agents"),
             local_gate.index("quiesce_local_release_workers"),
         )
         self.assertLess(
@@ -4974,6 +4983,390 @@ github_cli() {{
             cleanup.index("trap '' HUP INT QUIT TERM"),
             cleanup.index("cleanup_local_release_gate_resources"),
         )
+
+    def test_release_gate_validates_init_authority_before_host_mutation(self) -> None:
+        local_gate = self.script[
+            self.script.index("run_local_release_gate() {") : self.script.index(
+                "# Verify that Apple remotes cannot be pushed"
+            )
+        ]
+
+        self.assertLess(
+            local_gate.index('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${init_image_archive}"'),
+            local_gate.index("acquire_container_runtime_lock"),
+        )
+        self.assertLess(
+            local_gate.index('--root "${RELEASE_HOST_STATE_ROOT}" list'),
+            local_gate.index('for repository in "${path}"'),
+        )
+        self.assertLess(
+            local_gate.index("require_local_virtualization"),
+            local_gate.index('for repository in "${path}"'),
+        )
+        self.assertLess(
+            local_gate.index('run make -C "${containerization_path}" fetch-default-kernel'),
+            local_gate.index("acquire_container_runtime_lock"),
+        )
+
+    def test_release_recovers_host_state_before_workspace_materialization(self) -> None:
+        main = self.script[self.script.rindex("\nmain() {") :]
+        release = main[main.index("    release)") :]
+
+        self.assertLess(
+            release.index("recover_release_host_state_on_startup"),
+            release.index("run_isolated_release"),
+        )
+
+    def test_quiescence_is_journaled_before_runner_drain(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            launch_agents = home / "Library" / "LaunchAgents"
+            launch_agents.mkdir(parents=True)
+            label = "actions.runner.owner-container-compose.release-host"
+            plist = launch_agents / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            observed = root / "observed"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                "#!/bin/bash\n"
+                '[[ "${1:-}" == "list" ]] || exit 64\n'
+                f"printf '123 0 %s\\n' {shlex.quote(label)}\n",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "if quiesce_local_release_workers; then exit 99; fi; "
+                f"test -f {shlex.quote(str(observed))}; "
+                'test -z "$(python3 "${RELEASE_HOST_STATE_TOOL}" '
+                '--root "${RELEASE_HOST_STATE_ROOT}" list)"',
+                shell="/bin/bash",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(home))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_QUIESCE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_QUIESCE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=1\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=1\n"
+                    "prepare_competing_release_runner_for_bootout() {\n"
+                    '  python3 "${RELEASE_HOST_STATE_TOOL}" '
+                    '--root "${RELEASE_HOST_STATE_ROOT}" list '
+                    f"| grep -F {shlex.quote(label)} >/dev/null\n"
+                    f"  printf 'observed\\n' > {shlex.quote(str(observed))}\n"
+                    "  return 3\n"
+                    "}\n"
+                    "release_launch_agent_is_healthy() { return 0; }"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_next_invocation_recovers_retained_launch_agent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "homebrew.mxcl.devcontainer"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            state_root = root / "host-state"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(HOST_STATE_TOOL),
+                    "--root",
+                    str(state_root),
+                    "record",
+                    "--label",
+                    label,
+                    "--plist",
+                    str(plist),
+                ],
+                check=True,
+            )
+            state = root / "loaded"
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/bin/bash
+set -euo pipefail
+case "${1:-}" in
+  list)
+    if [[ -s "${FAKE_LAUNCHCTL_STATE:?}" ]]; then
+      awk '{ print "123 0 " $0 }' "${FAKE_LAUNCHCTL_STATE}"
+    fi
+    ;;
+  bootstrap)
+    label="$(basename "${3}" .plist)"
+    printf 'bootstrap %s\n' "${label}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    printf '%s\n' "${label}" > "${FAKE_LAUNCHCTL_STATE}"
+    ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "recover_release_host_state_on_startup; "
+                'test -z "${RELEASE_QUIESCED_LABELS[*]:-}"; '
+                'test -z "$(python3 "${RELEASE_HOST_STATE_TOOL}" '
+                '--root "${RELEASE_HOST_STATE_ROOT}" list)"',
+                shell="/bin/bash",
+                shell_setup=(
+                    f"RELEASE_HOST_STATE_ROOT={shlex.quote(str(state_root))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=2\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=1\n"
+                    "release_devcontainer_engine_is_ready() { return 0; }\n"
+                    "acquire_container_runtime_lock() { :; }\n"
+                    "release_container_runtime_lock() { :; }\n"
+                    f"export FAKE_LAUNCHCTL_STATE={shlex.quote(str(state))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(log.read_text(encoding="utf-8"), f"bootstrap {label}\n")
+
+    def test_malformed_retained_state_fails_before_launchctl_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state_root = root / "host-state"
+            subprocess.run(
+                [sys.executable, str(HOST_STATE_TOOL), "--root", str(state_root), "list"],
+                check=True,
+            )
+            journal = state_root / "quiesced-launch-agents.json"
+            journal.write_text('{"schema":1}\n', encoding="utf-8")
+            journal.chmod(0o600)
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> {shlex.quote(str(log))}\n",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "if recover_release_host_state_on_startup; then exit 99; fi; "
+                f"test ! -e {shlex.quote(str(log))}",
+                shell="/bin/bash",
+                shell_setup=(
+                    f"RELEASE_HOST_STATE_ROOT={shlex.quote(str(state_root))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "acquire_container_runtime_lock() { :; }\n"
+                    "release_container_runtime_lock() { :; }"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_next_invocation_resumes_a_retained_stopped_runner(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            label = "actions.runner.owner-container-compose.release-host"
+            plist = root / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            state_root = root / "host-state"
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(HOST_STATE_TOOL),
+                    "--root",
+                    str(state_root),
+                    "record",
+                    "--label",
+                    label,
+                    "--plist",
+                    str(plist),
+                ],
+                check=True,
+            )
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/bin/bash
+set -euo pipefail
+case "${1:-}" in
+  list) printf '4242 0 %s\n' "${FAKE_LABEL:?}" ;;
+  print) printf 'pid = 4242\n' ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+            process_inspector = root / "ps"
+            process_inspector.write_text(
+                f"""#!/bin/bash
+set -euo pipefail
+case "$*" in
+  '-o uid= -p 4242') printf '%s\n' '{os.getuid()}' ;;
+  '-o pgid= -p 4242') printf '4242\n' ;;
+  '-axo pgid=,state=,command=') printf '4242 T /runner/bin/Runner.Listener run\n' ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            process_inspector.chmod(0o755)
+            log = root / "signals.log"
+            signaler = root / "kill"
+            signaler.write_text(
+                "#!/bin/bash\n"
+                f"printf '%s\\n' \"$*\" >> {shlex.quote(str(log))}\n",
+                encoding="utf-8",
+            )
+            signaler.chmod(0o755)
+
+            result = self.run_release_function(
+                root,
+                "recover_release_host_state_on_startup; "
+                'test -z "$(python3 "${RELEASE_HOST_STATE_TOOL}" '
+                '--root "${RELEASE_HOST_STATE_ROOT}" list)"',
+                shell="/bin/bash",
+                shell_setup=(
+                    f"RELEASE_HOST_STATE_ROOT={shlex.quote(str(state_root))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    f"RELEASE_PS={shlex.quote(str(process_inspector))}\n"
+                    f"RELEASE_KILL={shlex.quote(str(signaler))}\n"
+                    "release_launch_agent_is_healthy() { return 0; }\n"
+                    f"export FAKE_LABEL={shlex.quote(label)}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            self.assertEqual(log.read_text(encoding="utf-8"), "-CONT -4242\n")
+
+    def test_sigkill_during_runner_drain_is_recovered_by_next_invocation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            home = root / "home"
+            launch_agents = home / "Library" / "LaunchAgents"
+            launch_agents.mkdir(parents=True)
+            label = "actions.runner.owner-container-compose.release-host"
+            plist = launch_agents / f"{label}.plist"
+            plist.write_text("fixture\n", encoding="utf-8")
+            state_root = root / "host-state"
+            state = root / "loaded"
+            state.write_text(f"{label}\n", encoding="utf-8")
+            ready = root / "journaled"
+            log = root / "launchctl.log"
+            launchctl = root / "launchctl"
+            launchctl.write_text(
+                """#!/bin/bash
+set -euo pipefail
+case "${1:-}" in
+  list)
+    if [[ -s "${FAKE_LAUNCHCTL_STATE:?}" ]]; then
+      awk '{ print "123 0 " $0 }' "${FAKE_LAUNCHCTL_STATE}"
+    fi
+    ;;
+  bootstrap)
+    label="$(basename "${3}" .plist)"
+    printf 'bootstrap %s\n' "${label}" >> "${FAKE_LAUNCHCTL_LOG:?}"
+    printf '%s\n' "${label}" > "${FAKE_LAUNCHCTL_STATE}"
+    ;;
+  *) exit 2 ;;
+esac
+""",
+                encoding="utf-8",
+            )
+            launchctl.chmod(0o755)
+            lines = [
+                "set -euo pipefail",
+                "export CONTAINER_STACK_RELEASE_LIBRARY=1",
+                f"source {shlex.quote(str(SCRIPT))}",
+                f"HOME={shlex.quote(str(home))}",
+                f"RELEASE_HOST_STATE_ROOT={shlex.quote(str(state_root))}",
+                f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}",
+                "RELEASE_QUIESCE_WAIT_ATTEMPTS=1",
+                "RELEASE_QUIESCE_POLL_SECONDS=0",
+                "prepare_competing_release_runner_for_bootout() {",
+                '  python3 "${RELEASE_HOST_STATE_TOOL}" '
+                '--root "${RELEASE_HOST_STATE_ROOT}" list '
+                f"| grep -F {shlex.quote(label)} >/dev/null",
+                f"  printf 'journaled\\n' > {shlex.quote(str(ready))}",
+                "  while :; do :; done",
+                "}",
+                "quiesce_local_release_workers",
+            ]
+            environment = self.non_interactive_environment()
+            environment.update(
+                {
+                    "FAKE_LAUNCHCTL_STATE": str(state),
+                    "FAKE_LAUNCHCTL_LOG": str(log),
+                }
+            )
+            process = subprocess.Popen(
+                ["/bin/bash", "-c", "\n".join(lines)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=environment,
+            )
+            for _ in range(100):
+                if ready.exists() or process.poll() is not None:
+                    break
+                time.sleep(0.02)
+            if not ready.exists():
+                if process.poll() is None:
+                    process.kill()
+                _, error = process.communicate(timeout=5)
+                self.fail(error or "runner drain did not reach the journaled boundary")
+            process.kill()
+            process.communicate(timeout=5)
+            self.assertEqual(process.returncode, -signal.SIGKILL)
+
+            retained = subprocess.run(
+                [
+                    sys.executable,
+                    str(HOST_STATE_TOOL),
+                    "--root",
+                    str(state_root),
+                    "list",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            self.assertIn(label, retained.stdout)
+            state.write_text("", encoding="utf-8")
+            recovered = self.run_release_function(
+                root,
+                "recover_retained_release_launch_agents; "
+                'test -z "$(python3 "${RELEASE_HOST_STATE_TOOL}" '
+                '--root "${RELEASE_HOST_STATE_ROOT}" list)"',
+                shell="/bin/bash",
+                shell_setup=(
+                    f"HOME={shlex.quote(str(home))}\n"
+                    f"RELEASE_HOST_STATE_ROOT={shlex.quote(str(state_root))}\n"
+                    f"RELEASE_LAUNCHCTL={shlex.quote(str(launchctl))}\n"
+                    "RELEASE_RESTORE_WAIT_ATTEMPTS=2\n"
+                    "RELEASE_RESTORE_POLL_SECONDS=0\n"
+                    "RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS=1\n"
+                    "competing_release_runner_is_online() { return 0; }\n"
+                    "acquire_container_runtime_lock() { :; }\n"
+                    "release_container_runtime_lock() { :; }\n"
+                    f"export FAKE_LAUNCHCTL_STATE={shlex.quote(str(state))}\n"
+                    f"export FAKE_LAUNCHCTL_LOG={shlex.quote(str(log))}"
+                ),
+            )
+
+            self.assertEqual(
+                recovered.returncode,
+                0,
+                recovered.stdout + recovered.stderr,
+            )
+            self.assertEqual(log.read_text(encoding="utf-8"), f"bootstrap {label}\n")
 
     def test_local_release_gate_retains_runtime_lock_until_restore_retry_succeeds(
         self,
@@ -8565,6 +8958,7 @@ gh() {
             "export CONTAINER_STACK_RELEASE_LIBRARY=1",
             f"source {shlex.quote(str(SCRIPT))}",
             f"ROOT={shlex.quote(str(root))}",
+            f"RELEASE_HOST_STATE_ROOT={shlex.quote(str(root / 'host-state'))}",
             "EXECUTE=1",
             "COMPOSE_MAIN_PROMOTION_MODE=pr",
             "COMPOSE_MAIN_MERGE_MODE=checked-admin",

--- a/Tools/release/test_release_host_state.py
+++ b/Tools/release/test_release_host_state.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Focused tests for durable release host-state restoration authority."""
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("release-host-state.py")
+SPEC = importlib.util.spec_from_file_location("release_host_state", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+HOST_STATE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = HOST_STATE
+SPEC.loader.exec_module(HOST_STATE)
+
+
+class ReleaseHostStateTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name) / "host-state"
+        self.label = "actions.runner.owner-container-compose.release-host"
+        self.plist = f"/tmp/{self.label}.plist"
+        self.entry = HOST_STATE.validate_launch_agent(self.label, self.plist)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_record_list_and_remove_are_idempotent(self) -> None:
+        HOST_STATE.record_launch_agent(self.root, self.entry)
+        HOST_STATE.record_launch_agent(self.root, self.entry)
+
+        self.assertEqual(HOST_STATE.load_launch_agents(self.root), [self.entry])
+        journal = self.root / HOST_STATE.JOURNAL
+        self.assertEqual(journal.stat().st_mode & 0o077, 0)
+
+        HOST_STATE.remove_launch_agent(self.root, self.entry)
+        HOST_STATE.remove_launch_agent(self.root, self.entry)
+
+        self.assertEqual(HOST_STATE.load_launch_agents(self.root), [])
+        self.assertFalse(journal.exists())
+
+    def test_conflicting_plist_is_rejected_without_replacing_authority(self) -> None:
+        HOST_STATE.record_launch_agent(self.root, self.entry)
+        conflicting = HOST_STATE.LaunchAgent(
+            label=self.label,
+            plist=f"/private/tmp/{self.label}.plist",
+        )
+
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "already maps"):
+            HOST_STATE.record_launch_agent(self.root, conflicting)
+
+        self.assertEqual(HOST_STATE.load_launch_agents(self.root), [self.entry])
+
+    def test_insertion_order_is_preserved_for_reverse_restoration(self) -> None:
+        second_label = "homebrew.mxcl.devcontainer"
+        second = HOST_STATE.validate_launch_agent(
+            second_label,
+            f"/tmp/{second_label}.plist",
+        )
+
+        HOST_STATE.record_launch_agent(self.root, self.entry)
+        HOST_STATE.record_launch_agent(self.root, second)
+
+        self.assertEqual(
+            HOST_STATE.load_launch_agents(self.root),
+            [self.entry, second],
+        )
+
+    def test_malformed_journal_fails_closed(self) -> None:
+        HOST_STATE.require_state_root(self.root)
+        journal = self.root / HOST_STATE.JOURNAL
+        journal.write_text('{"schema":1}\n', encoding="utf-8")
+        journal.chmod(0o600)
+
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "structure"):
+            HOST_STATE.load_launch_agents(self.root)
+
+    def test_insecure_or_linked_state_is_rejected(self) -> None:
+        HOST_STATE.record_launch_agent(self.root, self.entry)
+        journal = self.root / HOST_STATE.JOURNAL
+        payload = json.loads(journal.read_text(encoding="utf-8"))
+        journal.unlink()
+        target = self.root / "target.json"
+        target.write_text(json.dumps(payload), encoding="utf-8")
+        target.chmod(0o600)
+        journal.symlink_to(target)
+
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "untrusted"):
+            HOST_STATE.load_launch_agents(self.root)
+
+        journal.unlink()
+        target.rename(journal)
+        journal.chmod(0o644)
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "permissions"):
+            HOST_STATE.load_launch_agents(self.root)
+
+    def test_dangling_marker_and_journal_links_are_rejected(self) -> None:
+        HOST_STATE.require_state_root(self.root)
+        marker = self.root / HOST_STATE.ROOT_MARKER
+        marker.unlink()
+        marker.symlink_to(self.root / "missing-marker")
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "untrusted"):
+            HOST_STATE.load_launch_agents(self.root)
+
+        marker.unlink()
+        marker.write_text(HOST_STATE.ROOT_MARKER_VALUE, encoding="utf-8")
+        marker.chmod(0o600)
+        journal = self.root / HOST_STATE.JOURNAL
+        journal.symlink_to(self.root / "missing-journal")
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "untrusted"):
+            HOST_STATE.load_launch_agents(self.root)
+
+    def test_label_and_plist_identity_are_validated(self) -> None:
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "label"):
+            HOST_STATE.validate_launch_agent("bad\tlabel", self.plist)
+        with self.assertRaisesRegex(HOST_STATE.HostStateError, "does not match"):
+            HOST_STATE.validate_launch_agent(self.label, "/tmp/other.plist")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -24,6 +24,7 @@ readonly COMPOSE_PROMOTION_REVIEW_TOOL="${SELF_DIRECTORY}/../Tools/release/compo
 readonly HOMEBREW_PREFLIGHT_TOOL="${SELF_DIRECTORY}/../Tools/release/homebrew-preflight.py"
 readonly OCI_IMAGE_LAYOUT_VALIDATOR="${SELF_DIRECTORY}/../Tools/release/validate-oci-image-layout.py"
 readonly RELEASE_COMMAND_DEADLINE_RUNNER="${SELF_DIRECTORY}/../Tools/ci/run-command-with-deadline.py"
+readonly RELEASE_HOST_STATE_TOOL="${SELF_DIRECTORY}/../Tools/release/release-host-state.py"
 readonly RELEASE_WORKSPACE_TOOL="${SELF_DIRECTORY}/../Tools/release/release-workspace.py"
 readonly STABLE_RELEASE_LANE_CLASSIFIER="${SELF_DIRECTORY}/../Tools/release/stable-release-default-lane.py"
 # shellcheck disable=SC1091
@@ -178,6 +179,11 @@ Environment:
       deadline and the default 10-observation grace before one restart of a
       live but definitively unready service.
 
+  CONTAINER_STACK_RELEASE_HOST_STATE_ROOT
+      Override the private, marker-protected local restoration journal used by
+      focused tests. Production defaults to /private/tmp and records every
+      launch agent before the release controller can suspend or stop it.
+
   CONTAINER_STACK_RELEASE_DEVCONTAINER_CLI
   CONTAINER_STACK_RELEASE_CURL
   CONTAINER_STACK_RELEASE_GITHUB_CLI
@@ -267,12 +273,14 @@ RELEASE_SUSPENDED_RUNNER_PGIDS=()
 RELEASE_QUIESCED_ACTION_STARTED=()
 RELEASE_QUIESCED_DEADLINES=()
 RELEASE_QUIESCED_RESTARTED_UNREADY=()
+RELEASE_QUIESCED_RETAINED=()
 RELEASE_QUIESCE_WAIT_ATTEMPTS="${CONTAINER_STACK_RELEASE_QUIESCE_WAIT_ATTEMPTS:-30}"
 RELEASE_QUIESCE_POLL_SECONDS="${CONTAINER_STACK_RELEASE_QUIESCE_POLL_SECONDS:-1}"
 RELEASE_RESTORE_WAIT_ATTEMPTS="${CONTAINER_STACK_RELEASE_RESTORE_WAIT_ATTEMPTS:-60}"
 RELEASE_RESTORE_TIMEOUT_SECONDS="${CONTAINER_STACK_RELEASE_RESTORE_TIMEOUT_SECONDS:-60}"
 RELEASE_RESTORE_POLL_SECONDS="${CONTAINER_STACK_RELEASE_RESTORE_POLL_SECONDS:-1}"
 RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS="${CONTAINER_STACK_RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS:-10}"
+RELEASE_HOST_STATE_ROOT="${CONTAINER_STACK_RELEASE_HOST_STATE_ROOT:-/private/tmp/container-compose-release-host-state-$(id -u)}"
 RELEASE_DEVCONTAINER_CLI="${CONTAINER_STACK_RELEASE_DEVCONTAINER_CLI:-$(command -v devcontainer || true)}"
 RELEASE_CURL="${CONTAINER_STACK_RELEASE_CURL:-/usr/bin/curl}"
 RELEASE_GITHUB_CLI="${CONTAINER_STACK_RELEASE_GITHUB_CLI:-$(command -v gh || true)}"
@@ -2651,7 +2659,132 @@ prepare_competing_release_runner_for_bootout() {
   return 0
 }
 
+# Persist restoration authority before this process can suspend or stop a
+# launch agent. The journal is the cross-process source of truth; the arrays
+# below are only the current process's retry state.
+record_release_launch_agent_restoration() {
+  python3 "${RELEASE_HOST_STATE_TOOL}" --root "${RELEASE_HOST_STATE_ROOT}" \
+    record --label "$1" --plist "$2"
+}
+
+# Discard durable authority only after the exact service has passed its health
+# probe. Removal is idempotent so legacy in-memory-only fixtures remain valid.
+remove_release_launch_agent_restoration() {
+  python3 "${RELEASE_HOST_STATE_TOOL}" --root "${RELEASE_HOST_STATE_ROOT}" \
+    remove --label "$1" --plist "$2"
+}
+
+# Recover a previous controller's journal into this process. A malformed or
+# untrusted journal fails before launchctl can mutate the host.
+load_retained_release_launch_agents() {
+  local extra=""
+  local label=""
+  local plist=""
+  local retained=""
+
+  if [[ -n "${RELEASE_QUIESCED_LABELS[*]:-}" || \
+    -n "${RELEASE_QUIESCED_PLISTS[*]:-}" ]]; then
+    printf 'cannot load retained release host state over active restoration state\n' >&2
+    return 2
+  fi
+  if ! retained="$(python3 "${RELEASE_HOST_STATE_TOOL}" \
+    --root "${RELEASE_HOST_STATE_ROOT}" list)"; then
+    printf 'cannot load retained release host state: %s\n' \
+      "${RELEASE_HOST_STATE_ROOT}" >&2
+    return 1
+  fi
+  [[ -z "${retained}" ]] && return 0
+
+  while IFS=$'\t' read -r label plist extra; do
+    if [[ -z "${label}" || -z "${plist}" || -n "${extra}" ]]; then
+      printf 'invalid retained release launch-agent record\n' >&2
+      return 1
+    fi
+    RELEASE_QUIESCED_LABELS+=("${label}")
+    RELEASE_QUIESCED_PLISTS+=("${plist}")
+    RELEASE_QUIESCED_ACTION_STARTED+=(0)
+    RELEASE_QUIESCED_DEADLINES+=("")
+    RELEASE_QUIESCED_RESTARTED_UNREADY+=(0)
+    RELEASE_QUIESCED_RETAINED+=(1)
+  done <<<"${retained}"
+}
+
+# A killed controller can leave an Actions listener in SIGSTOP before bootout.
+# Resume that exact retained process group before its online registration is
+# accepted as recovery evidence.
+resume_retained_release_runner() {
+  local label="$1"
+  local live_status=0
+  local process_group=""
+  local stopped_status=0
+
+  release_launch_agent_has_live_process "${label}" || live_status=$?
+  case "${live_status}" in
+    0)
+      ;;
+    1)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+  process_group="$(release_runner_service_process_group "${label}")" || return 1
+  release_runner_process_group_is_stopped "${process_group}" || stopped_status=$?
+  case "${stopped_status}" in
+    0)
+      if ! "${RELEASE_KILL}" -CONT "-${process_group}" 2>/dev/null; then
+        if "${RELEASE_KILL}" -0 "-${process_group}" 2>/dev/null; then
+          printf 'failed to resume retained release runner process group: %s\n' \
+            "${process_group}" >&2
+          return 1
+        fi
+      fi
+      ;;
+    1)
+      ;;
+    *)
+      printf 'cannot establish retained release runner process state: %s\n' \
+        "${label}" >&2
+      return 1
+      ;;
+  esac
+}
+
+recover_retained_release_launch_agents() {
+  load_retained_release_launch_agents || return
+  if [[ -z "${RELEASE_QUIESCED_LABELS[*]:-}" ]]; then
+    return 0
+  fi
+  printf 'recovering retained release host state: %s\n' \
+    "${RELEASE_QUIESCED_LABELS[*]}"
+  restore_quiesced_release_launch_agents
+}
+
+# Recover host state before an outer release invocation clones, builds, or
+# waits for remote authority. The runtime lock serializes this journal with a
+# local gate that may still be exiting.
+recover_release_host_state_on_startup() {
+  [[ "${EXECUTE}" == "1" ]] || return 0
+  (
+    # These dynamic-scope arrays intentionally belong only to the recovery
+    # subshell; restore_quiesced_release_launch_agents consumes them there.
+    # shellcheck disable=SC2030
+    local -a RELEASE_QUIESCED_LABELS=() RELEASE_QUIESCED_PLISTS=() \
+      RELEASE_QUIESCED_ACTION_STARTED=() RELEASE_QUIESCED_DEADLINES=() \
+      RELEASE_QUIESCED_RESTARTED_UNREADY=() RELEASE_QUIESCED_RETAINED=() \
+      RELEASE_SUSPENDED_RUNNER_PGIDS=()
+
+    trap release_local_release_gate_host_state EXIT
+    acquire_container_runtime_lock || return
+    recover_retained_release_launch_agents || return
+    release_local_release_gate_host_state || return
+    trap - EXIT
+  )
+}
+
 # Restore only the launch agents this release invocation successfully stopped.
+# shellcheck disable=SC2031 # Dynamic-scope arrays are supplied by each caller.
 restore_quiesced_release_launch_agents() {
   local attempt=0
   local deadline=0
@@ -2665,6 +2798,7 @@ restore_quiesced_release_launch_agents() {
   local restore_action_started=0
   local restored=0
   local restarted_unready_service=0
+  local retained_entry=0
   local sleep_seconds=0
   local unready_live_attempts=0
   local user_domain=""
@@ -2673,6 +2807,7 @@ restore_quiesced_release_launch_agents() {
   local -a failed_labels=()
   local -a failed_plists=()
   local -a failed_restarted_unready=()
+  local -a failed_retained=()
   user_domain="gui/$(id -u)"
 
   if ! resume_suspended_release_runner_groups; then
@@ -2698,13 +2833,40 @@ restore_quiesced_release_launch_agents() {
       "${restarted_unready_service}" != 1 ]]; then
       restarted_unready_service=0
     fi
+    retained_entry="${RELEASE_QUIESCED_RETAINED[index]:-0}"
+    if [[ "${retained_entry}" != 0 && "${retained_entry}" != 1 ]]; then
+      retained_entry=1
+    fi
+    if ((retained_entry == 1)); then
+      case "${label}" in
+        actions.runner.*)
+          if ! resume_retained_release_runner "${label}"; then
+            printf 'failed to resume retained release runner %s\n' \
+              "${label}" >&2
+            failed_labels+=("${label}")
+            failed_plists+=("${plist}")
+            failed_action_started+=("${restore_action_started}")
+            failed_deadlines+=("${deadline}")
+            failed_restarted_unready+=("${restarted_unready_service}")
+            failed_retained+=(1)
+            restore_status=1
+            continue
+          fi
+          ;;
+      esac
+    fi
     unready_live_attempts=0
     for ((attempt = 1; attempt <= RELEASE_RESTORE_WAIT_ATTEMPTS; attempt++)); do
       health_status=0
       release_launch_agent_is_healthy "${label}" "${deadline}" || \
         health_status=$?
       if ((health_status == 0)); then
-        restored=1
+        if remove_release_launch_agent_restoration "${label}" "${plist}"; then
+          restored=1
+        else
+          printf 'failed to clear restored release launch-agent authority: %s\n' \
+            "${label}" >&2
+        fi
         break
       fi
       if ((health_status == 1)); then
@@ -2764,6 +2926,7 @@ restore_quiesced_release_launch_agents() {
       failed_action_started+=("${restore_action_started}")
       failed_deadlines+=("${deadline}")
       failed_restarted_unready+=("${restarted_unready_service}")
+      failed_retained+=("${retained_entry}")
       restore_status=1
     fi
   done
@@ -2773,12 +2936,14 @@ restore_quiesced_release_launch_agents() {
   RELEASE_QUIESCED_ACTION_STARTED=()
   RELEASE_QUIESCED_DEADLINES=()
   RELEASE_QUIESCED_RESTARTED_UNREADY=()
+  RELEASE_QUIESCED_RETAINED=()
   if ((${#failed_labels[@]} > 0)); then
     RELEASE_QUIESCED_LABELS=("${failed_labels[@]}")
     RELEASE_QUIESCED_PLISTS=("${failed_plists[@]}")
     RELEASE_QUIESCED_ACTION_STARTED=("${failed_action_started[@]}")
     RELEASE_QUIESCED_DEADLINES=("${failed_deadlines[@]}")
     RELEASE_QUIESCED_RESTARTED_UNREADY=("${failed_restarted_unready[@]}")
+    RELEASE_QUIESCED_RETAINED=("${failed_retained[@]}")
   fi
   return "${restore_status}"
 }
@@ -2868,6 +3033,16 @@ quiesce_local_release_workers() {
     fi
     case "${label}" in
       actions.runner.*)
+        if ! record_release_launch_agent_restoration "${label}" "${plist}"; then
+          restore_quiesced_release_launch_agents || true
+          return 1
+        fi
+        RELEASE_QUIESCED_LABELS+=("${label}")
+        RELEASE_QUIESCED_PLISTS+=("${plist}")
+        RELEASE_QUIESCED_ACTION_STARTED+=(0)
+        RELEASE_QUIESCED_DEADLINES+=("")
+        RELEASE_QUIESCED_RESTARTED_UNREADY+=(0)
+        RELEASE_QUIESCED_RETAINED+=(0)
         runner_status=0
         prepare_competing_release_runner_for_bootout "${label}" || runner_status=$?
         case "${runner_status}" in
@@ -2885,14 +3060,19 @@ quiesce_local_release_workers() {
             ;;
         esac
         ;;
+      *)
+        if ! record_release_launch_agent_restoration "${label}" "${plist}"; then
+          restore_quiesced_release_launch_agents || true
+          return 1
+        fi
+        RELEASE_QUIESCED_LABELS+=("${label}")
+        RELEASE_QUIESCED_PLISTS+=("${plist}")
+        RELEASE_QUIESCED_ACTION_STARTED+=(0)
+        RELEASE_QUIESCED_DEADLINES+=("")
+        RELEASE_QUIESCED_RESTARTED_UNREADY+=(0)
+        RELEASE_QUIESCED_RETAINED+=(0)
+        ;;
     esac
-    # Record recovery authority before mutation so an asynchronous exit cannot
-    # strand a successfully booted-out worker in the instruction boundary.
-    RELEASE_QUIESCED_LABELS+=("${label}")
-    RELEASE_QUIESCED_PLISTS+=("${plist}")
-    RELEASE_QUIESCED_ACTION_STARTED+=(0)
-    RELEASE_QUIESCED_DEADLINES+=("")
-    RELEASE_QUIESCED_RESTARTED_UNREADY+=(0)
     if ! "${RELEASE_LAUNCHCTL}" bootout "${user_domain}/${label}"; then
       resume_suspended_release_runner_groups || true
       loaded_status=0
@@ -3124,6 +3304,7 @@ run_local_release_gate() {
   local -a RELEASE_QUIESCED_ACTION_STARTED=()
   local -a RELEASE_QUIESCED_DEADLINES=()
   local -a RELEASE_QUIESCED_RESTARTED_UNREADY=()
+  local -a RELEASE_QUIESCED_RETAINED=()
   local -a RELEASE_SUSPENDED_RUNNER_PGIDS=()
   path="$(repo_path "${COMPOSE_REPO}")"
   candidate_sha="$(git -C "${path}" rev-parse HEAD)"
@@ -3144,6 +3325,38 @@ run_local_release_gate() {
     --tap "${HOMEBREW_TAP_REPO}" \
     --compose-repository "${path}" \
     --container-repository "${container_path}"
+  if [[ "${EXECUTE}" == "1" ]]; then
+    init_image_archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
+    if [[ "${init_image_archive}" != /* || ! -f "${init_image_archive}" ]]; then
+      printf 'local release gate requires an absolute retained OCI init-image archive via CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE: %s\n' \
+        "${init_image_archive:-unset}" >&2
+      return 2
+    fi
+    init_image_archive="$(cd "$(dirname "${init_image_archive}")" && pwd -P)/$(basename "${init_image_archive}")"
+    containerization_reference="$(python3 - "${path}/Tools/release/stack-refs.json" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(manifest["components"]["containerization"]["ref"])
+PY
+)"
+    required_init_references="vminit:container-compose ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
+    "${OCI_IMAGE_LAYOUT_VALIDATOR}" "${init_image_archive}" \
+      vminit:container-compose \
+      "ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
+    if [[ ! -f "${RELEASE_HOST_STATE_TOOL}" || -L "${RELEASE_HOST_STATE_TOOL}" ]]; then
+      printf 'release host-state tool is not a regular source file: %s\n' \
+        "${RELEASE_HOST_STATE_TOOL}" >&2
+      return 2
+    fi
+    python3 "${RELEASE_HOST_STATE_TOOL}" \
+      --root "${RELEASE_HOST_STATE_ROOT}" list >/dev/null
+  else
+    printf '%s\n' \
+      'would validate the retained OCI init-image authority before host mutation'
+  fi
   release_gate_path="$(release_gate_execution_path)"
   require_release_gate_gnu_tar "${release_gate_path}"
   release_gate_tar="$(PATH="${release_gate_path}" command -v tar)"
@@ -3153,6 +3366,7 @@ run_local_release_gate() {
       "${release_gate_path}" >&2
     return 1
   fi
+  require_local_virtualization
   for repository in "${path}" \
     "$(repo_path "container-builder-shim")" \
     "$(repo_path "containerization")" \
@@ -3176,42 +3390,20 @@ run_local_release_gate() {
   else
     printf 'would validate and pin release Hawkeye at %s\n' "${release_hawkeye}"
   fi
-  require_local_virtualization
+  run make -C "${containerization_path}" fetch-default-kernel
   if [[ "${EXECUTE}" == "1" ]]; then
     trap release_local_release_gate_host_state EXIT
     acquire_container_runtime_lock
+    recover_retained_release_launch_agents
     quiesce_local_release_workers
   else
     printf '%s\n' \
       'would quiesce and restore competing Container-family release workers'
   fi
-  run make -C "${containerization_path}" fetch-default-kernel
   if [[ "${EXECUTE}" != "1" ]]; then
     printf 'would package an immutable Container runtime candidate and run the complete local gate inside one fresh marker-protected runtime lifecycle\n'
     return 0
   fi
-
-  init_image_archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
-  if [[ "${init_image_archive}" != /* || ! -f "${init_image_archive}" ]]; then
-    printf 'local release gate requires an absolute retained OCI init-image archive via CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE: %s\n' \
-      "${init_image_archive:-unset}" >&2
-    return 2
-  fi
-  init_image_archive="$(cd "$(dirname "${init_image_archive}")" && pwd -P)/$(basename "${init_image_archive}")"
-
-  containerization_reference="$(python3 - "${path}/Tools/release/stack-refs.json" <<'PY'
-import json
-from pathlib import Path
-import sys
-
-manifest = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-print(manifest["components"]["containerization"]["ref"])
-PY
-)"
-  required_init_references="vminit:container-compose ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
-  "${OCI_IMAGE_LAYOUT_VALIDATOR}" "${init_image_archive}" \
-    vminit:container-compose \
-    "ghcr.io/stephenlclarke/containerization/vminit:${containerization_reference}"
 
   evidence_root="$(resolve_release_evidence_root "${path}" \
     "${PARITY_EVIDENCE_DIR:-.build/release-evidence}")"
@@ -6056,15 +6248,20 @@ main() {
       trap cleanup_current_init_image_authority EXIT
       ensure_compose_promotion_mode
       if [[ "${CONTAINER_STACK_RELEASE_LIBRARY:-0}" == "1" ]]; then
+        recover_release_host_state_on_startup
         release_current_stack
       elif [[ "${CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE:-0}" == "1" ]]; then
+        # An active child is untrusted until its marker-protected workspace is
+        # verified. Do not let an unmarked checkout reach host recovery.
         python3 "${RELEASE_WORKSPACE_TOOL}" verify \
           --build-root "${RELEASE_BUILD_ROOT}" "${ROOT}" >/dev/null
+        recover_release_host_state_on_startup
         for repo in "${REPOS[@]}"; do
           ensure_push_boundary "${repo}"
         done
         release_current_stack
       else
+        recover_release_host_state_on_startup
         run_isolated_release
       fi
       CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=1


### PR DESCRIPTION
## What changed

- journal every competing launch agent before runner suspension or launchd bootout
- restore retained agents at the start of the next release invocation, before workspace materialisation or build work
- resume a runner left in `SIGSTOP` before accepting its online registration as recovered
- retain journal entries until the exact service passes its existing health check
- validate the retained VM-init archive and the restoration journal before build work or host mutation

The journal is an atomic, owner-only, marker-protected file under `/private/tmp`. It is deliberately limited to host lifecycle state; build and test recovery remains the Nextflow boundary.

## Failure coverage

Focused tests cover:

- an actual `SIGKILL` after journalling and before runner drain, followed by successful next-invocation recovery
- a retained stopped Actions runner receiving `SIGCONT`
- recovery of an already booted-out launch agent
- malformed, linked, wrongly permissioned, and conflicting state failing closed
- idempotent record/remove and reverse restoration order
- macOS system Bash 3.2 and Homebrew Bash 5.3 syntax/behaviour
- the existing quiesce, restore, deadline, signal, runtime-lock, and readiness paths (35 affected tests)

Validation:

- `python3 -m unittest` for the 7 journal cases and focused controller recovery cases
- 35 affected existing controller tests
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `/bin/bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `/opt/homebrew/bin/bash -n scripts/CONTAINER_STACK_RELEASE.sh`

Closes #562
