### PR TITLE
build(deps): refresh lifecycle recovery stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "24c4726d104859149f9227007822dd79edbfa88d"
+        "revision" : "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "f9d57ad1c80944c43bec6fc74afe1bfac3956480"
+        "revision" : "9e0626e1171cee5c09b0adecb886f1b24784320c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,12 +19,12 @@ import PackageDescription
 
 let containerDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/container.git",
-    revision: "24c4726d104859149f9227007822dd79edbfa88d",
+    revision: "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
 )
 
 let containerizationDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/containerization.git",
-    revision: "f9d57ad1c80944c43bec6fc74afe1bfac3956480",
+    revision: "9e0626e1171cee5c09b0adecb886f1b24784320c",
 )
 
 let nioSSLDependency: Package.Dependency = .package(

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "24c4726d104859149f9227007822dd79edbfa88d",
+      "ref": "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "f9d57ad1c80944c43bec6fc74afe1bfac3956480",
+      "ref": "9e0626e1171cee5c09b0adecb886f1b24784320c",
       "repository": "stephenlclarke/containerization"
     }
   },


### PR DESCRIPTION
## Summary

- pin Container to the exact fork main commit carrying the Containerization lifecycle-recovery dependency
- pin Containerization to the exact reviewed process-deletion recovery commit
- keep the release stack manifest identical to SwiftPM resolution

## Validation

- `make --no-print-directory stack-consistency`
- `git diff --check`
- focused Containerization regression suite: 5/5 passed in the supplying change

## Related

- Fixes #569
- stephenlclarke/container#222
- stephenlclarke/containerization#79

## Compatibility

No Compose surface change. This refreshes the exact runtime stack used by the retained 0.14.3 release candidate.