### PR TITLE
fix(release): refresh retained candidates from main

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -7909,6 +7909,7 @@ esac
                 {
                     "README.md": "current candidate\n",
                     "docs/guides/INSTALL.md": "stable lane\n",
+                    "docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json": "{}\n",
                 },
                 "docs(release): align 0.6.71 candidate guidance",
             )
@@ -7923,6 +7924,28 @@ esac
             self.assertIn("retaining unpublished release candidate", result.stdout)
             self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
             self.assertNotEqual(candidate_head, remote_head)
+
+    def test_release_helper_rejects_other_release_document_data(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _remote, local = self.create_compose_checkout(root)
+            self.enable_ssh_signing(root, local)
+            self.commit_signed_files(
+                local,
+                {"docs/guides/INSTALL.json": "{}\n"},
+                "docs(release): disguise unreviewed document data",
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "release documentation repair changes an unexpected file",
+                result.stderr,
+            )
 
     def test_release_helper_rejects_release_docs_commits_with_source_changes(
         self,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1297,8 +1297,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("dirty worktree blocks recovery", recovery)
         self.assertLess(
             release.index('recover_unpublished_release_candidate "${version}"'),
+            release.index("restart_refreshed_release_controller"),
+        )
+        self.assertLess(
+            release.index("restart_refreshed_release_controller"),
             release.index("ensure_current_build_release_readiness"),
         )
+        restart = self.script[
+            self.script.index("restart_refreshed_release_controller() {") :
+            self.script.index("# Print and optionally execute a command.")
+        ]
+        self.assertIn("RELEASE_CONTROLLER_RESTART_REQUIRED", restart)
+        self.assertIn('exec /bin/bash "${controller}" release "${VERSION_SELECTOR}" --execute', restart)
 
     def test_release_plan_describes_the_stable_promotion_lanes(self) -> None:
         plan = self.script[self.script.index("\nplan() {") : self.script.index("\nmain() {")]
@@ -7536,12 +7546,14 @@ esac
             result = self.run_release_function(
                 root / "github",
                 "recover_unpublished_release_candidate 0.6.71; "
-                "printf 'base=%s\\n' \"${RECOVERED_UNPUBLISHED_RELEASE_BASE}\"",
+                "printf 'base=%s restart=%s\\n' "
+                '"${RECOVERED_UNPUBLISHED_RELEASE_BASE}" '
+                '"${RELEASE_CONTROLLER_RESTART_REQUIRED}"',
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("refreshed retained release candidate", result.stdout)
-            self.assertIn(f"base={remote_head}", result.stdout)
+            self.assertIn(f"base={remote_head} restart=1", result.stdout)
             refreshed_head = self.git(local, "rev-parse", "main")
             self.assertEqual(
                 self.git(local, "show", "-s", "--format=%P", refreshed_head).split(),
@@ -7558,11 +7570,39 @@ esac
             self.assertEqual(self.git(local, "status", "--short"), "")
 
             repeated = self.run_release_function(
-                root / "github", "recover_unpublished_release_candidate 0.6.71"
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "printf 'restart=%s\\n' "
+                '"${RELEASE_CONTROLLER_RESTART_REQUIRED}"',
             )
             self.assertEqual(repeated.returncode, 0, repeated.stderr)
             self.assertIn("retaining unpublished release candidate", repeated.stdout)
+            self.assertIn("restart=0", repeated.stdout)
             self.assertEqual(self.git(local, "rev-parse", "main"), refreshed_head)
+
+    def test_release_helper_reexecutes_the_refreshed_controller(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            scripts = root / "github" / "container-compose" / "scripts"
+            scripts.mkdir(parents=True)
+            controller = scripts / "CONTAINER_STACK_RELEASE.sh"
+            controller.write_text(
+                "#!/bin/bash\n"
+                "printf 'args=%s|%s|%s library=%s\\n' "
+                '"$1" "$2" "$3" "${CONTAINER_STACK_RELEASE_LIBRARY}"\n',
+                encoding="utf-8",
+            )
+
+            result = self.run_release_function(
+                root / "github",
+                "VERSION_SELECTOR=0.6.71; "
+                "RELEASE_CONTROLLER_RESTART_REQUIRED=1; "
+                "restart_refreshed_release_controller",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("restarting from refreshed release controller", result.stdout)
+            self.assertIn("args=release|0.6.71|--execute library=0", result.stdout)
 
     def test_release_helper_refreshes_the_same_candidate_after_main_advances_twice(
         self,

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1277,9 +1277,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_release_helper_retains_only_its_unpublished_candidate_before_readiness(self) -> None:
         recovery = self.script[
-            self.script.index("validate_unpublished_release_commit() {") : self.script.index(
-                "# Print and optionally execute a command."
-            )
+            self.script.index("validate_unpublished_release_refresh_commit() {") :
+            self.script.index("# Print and optionally execute a command.")
         ]
         release = self.script[self.script.index("release_current_stack() {") :]
         self.assertNotIn('git -C "${path}" reset --soft "${remote_head}"', recovery)
@@ -1287,6 +1286,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("RECOVERED_UNPUBLISHED_RELEASE_BASE", recovery)
         self.assertNotIn("reset --hard", recovery)
         self.assertIn('git -C "${path}" verify-commit "${commit}"', recovery)
+        self.assertIn('fetch_release_remote "${COMPOSE_REPO}"', recovery)
+        self.assertIn("merge-tree --write-tree", recovery)
+        self.assertIn('commit-tree -S "${merge_tree}"', recovery)
+        self.assertIn('ls-remote --heads "${remote}" refs/heads/main', recovery)
         self.assertIn('"chore(release): prepare ${version}"', recovery)
         self.assertIn("Package.resolved,Package.swift", recovery)
         self.assertIn("release preparation commit changes an unexpected file", recovery)
@@ -7506,6 +7509,207 @@ esac
             self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
             self.assertNotEqual(candidate_head, remote_head)
             self.assertEqual(self.git(local, "diff", "--cached", "--name-only"), "")
+
+    def test_release_helper_refreshes_a_candidate_after_main_advances(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, local = self.create_compose_checkout(root)
+            self.enable_ssh_signing(root, local)
+            self.commit_signed_files(
+                local,
+                {"Makefile": "COMPOSE_VERSION ?= 0.6.71\n"},
+                "chore(release): prepare 0.6.71",
+            )
+            candidate_head = self.git(local, "rev-parse", "main")
+
+            updater = root / "updater"
+            self.run_command(
+                "git", "clone", "--branch", "main", str(remote), str(updater)
+            )
+            self.configure_repo(updater)
+            self.commit_file(
+                updater, "REPAIR.md", "reviewed\n", "fix: reviewed main repair"
+            )
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+            remote_head = self.git(updater, "rev-parse", "main")
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "printf 'base=%s\\n' \"${RECOVERED_UNPUBLISHED_RELEASE_BASE}\"",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("refreshed retained release candidate", result.stdout)
+            self.assertIn(f"base={remote_head}", result.stdout)
+            refreshed_head = self.git(local, "rev-parse", "main")
+            self.assertEqual(
+                self.git(local, "show", "-s", "--format=%P", refreshed_head).split(),
+                [candidate_head, remote_head],
+            )
+            self.assertEqual(
+                self.git(local, "show", f"{refreshed_head}:Makefile"),
+                "COMPOSE_VERSION ?= 0.6.71",
+            )
+            self.assertEqual(
+                self.git(local, "show", f"{refreshed_head}:REPAIR.md"), "reviewed"
+            )
+            self.run_command("git", "-C", str(local), "verify-commit", refreshed_head)
+            self.assertEqual(self.git(local, "status", "--short"), "")
+
+            repeated = self.run_release_function(
+                root / "github", "recover_unpublished_release_candidate 0.6.71"
+            )
+            self.assertEqual(repeated.returncode, 0, repeated.stderr)
+            self.assertIn("retaining unpublished release candidate", repeated.stdout)
+            self.assertEqual(self.git(local, "rev-parse", "main"), refreshed_head)
+
+    def test_release_helper_refreshes_the_same_candidate_after_main_advances_twice(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, local = self.create_compose_checkout(root)
+            self.enable_ssh_signing(root, local)
+            self.commit_signed_files(
+                local,
+                {"Makefile": "COMPOSE_VERSION ?= 0.6.71\n"},
+                "chore(release): prepare 0.6.71",
+            )
+            candidate_head = self.git(local, "rev-parse", "main")
+
+            updater = root / "updater"
+            self.run_command(
+                "git", "clone", "--branch", "main", str(remote), str(updater)
+            )
+            self.configure_repo(updater)
+            self.commit_file(updater, "FIRST.md", "first\n", "fix: first main repair")
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+            first_remote_head = self.git(updater, "rev-parse", "main")
+            first = self.run_release_function(
+                root / "github", "recover_unpublished_release_candidate 0.6.71"
+            )
+            self.assertEqual(first.returncode, 0, first.stderr)
+            first_refresh_head = self.git(local, "rev-parse", "main")
+
+            self.commit_file(updater, "SECOND.md", "second\n", "fix: second main repair")
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+            second_remote_head = self.git(updater, "rev-parse", "main")
+            second = self.run_release_function(
+                root / "github", "recover_unpublished_release_candidate 0.6.71"
+            )
+
+            self.assertEqual(second.returncode, 0, second.stderr)
+            second_refresh_head = self.git(local, "rev-parse", "main")
+            self.assertEqual(
+                self.git(local, "show", "-s", "--format=%P", second_refresh_head).split(),
+                [first_refresh_head, second_remote_head],
+            )
+            self.run_command(
+                "git",
+                "-C",
+                str(local),
+                "merge-base",
+                "--is-ancestor",
+                candidate_head,
+                second_refresh_head,
+            )
+            self.run_command(
+                "git",
+                "-C",
+                str(local),
+                "merge-base",
+                "--is-ancestor",
+                first_remote_head,
+                second_refresh_head,
+            )
+            self.assertEqual(self.git(local, "show", "main:SECOND.md"), "second")
+            self.assertEqual(self.git(local, "status", "--short"), "")
+
+    def test_release_helper_rejects_a_conflicting_main_refresh_without_mutation(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, local = self.create_compose_checkout(root)
+            self.enable_ssh_signing(root, local)
+            self.commit_signed_files(
+                local,
+                {"Makefile": "COMPOSE_VERSION ?= 0.6.71\n"},
+                "chore(release): prepare 0.6.71",
+            )
+            candidate_head = self.git(local, "rev-parse", "main")
+
+            updater = root / "updater"
+            self.run_command(
+                "git", "clone", "--branch", "main", str(remote), str(updater)
+            )
+            self.configure_repo(updater)
+            self.commit_file(
+                updater,
+                "Makefile",
+                "COMPOSE_VERSION ?= 0.7.0\n",
+                "fix: reviewed conflicting repair",
+            )
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+
+            result = self.run_release_function(
+                root / "github", "recover_unpublished_release_candidate 0.6.71"
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("cannot be applied cleanly", result.stderr)
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
+            self.assertEqual(self.git(local, "status", "--short"), "")
+
+    def test_release_helper_rejects_a_forged_candidate_refresh_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, local = self.create_compose_checkout(root)
+            self.enable_ssh_signing(root, local)
+            self.commit_signed_files(
+                local,
+                {"Makefile": "COMPOSE_VERSION ?= 0.6.71\n"},
+                "chore(release): prepare 0.6.71",
+            )
+            candidate_head = self.git(local, "rev-parse", "main")
+            candidate_tree = self.git(local, "rev-parse", "main^{tree}")
+
+            updater = root / "updater"
+            self.run_command(
+                "git", "clone", "--branch", "main", str(remote), str(updater)
+            )
+            self.configure_repo(updater)
+            self.commit_file(
+                updater, "REPAIR.md", "reviewed\n", "fix: reviewed main repair"
+            )
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+            remote_head = self.git(updater, "rev-parse", "main")
+            self.run_command("git", "-C", str(local), "fetch", "origin", "main")
+            forged_head = self.run_command(
+                "git",
+                "-C",
+                str(local),
+                "commit-tree",
+                "-S",
+                candidate_tree,
+                "-p",
+                candidate_head,
+                "-p",
+                remote_head,
+                "-m",
+                "chore(release): refresh 0.6.71 candidate from main",
+            ).stdout.strip()
+            self.run_command("git", "-C", str(local), "reset", "--hard", forged_head)
+
+            result = self.run_release_function(
+                root / "github", "recover_unpublished_release_candidate 0.6.71"
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("tree is not the exact parent merge", result.stderr)
+            self.assertEqual(self.git(local, "rev-parse", "main"), forged_head)
+            self.assertEqual(self.git(local, "status", "--short"), "")
 
     def test_release_helper_retains_an_atomic_stack_pin_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -291,6 +291,7 @@ SECURITY_REASON="${CONTAINER_STACK_SECURITY_REASON:-}"
 MAINTENANCE_REASON="${CONTAINER_STACK_MAINTENANCE_REASON:-}"
 MILESTONE_SOAK_OVERRIDE_REASON="${CONTAINER_STACK_MILESTONE_SOAK_OVERRIDE_REASON:-}"
 RECOVERED_UNPUBLISHED_RELEASE_BASE=""
+RELEASE_CONTROLLER_RESTART_REQUIRED=0
 CURRENT_INIT_IMAGE_AUTHORITY_ROOT=""
 CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=0
 RELEASE_INIT_AUTHORITY_CACHE_ROOT="${CONTAINER_STACK_RELEASE_INIT_AUTHORITY_CACHE_ROOT:-$({ getconf DARWIN_USER_CACHE_DIR 2>/dev/null || printf '/private/tmp/'; })container-compose-release-authorities}"
@@ -867,6 +868,7 @@ validate_unpublished_release_commit() {
 recover_unpublished_release_candidate() {
   local version="$1" path remote local_head remote_head local_tree remote_tree current_head promotion_parent commit commits
   RECOVERED_UNPUBLISHED_RELEASE_BASE=""
+  RELEASE_CONTROLLER_RESTART_REQUIRED=0
   path="$(repo_path "${COMPOSE_REPO}")"
   remote="$(push_remote "${COMPOSE_REPO}")"
   fetch_release_remote "${COMPOSE_REPO}"
@@ -929,6 +931,7 @@ recover_unpublished_release_candidate() {
     refresh_unpublished_release_candidate \
       "${path}" "${remote}" "${local_head}" "${remote_head}" "${version}" || exit 1
     RECOVERED_UNPUBLISHED_RELEASE_BASE="${remote_head}"
+    RELEASE_CONTROLLER_RESTART_REQUIRED=1
     return 0
   fi
 
@@ -944,6 +947,28 @@ recover_unpublished_release_candidate() {
 
   RECOVERED_UNPUBLISHED_RELEASE_BASE="${remote_head}"
   printf 'retaining unpublished release candidate %s after an earlier local gate failure\n' "${local_head}"
+}
+
+# A retained candidate can acquire newer release-controller code and version
+# metadata when it is refreshed from canonical main. Replace this process so
+# no state computed by the old controller survives past that boundary. exec
+# preserves the marker-protected workspace lease because its PID is unchanged.
+restart_refreshed_release_controller() {
+  local path controller
+  if [[ "${RELEASE_CONTROLLER_RESTART_REQUIRED}" != "1" ]]; then
+    return 0
+  fi
+  path="$(repo_path "${COMPOSE_REPO}")"
+  controller="${path}/scripts/${SCRIPT_NAME}"
+  if [[ ! -f "${controller}" || -L "${controller}" ]]; then
+    printf 'refreshed release controller is missing or unsafe: %s\n' \
+      "${controller}" >&2
+    exit 1
+  fi
+  printf 'restarting from refreshed release controller: %s\n' "${controller}"
+  CONTAINER_STACK_RELEASE_LIBRARY=0
+  export CONTAINER_STACK_RELEASE_LIBRARY
+  exec /bin/bash "${controller}" release "${VERSION_SELECTOR}" --execute
 }
 
 # Print and optionally execute a command.
@@ -6229,6 +6254,7 @@ release_current_stack() {
   ensure_new_stable_release "${version}"
   ensure_release_intent
   recover_unpublished_release_candidate "${version}"
+  restart_refreshed_release_controller
   ensure_current_build_release_readiness
   require_current_stack_matches_sibling_mains
   require_release_upstream_alignment

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -654,8 +654,123 @@ PY
 # Retain a helper-created candidate after a local release gate fails before
 # promotion. Recommitting an identical tree changes the reviewed candidate
 # identity on every retry and makes evidence impossible to bind reliably.
+validate_unpublished_release_refresh_commit() {
+  local path="$1" commit="$2" version="$3" current_remote_head="$4"
+  local subject parents first_parent main_parent extra_parent
+  local expected_tree_output expected_tree actual_tree
+
+  subject="$(git -C "${path}" show -s --format=%s "${commit}")"
+  if [[ "${subject}" != "chore(release): refresh ${version} candidate from main" ]]; then
+    return 1
+  fi
+
+  parents="$(git -C "${path}" show -s --format=%P "${commit}")"
+  read -r first_parent main_parent extra_parent <<<"${parents}"
+  if [[
+    ! "${first_parent}" =~ ^[0-9a-f]{40}$
+    || ! "${main_parent}" =~ ^[0-9a-f]{40}$
+    || -n "${extra_parent}"
+  ]]; then
+    printf 'release candidate refresh has unexpected parents: %s\n' "${commit}" >&2
+    return 1
+  fi
+  if ! git -C "${path}" merge-base --is-ancestor \
+    "${main_parent}" "${current_remote_head}"; then
+    printf 'release candidate refresh does not contain canonical main history: %s\n' \
+      "${commit}" >&2
+    return 1
+  fi
+  if ! expected_tree_output="$(
+    git -C "${path}" merge-tree --write-tree \
+      "${first_parent}" "${main_parent}" 2>&1
+  )"; then
+    printf 'release candidate refresh parents no longer merge cleanly: %s\n%s\n' \
+      "${commit}" "${expected_tree_output}" >&2
+    return 1
+  fi
+  expected_tree="${expected_tree_output%%$'\n'*}"
+  actual_tree="$(git -C "${path}" rev-parse "${commit}^{tree}")"
+  if [[ ! "${expected_tree}" =~ ^[0-9a-f]{40}$ || "${actual_tree}" != "${expected_tree}" ]]; then
+    printf 'release candidate refresh tree is not the exact parent merge: %s\n' \
+      "${commit}" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Advance a retained, signed release candidate with reviewed commits that
+# landed on canonical main after the candidate was prepared. A signed merge
+# preserves every candidate commit identity while making the exact remote head
+# an ancestor. merge-tree proves the update is conflict-free without touching
+# the checkout; the branch moves only after the remote authority is rechecked.
+refresh_unpublished_release_candidate() {
+  local path="$1" remote="$2" local_head="$3" remote_head="$4" version="$5"
+  local base commit commits merge_output merge_tree live_remote_head refresh_head
+
+  base="$(git -C "${path}" merge-base "${local_head}" "${remote_head}")"
+  if [[ ! "${base}" =~ ^[0-9a-f]{40}$ || "${base}" == "${local_head}" || "${base}" == "${remote_head}" ]]; then
+    printf 'container-compose candidate has no safe diverged main base\n' >&2
+    return 1
+  fi
+
+  commits="$(git -C "${path}" rev-list --reverse "${base}..${local_head}")"
+  if [[ -z "${commits}" ]]; then
+    printf 'container-compose candidate has no retained release commits to refresh\n' >&2
+    return 1
+  fi
+  while IFS= read -r commit; do
+    validate_unpublished_release_commit \
+      "${path}" "${commit}" "${version}" "${remote_head}" || return 1
+  done <<<"${commits}"
+
+  if ! merge_output="$(
+    git -C "${path}" merge-tree --write-tree \
+      "${local_head}" "${remote_head}" 2>&1
+  )"; then
+    printf 'reviewed main cannot be applied cleanly to the retained release candidate:\n%s\n' \
+      "${merge_output}" >&2
+    return 1
+  fi
+  merge_tree="${merge_output%%$'\n'*}"
+  if [[ ! "${merge_tree}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'release candidate refresh did not produce an exact merge tree\n' >&2
+    return 1
+  fi
+
+  live_remote_head="$(
+    git -C "${path}" ls-remote --heads "${remote}" refs/heads/main \
+      | awk '{print $1}' | tail -n 1
+  )"
+  if [[ "${live_remote_head}" != "${remote_head}" ]]; then
+    printf 'container-compose main moved while refreshing the release candidate: expected %s, got %s\n' \
+      "${remote_head}" "${live_remote_head:-missing}" >&2
+    return 1
+  fi
+
+  refresh_head="$(
+    git -C "${path}" commit-tree -S "${merge_tree}" \
+      -p "${local_head}" -p "${remote_head}" \
+      -m "chore(release): refresh ${version} candidate from main"
+  )"
+  if [[ ! "${refresh_head}" =~ ^[0-9a-f]{40}$ ]] ||
+    ! git -C "${path}" verify-commit "${refresh_head}" >/dev/null 2>&1; then
+    printf 'could not create a verified release candidate refresh commit\n' >&2
+    return 1
+  fi
+
+  run git -C "${path}" merge --ff-only "${refresh_head}"
+  if [[ "$(git -C "${path}" rev-parse main)" != "${refresh_head}" ]] ||
+    [[ -n "$(git -C "${path}" status --short)" ]]; then
+    printf 'release candidate refresh did not leave an exact clean checkout\n' >&2
+    return 1
+  fi
+  printf 'refreshed retained release candidate %s with reviewed main %s\n' \
+    "${refresh_head}" "${remote_head}"
+}
+
 validate_unpublished_release_commit() {
-  local path="$1" commit="$2" version="$3" subject files file
+  local path="$1" commit="$2" version="$3" current_remote_head="${4:-}"
+  local subject files file
   subject="$(git -C "${path}" show -s --format=%s "${commit}")"
   files="$(git -C "${path}" diff-tree --no-commit-id --name-only -r "${commit}" | sort | paste -sd, -)"
 
@@ -663,6 +778,16 @@ validate_unpublished_release_commit() {
     printf 'unpublished release candidate contains an unverified commit: %s %s\n' \
       "${commit}" "${subject}" >&2
     return 1
+  fi
+
+  if [[ "${subject}" == "chore(release): refresh ${version} candidate from main" ]]; then
+    if [[ ! "${current_remote_head}" =~ ^[0-9a-f]{40}$ ]]; then
+      printf 'release candidate refresh validation requires canonical main\n' >&2
+      return 1
+    fi
+    validate_unpublished_release_refresh_commit \
+      "${path}" "${commit}" "${version}" "${current_remote_head}"
+    return
   fi
 
   if [[ "${subject}" == "chore(release): prepare ${version}" ]]; then
@@ -744,6 +869,7 @@ recover_unpublished_release_candidate() {
   RECOVERED_UNPUBLISHED_RELEASE_BASE=""
   path="$(repo_path "${COMPOSE_REPO}")"
   remote="$(push_remote "${COMPOSE_REPO}")"
+  fetch_release_remote "${COMPOSE_REPO}"
   local_head="$(git -C "${path}" rev-parse main)"
   remote_head="$(remote_main_commit "${COMPOSE_REPO}")"
 
@@ -759,8 +885,6 @@ recover_unpublished_release_candidate() {
     exit 1
   fi
   if ! git -C "${path}" merge-base --is-ancestor "${remote_head}" "${local_head}"; then
-    fetch_release_remote "${COMPOSE_REPO}"
-    remote_head="$(remote_main_commit "${COMPOSE_REPO}")"
     if [[ -z "${remote_head}" ]] ||
       ! git -C "${path}" cat-file -e "${remote_head}^{commit}" 2>/dev/null; then
       printf 'cannot inspect promoted container-compose main on %s\n' "${remote}" >&2
@@ -789,7 +913,8 @@ recover_unpublished_release_candidate() {
         exit 1
       fi
       while IFS= read -r commit; do
-        validate_unpublished_release_commit "${path}" "${commit}" "${version}" || exit 1
+        validate_unpublished_release_commit \
+          "${path}" "${commit}" "${version}" "${remote_head}" || exit 1
       done <<<"${commits}"
       if [[ "${current_head}" == "${promotion_parent}" ]]; then
         RECOVERED_UNPUBLISHED_RELEASE_BASE="${promotion_parent}"
@@ -797,8 +922,14 @@ recover_unpublished_release_candidate() {
       align_equivalent_compose_main "${path}" "${remote}" "${remote_head}" "${local_tree}"
       return 0
     fi
-    printf 'container-compose main is not based on %s/main; refusing to recover a release candidate\n' "${remote}" >&2
-    exit 1
+    if git -C "${path}" merge-base --is-ancestor "${local_head}" "${remote_head}"; then
+      printf 'container-compose main changed after candidate promotion; refusing to recover without exact promoted-tree evidence\n' >&2
+      exit 1
+    fi
+    refresh_unpublished_release_candidate \
+      "${path}" "${remote}" "${local_head}" "${remote_head}" "${version}" || exit 1
+    RECOVERED_UNPUBLISHED_RELEASE_BASE="${remote_head}"
+    return 0
   fi
 
   commits="$(git -C "${path}" rev-list --reverse "${remote_head}..${local_head}")"
@@ -807,7 +938,8 @@ recover_unpublished_release_candidate() {
     exit 1
   fi
   while IFS= read -r commit; do
-    validate_unpublished_release_commit "${path}" "${commit}" "${version}" || exit 1
+    validate_unpublished_release_commit \
+      "${path}" "${commit}" "${version}" "${remote_head}" || exit 1
   done <<<"${commits}"
 
   RECOVERED_UNPUBLISHED_RELEASE_BASE="${remote_head}"

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -839,7 +839,7 @@ validate_unpublished_release_commit() {
     IFS=',' read -r -a release_files <<<"${files}"
     for file in "${release_files[@]}"; do
       case "${file}" in
-        README.md|docs/*.md) ;;
+        README.md|docs/*.md|docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json) ;;
         *)
           printf 'release documentation repair changes an unexpected file: %s %s\n' \
             "${commit}" "${file}" >&2


### PR DESCRIPTION
## Summary

- fetch canonical Compose main before deciding how an unpublished stable candidate can recover
- preserve signed release-only commits while incorporating later reviewed main repairs through one signed exact-tree merge
- restart from the refreshed controller before any readiness, version, or promotion work continues
- retain the already reviewed fork-classification JSON recovery input while rejecting unrelated document data
- fail closed on conflicts, forged merge trees, unexpected ancestry, dirty state, or a remote head that moves during refresh

## Focused proof

- 19 candidate recovery tests passed before review; six refresh/restart-focused tests passed after the review repair
- successful refresh, repeat retry, and a second main advance preserve the original candidate identity
- the one-shot restart signal is set only by a real refresh and reset on an ordinary retry
- a functional subprocess test proves the refreshed controller is re-executed with the original release arguments and library mode disabled
- conflicting and forged refreshes leave the retained checkout unchanged
- a disposable clone of the actual 0.14.3 transaction refreshed cleanly from 30397c4d to current main 2ff509c2 with a verified signed merge and clean worktree
- Bash syntax, ShellCheck, Python compile, and diff hygiene passed

Closes #567