### PR TITLE
build(pipeline): recover compiler artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,16 +47,21 @@ override NEXTFLOW_VERSION := 26.04.6
 override NEXTFLOW_SHA256 := 182a63c74074e2dc7956ffa3c8cd59de952ed2c44394e21faf5e1736b945444c
 override NEXTFLOW_DIST_URL := https://github.com/nextflow-io/nextflow/releases/download/v$(NEXTFLOW_VERSION)/nextflow-$(NEXTFLOW_VERSION)-dist
 override NEXTFLOW_JAVA_VERSION := 21.0.11
-override NEXTFLOW_JAVA_HOME := /opt/homebrew/Cellar/openjdk@21/21.0.11/libexec/openjdk.jdk/Contents/Home
-override NEXTFLOW_JAVA_BIN := $(NEXTFLOW_JAVA_HOME)/bin/java
-override NEXTFLOW_JAVA_SHA256 := 04005388bac0c272ea914210ca519ce94b2f873ea3962b9874a6859f74d7f279
-override NEXTFLOW_JAVA_MODULES_SHA256 := 260cdb63fb9926b2d194f9df3f1fd6836687a0e40d9707a97ffff4ae196e5ff9
-override NEXTFLOW_JAVA_LIBJVM_SHA256 := 7b93b74aec0a296db97fe380a97ce75a4dac7b8c5afbf4fee3d7397ebfb5c844
-override NEXTFLOW_JAVA_RELEASE_SHA256 := 7befd86565133fbebfa54138e55ec5b03bb59649ea5dda35d9f9b95265226756
+override NEXTFLOW_JAVA_RELEASE := 21.0.11+10
+override NEXTFLOW_JAVA_DIST_URL := https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.tar.gz
+override NEXTFLOW_JAVA_ARCHIVE_SHA256 := 6ebcf221c9b41507b14c098e93c6ead6440b8d9bd154f8ec666c4c73abbdb201
+override NEXTFLOW_JAVA_TREE_SHA256 := 4957b91571c12af578ab6d0aed7019d23af127570d1152a31693ad61db6b3496
+override NEXTFLOW_JAVA_SHA256 := afb8ed976e06d85c89192312923301959535169abe087d70166cd00fb96de2e5
+override NEXTFLOW_JAVA_MODULES_SHA256 := 915c525cd0b9d4db404cdc2368bfb4f3e0ab2a6a598b2d6a76d932de19dd2d33
+override NEXTFLOW_JAVA_LIBJVM_SHA256 := 34bc0bc23d87abb85147409ccdbf604ccd3d2fe8b83ac567a966a5df8a81eded
+override NEXTFLOW_JAVA_RELEASE_SHA256 := 5fccc331767cf526748f17402c7355efb0d1c24f397c49ff9836760f4a3f3d17
+override PIPELINE_HAWKEYE_VERSION := 6.5.1
+override PIPELINE_HAWKEYE_SHA256 := 369e3c1577fed2b3a15b1dd6016bb75716873c69c6e7c1f829e9e818d37e99d7
 override PIPELINE_MARKER_VALUE := container-compose recoverable pipeline v1
 override PIPELINE_ENTRY := $(abspath main.nf)
 override PIPELINE_CONFIG := $(abspath nextflow.config)
 override PIPELINE_DEADLINE_RUNNER := $(abspath Tools/ci/run-command-with-deadline.py)
+override PIPELINE_PACKAGE_MATERIALIZER := $(abspath Tools/ci/materialize-pipeline-package.py)
 ifneq ($(origin CONTAINER_FAMILY_SOURCE_ROOT),undefined)
 override CONTAINER_FAMILY_SOURCE_ROOT := $(value CONTAINER_FAMILY_SOURCE_ROOT)
 endif
@@ -321,8 +326,13 @@ NEXTFLOW_BIN := $(PIPELINE_STATE_ROOT)/tools/nextflow/$(NEXTFLOW_VERSION)/nextfl
 else
 override NEXTFLOW_BIN := $(value NEXTFLOW_BIN)
 endif
+override NEXTFLOW_JAVA_ROOT := $(PIPELINE_STATE_ROOT)/tools/temurin/$(NEXTFLOW_JAVA_RELEASE)
+override NEXTFLOW_JAVA_HOME := $(NEXTFLOW_JAVA_ROOT)/Contents/Home
+override NEXTFLOW_JAVA_BIN := $(NEXTFLOW_JAVA_HOME)/bin/java
+override PIPELINE_HAWKEYE_ROOT := $(PIPELINE_STATE_ROOT)/tools/hawkeye/$(PIPELINE_HAWKEYE_VERSION)
+override PIPELINE_HAWKEYE_BIN := $(PIPELINE_HAWKEYE_ROOT)/hawkeye
 ifeq ($(origin PIPELINE_EXECUTION_PATH),undefined)
-PIPELINE_EXECUTION_PATH := /opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
+PIPELINE_EXECUTION_PATH := $(PIPELINE_HAWKEYE_ROOT):/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin
 else
 override PIPELINE_EXECUTION_PATH := $(value PIPELINE_EXECUTION_PATH)
 endif
@@ -452,9 +462,13 @@ else
 override PIPELINE_HOMEBREW_REF := $(value PIPELINE_HOMEBREW_REF)
 endif
 export NEXTFLOW_VERSION NEXTFLOW_SHA256 NEXTFLOW_DIST_URL NEXTFLOW_BIN
-export NEXTFLOW_JAVA_VERSION NEXTFLOW_JAVA_HOME NEXTFLOW_JAVA_BIN
+export NEXTFLOW_JAVA_VERSION NEXTFLOW_JAVA_RELEASE NEXTFLOW_JAVA_DIST_URL
+export NEXTFLOW_JAVA_ARCHIVE_SHA256 NEXTFLOW_JAVA_TREE_SHA256 NEXTFLOW_JAVA_ROOT
+export NEXTFLOW_JAVA_HOME NEXTFLOW_JAVA_BIN
 export NEXTFLOW_JAVA_SHA256 NEXTFLOW_JAVA_MODULES_SHA256
 export NEXTFLOW_JAVA_LIBJVM_SHA256 NEXTFLOW_JAVA_RELEASE_SHA256
+export PIPELINE_HAWKEYE_VERSION PIPELINE_HAWKEYE_SHA256
+export PIPELINE_HAWKEYE_ROOT PIPELINE_HAWKEYE_BIN
 export CONTAINER_FAMILY_SOURCE_ROOT
 export PIPELINE_STATE_ROOT PIPELINE_MARKER_VALUE PIPELINE_EXECUTION_PATH
 export PIPELINE_PROFILE PIPELINE_ACTION PIPELINE_STAGE_SELECTOR PIPELINE_ATTEMPT_ID
@@ -467,7 +481,7 @@ export PIPELINE_CONTAINERIZATION_REF PIPELINE_CONTAINER_REPO PIPELINE_CONTAINER_
 export PIPELINE_ENGINE_API_REPO PIPELINE_ENGINE_API_REF PIPELINE_DEVCONTAINER_REPO
 export PIPELINE_DEVCONTAINER_REF PIPELINE_K8S_REPO PIPELINE_K8S_REF
 export PIPELINE_HOMEBREW_REPO PIPELINE_HOMEBREW_REF PIPELINE_ENTRY PIPELINE_CONFIG
-export PIPELINE_DEADLINE_RUNNER
+export PIPELINE_DEADLINE_RUNNER PIPELINE_PACKAGE_MATERIALIZER
 # Reassert the denylist after all explicit exports for GNU Make 3.81.
 unexport BASH_ENV ENV SHELLOPTS BASHOPTS BASH_XTRACEFD PS4 CDPATH
 unexport JAVA_TOOL_OPTIONS _JAVA_OPTIONS JDK_JAVA_OPTIONS CLASSPATH
@@ -599,7 +613,7 @@ DOCKER_COMPOSE_PARITY_TARGETS := \
 SWIFT_TEST_FLAGS ?=
 SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -F -Xswiftc '$(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)' -Xlinker -rpath -Xlinker '$(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)' $(if $(strip $(SWIFT_TEST_RUNTIME_LIBRARY_PATH)),-Xlinker -rpath -Xlinker '$(SWIFT_TEST_RUNTIME_LIBRARY_PATH)'))
 
-.PHONY: all workflow ci ci-fast release-gate-environment-fingerprint-check release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-test-direct swift-runtime-test-build swift-runtime-test swift-coverage go-test go-build go-release-check cli-smoke cli-smoke-built container-stack-build container-stack-build-if-needed docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-parity-stages docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-external-dockerfile-parity docker-compose-build-external-secret-parity docker-compose-build-isolation-parity docker-compose-build-no-cache-filter-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-image-volumes-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-cpu-limit-parity docker-compose-privileged-parity docker-compose-security-opt-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-memory-byte-precision-parity docker-compose-memory-swap-limit-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-service-discovery-parity docker-compose-links-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-state-status-parity docker-compose-rm-parity docker-compose-lifecycle-hooks-parity docker-compose-signal-log-reliability-parity docker-compose-restart-policy-parity docker-compose-userns-mode-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-syntax coverage-python-tools-test release-tools-test ci-tools-test coverage-tools-test source-checks lint format fmt check check-licenses update-licenses pre-commit swift-style-tools swift-style-paths swift-style-check swift-style-format local-swift-stack-clean
+.PHONY: all workflow ci ci-fast release-gate-environment-fingerprint-check release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-test-direct swift-runtime-test-build swift-runtime-test swift-coverage swift-coverage-check go-test go-coverage-check go-build go-release-check cli-smoke cli-smoke-built container-stack-build container-stack-build-if-needed docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-parity-stages docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-external-dockerfile-parity docker-compose-build-external-secret-parity docker-compose-build-isolation-parity docker-compose-build-no-cache-filter-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-image-volumes-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-cpu-limit-parity docker-compose-privileged-parity docker-compose-security-opt-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-memory-byte-precision-parity docker-compose-memory-swap-limit-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-service-discovery-parity docker-compose-links-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-state-status-parity docker-compose-rm-parity docker-compose-lifecycle-hooks-parity docker-compose-signal-log-reliability-parity docker-compose-restart-policy-parity docker-compose-userns-mode-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-syntax coverage-python-tools-test release-tools-test ci-tools-test coverage-tools-test source-checks lint format fmt check check-licenses update-licenses pre-commit swift-style-tools swift-style-paths swift-style-check swift-style-format local-swift-stack-clean
 
 .PHONY: print-release-gate-static-fingerprint print-release-gate-fingerprint
 .PHONY: worktree-audit worktree-audit-strict
@@ -639,32 +653,29 @@ pipeline-source-check: source-preflight lint-static
 pipeline-tool-validation: coverage-tools-test performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test compose-events-harness-test
 
 pipeline-bootstrap: pipeline-state-init
-	@destination="$${NEXTFLOW_BIN}"; \
-	expected_sha256="$${NEXTFLOW_SHA256}"; \
-	if [[ -x "$$destination" ]] \
-		&& [[ "$$(/usr/bin/shasum -a 256 "$$destination" | /usr/bin/awk '{ print $$1 }')" == "$$expected_sha256" ]]; then \
-		printf 'Pinned Nextflow %s is already installed at %s\n' "$${NEXTFLOW_VERSION}" "$$destination"; \
-		exit 0; \
-	fi; \
-	/bin/mkdir -p "$$(/usr/bin/dirname "$$destination")"; \
-	temporary="$$(/usr/bin/mktemp "$$(/usr/bin/dirname "$$destination")/.nextflow-download.XXXXXX")"; \
-	cleanup() { /bin/rm -f -- "$$temporary"; }; \
-	trap cleanup EXIT HUP INT TERM; \
-	/usr/bin/curl --fail --location --proto '=https' --proto-redir '=https' \
-		--connect-timeout 20 --max-time 600 \
-		--retry 3 --retry-all-errors --output "$$temporary" "$${NEXTFLOW_DIST_URL}"; \
-	actual_sha256="$$(/usr/bin/shasum -a 256 "$$temporary" | /usr/bin/awk '{ print $$1 }')"; \
-	if [[ "$$actual_sha256" != "$$expected_sha256" ]]; then \
-		printf 'Nextflow digest mismatch: expected %s, got %s\n' \
-			"$$expected_sha256" "$$actual_sha256" >&2; \
-		exit 1; \
-	fi; \
-	/bin/chmod 0755 "$$temporary"; \
-	/bin/mv -f -- "$$temporary" "$$destination"; \
-	trap - EXIT HUP INT TERM; \
-	printf 'Installed verified Nextflow %s at %s\n' "$${NEXTFLOW_VERSION}" "$$destination"
+	@/usr/bin/lockf -t 300 "$${PIPELINE_STATE_ROOT}/bootstrap.lock" \
+		/usr/bin/python3 -I Tools/ci/bootstrap-nextflow-runtime.py \
+		--state-root "$${PIPELINE_STATE_ROOT}" \
+		--nextflow-version "$${NEXTFLOW_VERSION}" \
+		--nextflow-url "$${NEXTFLOW_DIST_URL}" \
+		--nextflow-sha256 "$${NEXTFLOW_SHA256}" \
+		--nextflow-bin "$${NEXTFLOW_BIN}" \
+		--java-version "$${NEXTFLOW_JAVA_VERSION}" \
+		--java-release "$${NEXTFLOW_JAVA_RELEASE}" \
+		--java-url "$${NEXTFLOW_JAVA_DIST_URL}" \
+		--java-archive-sha256 "$${NEXTFLOW_JAVA_ARCHIVE_SHA256}" \
+		--java-tree-sha256 "$${NEXTFLOW_JAVA_TREE_SHA256}" \
+		--java-root "$${NEXTFLOW_JAVA_ROOT}" \
+		--java-sha256 "$${NEXTFLOW_JAVA_SHA256}" \
+		--java-modules-sha256 "$${NEXTFLOW_JAVA_MODULES_SHA256}" \
+		--java-libjvm-sha256 "$${NEXTFLOW_JAVA_LIBJVM_SHA256}" \
+		--java-release-sha256 "$${NEXTFLOW_JAVA_RELEASE_SHA256}" \
+		--hawkeye-version "$${PIPELINE_HAWKEYE_VERSION}" \
+		--hawkeye-sha256 "$${PIPELINE_HAWKEYE_SHA256}" \
+		--hawkeye-installer "$(CURDIR)/scripts/install-hawkeye.sh" \
+		--hawkeye-bin "$${PIPELINE_HAWKEYE_BIN}"
 
-pipeline-runtime-check: pipeline-state-init
+pipeline-runtime-check: pipeline-bootstrap
 	@launcher="$${NEXTFLOW_BIN}"; \
 	state_root="$${PIPELINE_STATE_ROOT}"; \
 	java_home="$${NEXTFLOW_JAVA_HOME}"; \
@@ -685,6 +696,10 @@ pipeline-runtime-check: pipeline-state-init
 		exit 2; \
 	fi; \
 	hash_environment=(/usr/bin/env -i PATH=/usr/bin:/bin LANG=C LC_ALL=C); \
+	/usr/bin/python3 -I Tools/ci/bootstrap-nextflow-runtime.py verify-java \
+		--state-root "$$state_root" --java-release "$${NEXTFLOW_JAVA_RELEASE}" \
+		--java-root "$${NEXTFLOW_JAVA_ROOT}" \
+		--java-tree-sha256 "$${NEXTFLOW_JAVA_TREE_SHA256}"; \
 	digest_line="$$("$${hash_environment[@]}" /usr/bin/shasum -a 256 "$$launcher")"; \
 	actual_sha256="$${digest_line%% *}"; \
 	if [[ "$$actual_sha256" != "$${NEXTFLOW_SHA256}" ]]; then \
@@ -743,6 +758,29 @@ pipeline-runtime-check: pipeline-state-init
 		printf 'Nextflow version mismatch: expected %s, got %s\n' \
 			"$${NEXTFLOW_VERSION}" "$$actual_version" >&2; \
 		exit 2; \
+	fi; \
+	hawkeye="$${PIPELINE_HAWKEYE_BIN}"; \
+	if [[ -L "$$hawkeye" ]] || [[ ! -f "$$hawkeye" ]] || [[ ! -x "$$hawkeye" ]]; then \
+		printf 'Pinned Hawkeye is missing or indirect at %s.\n' "$$hawkeye" >&2; \
+		exit 2; \
+	fi; \
+	hawkeye_digest_line="$$($${hash_environment[@]} /usr/bin/shasum -a 256 "$$hawkeye")"; \
+	if [[ "$${hawkeye_digest_line%% *}" != "$${PIPELINE_HAWKEYE_SHA256}" ]]; then \
+		printf 'Pinned Hawkeye digest mismatch.\n' >&2; \
+		exit 2; \
+	fi; \
+	hawkeye_version="$$($${clean_environment[@]} "$$hawkeye" --version 2>&1)"; \
+	if [[ "$$hawkeye_version" != *"version: $${PIPELINE_HAWKEYE_VERSION}"* ]]; then \
+		printf 'Pinned Hawkeye version mismatch; expected %s.\n' \
+			"$${PIPELINE_HAWKEYE_VERSION}" >&2; \
+		exit 2; \
+	fi; \
+	hawkeye_check_help="$$($${clean_environment[@]} "$$hawkeye" check --help 2>&1)"; \
+	hawkeye_format_help="$$($${clean_environment[@]} "$$hawkeye" format --help 2>&1)"; \
+	if [[ "$$hawkeye_check_help" != *--fail-if-unknown* ]] \
+		|| [[ "$$hawkeye_format_help" != *--fail-if-updated* ]]; then \
+		printf 'Pinned Hawkeye does not satisfy the repository CLI contract.\n' >&2; \
+		exit 2; \
 	fi
 
 pipeline-state-init:
@@ -788,7 +826,7 @@ pipeline-state-init:
 		printf 'Pipeline state marker became indirect or invalid: %s\n' "$$marker" >&2; \
 		exit 2; \
 	fi; \
-	for managed_name in evidence nextflow-home recovery-proofs tmp tools work failures caches; do \
+	for managed_name in evidence nextflow-home recovery-proofs tmp tools work failures caches empty-dependencies; do \
 		managed_path="$$state_root/$$managed_name"; \
 		if [[ -L "$$managed_path" ]] || [[ -e "$$managed_path" && ! -d "$$managed_path" ]]; then \
 			printf 'Pipeline managed path must be a non-symbolic directory: %s\n' "$$managed_path" >&2; \
@@ -914,7 +952,7 @@ pipeline-execute: pipeline-runtime-check
 		printf 'Pipeline state marker became indirect or invalid: %s\n' "$$marker" >&2; \
 		exit 2; \
 	fi; \
-	for managed_name in evidence nextflow-home tmp work failures caches; do \
+	for managed_name in evidence nextflow-home tmp work failures caches empty-dependencies; do \
 		managed_path="$$canonical_state/$$managed_name"; \
 		if [[ -L "$$managed_path" ]] || [[ ! -d "$$managed_path" ]] \
 			|| [[ "$$(cd "$$managed_path" && pwd -P)" != "$$canonical_state/$$managed_name" ]]; then \
@@ -942,6 +980,15 @@ pipeline-execute: pipeline-runtime-check
 	devcontainer_repo="$${PIPELINE_DEVCONTAINER_REPO:-$$source_root/devcontainer}"; \
 	k8s_repo="$${PIPELINE_K8S_REPO:-$$source_root/container-k8s}"; \
 	homebrew_repo="$${PIPELINE_HOMEBREW_REPO:-$$source_root/homebrew-tap}"; \
+	materialization_lock="$$state_root/package-materialization.lock"; \
+	if [[ -L "$$materialization_lock" ]]; then \
+		printf 'Package materialization lock must not be a symbolic link: %s\n' \
+			"$$materialization_lock" >&2; \
+		exit 2; \
+	fi; \
+	/usr/bin/lockf -t 30 "$$materialization_lock" \
+		/usr/bin/python3 -I "$${PIPELINE_PACKAGE_MATERIALIZER}" \
+		--recover-only --destination "$$compose_repo"; \
 	operator_name="$$(/usr/bin/id -un)"; \
 	operator_home=; \
 	requires_operator_keychain=false; \
@@ -991,6 +1038,8 @@ pipeline-execute: pipeline-runtime-check
 		"$${NEXTFLOW_JAVA_SHA256}" "$${NEXTFLOW_JAVA_MODULES_SHA256}" \
 		"$${NEXTFLOW_JAVA_LIBJVM_SHA256}" "$${NEXTFLOW_JAVA_RELEASE_SHA256}" \
 		"$$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ)" >"$$attempt_dir/attempt.tsv"; \
+	printf 'java-tree-sha256\t%s\n' "$${NEXTFLOW_JAVA_TREE_SHA256}" \
+		>>"$$attempt_dir/attempt.tsv"; \
 	set --; \
 	if [[ -n "$$resume_session" ]]; then set -- -resume "$$resume_session"; fi; \
 	set +e; \
@@ -1122,13 +1171,51 @@ pipeline-execute: pipeline-runtime-check
 		fi; \
 	fi; \
 	if ((exit_status == 0 && evidence_status != 0)); then exit_status="$$evidence_status"; fi; \
-	printf 'evidence-exit\t%s\nexit\t%s\ncompleted-utc\t%s\n' \
-		"$$evidence_status" "$$exit_status" \
+	materialization_status=0; \
+	package_expected=false; \
+	if [[ "$$action" == run ]]; then \
+		if [[ "$${PIPELINE_PROFILE}" == repository ]] \
+			&& [[ -z "$${PIPELINE_STAGE_SELECTOR//[[:space:]]/}" ]]; then \
+			package_expected=true; \
+		else \
+			IFS=',' read -r -a selected_stages <<<"$${PIPELINE_STAGE_SELECTOR}"; \
+			for selected_stage in "$${selected_stages[@]}"; do \
+				if [[ "$${selected_stage//[[:space:]]/}" == compose-package ]]; then \
+					package_expected=true; \
+					break; \
+				fi; \
+			done; \
+		fi; \
+	fi; \
+	if ((exit_status == 0)) && [[ "$$package_expected" == true ]]; then \
+		package_receipt="$$attempt_dir/receipts/compose-package.receipt.tsv"; \
+		package_manifest="$$attempt_dir/receipts/compose-package.artifacts.tsv"; \
+		package_archive="$$attempt_dir/receipts/compose-package.artifacts.tar"; \
+		if [[ ! -s "$$package_receipt" ]] || [[ ! -s "$$package_manifest" ]] \
+			|| [[ ! -s "$$package_archive" ]]; then \
+			printf 'Required recovered package evidence is incomplete: %s\n' \
+				"$$attempt_dir/receipts" >&2; \
+			materialization_status=74; \
+		else \
+			set +e; \
+			/usr/bin/lockf -t 30 "$$materialization_lock" \
+				/usr/bin/python3 -I "$${PIPELINE_PACKAGE_MATERIALIZER}" \
+				--receipt "$$package_receipt" --manifest "$$package_manifest" \
+				--archive "$$package_archive" --destination "$$compose_repo"; \
+			materialization_status=$$?; \
+			set -e; \
+		fi; \
+	fi; \
+	if ((exit_status == 0 && materialization_status != 0)); then \
+		exit_status="$$materialization_status"; \
+	fi; \
+	printf 'evidence-exit\t%s\nmaterialization-exit\t%s\nexit\t%s\ncompleted-utc\t%s\n' \
+		"$$evidence_status" "$$materialization_status" "$$exit_status" \
 		"$$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$$attempt_dir/attempt.tsv"; \
 	printf 'Pipeline evidence: %s\n' "$$attempt_dir"; \
 	exit "$$exit_status"
 
-all: workflow
+all: pipeline
 
 workflow: ci package
 
@@ -2684,7 +2771,11 @@ docker-compose-restart-policy-parity: build docker-compose-reference
 coverage: swift-coverage go-test
 
 coverage-check: coverage
+	$(MAKE) --no-print-directory swift-coverage-check go-coverage-check
+
+swift-coverage-check:
 	$(PYTHON) Tools/coverage/check-coverage.py \
+		--scope swift \
 		--swift-core-minimum "$(SWIFT_CORE_COVERAGE_MIN)" \
 		--swift-runtime-spi-minimum "$(SWIFT_RUNTIME_SPI_COVERAGE_MIN)" \
 		--swift-provider-minimum "$(SWIFT_PROVIDER_COVERAGE_MIN)" \
@@ -2696,6 +2787,17 @@ coverage-check: coverage
 		--swift-provider coverage-provider.xml \
 		--swift-plugin coverage-plugin.xml \
 		--swift-aggregate coverage-aggregate.xml \
+		--go Tools/compose-normalizer/coverage.out
+
+go-coverage-check:
+	$(PYTHON) Tools/coverage/check-coverage.py \
+		--scope go \
+		--swift-core coverage-core.xml \
+		--swift-runtime-spi coverage-runtime-spi.xml \
+		--swift-provider coverage-provider.xml \
+		--swift-plugin coverage-plugin.xml \
+		--swift-aggregate coverage-aggregate.xml \
+		--go-minimum "$(GO_COVERAGE_MIN)" \
 		--go Tools/compose-normalizer/coverage.out
 
 sonar: coverage sonar-scan

--- a/Tools/ci/bootstrap-nextflow-runtime.py
+++ b/Tools/ci/bootstrap-nextflow-runtime.py
@@ -1,0 +1,676 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Install the checksum-pinned Nextflow, JDK and Hawkeye tools atomically."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import stat
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+from typing import Callable, Optional
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+
+
+STATE_MARKER = "container-compose recoverable pipeline v1"
+Download = Callable[[str, Path], None]
+
+
+class BootstrapError(RuntimeError):
+    """A deterministic bootstrap contract was not satisfied."""
+
+
+def sha256(path: Path) -> str:
+    """Return the SHA-256 digest for one regular file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def require_digest(value: str, name: str) -> str:
+    """Validate one lowercase SHA-256 command-line value."""
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise BootstrapError(f"{name} is not a lowercase SHA-256 digest")
+    return value
+
+
+def tree_sha256(root: Path) -> str:
+    """Return a deterministic digest of a complete regular-file directory tree."""
+    if root.is_symlink() or not root.is_dir():
+        raise BootstrapError(f"runtime tree is indirect or invalid: {root}")
+    digest = hashlib.sha256()
+    paths = [root, *sorted(root.rglob("*"), key=lambda path: path.relative_to(root).as_posix())]
+    for path in paths:
+        metadata = path.lstat()
+        relative = "." if path == root else path.relative_to(root).as_posix()
+        if stat.S_ISDIR(metadata.st_mode):
+            kind = "directory"
+            size = 0
+        elif stat.S_ISREG(metadata.st_mode):
+            kind = "file"
+            size = metadata.st_size
+        else:
+            raise BootstrapError(f"runtime tree contains an unsupported entry: {path}")
+        record = (
+            f"{kind}\0{stat.S_IMODE(metadata.st_mode):o}\0{relative}\0{size}\0"
+        ).encode("utf-8")
+        digest.update(len(record).to_bytes(8, "big"))
+        digest.update(record)
+        if kind == "file":
+            with path.open("rb") as stream:
+                for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                    digest.update(chunk)
+    return digest.hexdigest()
+
+
+def marked_state_root(path: Path) -> Path:
+    """Return a physical, marker-protected pipeline state root."""
+    if not path.is_absolute() or path.is_symlink() or not path.is_dir():
+        raise BootstrapError(f"pipeline state root is indirect or invalid: {path}")
+    root = path.resolve(strict=True)
+    marker = root / ".container-compose-pipeline-root"
+    if marker.is_symlink() or not marker.is_file():
+        raise BootstrapError(f"pipeline state marker is indirect or missing: {marker}")
+    if marker.read_text(encoding="utf-8").rstrip("\n") != STATE_MARKER:
+        raise BootstrapError(f"pipeline state marker does not match: {marker}")
+    return root
+
+
+def require_managed_parent(path: Path, expected: Path) -> Path:
+    """Create and verify one physical directory below the marked root."""
+    if path != expected:
+        raise BootstrapError(f"managed tool directory has the wrong path: {path}")
+    missing: list[Path] = []
+    existing = path
+    while not os.path.lexists(existing):
+        missing.append(existing)
+        existing = existing.parent
+    marked_ancestor: Optional[Path] = None
+    for ancestor in (existing, *existing.parents):
+        if ancestor.is_symlink() or not ancestor.is_dir():
+            raise BootstrapError(
+                f"managed tool ancestor is indirect or invalid: {ancestor}"
+            )
+        marker = ancestor / ".container-compose-pipeline-root"
+        if marker.is_symlink():
+            raise BootstrapError(f"pipeline state marker is indirect: {marker}")
+        if marker.is_file() and marker.read_text(encoding="utf-8").rstrip("\n") == STATE_MARKER:
+            marked_ancestor = ancestor
+            break
+    if marked_ancestor is None:
+        raise BootstrapError(f"managed tool directory is outside marked state: {path}")
+    for candidate in reversed(missing):
+        parent = candidate.parent
+        if parent.is_symlink() or not parent.is_dir():
+            raise BootstrapError(
+                f"managed tool ancestor became indirect or invalid: {parent}"
+            )
+        candidate.mkdir()
+        fsync_directory(parent)
+    if path.is_symlink() or not path.is_dir():
+        raise BootstrapError(f"managed tool directory is indirect or invalid: {path}")
+    physical = path.resolve(strict=True)
+    if physical != expected or not physical.is_relative_to(marked_ancestor):
+        raise BootstrapError(f"managed tool directory escaped its state root: {physical}")
+    return physical
+
+
+def https_download(url: str, destination: Path) -> None:
+    """Download one HTTPS resource with bounded retries and no credential helpers."""
+    if urllib.parse.urlparse(url).scheme != "https":
+        raise BootstrapError(f"runtime URL must use HTTPS: {url}")
+    last_error: Optional[Exception] = None
+    for attempt in range(3):
+        try:
+            request = urllib.request.Request(
+                url,
+                headers={"User-Agent": "container-compose-runtime-bootstrap/1"},
+            )
+            with urllib.request.urlopen(request, timeout=60) as response:
+                if urllib.parse.urlparse(response.geturl()).scheme != "https":
+                    raise BootstrapError("runtime download redirected away from HTTPS")
+                with destination.open("wb") as output:
+                    shutil.copyfileobj(response, output, length=1024 * 1024)
+            return
+        except (OSError, urllib.error.URLError) as error:
+            last_error = error
+            destination.unlink(missing_ok=True)
+            if attempt < 2:
+                time.sleep(attempt + 1)
+    raise BootstrapError(f"runtime download failed after three attempts: {last_error}")
+
+
+def fsync_directory(path: Path) -> None:
+    """Persist a completed atomic rename on the containing filesystem."""
+    descriptor = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def install_launcher(
+    *,
+    destination: Path,
+    expected_parent: Path,
+    version: str,
+    url: str,
+    expected_sha256: str,
+    downloader: Download = https_download,
+) -> None:
+    """Install or validate the exact Nextflow launcher."""
+    expected_sha256 = require_digest(expected_sha256, "Nextflow digest")
+    parent = require_managed_parent(destination.parent, expected_parent)
+    for candidate in parent.glob(".nextflow-download.*"):
+        if not re.fullmatch(r"[.]nextflow-download[.][A-Za-z0-9_-]+", candidate.name):
+            raise BootstrapError(f"unexpected Nextflow temporary path: {candidate}")
+        remove_managed_path(candidate, parent)
+    if (
+        destination.is_file()
+        and not destination.is_symlink()
+        and os.access(destination, os.X_OK)
+        and sha256(destination) == expected_sha256
+    ):
+        print(f"Pinned Nextflow {version} is already installed at {destination}")
+        return
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=".nextflow-download.", dir=parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        downloader(url, temporary)
+        actual_sha256 = sha256(temporary)
+        if actual_sha256 != expected_sha256:
+            raise BootstrapError(
+                "Nextflow digest mismatch: "
+                f"expected {expected_sha256}, got {actual_sha256}"
+            )
+        temporary.chmod(0o755)
+        os.replace(temporary, destination)
+        fsync_directory(parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+    print(f"Installed verified Nextflow {version} at {destination}")
+
+
+def valid_runtime(
+    root: Path, files: dict[Path, str], expected_tree_sha256: str
+) -> bool:
+    """Return whether every pinned runtime file is present and unchanged."""
+    if root.is_symlink() or not root.is_dir():
+        return False
+    for relative, expected_sha256 in files.items():
+        candidate = root / relative
+        if candidate.is_symlink() or not candidate.is_file():
+            return False
+        if sha256(candidate) != expected_sha256:
+            return False
+    try:
+        return tree_sha256(root) == expected_tree_sha256
+    except (BootstrapError, OSError):
+        return False
+
+
+def validate_archive(archive: tarfile.TarFile, expected_root: str) -> None:
+    """Reject paths or entry types that could escape the staging directory."""
+    members = archive.getmembers()
+    if not members:
+        raise BootstrapError("Temurin archive is empty")
+    roots: set[str] = set()
+    for member in members:
+        path = PurePosixPath(member.name)
+        if path.is_absolute() or ".." in path.parts or not path.parts:
+            raise BootstrapError(f"unsafe Temurin archive path: {member.name}")
+        roots.add(path.parts[0])
+        if not (member.isfile() or member.isdir()):
+            raise BootstrapError(f"unsupported Temurin archive entry: {member.name}")
+    if roots != {expected_root}:
+        raise BootstrapError(
+            f"Temurin archive has unexpected roots: {', '.join(sorted(roots))}"
+        )
+
+
+def remove_managed_path(path: Path, parent: Path) -> None:
+    """Remove only a named temporary entry in the verified tool parent."""
+    if path.parent != parent:
+        raise BootstrapError(f"refusing to remove unmanaged path: {path}")
+    if path.is_symlink() or path.is_file():
+        path.unlink(missing_ok=True)
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def recover_java_install(
+    *,
+    root: Path,
+    parent: Path,
+    runtime_files: dict[Path, str],
+    expected_tree_sha256: str,
+) -> None:
+    """Recover or remove exact temporary paths left by a hard interruption."""
+    previous_paths = list(parent.glob(".temurin-previous.*"))
+    staging_paths = list(parent.glob(".temurin-install.*"))
+    for candidate in previous_paths + staging_paths:
+        if not re.fullmatch(
+            r"[.]temurin-(previous|install)[.][A-Za-z0-9_-]+", candidate.name
+        ):
+            raise BootstrapError(f"unexpected Temurin temporary path: {candidate}")
+    for staging in staging_paths:
+        remove_managed_path(staging, parent)
+
+    valid_previous = [
+        candidate
+        for candidate in previous_paths
+        if valid_runtime(candidate, runtime_files, expected_tree_sha256)
+    ]
+    if valid_runtime(root, runtime_files, expected_tree_sha256):
+        for previous in previous_paths:
+            remove_managed_path(previous, parent)
+        return
+    if not os.path.lexists(root) and len(valid_previous) == 1:
+        recovered = valid_previous[0]
+        os.replace(recovered, root)
+        fsync_directory(parent)
+        previous_paths.remove(recovered)
+    elif not os.path.lexists(root) and len(valid_previous) > 1:
+        raise BootstrapError("multiple valid interrupted Temurin installations exist")
+    for previous in previous_paths:
+        remove_managed_path(previous, parent)
+
+
+def install_java(
+    *,
+    root: Path,
+    expected_parent: Path,
+    version: str,
+    release: str,
+    url: str,
+    archive_sha256: str,
+    expected_tree_sha256: str,
+    runtime_files: dict[Path, str],
+    temporary_root: Path,
+    downloader: Download = https_download,
+) -> None:
+    """Install or validate the exact Temurin runtime directory."""
+    archive_sha256 = require_digest(archive_sha256, "Temurin archive digest")
+    expected_tree_sha256 = require_digest(
+        expected_tree_sha256, "Temurin tree digest"
+    )
+    runtime_files = {
+        path: require_digest(digest, f"Temurin file digest for {path}")
+        for path, digest in runtime_files.items()
+    }
+    parent = require_managed_parent(root.parent, expected_parent)
+    recover_java_install(
+        root=root,
+        parent=parent,
+        runtime_files=runtime_files,
+        expected_tree_sha256=expected_tree_sha256,
+    )
+    if valid_runtime(root, runtime_files, expected_tree_sha256):
+        print(f"Pinned Temurin {release} is already installed at {root}")
+        return
+
+    descriptor, archive_name = tempfile.mkstemp(
+        prefix=".temurin-download.", dir=temporary_root
+    )
+    os.close(descriptor)
+    archive_path = Path(archive_name)
+    staging = Path(tempfile.mkdtemp(prefix=".temurin-install.", dir=parent))
+    previous = parent / f".temurin-previous.{uuid.uuid4().hex}"
+    moved_previous = False
+    try:
+        downloader(url, archive_path)
+        actual_archive_sha256 = sha256(archive_path)
+        if actual_archive_sha256 != archive_sha256:
+            raise BootstrapError(
+                "Temurin archive digest mismatch: "
+                f"expected {archive_sha256}, got {actual_archive_sha256}"
+            )
+        archive_root = f"jdk-{release}"
+        with tarfile.open(archive_path, "r:gz") as archive:
+            validate_archive(archive, archive_root)
+            try:
+                archive.extractall(staging, filter="fully_trusted")
+            except TypeError:
+                # Python 3.9 predates extraction filters. Every member was
+                # already checked above before this compatibility fallback.
+                archive.extractall(staging)
+        candidate = staging / archive_root
+        if not valid_runtime(candidate, runtime_files, expected_tree_sha256):
+            raise BootstrapError("extracted Temurin runtime does not match its file pins")
+        java = candidate / "Contents/Home/bin/java"
+        completed = subprocess.run(
+            [str(java), "-version"],
+            env={"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"},
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        if completed.returncode != 0 or f'version "{version}"' not in completed.stderr:
+            raise BootstrapError(f"extracted Temurin runtime is not Java {version}")
+        if os.path.lexists(root):
+            os.replace(root, previous)
+            moved_previous = True
+        try:
+            os.replace(candidate, root)
+        except BaseException:
+            if moved_previous:
+                os.replace(previous, root)
+                moved_previous = False
+            raise
+        fsync_directory(parent)
+        if moved_previous:
+            remove_managed_path(previous, parent)
+            moved_previous = False
+    finally:
+        archive_path.unlink(missing_ok=True)
+        remove_managed_path(staging, parent)
+        if moved_previous and not os.path.lexists(root):
+            os.replace(previous, root)
+        elif os.path.lexists(previous):
+            remove_managed_path(previous, parent)
+    print(f"Installed verified Temurin {release} at {root}")
+
+
+def valid_hawkeye(
+    executable: Path, version: str, expected_sha256: str
+) -> bool:
+    """Return whether one direct executable has the pinned Hawkeye CLI."""
+    if executable.is_symlink() or not executable.is_file() or not os.access(
+        executable, os.X_OK
+    ):
+        return False
+    if sha256(executable) != expected_sha256:
+        return False
+    environment = {"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"}
+    try:
+        version_result = subprocess.run(
+            [str(executable), "--version"],
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        check_result = subprocess.run(
+            [str(executable), "check", "--help"],
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        format_result = subprocess.run(
+            [str(executable), "format", "--help"],
+            env=environment,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    version_text = version_result.stdout + version_result.stderr
+    return (
+        version_result.returncode == 0
+        and re.search(
+            rf"(?:hawkeye\s+|version:\s*)v?{re.escape(version)}(?:\s|$)",
+            version_text,
+        )
+        is not None
+        and check_result.returncode == 0
+        and "--fail-if-unknown" in check_result.stdout + check_result.stderr
+        and format_result.returncode == 0
+        and "--fail-if-updated" in format_result.stdout + format_result.stderr
+    )
+
+
+def install_hawkeye(
+    *,
+    destination: Path,
+    expected_parent: Path,
+    version: str,
+    expected_sha256: str,
+    installer: Path,
+    temporary_root: Path,
+) -> None:
+    """Install the repository-pinned Hawkeye into durable pipeline state."""
+    expected_sha256 = require_digest(expected_sha256, "Hawkeye digest")
+    parent = require_managed_parent(destination.parent, expected_parent)
+    for candidate in list(parent.glob(".hawkeye-install.*")) + list(
+        parent.glob(".hawkeye-ready.*")
+    ):
+        if not re.fullmatch(
+            r"[.]hawkeye-(install|ready)[.][A-Za-z0-9_-]+", candidate.name
+        ):
+            raise BootstrapError(f"unexpected Hawkeye temporary path: {candidate}")
+        remove_managed_path(candidate, parent)
+    if valid_hawkeye(destination, version, expected_sha256):
+        print(f"Pinned Hawkeye {version} is already installed at {destination}")
+        return
+    if (
+        not installer.is_absolute()
+        or installer.is_symlink()
+        or not installer.is_file()
+        or not os.access(installer, os.X_OK)
+    ):
+        raise BootstrapError(f"Hawkeye installer is indirect or invalid: {installer}")
+
+    staging = Path(tempfile.mkdtemp(prefix=".hawkeye-install.", dir=parent))
+    ready = parent / f".hawkeye-ready.{uuid.uuid4().hex}"
+    try:
+        completed = subprocess.run(
+            [str(installer)],
+            cwd=staging,
+            env={
+                "HOME": str(staging),
+                "LANG": "C",
+                "LC_ALL": "C",
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "TMPDIR": str(temporary_root),
+            },
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=360,
+            check=False,
+        )
+        candidate = staging / ".local/bin/hawkeye"
+        if completed.returncode != 0:
+            raise BootstrapError(
+                "pinned Hawkeye installer failed: " + completed.stderr.rstrip()
+            )
+        if not valid_hawkeye(candidate, version, expected_sha256):
+            raise BootstrapError("installed Hawkeye does not match its CLI pin")
+        shutil.copyfile(candidate, ready)
+        ready.chmod(0o755)
+        if not valid_hawkeye(ready, version, expected_sha256):
+            raise BootstrapError("staged Hawkeye changed before installation")
+        os.replace(ready, destination)
+        fsync_directory(parent)
+    finally:
+        remove_managed_path(staging, parent)
+        ready.unlink(missing_ok=True)
+    print(f"Installed verified Hawkeye {version} at {destination}")
+
+
+def parse_arguments() -> argparse.Namespace:
+    """Parse the complete pinned runtime contract."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--state-root", type=Path, required=True)
+    parser.add_argument("--nextflow-version", required=True)
+    parser.add_argument("--nextflow-url", required=True)
+    parser.add_argument("--nextflow-sha256", required=True)
+    parser.add_argument("--nextflow-bin", type=Path, required=True)
+    parser.add_argument("--java-version", required=True)
+    parser.add_argument("--java-release", required=True)
+    parser.add_argument("--java-url", required=True)
+    parser.add_argument("--java-archive-sha256", required=True)
+    parser.add_argument("--java-tree-sha256", required=True)
+    parser.add_argument("--java-root", type=Path, required=True)
+    parser.add_argument("--java-sha256", required=True)
+    parser.add_argument("--java-modules-sha256", required=True)
+    parser.add_argument("--java-libjvm-sha256", required=True)
+    parser.add_argument("--java-release-sha256", required=True)
+    parser.add_argument("--hawkeye-version", required=True)
+    parser.add_argument("--hawkeye-sha256", required=True)
+    parser.add_argument("--hawkeye-installer", type=Path, required=True)
+    parser.add_argument("--hawkeye-bin", type=Path, required=True)
+    return parser.parse_args()
+
+
+def parse_verify_java_arguments() -> argparse.Namespace:
+    """Parse the standalone complete-runtime verification contract."""
+    parser = argparse.ArgumentParser(description="Verify one pinned Java tree.")
+    parser.add_argument("command", choices=("verify-java",))
+    parser.add_argument("--state-root", type=Path, required=True)
+    parser.add_argument("--java-release", required=True)
+    parser.add_argument("--java-root", type=Path, required=True)
+    parser.add_argument("--java-tree-sha256", required=True)
+    return parser.parse_args()
+
+
+def verify_java_tree(
+    *, state_root: Path, root: Path, release: str, expected_tree_sha256: str
+) -> None:
+    """Fail unless a complete installed runtime matches its pinned tree digest."""
+    state = marked_state_root(state_root)
+    parent = state / "tools/temurin"
+    if (
+        parent.is_symlink()
+        or not parent.is_dir()
+        or parent.resolve(strict=True) != parent
+    ):
+        raise BootstrapError(f"Temurin verification parent is invalid: {parent}")
+    expected = parent / release
+    if root != expected or root.is_symlink() or not root.is_dir():
+        raise BootstrapError(f"Temurin verification root escaped its pin: {root}")
+    expected_tree_sha256 = require_digest(
+        expected_tree_sha256, "Temurin tree digest"
+    )
+    actual = tree_sha256(root)
+    if actual != expected_tree_sha256:
+        raise BootstrapError(
+            "Temurin tree digest mismatch: "
+            f"expected {expected_tree_sha256}, got {actual}"
+        )
+
+
+def main() -> int:
+    """Install both runtime components below the marked pipeline root."""
+    if sys.argv[1:2] == ["verify-java"]:
+        verify_args = parse_verify_java_arguments()
+        verify_java_tree(
+            state_root=verify_args.state_root,
+            root=verify_args.java_root,
+            release=verify_args.java_release,
+            expected_tree_sha256=verify_args.java_tree_sha256,
+        )
+        return 0
+    args = parse_arguments()
+    state_root = marked_state_root(args.state_root)
+    tools = require_managed_parent(state_root / "tools", state_root / "tools")
+    temporary_root = require_managed_parent(state_root / "tmp", state_root / "tmp")
+    expected_launcher_parent = (
+        tools / "nextflow" / args.nextflow_version
+    )
+    expected_java_parent = tools / "temurin"
+    expected_hawkeye_parent = tools / "hawkeye" / args.hawkeye_version
+    if args.nextflow_bin.parent.resolve(strict=False) != expected_launcher_parent:
+        raise BootstrapError(
+            f"Nextflow destination escaped its pinned tool root: {args.nextflow_bin}"
+        )
+    if args.java_root.parent.resolve(strict=False) != expected_java_parent:
+        raise BootstrapError(
+            f"Temurin destination escaped its pinned tool root: {args.java_root}"
+        )
+    if args.hawkeye_bin.parent.resolve(strict=False) != expected_hawkeye_parent:
+        raise BootstrapError(
+            f"Hawkeye destination escaped its pinned tool root: {args.hawkeye_bin}"
+        )
+    if (
+        args.nextflow_bin.name != "nextflow"
+        or args.java_root.name != args.java_release
+        or args.hawkeye_bin.name != "hawkeye"
+    ):
+        raise BootstrapError("runtime destination name does not match its pin")
+    nextflow_bin = expected_launcher_parent / "nextflow"
+    java_root = expected_java_parent / args.java_release
+    install_launcher(
+        destination=nextflow_bin,
+        expected_parent=expected_launcher_parent,
+        version=args.nextflow_version,
+        url=args.nextflow_url,
+        expected_sha256=args.nextflow_sha256,
+    )
+    install_java(
+        root=java_root,
+        expected_parent=expected_java_parent,
+        version=args.java_version,
+        release=args.java_release,
+        url=args.java_url,
+        archive_sha256=args.java_archive_sha256,
+        expected_tree_sha256=args.java_tree_sha256,
+        runtime_files={
+            Path("Contents/Home/bin/java"): args.java_sha256,
+            Path("Contents/Home/lib/modules"): args.java_modules_sha256,
+            Path("Contents/Home/lib/server/libjvm.dylib"): args.java_libjvm_sha256,
+            Path("Contents/Home/release"): args.java_release_sha256,
+        },
+        temporary_root=temporary_root,
+    )
+    install_hawkeye(
+        destination=expected_hawkeye_parent / "hawkeye",
+        expected_parent=expected_hawkeye_parent,
+        version=args.hawkeye_version,
+        expected_sha256=args.hawkeye_sha256,
+        installer=args.hawkeye_installer,
+        temporary_root=temporary_root,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (BootstrapError, OSError, subprocess.SubprocessError, tarfile.TarError) as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(2) from error

--- a/Tools/ci/collect-compose-package-dependencies.sh
+++ b/Tools/ci/collect-compose-package-dependencies.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+set -euo pipefail
+exec </dev/null
+
+fail() {
+  printf '%s\n' "$1" >&2
+  exit 2
+}
+
+[[ "${1:-}" == true ]] || fail 'Compose package validation gate is not ready'
+/bin/mkdir compose-package-dependencies || fail 'Could not create dependency closure'
+expected_stages=',compose-release-build,compose-go-validation,'
+observed_stages=,
+observed_count=0
+for receipt in *.receipt.tsv; do
+  [[ -f "${receipt}" ]] || continue
+  stage="$(/usr/bin/awk -F '\t' '$1 == "stage" { print $2 }' "${receipt}")"
+  case "${expected_stages}" in
+    *,"${stage}",*) ;;
+    *)
+      printf 'unexpected Compose package dependency: %s\n' "${stage}" >&2
+      exit 2
+      ;;
+  esac
+  case "${observed_stages}" in
+    *,"${stage}",*)
+      printf 'duplicate Compose package dependency: %s\n' "${stage}" >&2
+      exit 2
+      ;;
+  esac
+  archive="${stage}.artifacts.tar"
+  manifest="${stage}.artifacts.tsv"
+  [[ -s "${archive}" ]] || fail "Missing dependency archive: ${stage}"
+  [[ -s "${manifest}" ]] || fail "Missing dependency manifest: ${stage}"
+  expected_archive_sha256="$(/usr/bin/awk -F '\t' \
+    '$1 == "artifact-archive-sha256" { print $2 }' "${receipt}")"
+  expected_manifest_sha256="$(/usr/bin/awk -F '\t' \
+    '$1 == "artifact-manifest-sha256" { print $2 }' "${receipt}")"
+  source_payload_sha256="$(/usr/bin/awk -F '\t' \
+    '$1 == "source-payload-sha256" { print $2 }' "${receipt}")"
+  [[ "${source_payload_sha256}" =~ ^[0-9a-f]{64}$ ]] || \
+    fail "Invalid dependency source payload: ${stage}"
+  [[ "$(/usr/bin/shasum -a 256 "${archive}" | /usr/bin/awk '{ print $1 }')" == \
+    "${expected_archive_sha256}" ]] || \
+    fail "Dependency archive digest changed: ${stage}"
+  [[ "$(/usr/bin/shasum -a 256 "${manifest}" | /usr/bin/awk '{ print $1 }')" == \
+    "${expected_manifest_sha256}" ]] || \
+    fail "Dependency manifest digest changed: ${stage}"
+  [[ "$(/usr/bin/awk -F '\t' '$1 == "artifact-count" { print $2 }' \
+    "${manifest}")" == 1 ]] || \
+    fail "Dependency manifest has the wrong artifact count: ${stage}"
+  artifact_path="$(/usr/bin/awk -F '\t' '$1 == "artifact" { print $2 }' \
+    "${manifest}")"
+  case "${stage}" in
+    compose-release-build) expected_artifact='.build/release/compose' ;;
+    compose-go-validation)
+      expected_artifact='Tools/compose-normalizer/compose-normalizer'
+      ;;
+  esac
+  [[ "${artifact_path}" == "${expected_artifact}" ]] || \
+    fail "Dependency manifest has the wrong artifact: ${stage}"
+  /bin/cp "${receipt}" "${archive}" "${manifest}" \
+    compose-package-dependencies/ || fail "Could not collect dependency: ${stage}"
+  observed_stages="${observed_stages}${stage},"
+  ((observed_count += 1))
+done
+[[ "${observed_count}" -eq 2 ]] || fail 'Compose package dependency count is incomplete'
+for stage in compose-release-build compose-go-validation; do
+  case "${observed_stages}" in
+    *,"${stage}",*) ;;
+    *) fail "Missing Compose package dependency: ${stage}" ;;
+  esac
+done
+[[ "$(/usr/bin/find compose-package-dependencies -maxdepth 1 -type f \
+  \( -name '*.receipt.tsv' -o -name '*.artifacts.tar' \
+  -o -name '*.artifacts.tsv' \) | /usr/bin/wc -l | /usr/bin/tr -d ' ')" -eq 6 ]] || \
+  fail 'Compose package dependency evidence has unmatched files'

--- a/Tools/ci/install-pipeline-dependencies.py
+++ b/Tools/ci/install-pipeline-dependencies.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify and install one pipeline dependency archive into staged source."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+from pathlib import Path, PurePosixPath
+import sys
+import tarfile
+
+
+class DependencyError(RuntimeError):
+    """Dependency evidence is malformed, corrupt or unsafe."""
+
+
+def sha256(path: Path) -> str:
+    """Return one regular file's SHA-256 digest."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_manifest(path: Path) -> dict[str, tuple[str, int]]:
+    """Read the exact artifact closure declared by one manifest."""
+    if path.is_symlink() or not path.is_file() or path.stat().st_size > 1024 * 1024:
+        raise DependencyError(f"dependency manifest is invalid: {path}")
+    rows = [
+        line.split("\t") for line in path.read_text(encoding="utf-8").splitlines()
+    ]
+    count_rows = [
+        row[1] for row in rows if len(row) == 2 and row[0] == "artifact-count"
+    ]
+    if len(count_rows) != 1 or not count_rows[0].isdigit():
+        raise DependencyError("dependency manifest artifact count is invalid")
+
+    artifacts: dict[str, tuple[str, int]] = {}
+    for row in rows:
+        if not row or row[0] != "artifact":
+            continue
+        if len(row) != 4:
+            raise DependencyError("dependency manifest artifact row is malformed")
+        name, digest, size = row[1:]
+        relative = PurePosixPath(name)
+        if (
+            relative.is_absolute()
+            or ".." in relative.parts
+            or not relative.parts
+            or name in artifacts
+            or len(digest) != 64
+            or any(character not in "0123456789abcdef" for character in digest)
+            or not size.isdigit()
+        ):
+            raise DependencyError(f"dependency manifest artifact is invalid: {name}")
+        artifacts[name] = (digest, int(size))
+    if len(artifacts) != int(count_rows[0]) or not artifacts:
+        raise DependencyError("dependency manifest artifact count does not match")
+    return artifacts
+
+
+def require_direct_parents(destination: Path, relative: PurePosixPath) -> None:
+    """Reject an existing parent that could redirect archive extraction."""
+    parent = destination
+    for component in relative.parts[:-1]:
+        parent /= component
+        if parent.is_symlink() or (
+            os.path.lexists(parent) and not parent.is_dir()
+        ):
+            raise DependencyError(
+                f"dependency archive member has an indirect or invalid parent: {relative}"
+            )
+
+
+def install(*, archive_path: Path, manifest_path: Path, destination: Path) -> None:
+    """Verify, collision-check, extract and reverify one dependency closure."""
+    if (
+        archive_path.is_symlink()
+        or not archive_path.is_file()
+        or destination.is_symlink()
+        or not destination.is_dir()
+    ):
+        raise DependencyError("dependency archive or destination is invalid")
+    artifacts = read_manifest(manifest_path)
+    with tarfile.open(archive_path, "r:") as archive:
+        members = archive.getmembers()
+        if tuple(member.name for member in members) != tuple(artifacts):
+            raise DependencyError("dependency archive does not match its manifest")
+        for member in members:
+            relative = PurePosixPath(member.name)
+            target = destination / relative
+            require_direct_parents(destination, relative)
+            if (
+                relative.is_absolute()
+                or ".." in relative.parts
+                or not member.isfile()
+                or os.path.lexists(target)
+            ):
+                raise DependencyError(
+                    f"dependency archive member is unsafe or collides: {member.name}"
+                )
+        try:
+            archive.extractall(destination, filter="fully_trusted")
+        except TypeError:
+            archive.extractall(destination)
+
+    for name, (expected_digest, expected_size) in artifacts.items():
+        extracted = destination / name
+        if extracted.is_symlink() or not extracted.is_file():
+            raise DependencyError(f"dependency extraction is invalid: {name}")
+        if sha256(extracted) != expected_digest or extracted.stat().st_size != expected_size:
+            raise DependencyError(f"dependency artifact changed during extraction: {name}")
+
+
+def main() -> int:
+    """Parse paths and install one dependency archive."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--destination", type=Path, required=True)
+    args = parser.parse_args()
+    install(
+        archive_path=args.archive,
+        manifest_path=args.manifest,
+        destination=args.destination,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (DependencyError, OSError, tarfile.TarError) as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(2) from error

--- a/Tools/ci/materialize-pipeline-package.py
+++ b/Tools/ci/materialize-pipeline-package.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify and materialize a recovered Compose package artifact."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path, PurePosixPath
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import uuid
+
+
+EXPECTED_ARTIFACTS = (
+    "dist/compose/bin/compose",
+    "dist/compose/config.toml",
+    "dist/compose/resources/compose-normalizer",
+    "dist/compose/resources/container-compose-icon.png",
+    "dist/compose/resources/build-info.json",
+    "container-compose-plugin-release-arm64.tar.gz",
+    "container-compose-plugin-release-arm64.tar.gz.sha256",
+)
+OUTPUT_ROOTS = (
+    "dist",
+    "container-compose-plugin-release-arm64.tar.gz",
+    "container-compose-plugin-release-arm64.tar.gz.sha256",
+)
+JOURNAL_NAME = ".pipeline-package-materialization.json"
+
+
+class MaterializationError(RuntimeError):
+    """Recovered package evidence is missing, corrupt or unsafe."""
+
+
+def sha256(path: Path) -> str:
+    """Return one regular file's SHA-256 digest."""
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_tsv(path: Path) -> list[list[str]]:
+    """Read a bounded tab-separated receipt without accepting controls."""
+    if path.is_symlink() or not path.is_file() or path.stat().st_size > 1024 * 1024:
+        raise MaterializationError(f"package evidence is indirect or invalid: {path}")
+    rows = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        fields = line.split("\t")
+        if not fields or any("\n" in field or "\r" in field for field in fields):
+            raise MaterializationError(f"package evidence contains controls: {path}")
+        rows.append(fields)
+    return rows
+
+
+def one(rows: list[list[str]], key: str) -> str:
+    """Return an exactly-once two-column receipt value."""
+    matches = [row[1] for row in rows if len(row) == 2 and row[0] == key]
+    if len(matches) != 1:
+        raise MaterializationError(f"package evidence field is not unique: {key}")
+    return matches[0]
+
+
+def require_sha256(value: str, field: str) -> str:
+    """Validate a lowercase SHA-256 value."""
+    if len(value) != 64 or any(character not in "0123456789abcdef" for character in value):
+        raise MaterializationError(f"package evidence has an invalid {field}")
+    return value
+
+
+def verify_evidence(
+    receipt: Path, manifest: Path, archive: Path
+) -> tuple[dict[str, str], str]:
+    """Verify the complete package receipt, manifest and archive closure."""
+    receipt_rows = read_tsv(receipt)
+    manifest_rows = read_tsv(manifest)
+    if one(receipt_rows, "stage") != "compose-package":
+        raise MaterializationError("package receipt has the wrong stage")
+    if one(receipt_rows, "repository") != "container-compose":
+        raise MaterializationError("package receipt has the wrong repository")
+    source_commit = one(receipt_rows, "source-commit")
+    if len(source_commit) != 40 or any(
+        character not in "0123456789abcdef" for character in source_commit
+    ):
+        raise MaterializationError("package receipt has an invalid source commit")
+    archive_digest = require_sha256(
+        one(receipt_rows, "artifact-archive-sha256"), "archive digest"
+    )
+    manifest_digest = require_sha256(
+        one(receipt_rows, "artifact-manifest-sha256"), "manifest digest"
+    )
+    if archive.is_symlink() or not archive.is_file() or sha256(archive) != archive_digest:
+        raise MaterializationError("package artifact archive digest does not match")
+    if sha256(manifest) != manifest_digest:
+        raise MaterializationError("package artifact manifest digest does not match")
+    if one(manifest_rows, "archive-sha256") != archive_digest:
+        raise MaterializationError("package manifest does not bind its archive")
+    if one(manifest_rows, "artifact-count") != str(len(EXPECTED_ARTIFACTS)):
+        raise MaterializationError("package manifest has the wrong artifact count")
+
+    artifacts: dict[str, str] = {}
+    for row in manifest_rows:
+        if not row or row[0] != "artifact":
+            continue
+        if len(row) != 4:
+            raise MaterializationError("package artifact row is malformed")
+        name, digest, size = row[1:]
+        require_sha256(digest, f"digest for {name}")
+        if not size.isdigit() or name in artifacts:
+            raise MaterializationError(f"package artifact row is invalid: {name}")
+        artifacts[name] = digest
+    if tuple(artifacts) != EXPECTED_ARTIFACTS:
+        raise MaterializationError("package manifest does not declare the exact outputs")
+
+    with tarfile.open(archive, "r:") as package:
+        members = package.getmembers()
+        names = tuple(member.name for member in members)
+        if names != EXPECTED_ARTIFACTS:
+            raise MaterializationError("package archive does not contain the exact outputs")
+        for member in members:
+            path = PurePosixPath(member.name)
+            if path.is_absolute() or ".." in path.parts or not member.isfile():
+                raise MaterializationError(f"unsafe package archive member: {member.name}")
+    return artifacts, source_commit
+
+
+def path_exists(path: Path) -> bool:
+    """Return whether a path or symbolic link occupies a destination."""
+    return os.path.lexists(path)
+
+
+def remove_output(path: Path) -> None:
+    """Remove one exact generated output without following symbolic links."""
+    if path.is_symlink() or path.is_file():
+        path.unlink()
+    elif path.is_dir():
+        shutil.rmtree(path)
+
+
+def write_journal(path: Path, payload: dict[str, object]) -> None:
+    """Atomically persist a materialization transaction before mutation."""
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=path.parent
+    )
+    try:
+        stream_descriptor = descriptor
+        descriptor = -1
+        with os.fdopen(stream_descriptor, "w", encoding="utf-8") as output:
+            json.dump(payload, output, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary_name, path)
+        descriptor = -1
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        Path(temporary_name).unlink(missing_ok=True)
+
+
+def recover_interrupted_transaction(destination: Path) -> None:
+    """Roll back a previously interrupted materialization transaction."""
+    journal = destination / JOURNAL_NAME
+    if not path_exists(journal):
+        return
+    if journal.is_symlink() or not journal.is_file() or journal.stat().st_size > 65536:
+        raise MaterializationError(f"package materialization journal is invalid: {journal}")
+    payload = json.loads(journal.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or payload.get("schema") != 1:
+        raise MaterializationError("package materialization journal has the wrong schema")
+    transaction = payload.get("transaction")
+    phase = payload.get("phase")
+    outputs = payload.get("outputs")
+    if (
+        not isinstance(transaction, str)
+        or len(transaction) != 32
+        or any(character not in "0123456789abcdef" for character in transaction)
+        or phase not in ("prepared", "committed")
+        or not isinstance(outputs, dict)
+        or set(outputs) != set(OUTPUT_ROOTS)
+        or any(not isinstance(value, bool) for value in outputs.values())
+    ):
+        raise MaterializationError("package materialization journal is malformed")
+    backup = destination / f".pipeline-package-previous.{transaction}"
+    if backup.is_symlink() or (path_exists(backup) and not backup.is_dir()):
+        raise MaterializationError(f"package materialization backup is invalid: {backup}")
+
+    if phase == "committed":
+        if backup.exists():
+            shutil.rmtree(backup)
+        journal.unlink()
+        return
+
+    for name in OUTPUT_ROOTS:
+        current = destination / name
+        previous = backup / name
+        if outputs[name]:
+            if path_exists(previous):
+                remove_output(current)
+                os.replace(previous, current)
+            elif not path_exists(current):
+                raise MaterializationError(
+                    f"package materialization cannot restore prior output: {name}"
+                )
+        else:
+            remove_output(current)
+    journal.unlink()
+    fsync_directory = os.open(destination, os.O_RDONLY)
+    try:
+        os.fsync(fsync_directory)
+    finally:
+        os.close(fsync_directory)
+    if backup.exists():
+        shutil.rmtree(backup)
+
+
+def checkout_destination(path: Path) -> Path:
+    """Return one physical Git checkout that may receive generated outputs."""
+    if not path.is_absolute() or not path.is_dir():
+        raise MaterializationError(f"package destination is invalid: {path}")
+    destination = path.resolve(strict=True)
+    if not (destination / ".git").exists():
+        raise MaterializationError(f"package destination is not a Git checkout: {destination}")
+    return destination
+
+
+def materialize(
+    *, receipt: Path, manifest: Path, archive: Path, destination: Path
+) -> None:
+    """Verify all bytes before replacing ignored generated outputs."""
+    destination = checkout_destination(destination)
+    recover_interrupted_transaction(destination)
+    artifacts, source_commit = verify_evidence(receipt, manifest, archive)
+    checkout_commit = subprocess.run(
+        ["/usr/bin/git", "-C", str(destination), "rev-parse", "--verify", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"},
+    ).stdout.strip()
+    if checkout_commit != source_commit:
+        raise MaterializationError(
+            "package source commit does not match the destination checkout"
+        )
+
+    staging = Path(tempfile.mkdtemp(prefix=".pipeline-package.", dir=destination))
+    transaction = uuid.uuid4().hex
+    backup = destination / f".pipeline-package-previous.{transaction}"
+    journal = destination / JOURNAL_NAME
+    try:
+        with tarfile.open(archive, "r:") as package:
+            try:
+                package.extractall(staging, filter="fully_trusted")
+            except TypeError:
+                package.extractall(staging)
+        for relative, expected_digest in artifacts.items():
+            staged = staging / relative
+            if staged.is_symlink() or not staged.is_file():
+                raise MaterializationError(f"staged package output is invalid: {relative}")
+            if sha256(staged) != expected_digest:
+                raise MaterializationError(f"staged package output digest changed: {relative}")
+        build_info = json.loads(
+            (staging / "dist/compose/resources/build-info.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        if not isinstance(build_info, dict) or build_info.get("commit") != source_commit:
+            raise MaterializationError("package build information has the wrong commit")
+        plugin = staging / "container-compose-plugin-release-arm64.tar.gz"
+        sidecar = staging / "container-compose-plugin-release-arm64.tar.gz.sha256"
+        sidecar_lines = sidecar.read_text(encoding="utf-8").splitlines()
+        sidecar_fields = sidecar_lines[0].split() if len(sidecar_lines) == 1 else []
+        if (
+            len(sidecar_fields) != 2
+            or sidecar_fields[0] != sha256(plugin)
+            or sidecar_fields[1] != plugin.name
+        ):
+            raise MaterializationError("package checksum sidecar does not match")
+
+        for name in OUTPUT_ROOTS:
+            output = destination / name
+            if output.is_symlink():
+                raise MaterializationError(f"package output destination is indirect: {output}")
+            if not path_exists(output):
+                continue
+            if name == "dist" and not output.is_dir():
+                raise MaterializationError(f"package output destination is invalid: {output}")
+            if name != "dist" and not output.is_file():
+                raise MaterializationError(f"package output destination is invalid: {output}")
+
+        original_outputs = {
+            name: path_exists(destination / name) for name in OUTPUT_ROOTS
+        }
+        backup.mkdir(mode=0o700)
+        write_journal(
+            journal,
+            {
+                "schema": 1,
+                "transaction": transaction,
+                "phase": "prepared",
+                "outputs": original_outputs,
+            },
+        )
+        for name in OUTPUT_ROOTS:
+            if original_outputs[name]:
+                os.replace(destination / name, backup / name)
+        for name in OUTPUT_ROOTS:
+            os.replace(staging / name, destination / name)
+        write_journal(
+            journal,
+            {
+                "schema": 1,
+                "transaction": transaction,
+                "phase": "committed",
+                "outputs": original_outputs,
+            },
+        )
+        shutil.rmtree(backup)
+        journal.unlink()
+        directory = os.open(destination, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    except BaseException:
+        if path_exists(journal):
+            recover_interrupted_transaction(destination)
+        raise
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def main() -> int:
+    """Parse the evidence paths and materialize one recovered package."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--receipt", type=Path)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--archive", type=Path)
+    parser.add_argument("--destination", type=Path, required=True)
+    parser.add_argument("--recover-only", action="store_true")
+    args = parser.parse_args()
+    destination = checkout_destination(args.destination)
+    if args.recover_only:
+        recover_interrupted_transaction(destination)
+        return 0
+    if args.receipt is None or args.manifest is None or args.archive is None:
+        parser.error("--receipt, --manifest and --archive are required")
+    materialize(
+        receipt=args.receipt,
+        manifest=args.manifest,
+        archive=args.archive,
+        destination=destination,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (
+        MaterializationError,
+        OSError,
+        subprocess.SubprocessError,
+        tarfile.TarError,
+        json.JSONDecodeError,
+    ) as error:
+        print(error, file=sys.stderr)
+        raise SystemExit(2) from error

--- a/Tools/ci/test_bootstrap_nextflow_runtime.py
+++ b/Tools/ci/test_bootstrap_nextflow_runtime.py
@@ -1,0 +1,347 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for the content-pinned Nextflow runtime bootstrap."""
+
+import importlib.util
+import os
+from pathlib import Path
+import shutil
+import tarfile
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("bootstrap-nextflow-runtime.py")
+SPEC = importlib.util.spec_from_file_location("bootstrap_nextflow_runtime", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"could not load {MODULE_PATH}")
+bootstrap = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bootstrap)
+
+
+class NextflowRuntimeBootstrapTests(unittest.TestCase):
+    """Keep runtime provisioning independent of mutable Homebrew paths."""
+
+    def state_root(self, root: Path) -> Path:
+        """Create one minimal marked pipeline state root."""
+        (root / "tools").mkdir(parents=True)
+        (root / "tmp").mkdir()
+        (root / ".container-compose-pipeline-root").write_text(
+            bootstrap.STATE_MARKER + "\n", encoding="utf-8"
+        )
+        return bootstrap.marked_state_root(root)
+
+    def test_launcher_is_installed_atomically_and_then_reused(self) -> None:
+        """A valid launcher never reaches the downloader a second time."""
+        with tempfile.TemporaryDirectory() as directory:
+            state = self.state_root(Path(directory) / "state")
+            payload = Path(directory) / "nextflow"
+            payload.write_bytes(b"pinned nextflow\n")
+            destination = state / "tools/nextflow/1.2.3/nextflow"
+            calls = 0
+
+            def download(_url: str, output: Path) -> None:
+                nonlocal calls
+                calls += 1
+                shutil.copyfile(payload, output)
+
+            arguments = {
+                "destination": destination,
+                "expected_parent": destination.parent,
+                "version": "1.2.3",
+                "url": "https://example.invalid/nextflow",
+                "expected_sha256": bootstrap.sha256(payload),
+                "downloader": download,
+            }
+            bootstrap.install_launcher(**arguments)
+            bootstrap.install_launcher(**arguments)
+
+            self.assertEqual(calls, 1)
+            self.assertEqual(destination.read_bytes(), payload.read_bytes())
+            self.assertTrue(os.access(destination, os.X_OK))
+
+    def test_managed_parent_rejects_a_symlink_before_creating_children(self) -> None:
+        """A tampered ancestor cannot redirect even temporary tool state."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = self.state_root(root / "state")
+            outside = root / "outside"
+            outside.mkdir()
+            (state / "tools/nextflow").symlink_to(
+                outside, target_is_directory=True
+            )
+            destination = state / "tools/nextflow/1.2.3/nextflow"
+
+            with self.assertRaisesRegex(
+                bootstrap.BootstrapError, "ancestor is indirect"
+            ):
+                bootstrap.install_launcher(
+                    destination=destination,
+                    expected_parent=destination.parent,
+                    version="1.2.3",
+                    url="https://example.invalid/nextflow",
+                    expected_sha256="0" * 64,
+                )
+
+            self.assertFalse((outside / "1.2.3").exists())
+
+    def make_java_archive(
+        self, root: Path, release: str
+    ) -> tuple[Path, dict[Path, str], str]:
+        """Create a tiny executable JDK-shaped fixture and its file pins."""
+        archive_root = root / f"jdk-{release}"
+        home = archive_root / "Contents/Home"
+        (home / "bin").mkdir(parents=True)
+        (home / "lib/server").mkdir(parents=True)
+        java = home / "bin/java"
+        java.write_text(
+            '#!/bin/sh\nprintf \'openjdk version "21.0.11" fixture\\n\' >&2\n',
+            encoding="utf-8",
+        )
+        java.chmod(0o755)
+        (home / "lib/modules").write_bytes(b"modules")
+        (home / "lib/server/libjvm.dylib").write_bytes(b"jvm")
+        (home / "lib/libzip.dylib").write_bytes(b"zip")
+        (home / "release").write_bytes(b"release")
+        archive = root / "temurin.tar.gz"
+        with tarfile.open(archive, "w:gz") as output:
+            output.add(archive_root, arcname=archive_root.name)
+        runtime_files = {
+            path.relative_to(archive_root): bootstrap.sha256(path)
+            for path in (
+                java,
+                home / "lib/modules",
+                home / "lib/server/libjvm.dylib",
+                home / "release",
+            )
+        }
+        return archive, runtime_files, bootstrap.tree_sha256(archive_root)
+
+    def test_java_archive_is_verified_installed_and_reused(self) -> None:
+        """The JDK becomes a durable content-addressed tool, not a Cellar alias."""
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_root = Path(directory)
+            state = self.state_root(fixture_root / "state")
+            release = "21.0.11+10"
+            archive, runtime_files, tree_digest = self.make_java_archive(
+                fixture_root, release
+            )
+            destination = state / "tools/temurin" / release
+            calls = 0
+
+            def download(_url: str, output: Path) -> None:
+                nonlocal calls
+                calls += 1
+                shutil.copyfile(archive, output)
+
+            arguments = {
+                "root": destination,
+                "expected_parent": destination.parent,
+                "version": "21.0.11",
+                "release": release,
+                "url": "https://example.invalid/temurin.tar.gz",
+                "archive_sha256": bootstrap.sha256(archive),
+                "expected_tree_sha256": tree_digest,
+                "runtime_files": runtime_files,
+                "temporary_root": state / "tmp",
+                "downloader": download,
+            }
+            bootstrap.install_java(**arguments)
+            bootstrap.install_java(**arguments)
+
+            self.assertEqual(calls, 1)
+            self.assertTrue(
+                bootstrap.valid_runtime(destination, runtime_files, tree_digest)
+            )
+
+    def test_java_reuse_rejects_corruption_outside_the_critical_file_subset(
+        self,
+    ) -> None:
+        """Every extracted JDK byte, not only launcher files, remains pinned."""
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_root = Path(directory)
+            state = self.state_root(fixture_root / "state")
+            release = "21.0.11+10"
+            archive, runtime_files, tree_digest = self.make_java_archive(
+                fixture_root, release
+            )
+            destination = state / "tools/temurin" / release
+            calls = 0
+
+            def download(_url: str, output: Path) -> None:
+                nonlocal calls
+                calls += 1
+                shutil.copyfile(archive, output)
+
+            arguments = {
+                "root": destination,
+                "expected_parent": destination.parent,
+                "version": "21.0.11",
+                "release": release,
+                "url": "https://example.invalid/temurin.tar.gz",
+                "archive_sha256": bootstrap.sha256(archive),
+                "expected_tree_sha256": tree_digest,
+                "runtime_files": runtime_files,
+                "temporary_root": state / "tmp",
+                "downloader": download,
+            }
+            bootstrap.install_java(**arguments)
+            (destination / "Contents/Home/lib/libzip.dylib").write_bytes(b"corrupt")
+            with self.assertRaisesRegex(
+                bootstrap.BootstrapError, "tree digest mismatch"
+            ):
+                bootstrap.verify_java_tree(
+                    state_root=state,
+                    root=destination,
+                    release=release,
+                    expected_tree_sha256=tree_digest,
+                )
+            bootstrap.install_java(**arguments)
+
+            self.assertEqual(calls, 2)
+            self.assertTrue(
+                bootstrap.valid_runtime(destination, runtime_files, tree_digest)
+            )
+
+    def test_java_install_restores_an_interrupted_previous_runtime(self) -> None:
+        """A hard kill between the two atomic renames needs no redownload."""
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_root = Path(directory)
+            state = self.state_root(fixture_root / "state")
+            release = "21.0.11+10"
+            archive, runtime_files, tree_digest = self.make_java_archive(
+                fixture_root, release
+            )
+            destination = state / "tools/temurin" / release
+
+            def download(_url: str, output: Path) -> None:
+                shutil.copyfile(archive, output)
+
+            arguments = {
+                "root": destination,
+                "expected_parent": destination.parent,
+                "version": "21.0.11",
+                "release": release,
+                "url": "https://example.invalid/temurin.tar.gz",
+                "archive_sha256": bootstrap.sha256(archive),
+                "expected_tree_sha256": tree_digest,
+                "runtime_files": runtime_files,
+                "temporary_root": state / "tmp",
+                "downloader": download,
+            }
+            bootstrap.install_java(**arguments)
+            previous = destination.parent / f".temurin-previous.{'a' * 32}"
+            os.replace(destination, previous)
+
+            def unexpected_download(_url: str, _output: Path) -> None:
+                self.fail("recovery should not download the JDK again")
+
+            arguments["downloader"] = unexpected_download
+            bootstrap.install_java(**arguments)
+
+            self.assertTrue(
+                bootstrap.valid_runtime(destination, runtime_files, tree_digest)
+            )
+            self.assertFalse(previous.exists())
+
+    def test_java_archive_rejects_parent_traversal(self) -> None:
+        """A matching download still cannot write outside its staging root."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive_path = root / "unsafe.tar.gz"
+            payload = root / "payload"
+            payload.write_bytes(b"unsafe")
+            with tarfile.open(archive_path, "w:gz") as archive:
+                archive.add(payload, arcname="../escaped")
+
+            with tarfile.open(archive_path, "r:gz") as archive:
+                with self.assertRaisesRegex(bootstrap.BootstrapError, "unsafe"):
+                    bootstrap.validate_archive(archive, "jdk-21.0.11+10")
+
+    def test_hawkeye_is_installed_atomically_and_then_reused(self) -> None:
+        """The graph uses its archive-pinned Hawkeye, not a mutable Cellar tool."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = self.state_root(root / "state")
+            installer = root / "install-hawkeye.sh"
+            counter = root / "installer-calls"
+            hawkeye_payload = (
+                "#!/bin/sh\n"
+                "case \"${1:-}:${2:-}\" in\n"
+                "  --version:) printf '%s\\n' 'version: 6.5.1' ;;\n"
+                "  check:--help) printf '%s\\n' '--fail-if-unknown' ;;\n"
+                "  format:--help) printf '%s\\n' '--fail-if-updated' ;;\n"
+                "  *) exit 64 ;;\n"
+                "esac\n"
+            )
+            expected_hawkeye = root / "expected-hawkeye"
+            expected_hawkeye.write_text(hawkeye_payload, encoding="utf-8")
+            installer_source = (
+                "#!/bin/sh\n"
+                "set -eu\n"
+                f"printf x >>'{counter}'\n"
+                "mkdir -p .local/bin\n"
+                "cat >.local/bin/hawkeye <<'EOF'\n"
+                + hawkeye_payload
+                + "EOF\nchmod 0755 .local/bin/hawkeye\n"
+            )
+            installer.write_text(
+                installer_source,
+                encoding="utf-8",
+            )
+            installer.chmod(0o755)
+            destination = state / "tools/hawkeye/6.5.1/hawkeye"
+            arguments = {
+                "destination": destination,
+                "expected_parent": destination.parent,
+                "version": "6.5.1",
+                "expected_sha256": bootstrap.sha256(expected_hawkeye),
+                "installer": installer,
+                "temporary_root": state / "tmp",
+            }
+
+            bootstrap.install_hawkeye(**arguments)
+            interrupted = destination.parent / ".hawkeye-install.abcd"
+            interrupted.mkdir()
+            destination.write_text(hawkeye_payload + "# impostor\n", encoding="utf-8")
+            destination.chmod(0o755)
+            bootstrap.install_hawkeye(**arguments)
+
+            self.assertEqual(counter.read_text(encoding="utf-8"), "xx")
+            self.assertTrue(
+                bootstrap.valid_hawkeye(
+                    destination, "6.5.1", bootstrap.sha256(expected_hawkeye)
+                )
+            )
+            self.assertFalse(interrupted.exists())
+
+    def test_state_root_requires_the_exact_marker(self) -> None:
+        """Bootstrap never claims an arbitrary tools directory."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "state"
+            root.mkdir()
+            (root / ".container-compose-pipeline-root").write_text(
+                "wrong\n", encoding="utf-8"
+            )
+
+            with self.assertRaisesRegex(bootstrap.BootstrapError, "does not match"):
+                bootstrap.marked_state_root(root)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/test_collect_compose_package_dependencies.py
+++ b/Tools/ci/test_collect_compose_package_dependencies.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for Compose package dependency collection."""
+
+import hashlib
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("collect-compose-package-dependencies.sh")
+ARTIFACTS = {
+    "compose-release-build": ".build/release/compose",
+    "compose-go-validation": "Tools/compose-normalizer/compose-normalizer",
+}
+
+
+def sha256(path: Path) -> str:
+    """Return one fixture file's SHA-256 digest."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+class ComposePackageDependencyCollectionTests(unittest.TestCase):
+    """Only the two exact content-addressed compiler products may be packaged."""
+
+    def write_evidence(self, root: Path, stage: str, payload: str) -> None:
+        """Write one producer's authenticated evidence fixture."""
+        archive = root / f"{stage}.artifacts.tar"
+        archive.write_bytes(f"archive for {stage}\n".encode())
+        manifest = root / f"{stage}.artifacts.tsv"
+        manifest.write_text(
+            "\n".join(
+                (
+                    "schema\t1",
+                    f"stage\t{stage}",
+                    "repository\tcontainer-compose",
+                    f"artifact\t{ARTIFACTS[stage]}\t{'a' * 64}\t1",
+                    "artifact-count\t1",
+                    f"archive-sha256\t{sha256(archive)}",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (root / f"{stage}.receipt.tsv").write_text(
+            "\n".join(
+                (
+                    "schema\t3",
+                    f"stage\t{stage}",
+                    "repository\tcontainer-compose",
+                    f"source-payload-sha256\t{payload}",
+                    f"artifact-archive-sha256\t{sha256(archive)}",
+                    f"artifact-manifest-sha256\t{sha256(manifest)}",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def run_collector(self, root: Path) -> subprocess.CompletedProcess[str]:
+        """Run the collector in a closed-input fixture directory."""
+        return subprocess.run(
+            ["/bin/bash", "-p", SCRIPT, "true"],
+            cwd=root,
+            stdin=subprocess.DEVNULL,
+            check=False,
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin", "LANG": "C", "LC_ALL": "C"},
+        )
+
+    def test_collects_exact_content_addressed_producer_evidence(self) -> None:
+        """Both compiler products form one six-file dependency closure."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for index, stage in enumerate(ARTIFACTS):
+                self.write_evidence(root, stage, str(index + 1) * 64)
+
+            result = self.run_collector(root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            collected = root / "compose-package-dependencies"
+            self.assertEqual(len(list(collected.iterdir())), 6)
+
+    def test_collects_nextflow_staged_symlink_inputs(self) -> None:
+        """Nextflow stages producer files as links while outputs are regular files."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            producer = root / "producer"
+            producer.mkdir()
+            for index, stage in enumerate(ARTIFACTS):
+                self.write_evidence(producer, stage, str(index + 1) * 64)
+            for evidence in producer.iterdir():
+                (root / evidence.name).symlink_to(evidence)
+
+            result = self.run_collector(root)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            collected = root / "compose-package-dependencies"
+            self.assertEqual(len(list(collected.iterdir())), 6)
+            self.assertTrue(all(path.is_file() for path in collected.iterdir()))
+
+    def test_rejects_a_producer_without_source_content_identity(self) -> None:
+        """Every product must identify the exact selected source payload."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.write_evidence(root, "compose-release-build", "a" * 64)
+            self.write_evidence(root, "compose-go-validation", "not-a-digest")
+
+            result = self.run_collector(root)
+
+            self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_a_tampered_producer_archive(self) -> None:
+        """An archive changed after receipt creation is never forwarded."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for stage in ARTIFACTS:
+                self.write_evidence(root, stage, "a" * 64)
+            (root / "compose-release-build.artifacts.tar").write_bytes(b"tampered")
+
+            result = self.run_collector(root)
+
+            self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/test_install_pipeline_dependencies.py
+++ b/Tools/ci/test_install_pipeline_dependencies.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for verified pipeline dependency installation."""
+
+import importlib.util
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).with_name("install-pipeline-dependencies.py")
+SPEC = importlib.util.spec_from_file_location("install_pipeline_dependencies", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"could not load {MODULE_PATH}")
+installer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(installer)
+
+
+class PipelineDependencyInstallationTests(unittest.TestCase):
+    """Recovered products must be exact and must not overwrite source."""
+
+    def evidence(self, root: Path) -> tuple[Path, Path]:
+        """Create one valid single-file dependency closure."""
+        payload = root / "payload"
+        artifact = payload / ".build/release/compose"
+        artifact.parent.mkdir(parents=True)
+        artifact.write_bytes(b"compose")
+        archive = root / "dependency.tar"
+        with tarfile.open(archive, "w:") as output:
+            output.add(artifact, arcname=".build/release/compose", recursive=False)
+        manifest = root / "dependency.tsv"
+        manifest.write_text(
+            "\n".join(
+                (
+                    "schema\t1",
+                    "artifact\t.build/release/compose\t"
+                    f"{installer.sha256(artifact)}\t{artifact.stat().st_size}",
+                    "artifact-count\t1",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return archive, manifest
+
+    def test_installs_verified_dependency(self) -> None:
+        """An exact archive is installed at its declared path."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive, manifest = self.evidence(root)
+            destination = root / "source"
+            destination.mkdir()
+
+            installer.install(
+                archive_path=archive,
+                manifest_path=manifest,
+                destination=destination,
+            )
+
+            self.assertEqual(
+                (destination / ".build/release/compose").read_bytes(), b"compose"
+            )
+
+    def test_rejects_collision_before_extraction(self) -> None:
+        """A dependency cannot replace a file captured from source."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive, manifest = self.evidence(root)
+            destination = root / "source"
+            existing = destination / ".build/release/compose"
+            existing.parent.mkdir(parents=True)
+            existing.write_bytes(b"source")
+
+            with self.assertRaisesRegex(installer.DependencyError, "collides"):
+                installer.install(
+                    archive_path=archive,
+                    manifest_path=manifest,
+                    destination=destination,
+                )
+
+            self.assertEqual(existing.read_bytes(), b"source")
+
+    def test_rejects_symlinked_parent_before_extraction(self) -> None:
+        """A staged source symlink cannot redirect dependency extraction."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive, manifest = self.evidence(root)
+            destination = root / "source"
+            destination.mkdir()
+            outside = root / "outside"
+            outside.mkdir()
+            (destination / ".build").symlink_to(outside, target_is_directory=True)
+
+            with self.assertRaisesRegex(
+                installer.DependencyError, "indirect or invalid parent"
+            ):
+                installer.install(
+                    archive_path=archive,
+                    manifest_path=manifest,
+                    destination=destination,
+                )
+
+            self.assertFalse((outside / "release/compose").exists())
+
+    def test_rejects_manifest_digest_mismatch(self) -> None:
+        """A false per-file digest is detected after extraction."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            archive, manifest = self.evidence(root)
+            manifest.write_text(
+                manifest.read_text(encoding="utf-8").replace(
+                    installer.sha256(root / "payload/.build/release/compose"), "0" * 64
+                ),
+                encoding="utf-8",
+            )
+            destination = root / "source"
+            destination.mkdir()
+
+            with self.assertRaisesRegex(installer.DependencyError, "changed"):
+                installer.install(
+                    archive_path=archive,
+                    manifest_path=manifest,
+                    destination=destination,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/test_materialize_pipeline_package.py
+++ b/Tools/ci/test_materialize_pipeline_package.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Tests for recovered Compose package materialization."""
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = Path(__file__).with_name("materialize-pipeline-package.py")
+SPEC = importlib.util.spec_from_file_location("materialize_pipeline_package", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"could not load {MODULE_PATH}")
+materializer = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(materializer)
+
+
+class PipelinePackageMaterializationTests(unittest.TestCase):
+    """Only verified exact package outputs may reach the checkout."""
+
+    def evidence(self, root: Path, commit: str) -> tuple[Path, Path, Path]:
+        """Create one valid package archive, manifest and receipt."""
+        payload = root / "payload"
+        for name in materializer.EXPECTED_ARTIFACTS:
+            (payload / name).parent.mkdir(parents=True, exist_ok=True)
+        (payload / materializer.EXPECTED_ARTIFACTS[0]).write_bytes(b"compose")
+        (payload / materializer.EXPECTED_ARTIFACTS[1]).write_text(
+            "[compose]\n", encoding="utf-8"
+        )
+        (payload / materializer.EXPECTED_ARTIFACTS[2]).write_bytes(b"normalizer")
+        (payload / materializer.EXPECTED_ARTIFACTS[3]).write_bytes(b"png")
+        (payload / materializer.EXPECTED_ARTIFACTS[4]).write_text(
+            json.dumps({"commit": commit}) + "\n", encoding="utf-8"
+        )
+        plugin = payload / materializer.EXPECTED_ARTIFACTS[5]
+        plugin.write_bytes(b"plugin archive")
+        (payload / materializer.EXPECTED_ARTIFACTS[6]).write_text(
+            f"{materializer.sha256(plugin)}  {plugin.name}\n", encoding="utf-8"
+        )
+
+        archive = root / "compose-package.artifacts.tar"
+        with tarfile.open(archive, "w:") as output:
+            for name in materializer.EXPECTED_ARTIFACTS:
+                output.add(payload / name, arcname=name, recursive=False)
+        manifest = root / "compose-package.artifacts.tsv"
+        manifest_lines = [
+            "schema\t1",
+            "stage\tcompose-package",
+            "repository\tcontainer-compose",
+        ]
+        for name in materializer.EXPECTED_ARTIFACTS:
+            path = payload / name
+            manifest_lines.append(
+                f"artifact\t{name}\t{materializer.sha256(path)}\t{path.stat().st_size}"
+            )
+        manifest_lines.extend(
+            (
+                f"artifact-count\t{len(materializer.EXPECTED_ARTIFACTS)}",
+                f"archive-sha256\t{materializer.sha256(archive)}",
+            )
+        )
+        manifest.write_text("\n".join(manifest_lines) + "\n", encoding="utf-8")
+        receipt = root / "compose-package.receipt.tsv"
+        receipt.write_text(
+            "\n".join(
+                (
+                    "schema\t3",
+                    "stage\tcompose-package",
+                    "repository\tcontainer-compose",
+                    f"source-commit\t{commit}",
+                    f"artifact-archive-sha256\t{materializer.sha256(archive)}",
+                    f"artifact-manifest-sha256\t{materializer.sha256(manifest)}",
+                )
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return receipt, manifest, archive
+
+    def destination(self, root: Path) -> tuple[Path, str]:
+        """Create a worktree-shaped output destination."""
+        destination = root / "checkout"
+        destination.mkdir()
+        subprocess.run(["/usr/bin/git", "init", "--quiet", destination], check=True)
+        subprocess.run(
+            ["/usr/bin/git", "-C", destination, "config", "user.name", "Fixture"],
+            check=True,
+        )
+        subprocess.run(
+            [
+                "/usr/bin/git",
+                "-C",
+                destination,
+                "config",
+                "user.email",
+                "fixture@example.invalid",
+            ],
+            check=True,
+        )
+        (destination / "README.md").write_text("fixture\n", encoding="utf-8")
+        subprocess.run(
+            ["/usr/bin/git", "-C", destination, "add", "README.md"], check=True
+        )
+        subprocess.run(
+            ["/usr/bin/git", "-C", destination, "commit", "--quiet", "-m", "fixture"],
+            check=True,
+        )
+        commit = subprocess.run(
+            ["/usr/bin/git", "-C", destination, "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        return destination, commit
+
+    def test_materializes_every_verified_output(self) -> None:
+        """A valid recovered package restores the normal Make outputs."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            destination, commit = self.destination(root)
+            receipt, manifest, archive = self.evidence(root, commit)
+
+            materializer.materialize(
+                receipt=receipt,
+                manifest=manifest,
+                archive=archive,
+                destination=destination,
+            )
+
+            for name in materializer.EXPECTED_ARTIFACTS:
+                self.assertTrue((destination / name).is_file(), name)
+
+    def test_rejects_corruption_before_touching_existing_outputs(self) -> None:
+        """Digest failure remains fail-fast and leaves the checkout unchanged."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            destination, commit = self.destination(root)
+            receipt, manifest, archive = self.evidence(root, commit)
+            existing = destination / "container-compose-plugin-release-arm64.tar.gz"
+            existing.write_bytes(b"existing")
+            archive.write_bytes(archive.read_bytes() + b"corrupt")
+
+            with self.assertRaisesRegex(
+                materializer.MaterializationError, "archive digest"
+            ):
+                materializer.materialize(
+                    receipt=receipt,
+                    manifest=manifest,
+                    archive=archive,
+                    destination=destination,
+                )
+
+            self.assertEqual(existing.read_bytes(), b"existing")
+            self.assertFalse((destination / "dist").exists())
+
+    def test_failed_replacement_restores_every_existing_output(self) -> None:
+        """A mid-commit failure rolls all generated outputs back together."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            destination, commit = self.destination(root)
+            receipt, manifest, archive = self.evidence(root, commit)
+            (destination / "dist").mkdir()
+            (destination / "dist/old").write_bytes(b"old dist")
+            plugin = destination / materializer.OUTPUT_ROOTS[1]
+            sidecar = destination / materializer.OUTPUT_ROOTS[2]
+            plugin.write_bytes(b"old plugin")
+            sidecar.write_bytes(b"old sidecar")
+            real_replace = materializer.os.replace
+            failure_injected = False
+
+            def replace_with_failure(source, target):
+                nonlocal failure_injected
+                if (
+                    not failure_injected
+                    and Path(source).name == materializer.OUTPUT_ROOTS[1]
+                    and Path(target).name == plugin.name
+                ):
+                    failure_injected = True
+                    raise OSError("injected replacement failure")
+                return real_replace(source, target)
+
+            with mock.patch.object(
+                materializer.os, "replace", side_effect=replace_with_failure
+            ):
+                with self.assertRaisesRegex(OSError, "injected replacement failure"):
+                    materializer.materialize(
+                        receipt=receipt,
+                        manifest=manifest,
+                        archive=archive,
+                        destination=destination,
+                    )
+
+            self.assertEqual((destination / "dist/old").read_bytes(), b"old dist")
+            self.assertEqual(plugin.read_bytes(), b"old plugin")
+            self.assertEqual(sidecar.read_bytes(), b"old sidecar")
+            self.assertFalse((destination / materializer.JOURNAL_NAME).exists())
+            self.assertEqual(
+                list(destination.glob(".pipeline-package-previous.*")), []
+            )
+
+    def test_next_invocation_recovers_an_interrupted_transaction(self) -> None:
+        """A hard interruption cannot leave generated outputs or a dirty journal."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            destination, _ = self.destination(root)
+            transaction = "a" * 32
+            backup = destination / f".pipeline-package-previous.{transaction}"
+            backup.mkdir()
+            (backup / "dist").mkdir()
+            (backup / "dist/old").write_bytes(b"old dist")
+            (destination / "dist").mkdir()
+            (destination / "dist/new").write_bytes(b"partial new dist")
+            materializer.write_journal(
+                destination / materializer.JOURNAL_NAME,
+                {
+                    "schema": 1,
+                    "transaction": transaction,
+                    "phase": "prepared",
+                    "outputs": {
+                        "dist": True,
+                        materializer.OUTPUT_ROOTS[1]: False,
+                        materializer.OUTPUT_ROOTS[2]: False,
+                    },
+                },
+            )
+
+            materializer.recover_interrupted_transaction(destination)
+
+            self.assertEqual((destination / "dist/old").read_bytes(), b"old dist")
+            self.assertFalse((destination / "dist/new").exists())
+            self.assertFalse((destination / materializer.JOURNAL_NAME).exists())
+            self.assertFalse(backup.exists())
+
+    def test_next_invocation_finishes_a_committed_transaction(self) -> None:
+        """A crash during backup cleanup retains the complete new package."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            destination, _ = self.destination(root)
+            transaction = "b" * 32
+            backup = destination / f".pipeline-package-previous.{transaction}"
+            backup.mkdir()
+            (backup / "dist").mkdir()
+            (backup / "dist/old").write_bytes(b"old dist")
+            (destination / "dist").mkdir()
+            (destination / "dist/new").write_bytes(b"complete new dist")
+            materializer.write_journal(
+                destination / materializer.JOURNAL_NAME,
+                {
+                    "schema": 1,
+                    "transaction": transaction,
+                    "phase": "committed",
+                    "outputs": {
+                        "dist": True,
+                        materializer.OUTPUT_ROOTS[1]: False,
+                        materializer.OUTPUT_ROOTS[2]: False,
+                    },
+                },
+            )
+
+            materializer.recover_interrupted_transaction(destination)
+
+            self.assertEqual(
+                (destination / "dist/new").read_bytes(), b"complete new dist"
+            )
+            self.assertFalse((destination / materializer.JOURNAL_NAME).exists())
+            self.assertFalse(backup.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -30,6 +30,12 @@ PIPELINE_MAKEFILE = (REPOSITORY_ROOT / "Makefile").read_text(encoding="utf-8")
 REPOSITORY_STAGE = (
     REPOSITORY_ROOT / "build-pipeline/modules/repository-stage.nf"
 ).read_text(encoding="utf-8")
+PACKAGE_DEPENDENCY_STAGE = (
+    REPOSITORY_ROOT / "build-pipeline/modules/compose-package-dependencies.nf"
+).read_text(encoding="utf-8")
+PACKAGE_DEPENDENCY_COLLECTOR = (
+    REPOSITORY_ROOT / "Tools/ci/collect-compose-package-dependencies.sh"
+).read_text(encoding="utf-8")
 STABLE_RELEASE_WORKFLOW = (
     REPOSITORY_ROOT / ".github/workflows/stable-release-gate.yml"
 ).read_text(encoding="utf-8")
@@ -43,6 +49,115 @@ RECOVERY_PROOF = (
 
 class ReleaseStageGitHistoryTests(unittest.TestCase):
     """Keep history-sensitive validation on verified Git bundles."""
+
+    def test_default_make_uses_the_recoverable_repository_graph(self) -> None:
+        """The normal CLI entry point must use one durable build graph."""
+        self.assertIn("all: pipeline", PIPELINE_MAKEFILE)
+        self.assertIn("workflow: ci package", PIPELINE_MAKEFILE)
+
+    def test_nextflow_runtime_is_immutable_and_not_homebrew_versioned(self) -> None:
+        """A brew upgrade cannot move the orchestration runtime underneath a run."""
+        self.assertNotIn("/opt/homebrew/Cellar", PIPELINE_MAKEFILE)
+        self.assertIn("NEXTFLOW_JAVA_ARCHIVE_SHA256", PIPELINE_MAKEFILE)
+        self.assertIn("NEXTFLOW_JAVA_TREE_SHA256", PIPELINE_MAKEFILE)
+        self.assertIn("verify-java", PIPELINE_MAKEFILE)
+        self.assertIn("bootstrap-nextflow-runtime.py", PIPELINE_MAKEFILE)
+        self.assertIn("tools/temurin/$(NEXTFLOW_JAVA_RELEASE)", PIPELINE_MAKEFILE)
+        self.assertIn("PIPELINE_HAWKEYE_VERSION := 6.5.1", PIPELINE_MAKEFILE)
+        self.assertIn("PIPELINE_HAWKEYE_SHA256 :=", PIPELINE_MAKEFILE)
+        self.assertIn(
+            "tools/hawkeye/$(PIPELINE_HAWKEYE_VERSION)", PIPELINE_MAKEFILE
+        )
+        self.assertIn(
+            '--hawkeye-installer "$(CURDIR)/scripts/install-hawkeye.sh"',
+            PIPELINE_MAKEFILE,
+        )
+
+    def test_compose_package_consumes_verified_compiler_products(self) -> None:
+        """Packaging must not rebuild products that the graph already proved."""
+        package_stage = PIPELINE_SOURCE.split(
+            "['container-compose', 'compose-package'", 1
+        )[1].split("def releaseHostedSourceStageSpecs", 1)[0]
+        self.assertIn("package-built", package_stage)
+        self.assertNotIn("build-release", package_stage)
+        self.assertNotIn("go-build", package_stage)
+        self.assertIn("compose-release-build", PIPELINE_SOURCE)
+        self.assertIn("compose-go-validation", PIPELINE_SOURCE)
+        self.assertIn("COLLECT_COMPOSE_PACKAGE_DEPENDENCIES", PIPELINE_SOURCE)
+        self.assertIn('/bin/bash -p ${collector}', PACKAGE_DEPENDENCY_STAGE)
+        self.assertNotIn('!{collector}', PACKAGE_DEPENDENCY_STAGE)
+        self.assertIn("install-pipeline-dependencies.py", PIPELINE_SOURCE)
+        self.assertIn("noDependencyInstaller", PIPELINE_SOURCE)
+        self.assertEqual(
+            PIPELINE_SOURCE.count("        noDependencyInstaller,"), 4
+        )
+        self.assertEqual(PIPELINE_SOURCE.count("        dependencyInstaller,"), 1)
+        self.assertIn("source-commit", REPOSITORY_STAGE)
+        self.assertIn("dependency-count", REPOSITORY_STAGE)
+        self.assertIn("PIPELINE_PACKAGE_MATERIALIZER", PIPELINE_MAKEFILE)
+        pipeline_execute = PIPELINE_MAKEFILE.split("pipeline-execute:", 1)[1]
+        recovery = pipeline_execute.index("--recover-only --destination")
+        nextflow_run = pipeline_execute.index('"$${NEXTFLOW_BIN}" -log')
+        self.assertLess(recovery, nextflow_run)
+        self.assertEqual(
+            pipeline_execute.count(
+                '/usr/bin/lockf -t 30 "$$materialization_lock"'
+            ),
+            2,
+        )
+        release_build_stage = PIPELINE_SOURCE.split(
+            "['container-compose', 'compose-release-build'", 1
+        )[1].split("['container-builder-shim'", 1)[0]
+        self.assertIn(
+            "'Package.swift Package.resolved Sources Tests ",
+            release_build_stage,
+        )
+        self.assertTrue(release_build_stage.rstrip().endswith("'none'],"))
+        go_build_stage = PIPELINE_SOURCE.split(
+            "['container-compose', 'compose-go-validation'", 1
+        )[1].split("['container-compose', 'compose-tool-validation'", 1)[0]
+        self.assertTrue(go_build_stage.rstrip().endswith("'none'],"))
+        self.assertIn("source-payload-sha256", PACKAGE_DEPENDENCY_COLLECTOR)
+        self.assertNotIn("source-commit", PACKAGE_DEPENDENCY_COLLECTOR)
+        self.assertIn(
+            "Tools/release/runtime-capabilities.json", package_stage
+        )
+
+    def test_nextflow_dependency_links_resolve_only_inside_pipeline_state(self) -> None:
+        """Nextflow path staging must not defeat dependency-root validation."""
+        self.assertIn(
+            '"${params.stateRoot}/empty-dependencies"', PIPELINE_SOURCE
+        )
+        self.assertNotIn(
+            '"${projectDir}/build-pipeline/empty-stage-dependencies"',
+            PIPELINE_SOURCE,
+        )
+        self.assertIn("caches empty-dependencies", PIPELINE_MAKEFILE)
+        self.assertIn(
+            'require_managed_directory empty-dependencies', REPOSITORY_STAGE
+        )
+        self.assertIn(
+            'canonical_dependencies="$(cd "$dependencies_root" && pwd -P)"',
+            REPOSITORY_STAGE,
+        )
+        self.assertIn('"$state_root/work/"*', REPOSITORY_STAGE)
+        self.assertIn(
+            'stage dependency root escaped pipeline state', REPOSITORY_STAGE
+        )
+
+    def test_parallel_compose_lanes_each_enforce_their_coverage_floor(self) -> None:
+        """Moving to the graph must preserve coverage without rerunning tests."""
+        swift_stage = PIPELINE_SOURCE.split(
+            "['container-compose', 'compose-swift-validation'", 1
+        )[1].split("['container-compose', 'compose-go-validation'", 1)[0]
+        go_stage = PIPELINE_SOURCE.split(
+            "['container-compose', 'compose-go-validation'", 1
+        )[1].split("['container-compose', 'compose-tool-validation'", 1)[0]
+        self.assertIn("swift-coverage swift-coverage-check", swift_stage)
+        self.assertNotIn("swift-test ", swift_stage)
+        self.assertIn("go-test go-coverage-check go-build", go_stage)
+        self.assertEqual(PIPELINE_SOURCE.count("swift-coverage "), 1)
+        self.assertEqual(PIPELINE_SOURCE.count("go-test "), 1)
 
     def test_stage_tools_include_nested_process_dependencies(self) -> None:
         devcontainer_stage = PIPELINE_SOURCE.split(
@@ -59,12 +174,17 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
         )[1].split("['container-builder-shim'", 1)[0]
         compose_go = PIPELINE_SOURCE.split(
             "['container-compose', 'compose-go-validation'", 1
-        )[1].split("['container-builder-shim'", 1)[0]
+        )[1].split("['container-compose', 'compose-tool-validation'", 1)[0]
+        compose_tools = PIPELINE_SOURCE.split(
+            "['container-compose', 'compose-tool-validation'", 1
+        )[1].split("['container-compose', 'compose-release-build'", 1)[0]
 
         self.assertIn("pipeline-source-check", compose_source)
         self.assertNotIn(" coverage-tools-test", compose_source)
-        self.assertIn("-j4", compose_go)
-        self.assertIn("pipeline-tool-validation go-test go-build", compose_go)
+        self.assertIn("-j4", compose_tools)
+        self.assertIn("go-test go-coverage-check go-build", compose_go)
+        self.assertNotIn("pipeline-tool-validation", compose_go)
+        self.assertIn("pipeline-tool-validation", compose_tools)
         self.assertIn(
             "pipeline-source-check: source-preflight lint-static",
             PIPELINE_MAKEFILE,

--- a/Tools/coverage/check-coverage.py
+++ b/Tools/coverage/check-coverage.py
@@ -74,6 +74,9 @@ def check(name: str, actual: float, minimum: float) -> bool:
 def main() -> int:
     """Parse arguments and check all configured coverage reports."""
     parser = argparse.ArgumentParser(description="Check generated coverage reports.")
+    parser.add_argument(
+        "--scope", choices=("all", "swift", "go"), default="all"
+    )
     parser.add_argument("--swift-core-minimum", type=float, default=90.0)
     parser.add_argument("--swift-runtime-spi-minimum", type=float, default=95.0)
     parser.add_argument("--swift-provider-minimum", type=float, default=75.0)
@@ -96,9 +99,11 @@ def main() -> int:
         ("ComposePlugin", args.swift_plugin, args.swift_plugin_minimum),
         ("First-party Swift aggregate", args.swift_aggregate, args.swift_aggregate_minimum),
     ]
-    for name, path, minimum in swift_checks:
-        ok = check(name, generic_line_coverage(path), minimum) and ok
-    ok = check("Go", go_statement_coverage(args.go), args.go_minimum) and ok
+    if args.scope in ("all", "swift"):
+        for name, path, minimum in swift_checks:
+            ok = check(name, generic_line_coverage(path), minimum) and ok
+    if args.scope in ("all", "go"):
+        ok = check("Go", go_statement_coverage(args.go), args.go_minimum) and ok
     return 0 if ok else 1
 
 

--- a/Tools/coverage/test_check_coverage.py
+++ b/Tools/coverage/test_check_coverage.py
@@ -164,6 +164,78 @@ class CoverageCheckTests(unittest.TestCase):
                 result.stderr,
             )
 
+    def test_swift_scope_does_not_require_a_go_report(self) -> None:
+        """The recoverable Swift lane owns only the Swift coverage floor."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            covered = root / "covered.xml"
+            covered.write_text(
+                '<coverage version="1"><lineToCover covered="true" /></coverage>',
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("check-coverage.py")),
+                    "--scope",
+                    "swift",
+                    "--swift-core",
+                    str(covered),
+                    "--swift-runtime-spi",
+                    str(covered),
+                    "--swift-provider",
+                    str(covered),
+                    "--swift-plugin",
+                    str(covered),
+                    "--swift-aggregate",
+                    str(covered),
+                    "--go",
+                    str(root / "missing-go.out"),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("Go coverage", result.stdout)
+
+    def test_go_scope_does_not_require_swift_reports(self) -> None:
+        """The recoverable Go lane owns only the Go coverage floor."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            go_coverage = root / "coverage.out"
+            go_coverage.write_text(
+                "mode: atomic\nmain.go:1.1,2.1 1 1\n", encoding="utf-8"
+            )
+            missing_swift = root / "missing-swift.xml"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(Path(__file__).with_name("check-coverage.py")),
+                    "--scope",
+                    "go",
+                    "--swift-core",
+                    str(missing_swift),
+                    "--swift-runtime-spi",
+                    str(missing_swift),
+                    "--swift-provider",
+                    str(missing_swift),
+                    "--swift-plugin",
+                    str(missing_swift),
+                    "--swift-aggregate",
+                    str(missing_swift),
+                    "--go",
+                    str(go_coverage),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("ComposeCore coverage", result.stdout)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/build-pipeline/modules/compose-package-dependencies.nf
+++ b/build-pipeline/modules/compose-package-dependencies.nf
@@ -1,0 +1,16 @@
+process COLLECT_COMPOSE_PACKAGE_DEPENDENCIES {
+    tag 'dependencies:compose-package'
+    cache 'deep'
+    errorStrategy 'terminate'
+
+    input:
+    path buildEvidence
+    val validationReady
+    path collector
+
+    output:
+    path 'compose-package-dependencies', emit: prepared
+
+    script:
+    "/bin/bash -p ${collector} ${validationReady}"
+}

--- a/build-pipeline/modules/repository-stage.nf
+++ b/build-pipeline/modules/repository-stage.nf
@@ -17,7 +17,9 @@ process RUN_REPOSITORY_STAGE {
         val(deadlineSeconds), val(stageCommandBase64), val(artifactPaths),
         val(sourcePaths), path(sourcePayload), path(sourceMetadata),
         path(stageTools), val(gateReady)
+    path dependencies
     path deadlineRunner
+    path dependencyInstaller
     val stateRootBase64
     val sessionIdentifier
 
@@ -51,7 +53,9 @@ process RUN_REPOSITORY_STAGE {
     source_payload="$task_root/!{sourcePayload}"
     source_metadata="$task_root/!{sourceMetadata}"
     stage_tools="$task_root/!{stageTools}"
+    dependencies_root="$task_root/!{dependencies}"
     staged_deadline_runner="$task_root/!{deadlineRunner}"
+    dependency_installer="$task_root/!{dependencyInstaller}"
     state_root="$(decode_parameter '!{stateRootBase64}')"
     session_identifier="!{sessionIdentifier}"
     success_receipt="$task_root/!{stageName}.receipt.tsv"
@@ -65,6 +69,8 @@ process RUN_REPOSITORY_STAGE {
     stage_runner_pid=
     failure_session_root=
     semantic_cache_root=
+    dependency_count=0
+    dependency_records="$task_root/dependencies.tsv"
 
     record_result_and_cleanup() {
         local stage_status="$1"
@@ -185,6 +191,7 @@ process RUN_REPOSITORY_STAGE {
     test -s "$source_metadata"
     test -s "$stage_tools"
     test -x "$staged_deadline_runner"
+    test -f "$dependency_installer"
     case "$state_root" in /*) ;; *) exit 2 ;; esac
     [[ "$session_identifier" =~ ^[[:xdigit:]]{8}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{4}-[[:xdigit:]]{12}$ ]]
     if [[ -L "$state_root" ]] || [[ ! -d "$state_root" ]]; then
@@ -221,6 +228,24 @@ process RUN_REPOSITORY_STAGE {
     }
     require_managed_directory caches
     require_managed_directory failures
+    require_managed_directory work
+    require_managed_directory empty-dependencies
+
+    if [[ ! -d "$dependencies_root" ]]; then
+        printf 'stage dependency root is invalid: %s\n' \
+            "$dependencies_root" >&2
+        exit 2
+    fi
+    canonical_dependencies="$(cd "$dependencies_root" && pwd -P)"
+    case "$canonical_dependencies" in
+        "$state_root/empty-dependencies"|"$state_root/work/"*) ;;
+        *)
+            printf 'stage dependency root escaped pipeline state: %s\n' \
+                "$canonical_dependencies" >&2
+            exit 2
+            ;;
+    esac
+    dependencies_root="$canonical_dependencies"
 
     failure_session_root="$state_root/failures/$session_identifier"
     if [[ -L "$failure_session_root" ]] ||
@@ -579,6 +604,8 @@ process RUN_REPOSITORY_STAGE {
     metadata_environment=(
         "PIPELINE_ORIGINAL_COMMIT=$expected_commit"
         "PIPELINE_ORIGINAL_DESCRIBE=$expected_describe"
+        "PIPELINE_ORIGINAL_BRANCH=$expected_branch"
+        "PIPELINE_ORIGINAL_ORIGIN=$expected_origin"
         "PIPELINE_INTERNAL_CACHE_ROOT=$execution_root/cache"
     )
     if [[ "$stage_name" == container-release-validation ]]; then
@@ -672,6 +699,90 @@ process RUN_REPOSITORY_STAGE {
     fi
     [[ -z "$(run_clean /usr/bin/git -C "$execution_root/source" \
         status --porcelain=v1 --untracked-files=all)" ]]
+
+    : >"$dependency_records"
+    unexpected_dependency="$(/usr/bin/find -P "$dependencies_root" \
+        -mindepth 1 -maxdepth 1 \
+        \\( ! -type f -o \
+        \\( ! -name .keep ! -name '*.receipt.tsv' \
+        ! -name '*.artifacts.tar' ! -name '*.artifacts.tsv' \\) \\) \
+        -print -quit)"
+    if [[ -n "$unexpected_dependency" ]]; then
+        printf 'stage dependency root contains an unsupported entry: %s\n' \
+            "$unexpected_dependency" >&2
+        exit 2
+    fi
+    for dependency_receipt in "$dependencies_root"/*.receipt.tsv; do
+        [[ -f "$dependency_receipt" ]] || continue
+        dependency_stage="$(/usr/bin/awk -F '\t' \
+            '$1 == "stage" { print $2 }' "$dependency_receipt")"
+        if ! [[ "$dependency_stage" =~ ^[a-z0-9][a-z0-9-]*$ ]] ||
+            [[ "$(/usr/bin/basename "$dependency_receipt")" != \
+                "${dependency_stage}.receipt.tsv" ]]; then
+            printf 'stage dependency receipt is invalid: %s\n' \
+                "$dependency_receipt" >&2
+            exit 2
+        fi
+        dependency_archive="$dependencies_root/${dependency_stage}.artifacts.tar"
+        dependency_manifest="$dependencies_root/${dependency_stage}.artifacts.tsv"
+        if [[ -L "$dependency_archive" ]] || [[ ! -f "$dependency_archive" ]] ||
+            [[ -L "$dependency_manifest" ]] || [[ ! -f "$dependency_manifest" ]]; then
+            printf 'stage dependency evidence is incomplete: %s\n' \
+                "$dependency_stage" >&2
+            exit 2
+        fi
+        expected_dependency_archive_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-archive-sha256" { print $2 }' \
+            "$dependency_receipt")"
+        expected_dependency_manifest_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-manifest-sha256" { print $2 }' \
+            "$dependency_receipt")"
+        actual_dependency_archive_sha256="$(/usr/bin/shasum -a 256 \
+            "$dependency_archive" | /usr/bin/awk '{ print $1 }')"
+        actual_dependency_manifest_sha256="$(/usr/bin/shasum -a 256 \
+            "$dependency_manifest" | /usr/bin/awk '{ print $1 }')"
+        manifest_dependency_archive_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "archive-sha256" { print $2 }' "$dependency_manifest")"
+        manifest_dependency_count="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-count" { print $2 }' "$dependency_manifest")"
+        if ! [[ "$expected_dependency_archive_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+            ! [[ "$expected_dependency_manifest_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+            [[ "$actual_dependency_archive_sha256" != \
+                "$expected_dependency_archive_sha256" ]] ||
+            [[ "$actual_dependency_manifest_sha256" != \
+                "$expected_dependency_manifest_sha256" ]] ||
+            [[ "$manifest_dependency_archive_sha256" != \
+                "$expected_dependency_archive_sha256" ]] ||
+            ! [[ "$manifest_dependency_count" =~ ^[1-9][0-9]*$ ]]; then
+            printf 'stage dependency digest is invalid: %s\n' \
+                "$dependency_stage" >&2
+            exit 2
+        fi
+        run_clean /usr/bin/python3 "$dependency_installer" \
+            --archive "$dependency_archive" \
+            --manifest "$dependency_manifest" \
+            --destination "$execution_root/source"
+        printf 'dependency\t%s\t%s\t%s\n' "$dependency_stage" \
+            "$actual_dependency_archive_sha256" \
+            "$actual_dependency_manifest_sha256" >>"$dependency_records"
+        ((dependency_count += 1))
+    done
+    dependency_receipt_count="$(/usr/bin/find -P "$dependencies_root" \
+        -mindepth 1 -maxdepth 1 -type f -name '*.receipt.tsv' | \
+        /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+    dependency_archive_count="$(/usr/bin/find -P "$dependencies_root" \
+        -mindepth 1 -maxdepth 1 -type f -name '*.artifacts.tar' | \
+        /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+    dependency_manifest_count="$(/usr/bin/find -P "$dependencies_root" \
+        -mindepth 1 -maxdepth 1 -type f -name '*.artifacts.tsv' | \
+        /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+    if [[ "$dependency_receipt_count" -ne "$dependency_count" ]] ||
+        [[ "$dependency_archive_count" -ne "$dependency_count" ]] ||
+        [[ "$dependency_manifest_count" -ne "$dependency_count" ]]; then
+        printf 'stage dependency evidence has unmatched files: %s\n' \
+            "$dependencies_root" >&2
+        exit 2
+    fi
 
     stage_command="$execution_root/stage-command.sh"
     {
@@ -769,6 +880,10 @@ process RUN_REPOSITORY_STAGE {
         printf 'source-format\t%s\n' "$source_format"
         printf 'source-payload-sha256\t%s\n' "$actual_payload_sha256"
         printf 'source-metadata-sha256\t%s\n' "$source_metadata_sha256"
+        [[ -z "$expected_commit" ]] || \
+            printf 'source-commit\t%s\n' "$expected_commit"
+        [[ -z "$expected_branch" ]] || \
+            printf 'source-branch\t%s\n' "$expected_branch"
         printf 'classification\t%s\n' "$failure_class"
         printf 'deadline-seconds\t%s\n' "$deadline_seconds"
         printf 'command-sha256\t%s\n' "$command_sha256"
@@ -780,6 +895,8 @@ process RUN_REPOSITORY_STAGE {
         printf 'artifact-manifest-sha256\t%s\n' \
             "$artifact_manifest_sha256"
         printf 'artifact-count\t%s\n' "$artifact_count"
+        printf 'dependency-count\t%s\n' "$dependency_count"
+        /bin/cat "$dependency_records"
         printf 'stdin-closed\ttrue\n'
         printf 'environment\tallowlisted\n'
         printf 'timezone\tUTC\n'
@@ -788,6 +905,7 @@ process RUN_REPOSITORY_STAGE {
     } >"$success_receipt"
     ''', [
         artifactPaths: artifactPaths,
+        dependencyInstaller: dependencyInstaller,
         deadlineRunner: deadlineRunner,
         deadlineSeconds: deadlineSeconds,
         failureClass: failureClass,
@@ -800,6 +918,7 @@ process RUN_REPOSITORY_STAGE {
         stageCommandBase64: stageCommandBase64,
         stageName: stageName,
         stageTools: stageTools,
+        dependencies: dependencies,
         stateRootBase64: stateRootBase64,
     ])
 }

--- a/main.nf
+++ b/main.nf
@@ -12,6 +12,12 @@ include {
 include {
     RUN_REPOSITORY_STAGE as RUN_DOCUMENTATION_STAGE
 } from './build-pipeline/modules/repository-stage'
+include {
+    RUN_REPOSITORY_STAGE as RUN_PACKAGE_STAGE
+} from './build-pipeline/modules/repository-stage'
+include {
+    COLLECT_COMPOSE_PACKAGE_DEPENDENCIES
+} from './build-pipeline/modules/compose-package-dependencies'
 
 def renderShellScript(String template, Map values) {
     values.inject(template) { rendered, entry ->
@@ -125,14 +131,23 @@ def sourceStageSpecs() {
 def functionalStageSpecs() {
     [
         ['container-compose', 'compose-swift-validation', 'test', params.functionalTimeoutSeconds as Integer,
-            'CONTAINER_COMPOSE_RUN_RUNTIME_TESTS=0 make --no-print-directory SWIFT=/usr/bin/swift PYTHON=python3 swift-test build cli-smoke-built',
+            'CONTAINER_COMPOSE_RUN_RUNTIME_TESTS=0 make --no-print-directory SWIFT=/usr/bin/swift PYTHON=python3 swift-coverage swift-coverage-check build cli-smoke-built',
             'make,apple-swift,go,python3,otool,codesign',
             'Package.swift Package.resolved Sources Tests Tools scripts Makefile config.toml docs/project/STATUS.md docs/images/container-compose-icon-octopus.png examples/logging/compose.yml',
             'none'],
         ['container-compose', 'compose-go-validation', 'test', params.functionalTimeoutSeconds as Integer,
-            'HAWKEYE_AUTO_INSTALL=0 GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org make --no-print-directory -j4 PYTHON=python3 SWIFT=/usr/bin/swift GO=go MARKDOWNLINT=markdownlint HAWKEYE=hawkeye pipeline-tool-validation go-test go-build',
-            'make,apple-swift,go,gofmt,python3,ruby,markdownlint,hawkeye,otool',
-            '.', 'commit'],
+            'GOTOOLCHAIN=local GOPROXY=https://proxy.golang.org GOSUMDB=sum.golang.org make --no-print-directory PYTHON=python3 GO=go go-test go-coverage-check go-build',
+            'make,go,python3,otool',
+            'Tools/compose-normalizer Tools/coverage/check-coverage.py Makefile', 'none'],
+        ['container-compose', 'compose-tool-validation', 'test', params.functionalTimeoutSeconds as Integer,
+            'HAWKEYE_AUTO_INSTALL=0 make --no-print-directory -j4 PYTHON=python3 SWIFT=/usr/bin/swift GO=go MARKDOWNLINT=markdownlint HAWKEYE=hawkeye pipeline-tool-validation',
+            'make,apple-swift,go,gofmt,python3,ruby,markdownlint,hawkeye',
+            'Tools Makefile', 'none'],
+        ['container-compose', 'compose-release-build', 'build', params.functionalTimeoutSeconds as Integer,
+            'make --no-print-directory SWIFT=/usr/bin/swift PYTHON=python3 build-release',
+            'make,apple-swift,python3',
+            'Package.swift Package.resolved Sources Tests Tools/ci/run-with-local-swift-stack.py Makefile',
+            'none'],
         ['container-builder-shim', 'builder-validation', 'test', params.functionalTimeoutSeconds as Integer,
             'GOTOOLCHAIN=local GIT_TAG="$PIPELINE_ORIGINAL_DESCRIBE" make --no-print-directory GO=go coverage build',
             'make,go',
@@ -163,6 +178,16 @@ def functionalStageSpecs() {
             'make,apple-swift',
             'Package.swift Package.resolved Sources Tests Makefile APPLE_CONTAINER_REF',
             'none'],
+    ]
+}
+
+def packageStageSpecs() {
+    [
+        ['container-compose', 'compose-package', 'build', params.functionalTimeoutSeconds as Integer,
+            'compose_source="$PIPELINE_ORIGINAL_ORIGIN"; compose_source="${compose_source#https://github.com/}"; compose_source="${compose_source#git@github.com:}"; compose_source="${compose_source%.git}"; CONTAINER_COMPOSE_SOURCE="$compose_source" CONTAINER_COMPOSE_BRANCH="$PIPELINE_ORIGINAL_BRANCH" CONTAINER_COMPOSE_COMMIT="$PIPELINE_ORIGINAL_COMMIT" make --no-print-directory PYTHON=python3 GO=go CODESIGN=/usr/bin/codesign package-built PACKAGE_BUILD_CONFIGURATION=release',
+            'make,go,python3,codesign,otool',
+            'Makefile Package.swift Package.resolved config.toml docs/images/container-compose-icon-octopus.png Tools/compose-normalizer/go.mod Tools/release/go-module-version.py Tools/release/resolve-container-ref.py Tools/release/resolve-containerization-pin.py Tools/release/runtime-capabilities.json Tools/release/write-build-info.py Tools/release/write-sha256-sidecar.py',
+            'branch,commit,origin'],
     ]
 }
 
@@ -239,6 +264,9 @@ def benchmarkReconstructionFunctionalStageSpecs() {
 def stageArtifactPaths(stageName) {
     [
         'containerization-benchmark-cctl': 'bin/cctl',
+        'compose-release-build': '.build/release/compose',
+        'compose-go-validation': 'Tools/compose-normalizer/compose-normalizer',
+        'compose-package': 'dist/compose/bin/compose dist/compose/config.toml dist/compose/resources/compose-normalizer dist/compose/resources/container-compose-icon.png dist/compose/resources/build-info.json container-compose-plugin-release-arm64.tar.gz container-compose-plugin-release-arm64.tar.gz.sha256',
     ].get(stageName.toString(), 'none')
 }
 
@@ -262,6 +290,9 @@ def pipelineSelection() {
     def selectedFunctionals = functionalStages.findAll { stage ->
         profileRepositoryNames.contains(stage[0])
     }
+    def packageStages = packageStageSpecs()
+    def selectedPackages = params.pipelineProfile == 'repository' ?
+        packageStages : []
 
     if (params.pipelineProfile == 'focused' ||
         params.stageSelector.toString().trim()) {
@@ -270,16 +301,25 @@ def pipelineSelection() {
                 .collect { stageName -> stageName.trim() }
                 .findAll { stageName -> stageName } :
             ['compose-source', 'compose-swift-validation',
-                'compose-go-validation']
-        def knownStages = (sourceStages + functionalStages).collect { stage -> stage[1] }
+                'compose-go-validation', 'compose-tool-validation']
+        def knownStages = (sourceStages + functionalStages + packageStages)
+            .collect { stage -> stage[1] }
         def unknownStages = requestedStages.findAll { stageName ->
             !knownStages.contains(stageName)
         }
         if (unknownStages) {
             error "Unknown focused stage(s): ${unknownStages.join(', ')}"
         }
+        if (requestedStages.contains('compose-package')) {
+            requestedStages = (requestedStages + [
+                'compose-release-build', 'compose-go-validation',
+            ]).unique()
+        }
         selectedSources = sourceStages.findAll { stage -> requestedStages.contains(stage[1]) }
         selectedFunctionals = functionalStages.findAll { stage ->
+            requestedStages.contains(stage[1])
+        }
+        selectedPackages = packageStages.findAll { stage ->
             requestedStages.contains(stage[1])
         }
         def functionalRepositoryNames = selectedFunctionals
@@ -291,7 +331,8 @@ def pipelineSelection() {
         }
     }
 
-    def selectedRepositoryNames = (selectedSources + selectedFunctionals)
+    def selectedRepositoryNames = (selectedSources + selectedFunctionals +
+        selectedPackages)
         .collect { stage -> stage[0] }
         .unique()
     def selectedRepositories = repositories.findAll { repository ->
@@ -301,11 +342,13 @@ def pipelineSelection() {
         repositories: selectedRepositories,
         sourceStages: selectedSources,
         functionalStages: selectedFunctionals,
+        packageStages: selectedPackages,
     ]
 }
 
 def repositoryInputSpecs(selection) {
-    def selectedStages = selection.sourceStages + selection.functionalStages
+    def selectedStages = selection.sourceStages + selection.functionalStages +
+        selection.packageStages
     selection.repositories.collect { repository ->
         def requirements = selectedStages
             .findAll { stage -> stage[0] == repository[0] }
@@ -324,7 +367,8 @@ def repositoryInputSpecs(selection) {
 }
 
 def encodedStageInputSpecs(selection) {
-    (selection.sourceStages + selection.functionalStages).collect { stage ->
+    (selection.sourceStages + selection.functionalStages +
+        selection.packageStages).collect { stage ->
         [
             stage[0], stage[1], stage[2], stage[3],
             encodeParameter(stage[4]),
@@ -1662,6 +1706,8 @@ workflow PLAN {
         ${selection.sourceStages.collect { stage -> stage[1] }.join('\n        ')}
       functional stages:
         ${selection.functionalStages.collect { stage -> stage[1] }.join('\n        ')}
+      package stages:
+        ${selection.packageStages.collect { stage -> stage[1] }.join('\n        ')}
       runtime/parity/release mutation: disabled in this migration phase
     """.stripIndent()
 }
@@ -1700,6 +1746,14 @@ workflow PIPELINE {
     persistSessionReceipt(params.evidenceDir, workflow.sessionId)
     launcher = channel.value(file(params.launcherPath, checkIfExists: true))
     deadlineRunner = channel.value(file(params.deadlineRunner, checkIfExists: true))
+    dependencyInstaller = channel.value(file(
+        "${projectDir}/Tools/ci/install-pipeline-dependencies.py",
+        checkIfExists: true,
+    ))
+    noDependencyInstaller = channel.value(file(
+        '/usr/bin/false',
+        checkIfExists: true,
+    ))
     repositories = channel.fromList(repositoryInputSpecs(selection))
     stages = channel.fromList(encodedStageInputSpecs(selection))
     PREFLIGHT_GRAPH(
@@ -1721,9 +1775,15 @@ workflow PIPELINE {
         .map { item -> item + [true] }
     stateRootBase64 = channel.value(encodeParameter(params.stateRoot))
     sessionIdentifier = channel.value(workflow.sessionId.toString())
+    emptyDependencies = channel.value(file(
+        "${params.stateRoot}/empty-dependencies",
+        checkIfExists: true,
+    ))
     RUN_SOURCE_STAGE(
         sourceInputs,
+        emptyDependencies,
         deadlineRunner,
+        noDependencyInstaller,
         stateRootBase64,
         sessionIdentifier,
     )
@@ -1761,13 +1821,17 @@ workflow PIPELINE {
     }
     RUN_SWIFT_STAGE(
         swiftFunctionalInputs,
+        emptyDependencies,
         deadlineRunner,
+        noDependencyInstaller,
         stateRootBase64,
         sessionIdentifier,
     )
     RUN_LIGHTWEIGHT_STAGE(
         lightweightFunctionalInputs,
+        emptyDependencies,
         deadlineRunner,
+        noDependencyInstaller,
         stateRootBase64,
         sessionIdentifier,
     )
@@ -1788,10 +1852,48 @@ workflow PIPELINE {
             item[10] && item[11]) }
     RUN_DOCUMENTATION_STAGE(
         documentationInputs,
+        emptyDependencies,
         deadlineRunner,
+        noDependencyInstaller,
         stateRootBase64,
         sessionIdentifier,
     )
+
+    packageStageEvidence = channel.empty()
+    if (selection.packageStages) {
+        packageStageNames = selection.packageStages.collect { stage -> stage[1] }
+        packageInputs = PREPARE_STAGE_GRAPH.out
+            .filter { item -> packageStageNames.contains(item[0]) }
+            .map { item -> tuple(item[1], item[0], item[2], item[3], item[4],
+                item[5], item[6], item[7], item[8], item[9]) }
+            .combine(repositorySourceGates, by: 0)
+            .map { item -> tuple(item[1], item[0], item[2], item[3], item[4],
+                item[5], item[6], item[7], item[8], item[9], item[10]) }
+        packageBuildEvidence = RUN_SWIFT_STAGE.out.receipt
+            .concat(RUN_LIGHTWEIGHT_STAGE.out.receipt)
+            .filter { item -> item[1] in [
+                'compose-release-build', 'compose-go-validation',
+            ] }
+            .flatMap { item -> [item[2], item[5], item[6]] }
+            .collect()
+        COLLECT_COMPOSE_PACKAGE_DEPENDENCIES(
+            packageBuildEvidence,
+            validationCompletionGate,
+            channel.value(file(
+                "${projectDir}/Tools/ci/collect-compose-package-dependencies.sh",
+                checkIfExists: true,
+            )),
+        )
+        RUN_PACKAGE_STAGE(
+            packageInputs,
+            COLLECT_COMPOSE_PACKAGE_DEPENDENCIES.out.prepared,
+            deadlineRunner,
+            dependencyInstaller,
+            stateRootBase64,
+            sessionIdentifier,
+        )
+        packageStageEvidence = RUN_PACKAGE_STAGE.out.receipt
+    }
 
     allStageEvidence = RUN_SOURCE_STAGE.out.receipt
         .flatMap { item -> [item[2], item[3], item[4], item[5], item[6]] }
@@ -1801,6 +1903,8 @@ workflow PIPELINE {
             .flatMap { item -> [item[2], item[3], item[4], item[5], item[6]] })
         .concat(RUN_DOCUMENTATION_STAGE.out.receipt
             .flatMap { item -> [item[2], item[3], item[4], item[5], item[6]] })
+        .concat(packageStageEvidence
+            .flatMap { item -> [item[2], item[3], item[4], item[5], item[6]] })
         .collect()
     allRepositoryReceipts = repositoryReceipts
         .flatMap { item -> [item[1], item[2]] }
@@ -1808,7 +1912,8 @@ workflow PIPELINE {
     PIPELINE_SUMMARY(
         channel.value(params.pipelineProfile.toString()),
         channel.value(encodeParameter(
-            (selection.sourceStages + selection.functionalStages)
+            (selection.sourceStages + selection.functionalStages +
+                selection.packageStages)
                 .collect { stage -> stage[1] }
                 .join(','),
         )),

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,6 +29,10 @@ process {
     withName: RUN_DOCUMENTATION_STAGE {
         maxForks = 1
     }
+
+    withName: RUN_PACKAGE_STAGE {
+        maxForks = 1
+    }
 }
 
 trace {


### PR DESCRIPTION
## Outcome

Moves the default Compose build onto the pinned OSS Nextflow artifact graph while retaining SwiftPM and Go as the build authorities, Make as the CLI, and GitHub Actions as the signing, attestation, and publication authority.

The graph now emits immutable Swift and Go products, binds their receipts and digests into the package stage, materializes the seven-output package contract transactionally, and resumes after a coding or packaging failure without recompiling unrelated successful stages.

This is the compiler-artifact/checkpoint slice of #324. It does not change runtime functionality, parity, documentation, signing authority, or publication policy.

## Determinism and recovery

- pins Nextflow 26.04.6, Temurin 21.0.11+10, and Hawkeye 6.5.1 by checksum below the marked state root;
- verifies the complete JDK closure and the Hawkeye binary before either executable is run or reused;
- rejects indirect, escaped, stale, malformed, or corrupt runtime/dependency/package state, including staged-source and managed-ancestor symlinks;
- serializes recovery and final package materialization through one bounded state-root lock;
- excludes the dependency installer from dependency-free compiler cache keys, so an installer correction invalidates packaging only;
- caches compiler work by its selected source payload while package identity remains bound to the exact Git commit;
- journals generated-output replacement and recovers prepared or committed transactions;
- makes plain `make` run the package-producing graph; `make workflow` remains the explicit legacy fallback.

## Evidence

Attempt 007 proved recovery from three successive package-layer corrections in the same session. It completed in 31 seconds with the Swift release product (originally 2m25s), Go normalizer (originally 22.9s), and dependency collector all cached; only the corrected 7.9s package stage ran.

Attempt 009 established the final exact-head artifact boundary at `d3d86d027930a670b84243e2ea17e16fa2eeb2fa`. The focused graph completed in 3m07s: Swift release build 2m30s, Go validation 27s, and package 9.9s. Its exact-head receipt records exit 0, seven hash-verified outputs, two exact compiler dependencies, closed stdin, an allowlisted environment, and successful transactional materialization.

Attempt 010 resumed that same exact-head session in 6 seconds. Source capture, Swift release build, Go validation, dependency collection, package stage, and summary were all restored from cache without recompilation.

## Review corrections

The repeated exact-head review found four trust-boundary defects and all were corrected before the final clean review:

- recovery and final package materialization now share a bounded lock;
- runtime reuse now validates the complete JDK tree rather than a four-file subset;
- managed ancestors are rejected before any child directory can be created;
- Hawkeye is digest-verified before version/help probing or reuse.

The final review of `d3d86d0279` found no further issues.

## Focused validation

- 51 bootstrap, source-history, dependency, coverage-policy, and materialization tests passed;
- Nextflow lint passed;
- ShellCheck and Bash syntax checks passed;
- Python syntax checks passed;
- synthetic missing/corrupt evidence recovery passed with both upstream stages cached;
- repository pipeline plan passed;
- Git diff hygiene passed.

No full unit, parity, CodeQL, DocC, or release cycle was repeated for this build-system-only slice.
