### PR TITLE
fix(release): refresh retained sibling mains

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2508,6 +2508,146 @@ github_cli() {{
         )
         self.assertIn("trap cleanup_current_init_image_authority EXIT", self.script)
 
+    def test_current_stack_compares_fresh_remote_sibling_mains(self) -> None:
+        start = self.script.index(
+            "refresh_release_sibling_main() {"
+        )
+        end = self.script.index(
+            "# Remove only the marker-protected authority", start
+        )
+        comparison = self.script[start:end]
+
+        self.assertIn(
+            'fetch_release_remote "${component}"', comparison
+        )
+        self.assertIn(
+            'rev-parse "refs/remotes/${remote}/main"', comparison
+        )
+        self.assertIn(
+            'merge-base --is-ancestor "${local_ref}" "${remote_ref}"', comparison
+        )
+        self.assertIn('merge --ff-only "${remote_ref}"', comparison)
+        self.assertIn('refresh_release_sibling_main "${component}"', comparison)
+        self.assertIn('"${published_ref}" != "${local_ref}"', comparison)
+
+    def test_current_stack_refreshes_stale_local_sibling_branches(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote_refs: dict[str, str] = {}
+            for component in (
+                "container-builder-shim",
+                "containerization",
+                "container",
+            ):
+                remote = root / f"{component}.git"
+                seed = root / f"{component}-seed"
+                local = root / component
+                self.run_command(
+                    "git", "init", "--bare", "--initial-branch=main", str(remote)
+                )
+                self.run_command(
+                    "git", "init", "--initial-branch=main", str(seed)
+                )
+                self.git(seed, "config", "user.name", "Release Test")
+                self.git(seed, "config", "user.email", "release-test@example.invalid")
+                marker = seed / "revision"
+                marker.write_text("local\n", encoding="utf-8")
+                self.git(seed, "add", "revision")
+                self.git(seed, "commit", "-m", "test: create local revision")
+                self.git(seed, "remote", "add", "origin", str(remote))
+                self.git(seed, "push", "-u", "origin", "main")
+                self.run_command("git", "clone", str(remote), str(local))
+                if component in {"container-builder-shim", "container"}:
+                    self.git(local, "remote", "rename", "origin", "fork")
+
+                marker.write_text("remote\n", encoding="utf-8")
+                self.git(seed, "add", "revision")
+                self.git(seed, "commit", "-m", "test: advance remote revision")
+                self.git(seed, "push", "origin", "main")
+                remote_refs[component] = self.git(seed, "rev-parse", "HEAD")
+                self.assertNotEqual(
+                    self.git(local, "rev-parse", "main"), remote_refs[component]
+                )
+
+            compose = root / "container-compose"
+            self.run_command("git", "init", "--initial-branch=main", str(compose))
+            self.git(compose, "config", "user.name", "Release Test")
+            self.git(
+                compose,
+                "config",
+                "user.email",
+                "release-test@example.invalid",
+            )
+            manifest = compose / "Tools" / "release" / "stack-refs.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "components": {
+                            component: {"ref": reference}
+                            for component, reference in remote_refs.items()
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.git(compose, "add", str(manifest.relative_to(compose)))
+            self.git(compose, "commit", "-m", "test: create Current stack")
+            self.git(compose, "tag", "current")
+
+            dry_run = self.run_release_function(
+                root,
+                "require_current_stack_matches_sibling_mains",
+                shell_setup="EXECUTE=0",
+            )
+
+            self.assertEqual(dry_run.returncode, 0, dry_run.stderr)
+            for component, reference in remote_refs.items():
+                self.assertNotEqual(
+                    self.git(root / component, "rev-parse", "main"), reference
+                )
+
+            completed = self.run_release_function(
+                root, "require_current_stack_matches_sibling_mains"
+            )
+
+            self.assertEqual(
+                completed.returncode,
+                0,
+                f"{completed.stderr}\nexpected remote refs: {remote_refs}",
+            )
+            for component, reference in remote_refs.items():
+                self.assertEqual(
+                    self.git(root / component, "rev-parse", "main"), reference
+                )
+
+            retained_builder = root / "container-builder-shim"
+            dirty_marker = retained_builder / "dirty"
+            dirty_marker.write_text("uncommitted\n", encoding="utf-8")
+            dirty = self.run_release_function(
+                root, "require_current_stack_matches_sibling_mains"
+            )
+            self.assertNotEqual(dirty.returncode, 0)
+            self.assertIn("is not a clean main branch", dirty.stderr)
+            dirty_marker.unlink()
+
+            self.git(retained_builder, "config", "user.name", "Release Test")
+            self.git(
+                retained_builder,
+                "config",
+                "user.email",
+                "release-test@example.invalid",
+            )
+            divergent_marker = retained_builder / "divergent"
+            divergent_marker.write_text("local\n", encoding="utf-8")
+            self.git(retained_builder, "add", "divergent")
+            self.git(retained_builder, "commit", "-m", "test: diverge local main")
+            divergent = self.run_release_function(
+                root, "require_current_stack_matches_sibling_mains"
+            )
+            self.assertNotEqual(divergent.returncode, 0)
+            self.assertIn("cannot fast-forward", divergent.stderr)
+
     def test_stable_controller_accepts_only_the_exact_explicit_vm_init(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -8371,6 +8371,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/558"
     },
     {
+      "id": "container-compose-571",
+      "owner": "stephenlclarke/container-compose",
+      "title": "fix(release): refresh retained sibling mains",
+      "state": "active-draft",
+      "lastVerified": "2026-09-08",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-571.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-572.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/572"
+    },
+    {
       "id": "process-list-compose-top-process-list",
       "owner": "stephenlclarke/container-compose",
       "title": "Pull request: support Docker-shaped `container compose top`",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-07
 
-Entries: 425. Document snapshots: 742. Current supporting documents: 136.
+Entries: 426. Document snapshots: 744. Current supporting documents: 138.
 
-States: `active-draft` 30, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 31, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -255,6 +255,7 @@ States: `active-draft` 30, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [chore(release): refresh 0.14.3 upstream authority](https://github.com/stephenlclarke/container-compose/pull/534) | `active-draft` | `228897171d71`, `40ab92d74a02`, `847655d373a2`, `f9d57ad1c809` | [Issue details](container-compose/ISSUE-533.md); [PR details](container-compose/PR-534.md) |
 | `stephenlclarke/container-compose` | [chore(release): refresh 0.14.3 Container classification authority](https://github.com/stephenlclarke/container-compose/pull/545) | `active-draft` | `09acdc2f1df2`, `aaacb3ed973f` | [Issue details](container-compose/ISSUE-544.md); [PR details](container-compose/PR-545.md) |
 | `stephenlclarke/container-compose` | [chore(release): refresh corrected builder classification authority](https://github.com/stephenlclarke/container-compose/pull/558) | `active-draft` | `25399784a692`, `8538b2e7931f`, `d8ccda0fd6f3`, `f99e66b89402` | [Issue details](container-compose/ISSUE-557.md); [PR details](container-compose/PR-558.md) |
+| `stephenlclarke/container-compose` | [fix(release): refresh retained sibling mains](https://github.com/stephenlclarke/container-compose/pull/572) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-571.md); [PR details](container-compose/PR-572.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-571.md
+++ b/docs/upstream/container-compose/ISSUE-571.md
@@ -1,0 +1,25 @@
+# Issue 571: resolve retained sibling release authority from remote main
+
+## Problem
+
+The retained 0.14.3 transaction correctly refreshed its Compose candidate to the reviewed Current parent, but its sibling Containerization and Container clones still had the `main` commits captured when the transaction began. The stable preflight then compared the Current manifest with those stale local branches and stopped before expensive validation even though the published Current stack already matched GitHub.
+
+Container also excludes the mutable `homebrew-main` tag while fetching release refs. Supplying only that negative refspec prevented Git from applying the remote's normal positive branch refspec, so the retained Container clone could not refresh `fork/main`.
+
+## Scope
+
+- Fetch each sibling's canonical writable remote at the stable Current boundary.
+- Cleanly fast-forward retained sibling `main` branches to the fetched remote commits.
+- Fail closed for dirty, divergent, or unresolvable sibling checkouts.
+- Preserve dry-run as a read-only remote-authority check.
+- Keep completed parity evidence and all other valid release checkpoints intact.
+
+## Acceptance evidence
+
+- A focused behavioral regression advances three local Git remotes, proves dry-run leaves the stale retained clones untouched, then proves execution fast-forwards all three clones to the exact remote commits.
+- The regression exercises Container's positive branch and negative mutable-tag refspecs together.
+- Focused retained-workspace recovery tests pass.
+- Bash syntax, ShellCheck, Python formatting, and diff checks pass.
+- Required pull-request checks pass on the exact head.
+
+Implementation: [pull request 572](https://github.com/stephenlclarke/container-compose/pull/572).

--- a/docs/upstream/container-compose/PR-572.md
+++ b/docs/upstream/container-compose/PR-572.md
@@ -1,0 +1,24 @@
+# Pull request 572: refresh retained sibling main authority
+
+## Change
+
+This pull request makes a retained stable release transaction resolve each sibling repository's current writable-remote `main` before comparing it with the published Current stack. Execute mode cleanly fast-forwards retained sibling branches, while dry-run remains read-only and compares against remote authority directly.
+
+It also preserves Container's positive branch refspec when excluding the mutable `homebrew-main` tag, so the branch fetch cannot silently omit `fork/main`.
+
+## Scope boundary
+
+This changes release-controller authority reconciliation only. It does not rerun parity, build release artifacts, publish Homebrew formulae, run CodeQL, or rebuild documentation.
+
+## Validation
+
+- focused stale-sibling dry-run and execute-mode regressions
+- focused retained-workspace checkpoint recovery regressions
+- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
+- ShellCheck for the changed release script
+- Python compilation for the focused controller test
+- Markdown lint for the handoff documents
+- `git diff --check`
+- required hosted checks on the exact pull-request head
+
+Closes [#571](https://github.com/stephenlclarke/container-compose/issues/571).

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -468,21 +468,67 @@ PY
   fi
 }
 
+# Advance one clean retained sibling checkout to the canonical fork main. A
+# failed release transaction is intentionally reusable, so its sibling clones
+# can be older than the Current stack that repaired the failure.
+refresh_release_sibling_main() {
+  local component="$1" path remote remote_ref local_ref
+  path="$(repo_path "${component}")"
+  remote="$(push_remote "${component}")"
+  if [[ "$(git -C "${path}" branch --show-current)" != "main" ]] ||
+    [[ -n "$(git -C "${path}" status --short)" ]]; then
+    printf 'retained %s checkout is not a clean main branch\n' "${component}" >&2
+    return 1
+  fi
+
+  fetch_release_remote "${component}"
+  if ! remote_ref="$(git -C "${path}" rev-parse "refs/remotes/${remote}/main")" ||
+    [[ ! "${remote_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'cannot resolve freshly fetched canonical main for %s\n' \
+      "${component}" >&2
+    return 1
+  fi
+  local_ref="$(git -C "${path}" rev-parse main)"
+  if [[ "${local_ref}" == "${remote_ref}" ]]; then
+    return 0
+  fi
+  if ! git -C "${path}" merge-base --is-ancestor "${local_ref}" "${remote_ref}"; then
+    printf 'retained %s main cannot fast-forward from %s to canonical remote %s\n' \
+      "${component}" "${local_ref}" "${remote_ref}" >&2
+    return 1
+  fi
+
+  run git -C "${path}" merge --ff-only "${remote_ref}"
+  if [[ "$(git -C "${path}" rev-parse main)" != "${remote_ref}" ]] ||
+    [[ -n "$(git -C "${path}" status --short)" ]]; then
+    printf 'retained %s checkout did not reach clean canonical remote main\n' \
+      "${component}" >&2
+    return 1
+  fi
+}
+
 # A stable candidate must be the exact stack already published as Current.
-# Refuse a sibling-main advance before the release helper mutates dependency
-# pins or creates commits; the normal main/Current lane must integrate it first.
+# Refresh retained sibling checkouts first, then refuse a sibling-main advance
+# before dependency pins or release commits can change.
 require_current_stack_matches_sibling_mains() {
   local path current_commit component published_ref local_ref
   path="$(repo_path "${COMPOSE_REPO}")"
   current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
   for component in container-builder-shim containerization container; do
+    if [[ "${EXECUTE}" == "1" ]]; then
+      refresh_release_sibling_main "${component}"
+      local_ref="$(git -C "$(repo_path "${component}")" rev-parse main)"
+    elif ! local_ref="$(remote_main_commit "${component}")" ||
+      [[ ! "${local_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+      printf 'cannot resolve canonical remote main for %s\n' "${component}" >&2
+      return 1
+    fi
     published_ref="$(git -C "${path}" show \
       "${current_commit}:Tools/release/stack-refs.json" | python3 -c \
       'import json, sys; print(json.load(sys.stdin)["components"][sys.argv[1]]["ref"])' \
       "${component}")"
-    local_ref="$(git -C "$(repo_path "${component}")" rev-parse main)"
     if [[ "${published_ref}" != "${local_ref}" ]]; then
-      printf 'Current stack uses %s %s, but sibling main is %s; integrate and publish exact Current before stable release\n' \
+      printf 'Current stack uses %s %s, but canonical sibling main is %s; integrate and publish exact Current before stable release\n' \
         "${component}" "${published_ref:-missing}" "${local_ref}" >&2
       return 1
     fi
@@ -1025,8 +1071,13 @@ fetch_release_remote() {
   if [[ "${repo}" == "${CONTAINER_REPO}" ]]; then
     # The legacy Homebrew lane retargets this pointer on every runtime build.
     # Stable release preparation does not consume it, so exclude it while
-    # fetching immutable package and semantic tags.
-    fetch_args+=("^refs/tags/homebrew-main")
+    # fetching immutable package and semantic tags. The explicit negative
+    # refspec disables Git's configured branch refspec unless a positive one
+    # is also supplied, so retain the canonical fork branch mapping here.
+    fetch_args+=(
+      "+refs/heads/*:refs/remotes/${remote}/*"
+      "^refs/tags/homebrew-main"
+    )
   fi
 
   if [[ "${EXECUTE}" != "1" ]]; then


### PR DESCRIPTION
## Change

Refreshes each clean retained sibling transaction clone from its canonical writable remote before stable Current/pin comparison. Dirty or divergent checkouts fail closed; dry-run resolves remote authority without mutation.

This also restores Container's positive branch refspec while excluding the mutable `homebrew-main` tag. Without the positive refspec, Git did not update `fork/main`.

## Validation

- focused stale, dry-run, dirty, divergent, and Container-refspec regressions
- focused retained-workspace recovery tests
- `bash -n scripts/CONTAINER_STACK_RELEASE.sh`
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `markdownlint docs/upstream/container-compose/ISSUE-571.md`
- `git diff --check`

Closes #571.
