### PR TITLE
fix(ci): enforce exact authority at every workflow stage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,8 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       checkout_ref: ${{ steps.resolve.outputs.checkout_ref }}
+      release_id: ${{ steps.resolve.outputs.release_id }}
+      release_tag: ${{ steps.resolve.outputs.release_tag }}
     steps:
       - name: Require an immutable published release
         id: resolve
@@ -60,17 +62,35 @@ jobs:
             exit 1
           fi
           release="$(
-            gh release view "${RELEASE_REF}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --json isDraft,tagName
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_REF}"
           )"
-          if [[ "$(jq -r .isDraft <<<"${release}")" != "false" ||
-                "$(jq -r .tagName <<<"${release}")" != "${RELEASE_REF}" ]]; then
+          expected_prerelease=false
+          [[ "${RELEASE_REF}" == "current" ]] && expected_prerelease=true
+          if [[ "$(jq -r .draft <<<"${release}")" != "false" ||
+                "$(jq -r .tag_name <<<"${release}")" != "${RELEASE_REF}" ||
+                "$(jq -r .prerelease <<<"${release}")" != "${expected_prerelease}" ]]; then
             printf 'CodeQL recovery release is not published and immutable: %s\n' \
               "${RELEASE_REF}" >&2
             exit 1
           fi
-          printf 'checkout_ref=%s\n' "${RELEASE_REF}" >> "${GITHUB_OUTPUT}"
+          remote="https://github.com/${GITHUB_REPOSITORY}.git"
+          checkout_ref="$(
+            git ls-remote --tags "${remote}" \
+              "refs/tags/${RELEASE_REF}" "refs/tags/${RELEASE_REF}^{}" \
+              | awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+          )"
+          release_id="$(jq -er '.id' <<<"${release}")"
+          if [[ ! "${checkout_ref}" =~ ^[0-9a-f]{40}$ ]] || \
+            [[ ! "${release_id}" =~ ^[0-9]+$ ]]; then
+            printf 'CodeQL recovery could not resolve exact release authority: %s\n' \
+              "${RELEASE_REF}" >&2
+            exit 1
+          fi
+          {
+            printf 'checkout_ref=%s\n' "${checkout_ref}"
+            printf 'release_id=%s\n' "${release_id}"
+            printf 'release_tag=%s\n' "${RELEASE_REF}"
+          } >> "${GITHUB_OUTPUT}"
 
   analyze:
     name: Analyze Go Release
@@ -83,6 +103,14 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve-release.outputs.checkout_ref }}
+
+      - name: Verify exact release checkout
+        env:
+          RELEASE_SHA: ${{ needs.resolve-release.outputs.checkout_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -121,6 +149,15 @@ jobs:
           mkdir -p "$GOCACHE" "$GOMODCACHE"
           make go-build
 
+      - name: Verify release source remained exact
+        env:
+          RELEASE_SHA: ${{ needs.resolve-release.outputs.checkout_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${RELEASE_SHA}" ]]
+          [[ -z "$(git status --porcelain --untracked-files=no)" ]]
+
       - name: Analyze
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
@@ -128,18 +165,44 @@ jobs:
 
   verify:
     name: CodeQL
-    needs: analyze
+    needs:
+      - resolve-release
+      - analyze
     if: always()
     runs-on: ubuntu-24.04
     steps:
       - name: Require successful release analysis
         env:
           ANALYSIS_RESULT: ${{ needs.analyze.result }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_ID: ${{ needs.resolve-release.outputs.release_id }}
+          RELEASE_SHA: ${{ needs.resolve-release.outputs.checkout_ref }}
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
         shell: bash
         run: |
           set -euo pipefail
           if [[ "${ANALYSIS_RESULT}" != "success" ]]; then
             printf 'CodeQL release analysis did not complete successfully: %s\n' \
               "${ANALYSIS_RESULT}" >&2
+            exit 1
+          fi
+          release="$(
+            gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}"
+          )"
+          current_release_id="$(jq -er '.id' <<<"${release}")"
+          expected_prerelease=false
+          [[ "${RELEASE_TAG}" == "current" ]] && expected_prerelease=true
+          current_tag_sha="$(
+            git ls-remote --tags "https://github.com/${GITHUB_REPOSITORY}.git" \
+              "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" \
+              | awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+          )"
+          if [[ "$(jq -r '.draft' <<<"${release}")" != "false" ]] || \
+            [[ "$(jq -r '.tag_name' <<<"${release}")" != "${RELEASE_TAG}" ]] || \
+            [[ "$(jq -r '.prerelease' <<<"${release}")" != "${expected_prerelease}" ]] || \
+            [[ "${current_release_id}" != "${RELEASE_ID}" ]] || \
+            [[ "${current_tag_sha}" != "${RELEASE_SHA}" ]]; then
+            printf 'CodeQL release authority changed while analysis ran: %s\n' \
+              "${RELEASE_TAG}" >&2
             exit 1
           fi

--- a/.github/workflows/current-demo.yml
+++ b/.github/workflows/current-demo.yml
@@ -378,7 +378,11 @@ jobs:
             local release_id
             local release_target
             local release_upload_url
+            local checkout_sha
+            local tracked_status
             local expected_upload_url
+            checkout_sha="$(git rev-parse HEAD)" || return 1
+            tracked_status="$(git status --porcelain --untracked-files=no)" || return 1
             main_sha="$(
               git ls-remote --heads "${remote}" refs/heads/main \
                 | awk '{ print $1 }' \
@@ -410,7 +414,9 @@ jobs:
             fi
             [[ "${PUBLISH_SHA}" == "${main_sha}" &&
                "${PUBLISH_SHA}" == "${current_tag_sha}" &&
-               "${PUBLISH_SHA}" == "${release_target}" ]] || return 1
+               "${PUBLISH_SHA}" == "${release_target}" &&
+               "${PUBLISH_SHA}" == "${checkout_sha}" &&
+               -z "${tracked_status}" ]] || return 1
             CURRENT_RELEASE_ID="${release_id}"
           }
 
@@ -480,7 +486,26 @@ jobs:
           upload_status=$?
           set -e
           if ((upload_status == 0)); then
-            exit 0
+            if ! current_release_matches ||
+               [[ "${CURRENT_RELEASE_ID}" != "${publication_release_id}" ]]; then
+              printf 'Current moved after demo upload; refusing to accept a stale publication.\n' >&2
+              exit 75
+            fi
+            published_asset_id="$(release_asset_id "${publication_release_id}")"
+            published_demo="${recovery_demo_dir}/${DEMO_ASSET}"
+            if [[ -n "${published_asset_id}" ]] &&
+              download_release_asset "${published_asset_id}" "${published_demo}"; then
+              published_sha256="$(shasum -a 256 \
+                "${published_demo}" | awk '{ print $1 }')"
+              candidate_sha256="$(shasum -a 256 "${DEMO_OUTPUT}" | awk '{ print $1 }')"
+              if [[ "${published_sha256}" == "${candidate_sha256}" ]]; then
+                printf 'Current demo output verified against release %s.\n' \
+                  "${publication_release_id}"
+                exit 0
+              fi
+            fi
+            printf 'Current demo upload returned success without the exact published output.\n' >&2
+            upload_status=1
           fi
 
           if [[ ! -s "${prior_demo}" ]]; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,9 +39,12 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       compose_ref: ${{ steps.release.outputs.compose_ref }}
+      compose_release_id: ${{ steps.release.outputs.release_id }}
       container_ref: ${{ steps.stack.outputs.container_ref }}
       containerization_ref: ${{ steps.stack.outputs.containerization_ref }}
       k8s_ref: ${{ steps.stack.outputs.k8s_ref }}
+      k8s_release_id: ${{ steps.k8s-authority.outputs.release_id }}
+      k8s_release_tag: ${{ steps.stack.outputs.k8s_release_tag }}
     steps:
       - name: Require exact published release inputs
         id: release
@@ -74,12 +77,16 @@ jobs:
             exit 1
           fi
           release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")"
-          if [[ "$(jq -r '.draft or .prerelease' <<<"${release}")" != "false" ]]; then
+          if [[ "$(jq -r '.draft or .prerelease' <<<"${release}")" != "false" ]] || \
+            [[ "$(jq -r '.tag_name' <<<"${release}")" != "${RELEASE_TAG}" ]] || \
+            [[ ! "$(jq -r '.id' <<<"${release}")" =~ ^[0-9]+$ ]]; then
             printf 'documentation requires a published stable release: %s\n' \
               "${RELEASE_TAG}" >&2
             exit 1
           fi
           printf 'compose_ref=%s\n' "${compose_ref}" >> "${GITHUB_OUTPUT}"
+          printf 'release_id=%s\n' "$(jq -er '.id' <<<"${release}")" \
+            >> "${GITHUB_OUTPUT}"
           printf 'Released documentation input: %s at %s.\n' \
             "${RELEASE_TAG}" "${compose_ref}" >> "${GITHUB_STEP_SUMMARY}"
 
@@ -143,6 +150,7 @@ jobs:
           PY
 
       - name: Verify released container-k8s authority
+        id: k8s-authority
         env:
           GH_TOKEN: ${{ github.token }}
           K8S_REF: ${{ steps.stack.outputs.k8s_ref }}
@@ -162,12 +170,16 @@ jobs:
             gh api \
               "repos/stephenlclarke/container-k8s/releases/tags/${K8S_RELEASE_TAG}"
           )"
-          if [[ "$(jq -r '.draft' <<<"${k8s_release}")" != "false" ]] || \
+          if [[ "$(jq -r '.draft or .prerelease' <<<"${k8s_release}")" != "false" ]] || \
+            [[ "$(jq -r '.tag_name' <<<"${k8s_release}")" != "${K8S_RELEASE_TAG}" ]] || \
+            [[ ! "$(jq -r '.id' <<<"${k8s_release}")" =~ ^[0-9]+$ ]] || \
             [[ "${k8s_tag_ref}" != "${K8S_REF}" ]]; then
             printf 'container-k8s ref is not attached to a published release: %s at %s\n' \
               "${K8S_RELEASE_TAG}" "${K8S_REF}" >&2
             exit 1
           fi
+          printf 'release_id=%s\n' "$(jq -er '.id' <<<"${k8s_release}")" \
+            >> "${GITHUB_OUTPUT}"
 
   build-sites:
     name: Build ${{ matrix.site }} DocC Site
@@ -267,6 +279,15 @@ jobs:
               ;;
           esac
 
+      - name: Verify documentation source remained exact
+        env:
+          EXPECTED_REF: ${{ matrix.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C source rev-parse HEAD)" == "${EXPECTED_REF}" ]]
+          [[ -z "$(git -C source status --porcelain --untracked-files=no)" ]]
+
       - name: Archive DocC site
         env:
           SITE: ${{ matrix.site }}
@@ -313,15 +334,84 @@ jobs:
 
   deploy:
     name: Deploy GitHub Pages
-    needs: upload-pages-artifact
+    needs:
+      - resolve-release
+      - upload-pages-artifact
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       id-token: write
       pages: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Checkout immutable documentation controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+          path: release-tools
+          ref: ${{ github.sha }}
+
+      - name: Verify immutable documentation controls
+        env:
+          RELEASE_CONTROL_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C release-tools rev-parse HEAD)" == "${RELEASE_CONTROL_SHA}" ]]
+          [[ -z "$(git -C release-tools status --porcelain --untracked-files=no)" ]]
+
+      - name: Re-resolve documentation authority before deployment
+        id: authority
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          authority="$(
+            python3 release-tools/Tools/release/documentation-authority.py \
+              --compose-repository "${GITHUB_REPOSITORY}" \
+              --compose-tag "${{ inputs.ref }}" \
+              --compose-release-id "${{ needs.resolve-release.outputs.compose_release_id }}" \
+              --compose-ref "${{ needs.resolve-release.outputs.compose_ref }}" \
+              --component "stephenlclarke/container=${{ needs.resolve-release.outputs.container_ref }}" \
+              --component "stephenlclarke/containerization=${{ needs.resolve-release.outputs.containerization_ref }}" \
+              --k8s-repository stephenlclarke/container-k8s \
+              --k8s-tag "${{ needs.resolve-release.outputs.k8s_release_tag }}" \
+              --k8s-release-id "${{ needs.resolve-release.outputs.k8s_release_id }}" \
+              --k8s-ref "${{ needs.resolve-release.outputs.k8s_ref }}"
+          )"
+          printf 'digest=%s\n' "${authority}" >> "${GITHUB_OUTPUT}"
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5
+
+      - name: Verify documentation authority after deployment
+        env:
+          EXPECTED_AUTHORITY: ${{ steps.authority.outputs.digest }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_CONTROL_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C release-tools rev-parse HEAD)" == "${RELEASE_CONTROL_SHA}" ]]
+          [[ -z "$(git -C release-tools status --porcelain --untracked-files=no)" ]]
+          current="$(
+            python3 release-tools/Tools/release/documentation-authority.py \
+              --compose-repository "${GITHUB_REPOSITORY}" \
+              --compose-tag "${{ inputs.ref }}" \
+              --compose-release-id "${{ needs.resolve-release.outputs.compose_release_id }}" \
+              --compose-ref "${{ needs.resolve-release.outputs.compose_ref }}" \
+              --component "stephenlclarke/container=${{ needs.resolve-release.outputs.container_ref }}" \
+              --component "stephenlclarke/containerization=${{ needs.resolve-release.outputs.containerization_ref }}" \
+              --k8s-repository stephenlclarke/container-k8s \
+              --k8s-tag "${{ needs.resolve-release.outputs.k8s_release_tag }}" \
+              --k8s-release-id "${{ needs.resolve-release.outputs.k8s_release_id }}" \
+              --k8s-ref "${{ needs.resolve-release.outputs.k8s_ref }}"
+          )"
+          if [[ "${current}" != "${EXPECTED_AUTHORITY}" ]]; then
+            printf 'documentation authority changed while Pages deployed\n' >&2
+            exit 1
+          fi

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -82,7 +82,43 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ github.sha }}
+
+      - name: Resolve exact external checkouts
+        id: external-checkouts
+        env:
+          CONTROLS_REF: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${CONTROLS_REF}" ]]
+
+          # Resolve one external checkout before any expensive reconstruction.
+          resolve_main() {
+            local variable="$1" repository="$2" revision
+            revision="$(
+              git ls-remote --heads "https://github.com/${repository}.git" \
+                refs/heads/main | awk '{ print $1 }' | tail -n 1
+            )"
+            if [[ ! "${revision}" =~ ^[0-9a-f]{40}$ ]]; then
+              printf 'benchmark checkout authority is invalid: %s@main\n' \
+                "${repository}" >&2
+              exit 1
+            fi
+            printf -v "${variable}" '%s' "${revision}"
+          }
+
+          resolve_main homebrew_ref stephenlclarke/homebrew-tap
+          resolve_main containerization_ref stephenlclarke/containerization
+          {
+            printf 'homebrew_ref=%s\n' "${homebrew_ref}"
+            printf 'containerization_ref=%s\n' "${containerization_ref}"
+          } >> "${GITHUB_OUTPUT}"
+          {
+            printf 'CONTROLS_REF=%s\n' "${CONTROLS_REF}"
+            printf 'HOMEBREW_REF=%s\n' "${homebrew_ref}"
+            printf 'CONTAINERIZATION_SOURCE_REF=%s\n' "${containerization_ref}"
+          } >> "${GITHUB_ENV}"
 
       - name: Checkout complete Homebrew distribution history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -90,6 +126,7 @@ jobs:
           repository: stephenlclarke/homebrew-tap
           path: homebrew-tap
           fetch-depth: 0
+          ref: ${{ steps.external-checkouts.outputs.homebrew_ref }}
 
       - name: Checkout Containerization source authority
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -97,6 +134,16 @@ jobs:
           repository: stephenlclarke/containerization
           path: containerization-source
           fetch-depth: 0
+          ref: ${{ steps.external-checkouts.outputs.containerization_ref }}
+
+      - name: Verify exact benchmark checkouts
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${CONTROLS_REF}" ]]
+          [[ "$(git -C homebrew-tap rev-parse HEAD)" == "${HOMEBREW_REF}" ]]
+          [[ "$(git -C containerization-source rev-parse HEAD)" == \
+            "${CONTAINERIZATION_SOURCE_REF}" ]]
 
       - name: Verify unattended documentation signing
         shell: bash
@@ -144,8 +191,39 @@ jobs:
             > "${RUNNER_TEMP}/comparison.json"
           target="$(jq -r '.target' "${RUNNER_TEMP}/comparison.json")"
           baseline="$(jq -r '.baseline' "${RUNNER_TEMP}/comparison.json")"
-          printf 'TARGET_VERSION=%s\nBASELINE_VERSION=%s\n' \
-            "${target}" "${baseline}" >> "${GITHUB_ENV}"
+
+          # Resolve one published release to its immutable object and tag identities.
+          resolve_release() {
+            local label="$1" tag="$2" release release_id release_ref
+            release="$(
+              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
+            )"
+            release_id="$(jq -er '.id' <<<"${release}")"
+            release_ref="$(
+              git ls-remote --tags \
+                "https://github.com/${GITHUB_REPOSITORY}.git" \
+                "refs/tags/${tag}" "refs/tags/${tag}^{}" |
+                awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+            )"
+            if [[ "$(jq -r '.draft or .prerelease' <<<"${release}")" != "false" ]] ||
+              [[ "$(jq -r '.tag_name' <<<"${release}")" != "${tag}" ]] ||
+              [[ ! "${release_id}" =~ ^[0-9]+$ ]] ||
+              [[ ! "${release_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+              printf 'benchmark release authority is invalid: %s\n' "${tag}" >&2
+              exit 1
+            fi
+            printf '%s_RELEASE_ID=%s\n' "${label}" "${release_id}" \
+              >> "${GITHUB_ENV}"
+            printf '%s_RELEASE_REF=%s\n' "${label}" "${release_ref}" \
+              >> "${GITHUB_ENV}"
+          }
+
+          {
+            printf 'TARGET_VERSION=%s\n' "${target}"
+            printf 'BASELINE_VERSION=%s\n' "${baseline}"
+          } >> "${GITHUB_ENV}"
+          resolve_release TARGET "${target}"
+          resolve_release BASELINE "${baseline}"
           printf 'Reconstructing %s and %s from exact retained authorities.\n' \
             "${target}" "${baseline}" >> "${GITHUB_STEP_SUMMARY}"
 
@@ -349,7 +427,15 @@ jobs:
             Tools/release/verify-developer-id-archive.sh \
               "${distribution}/container-compose-plugin-release-arm64.tar.gz"
 
-            source_commit="$(git rev-parse --verify "refs/tags/${version}^{commit}")"
+            case "${version}" in
+              "${TARGET_VERSION}") source_commit="${TARGET_RELEASE_REF}" ;;
+              "${BASELINE_VERSION}") source_commit="${BASELINE_RELEASE_REF}" ;;
+              *)
+                printf 'version has no exact release authority: %s\n' \
+                  "${version}" >&2
+                exit 1
+                ;;
+            esac
             git show "${source_commit}:Tools/release/stack-refs.json" \
               > "${version_root}/stack-refs.json"
             containerization_ref="$(jq -r \
@@ -605,6 +691,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Recheck the exact inputs used to produce this report.
+          verify_authority() {
+            /usr/bin/python3 Tools/parity/benchmark-authority.py \
+              --source . \
+              --controls-ref "${CONTROLS_REF}" \
+              --allow-output "${REPORT_PATH}" \
+              --release "${GITHUB_REPOSITORY}|${TARGET_VERSION}|${TARGET_RELEASE_ID}|${TARGET_RELEASE_REF}" \
+              --release "${GITHUB_REPOSITORY}|${BASELINE_VERSION}|${BASELINE_RELEASE_ID}|${BASELINE_RELEASE_REF}" \
+              --checkout "homebrew-tap|${HOMEBREW_REF}" \
+              --checkout "containerization-source|${CONTAINERIZATION_SOURCE_REF}"
+          }
+
+          expected_authority="$(verify_authority)"
           branch="docs/historical-benchmark-${TARGET_VERSION}-vs-${BASELINE_VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git switch -c "${branch}"
           git add -- "${REPORT_PATH}"
@@ -618,6 +717,29 @@ jobs:
           pr_number="${pr_url##*/}"
           gh workflow run ci.yml --repo "${GITHUB_REPOSITORY}" \
             --ref "${branch}" -f documentation_pr="${pr_number}"
+          local_head="$(git rev-parse HEAD)"
+          remote_head="$(
+            git ls-remote --heads origin "refs/heads/${branch}" |
+              awk '{ print $1 }' | tail -n 1
+          )"
+          pr_details="$(
+            gh pr view "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+              --json baseRefName,headRefName,headRefOid,state,url
+          )"
+          if [[ "${remote_head}" != "${local_head}" ]] ||
+            ! jq -e --arg base main --arg head "${local_head}" \
+              --arg name "${branch}" --arg url "${pr_url}" \
+              '.baseRefName == $base and .headRefName == $name and
+                .headRefOid == $head and .state == "OPEN" and .url == $url' \
+              <<<"${pr_details}" >/dev/null; then
+            printf 'benchmark report pull request is not bound to its exact output commit\n' >&2
+            exit 1
+          fi
+          current_authority="$(verify_authority)"
+          if [[ "${current_authority}" != "${expected_authority}" ]]; then
+            printf 'benchmark authority changed during report publication\n' >&2
+            exit 1
+          fi
           printf 'Documentation report pull request: %s\n' "${pr_url}" \
             >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -480,6 +480,17 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.sha }}
 
+      - name: Verify exact preflight source controls
+        env:
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+          RELEASE_CONTROL_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C container-compose rev-parse HEAD)" == "${PUBLISH_SHA}" ]]
+          [[ "$(git -C release-tools rev-parse HEAD)" == \
+            "${RELEASE_CONTROL_SHA}" ]]
+
       - name: Require Current stack pins to match fork mains
         if: needs.resolve-publish-context.outputs.ref_type == 'branch'
         env:
@@ -550,6 +561,15 @@ jobs:
           fetch-depth: 1
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
+      - name: Record exact preflight inputs
+        id: preflight-inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          tap_ref="$(git -C homebrew-tap rev-parse HEAD)"
+          [[ "${tap_ref}" =~ ^[0-9a-f]{40}$ ]]
+          printf 'tap_ref=%s\n' "${tap_ref}" >> "${GITHUB_OUTPUT}"
+
       - name: Validate Homebrew configuration before builds
         shell: bash
         run: |
@@ -558,6 +578,21 @@ jobs:
             --tap homebrew-tap \
             --compose-repository container-compose \
             --container-repository container
+          [[ "$(git -C container-compose rev-parse HEAD)" == \
+            "${{ needs.resolve-publish-context.outputs.sha }}" ]]
+          [[ "$(git -C release-tools rev-parse HEAD)" == "${{ github.sha }}" ]]
+          [[ "$(git -C container rev-parse HEAD)" == \
+            "${{ steps.container-source.outputs.ref }}" ]]
+          [[ "$(git -C homebrew-tap rev-parse HEAD)" == \
+            "${{ steps.preflight-inputs.outputs.tap_ref }}" ]]
+          remote_tap_ref="$(
+            git -C homebrew-tap ls-remote --heads origin refs/heads/main |
+              awk '{ print $1 }' | tail -n 1
+          )"
+          [[ "${remote_tap_ref}" == "${{ steps.preflight-inputs.outputs.tap_ref }}" ]]
+          for repository in container-compose release-tools container homebrew-tap; do
+            [[ -z "$(git -C "${repository}" status --porcelain --untracked-files=no)" ]]
+          done
 
   codeql-release:
     name: CodeQL
@@ -579,6 +614,14 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ needs.resolve-publish-context.outputs.checkout_ref }}
+
+      - name: Verify exact CodeQL release source
+        env:
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${PUBLISH_SHA}" ]]
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -617,10 +660,44 @@ jobs:
           mkdir -p "$GOCACHE" "$GOMODCACHE"
           make go-build
 
+      - name: Verify CodeQL release authority remained exact
+        env:
+          PUBLISH_REF_NAME: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${PUBLISH_SHA}" ]]
+          [[ -z "$(git status --porcelain --untracked-files=no)" ]]
+          tag_ref="$(
+            git ls-remote --tags origin \
+              "refs/tags/${PUBLISH_REF_NAME}" \
+              "refs/tags/${PUBLISH_REF_NAME}^{}" |
+              awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+          )"
+          [[ "${tag_ref}" == "${PUBLISH_SHA}" ]]
+
       - name: Analyze CodeQL release source
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:swift-go"
+
+      - name: Verify CodeQL release authority after analysis
+        env:
+          PUBLISH_REF_NAME: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${PUBLISH_SHA}" ]]
+          [[ -z "$(git status --porcelain --untracked-files=no)" ]]
+          tag_ref="$(
+            git ls-remote --tags origin \
+              "refs/tags/${PUBLISH_REF_NAME}" \
+              "refs/tags/${PUBLISH_REF_NAME}^{}" |
+              awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+          )"
+          [[ "${tag_ref}" == "${PUBLISH_SHA}" ]]
 
   package:
     name: Package
@@ -648,6 +725,19 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.resolve-publish-context.outputs.checkout_ref }}
           token: ${{ github.token }}
+
+      - name: Verify exact container-compose checkout
+        env:
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git -C container-compose rev-parse HEAD)"
+          if [[ "${actual}" != "${PUBLISH_SHA}" ]]; then
+            printf 'container-compose checkout mismatch: expected %s, got %s\n' \
+              "${PUBLISH_SHA}" "${actual}" >&2
+            exit 1
+          fi
 
       - name: Select release lane
         id: lane
@@ -787,6 +877,7 @@ jobs:
           python3 - <<'PY' >> "$GITHUB_OUTPUT"
           import json
           from pathlib import Path
+          import re
 
           manifest = Path("Tools/release/stack-refs.json")
           if not manifest.exists():
@@ -800,7 +891,10 @@ jobs:
 
           def ref(name):
               value = components.get(name, {})
-              return value.get("ref", "")
+              revision = value.get("ref", "")
+              if revision and re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+                  raise SystemExit(f"{name} stack ref is not immutable: {revision}")
+              return revision
 
           print(f"container_builder_shim_ref={ref('container-builder-shim')}")
           print(f"containerization_ref={ref('containerization')}")
@@ -844,6 +938,19 @@ jobs:
           path: container
           fetch-depth: 0
           ref: ${{ steps.container-ref.outputs.ref }}
+
+      - name: Verify container-builder-shim dependency ref
+        if: steps.stack-refs.outputs.container_builder_shim_ref != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git -C container-builder-shim rev-parse HEAD)"
+          expected="${{ steps.stack-refs.outputs.container_builder_shim_ref }}"
+          if [[ "${actual}" != "${expected}" ]]; then
+            printf 'container-builder-shim checkout mismatch: expected %s, got %s\n' \
+              "${expected}" "${actual}" >&2
+            exit 1
+          fi
 
       - name: Verify container dependency ref
         shell: bash
@@ -1800,6 +1907,127 @@ jobs:
           python3 ../release-tools/Tools/release/retain-release-assets.py \
             "${retention_arguments[@]}"
 
+      - name: Verify exact published output closure
+        if: steps.current-freshness.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PUBLISH_REF_TYPE: ${{ needs.resolve-publish-context.outputs.ref_type }}
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+          RELEASE_TAG: ${{ steps.lane.outputs.release_tag }}
+          RELEASE_PRERELEASE: ${{ steps.lane.outputs.release_prerelease }}
+          UPDATE_TAP: ${{ steps.lane.outputs.update_tap }}
+          ASSET: ${{ steps.lane.outputs.asset }}
+          RUNTIME_LOCAL_ASSET: ${{ steps.runtime-package.outputs.local_asset }}
+          CURRENT_INIT_LOCAL_ASSET: ${{ steps.current-init-image.outputs.local_asset }}
+          AUTHORITY_LOCAL_ASSET: ${{ steps.authority-bundle.outputs.local_asset }}
+          HIGHLIGHTS_ASSET: ${{ steps.lane.outputs.highlights_asset }}
+          QUALITY_SNAPSHOT_ASSET: ${{ steps.lane.outputs.quality_snapshot_asset }}
+          COMPOSE_FORMULA: ${{ steps.lane.outputs.formula }}
+          CONTAINER_FORMULA: ${{ steps.lane.outputs.container_formula }}
+          RELEASE_CONTROL_SHA: ${{ github.sha }}
+          BUILDER_REF: ${{ steps.stack-refs.outputs.container_builder_shim_ref }}
+          CONTAINERIZATION_REF: ${{ steps.stack-refs.outputs.containerization_ref }}
+          CONTAINER_REF: ${{ steps.container-ref.outputs.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Ensure a package input checkout still has its resolved commit.
+          verify_checkout() {
+            local path="$1" expected="$2" actual
+            [[ -n "${expected}" ]] || return 0
+            actual="$(git -C "${path}" rev-parse HEAD)"
+            if [[ "${actual}" != "${expected}" ]]; then
+              printf '%s checkout changed during package publication: expected %s, got %s\n' \
+                "${path}" "${expected}" "${actual}" >&2
+              exit 1
+            fi
+            if [[ -n "$(git -C "${path}" status --porcelain --untracked-files=no)" ]]; then
+              printf '%s checkout gained tracked changes during package publication\n' \
+                "${path}" >&2
+              exit 1
+            fi
+          }
+
+          # Bind one locally produced asset to its hosted release output.
+          add_asset() {
+            local path="$1" name digest
+            [[ -f "${path}" ]]
+            name="$(basename "${path}")"
+            digest="$(shasum -a 256 "${path}" | awk '{ print $1 }')"
+            authority_arguments+=(--asset "${name}=${digest}")
+          }
+
+          verify_checkout container-compose "${PUBLISH_SHA}"
+          verify_checkout release-tools "${RELEASE_CONTROL_SHA}"
+          verify_checkout container-builder-shim "${BUILDER_REF}"
+          verify_checkout containerization "${CONTAINERIZATION_REF}"
+          verify_checkout container "${CONTAINER_REF}"
+
+          if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
+            current_main="$(
+              git -C container-compose ls-remote --heads origin refs/heads/main |
+                awk '{ print $1 }' | tail -n 1
+            )"
+            if [[ "${current_main}" != "${PUBLISH_SHA}" ]]; then
+              printf 'Current release input changed during publication: expected %s, got %s\n' \
+                "${PUBLISH_SHA}" "${current_main:-missing}" >&2
+              exit 1
+            fi
+            for component in container-builder-shim containerization container; do
+              repository="$(jq -er --arg component "${component}" \
+                '.components[$component].repository' \
+                container-compose/Tools/release/stack-refs.json)"
+              expected="$(jq -er --arg component "${component}" \
+                '.components[$component].ref' \
+                container-compose/Tools/release/stack-refs.json)"
+              current="$(
+                git ls-remote --heads "https://github.com/${repository}.git" \
+                  refs/heads/main | awk '{ print $1 }' | tail -n 1
+              )"
+              if [[ "${current}" != "${expected}" ]]; then
+                printf 'Current release dependency changed during publication: %s expected %s, got %s\n' \
+                  "${component}" "${expected}" "${current:-missing}" >&2
+                exit 1
+              fi
+            done
+          fi
+
+          authority_arguments=(
+            --repository "${GITHUB_REPOSITORY}"
+            --release-tag "${RELEASE_TAG}"
+            --release-ref "${PUBLISH_SHA}"
+            --release-prerelease "${RELEASE_PRERELEASE}"
+          )
+          add_asset "${RUNNER_TEMP}/${ASSET}"
+          add_asset "${RUNNER_TEMP}/${ASSET}.sha256"
+          add_asset "${RUNTIME_LOCAL_ASSET}"
+          add_asset "${RUNTIME_LOCAL_ASSET}.sha256"
+          add_asset "${RUNNER_TEMP}/${HIGHLIGHTS_ASSET}"
+          add_asset "${RUNNER_TEMP}/${QUALITY_SNAPSHOT_ASSET}"
+          if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
+            add_asset "${CURRENT_INIT_LOCAL_ASSET}"
+            add_asset "${CURRENT_INIT_LOCAL_ASSET}.sha256"
+          else
+            add_asset "${AUTHORITY_LOCAL_ASSET}"
+            add_asset "${AUTHORITY_LOCAL_ASSET}.sha256"
+          fi
+          if [[ "${UPDATE_TAP}" == "true" ]]; then
+            tap_ref="$(git -C homebrew-tap rev-parse HEAD)"
+            authority_arguments+=(
+              --tap homebrew-tap
+              --tap-ref "${tap_ref}"
+              --formula "homebrew-tap/Formula/${COMPOSE_FORMULA}"
+              --formula "homebrew-tap/Formula/${CONTAINER_FORMULA}"
+            )
+          fi
+          authority="$(
+            python3 release-tools/Tools/release/package-publication-authority.py \
+              "${authority_arguments[@]}"
+          )"
+          printf 'Published output authority SHA-256: %s.\n' "${authority}" \
+            >> "${GITHUB_STEP_SUMMARY}"
+
   repair-stable-tap:
     name: Repair Stable Homebrew Formulae
     needs: resolve-publish-context
@@ -1824,6 +2052,19 @@ jobs:
           fetch-depth: 1
           ref: ${{ github.sha }}
           token: ${{ github.token }}
+
+      - name: Verify exact container-compose checkout
+        env:
+          PUBLISH_SHA: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git -C container-compose rev-parse HEAD)"
+          if [[ "${actual}" != "${PUBLISH_SHA}" ]]; then
+            printf 'container-compose checkout mismatch: expected %s, got %s\n' \
+              "${PUBLISH_SHA}" "${actual}" >&2
+            exit 1
+          fi
 
       - name: Verify immutable release control tools
         env:
@@ -1986,3 +2227,34 @@ jobs:
           git add Formula/container-compose.rb Formula/container.rb
           git commit -m "chore(homebrew): repair stable stack ${RELEASE_VERSION}"
           git push
+
+      - name: Verify repaired stable Homebrew output closure
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CONTAINER_REF: ${{ steps.container-ref.outputs.ref }}
+          RELEASE_CONTROL_SHA: ${{ github.sha }}
+          RELEASE_TAG: ${{ needs.resolve-publish-context.outputs.ref_name }}
+          RELEASE_REF: ${{ needs.resolve-publish-context.outputs.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git -C container-compose rev-parse HEAD)" == "${RELEASE_REF}" ]]
+          [[ "$(git -C release-tools rev-parse HEAD)" == "${RELEASE_CONTROL_SHA}" ]]
+          [[ "$(git -C container rev-parse HEAD)" == "${CONTAINER_REF}" ]]
+          for repository in container-compose release-tools container; do
+            [[ -z "$(git -C "${repository}" status --porcelain --untracked-files=no)" ]]
+          done
+          tap_ref="$(git -C homebrew-tap rev-parse HEAD)"
+          authority="$(
+            python3 release-tools/Tools/release/package-publication-authority.py \
+              --repository "${GITHUB_REPOSITORY}" \
+              --release-tag "${RELEASE_TAG}" \
+              --release-ref "${RELEASE_REF}" \
+              --release-prerelease false \
+              --tap homebrew-tap \
+              --tap-ref "${tap_ref}" \
+              --formula homebrew-tap/Formula/container-compose.rb \
+              --formula homebrew-tap/Formula/container.rb
+          )"
+          printf 'Repaired tap authority SHA-256: %s.\n' "${authority}" \
+            >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -59,12 +59,28 @@ jobs:
       target: ${{ steps.versions.outputs.target }}
       baseline: ${{ steps.versions.outputs.baseline }}
       latest: ${{ steps.versions.outputs.latest }}
+      controls_ref: ${{ steps.controls.outputs.ref }}
+      homebrew_ref: ${{ steps.versions.outputs.homebrew_ref }}
+      target_release_id: ${{ steps.versions.outputs.target_release_id }}
+      target_release_ref: ${{ steps.versions.outputs.target_release_ref }}
+      baseline_release_id: ${{ steps.versions.outputs.baseline_release_id }}
+      baseline_release_ref: ${{ steps.versions.outputs.baseline_release_ref }}
     steps:
       - name: Checkout benchmark controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 1
-          ref: main
+          ref: ${{ github.sha }}
+
+      - name: Verify exact benchmark controls
+        id: controls
+        env:
+          CONTROLS_REF: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${CONTROLS_REF}" ]]
+          printf 'ref=%s\n' "${CONTROLS_REF}" >> "${GITHUB_OUTPUT}"
 
       - name: Resolve target and comparison releases
         id: versions
@@ -93,10 +109,50 @@ jobs:
           target="$(jq -r '.target' "${RUNNER_TEMP}/comparison.json")"
           baseline="$(jq -r '.baseline' "${RUNNER_TEMP}/comparison.json")"
           latest="$(jq -r '.latest' "${RUNNER_TEMP}/comparison.json")"
+
+          # Resolve one published release to its immutable object and tag identities.
+          resolve_release() {
+            local label="$1" tag="$2" release release_id release_ref
+            release="$(
+              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}"
+            )"
+            release_id="$(jq -er '.id' <<<"${release}")"
+            release_ref="$(
+              git ls-remote --tags \
+                "https://github.com/${GITHUB_REPOSITORY}.git" \
+                "refs/tags/${tag}" "refs/tags/${tag}^{}" |
+                awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+            )"
+            if [[ "$(jq -r '.draft or .prerelease' <<<"${release}")" != "false" ]] ||
+              [[ "$(jq -r '.tag_name' <<<"${release}")" != "${tag}" ]] ||
+              [[ ! "${release_id}" =~ ^[0-9]+$ ]] ||
+              [[ ! "${release_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+              printf 'benchmark release authority is invalid: %s\n' "${tag}" >&2
+              exit 1
+            fi
+            printf '%s_release_id=%s\n' "${label}" "${release_id}" \
+              >> "${GITHUB_OUTPUT}"
+            printf '%s_release_ref=%s\n' "${label}" "${release_ref}" \
+              >> "${GITHUB_OUTPUT}"
+          }
+
+          resolve_release target "${target}"
+          resolve_release baseline "${baseline}"
+          homebrew_ref="$(
+            git ls-remote --heads \
+              https://github.com/stephenlclarke/homebrew-tap.git \
+              refs/heads/main | awk '{ print $1 }' | tail -n 1
+          )"
+          if [[ ! "${homebrew_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'Homebrew benchmark authority is invalid: %s\n' \
+              "${homebrew_ref:-missing}" >&2
+            exit 1
+          fi
           {
             printf 'target=%s\n' "${target}"
             printf 'baseline=%s\n' "${baseline}"
             printf 'latest=%s\n' "${latest}"
+            printf 'homebrew_ref=%s\n' "${homebrew_ref}"
           } >> "${GITHUB_OUTPUT}"
           printf 'Benchmarking %s against %s.\n' "${target}" "${baseline}" \
             >> "${GITHUB_STEP_SUMMARY}"
@@ -113,6 +169,12 @@ jobs:
       TARGET_VERSION: ${{ needs.resolve.outputs.target }}
       BASELINE_VERSION: ${{ needs.resolve.outputs.baseline }}
       LATEST_STABLE_VERSION: ${{ needs.resolve.outputs.latest }}
+      CONTROLS_REF: ${{ needs.resolve.outputs.controls_ref }}
+      HOMEBREW_REF: ${{ needs.resolve.outputs.homebrew_ref }}
+      TARGET_RELEASE_ID: ${{ needs.resolve.outputs.target_release_id }}
+      TARGET_RELEASE_REF: ${{ needs.resolve.outputs.target_release_ref }}
+      BASELINE_RELEASE_ID: ${{ needs.resolve.outputs.baseline_release_id }}
+      BASELINE_RELEASE_REF: ${{ needs.resolve.outputs.baseline_release_ref }}
       REPETITIONS: ${{ inputs.repetitions }}
       RUNTIME_ROOT_PREFIX: /private/tmp/ccpb-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
@@ -136,7 +198,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
-          ref: main
+          ref: ${{ needs.resolve.outputs.controls_ref }}
 
       - name: Checkout complete Homebrew distribution history
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -144,6 +206,14 @@ jobs:
           repository: stephenlclarke/homebrew-tap
           path: homebrew-tap
           fetch-depth: 0
+          ref: ${{ needs.resolve.outputs.homebrew_ref }}
+
+      - name: Verify exact benchmark checkouts
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${CONTROLS_REF}" ]]
+          [[ "$(git -C homebrew-tap rev-parse HEAD)" == "${HOMEBREW_REF}" ]]
 
       - name: Verify unattended documentation signing
         shell: bash
@@ -385,6 +455,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Recheck the exact inputs used to produce this report.
+          verify_authority() {
+            python3 Tools/parity/benchmark-authority.py \
+              --source . \
+              --controls-ref "${CONTROLS_REF}" \
+              --allow-output "${REPORT_PATH}" \
+              --release "${GITHUB_REPOSITORY}|${TARGET_VERSION}|${TARGET_RELEASE_ID}|${TARGET_RELEASE_REF}" \
+              --release "${GITHUB_REPOSITORY}|${BASELINE_VERSION}|${BASELINE_RELEASE_ID}|${BASELINE_RELEASE_REF}" \
+              --checkout "homebrew-tap|${HOMEBREW_REF}"
+          }
+
+          expected_authority="$(verify_authority)"
           branch="docs/benchmark-${TARGET_VERSION}-vs-${BASELINE_VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           git switch -c "${branch}"
           git add -- "${REPORT_PATH}"
@@ -402,6 +484,29 @@ jobs:
             --repo "${GITHUB_REPOSITORY}" \
             --ref "${branch}" \
             -f documentation_pr="${pr_number}"
+          local_head="$(git rev-parse HEAD)"
+          remote_head="$(
+            git ls-remote --heads origin "refs/heads/${branch}" |
+              awk '{ print $1 }' | tail -n 1
+          )"
+          pr_details="$(
+            gh pr view "${pr_number}" --repo "${GITHUB_REPOSITORY}" \
+              --json baseRefName,headRefName,headRefOid,state,url
+          )"
+          if [[ "${remote_head}" != "${local_head}" ]] ||
+            ! jq -e --arg base main --arg head "${local_head}" \
+              --arg name "${branch}" --arg url "${pr_url}" \
+              '.baseRefName == $base and .headRefName == $name and
+                .headRefOid == $head and .state == "OPEN" and .url == $url' \
+              <<<"${pr_details}" >/dev/null; then
+            printf 'benchmark report pull request is not bound to its exact output commit\n' >&2
+            exit 1
+          fi
+          current_authority="$(verify_authority)"
+          if [[ "${current_authority}" != "${expected_authority}" ]]; then
+            printf 'benchmark authority changed during report publication\n' >&2
+            exit 1
+          fi
           printf 'Documentation report pull request: %s\n' "${pr_url}" \
             >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -611,13 +611,24 @@ jobs:
           summary+=" Authority receipt SHA-256: ${AUTHORITY_RECEIPT_SHA256}."
           summary+=" Authority artifact ID: ${AUTHORITY_ARTIFACT_ID}."
           summary+=" Authority artifact digest: ${AUTHORITY_ARTIFACT_DIGEST}."
-          gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
-            -f "name=${authority_name}" \
-            -f "head_sha=${CANDIDATE_SHA}" \
-            -f 'status=completed' \
-            -f 'conclusion=success' \
-            -f "external_id=${GITHUB_RUN_ID}" \
-            -f "details_url=${details_url}" \
-            -f "output[title]=${authority_name}" \
-            -f "output[summary]=${summary}" \
-            --silent
+          check_run="$(
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/check-runs" \
+              -f "name=${authority_name}" \
+              -f "head_sha=${CANDIDATE_SHA}" \
+              -f 'status=completed' \
+              -f 'conclusion=success' \
+              -f "external_id=${GITHUB_RUN_ID}" \
+              -f "details_url=${details_url}" \
+              -f "output[title]=${authority_name}" \
+              -f "output[summary]=${summary}"
+          )"
+          if ! jq -e \
+            --arg name "${authority_name}" \
+            --arg sha "${CANDIDATE_SHA}" \
+            --arg run "${GITHUB_RUN_ID}" \
+            '.name == $name and .head_sha == $sha and .external_id == $run and
+              .status == "completed" and .conclusion == "success"' \
+            <<<"${check_run}" >/dev/null; then
+            printf 'stable release authority check output does not match its exact candidate\n' >&2
+            exit 75
+          fi

--- a/Tools/ci/collect-compose-package-dependencies.sh
+++ b/Tools/ci/collect-compose-package-dependencies.sh
@@ -52,10 +52,41 @@ for receipt in *.receipt.tsv; do
     '$1 == "artifact-archive-sha256" { print $2 }' "${receipt}")"
   expected_manifest_sha256="$(/usr/bin/awk -F '\t' \
     '$1 == "artifact-manifest-sha256" { print $2 }' "${receipt}")"
+  receipt_schema="$(/usr/bin/awk -F '\t' \
+    '$1 == "schema" { print $2 }' "${receipt}")"
+  receipt_repository="$(/usr/bin/awk -F '\t' \
+    '$1 == "repository" { print $2 }' "${receipt}")"
+  source_format="$(/usr/bin/awk -F '\t' \
+    '$1 == "source-format" { print $2 }' "${receipt}")"
   source_payload_sha256="$(/usr/bin/awk -F '\t' \
     '$1 == "source-payload-sha256" { print $2 }' "${receipt}")"
+  source_execution_head="$(/usr/bin/awk -F '\t' \
+    '$1 == "source-execution-head" { print $2 }' "${receipt}")"
+  source_tracked_clean="$(/usr/bin/awk -F '\t' \
+    '$1 == "source-tracked-clean" { print $2 }' "${receipt}")"
+  stage_inputs_sha256="$(/usr/bin/awk -F '\t' \
+    '$1 == "stage-inputs-sha256" { print $2 }' "${receipt}")"
+  receipt_artifact_count="$(/usr/bin/awk -F '\t' \
+    '$1 == "artifact-count" { print $2 }' "${receipt}")"
+  receipt_exit="$(/usr/bin/awk -F '\t' \
+    '$1 == "exit" { print $2 }' "${receipt}")"
+  [[ "${receipt_schema}" == 4 ]] || \
+    fail "Unsupported dependency receipt schema: ${stage}"
+  [[ "${receipt_repository}" == container-compose ]] || \
+    fail "Unsupported dependency repository: ${stage}"
+  [[ "${source_format}" == git-tree-archive ]] || \
+    fail "Unsupported dependency source format: ${stage}"
   [[ "${source_payload_sha256}" =~ ^[0-9a-f]{64}$ ]] || \
     fail "Invalid dependency source payload: ${stage}"
+  [[ "${stage_inputs_sha256}" =~ ^[0-9a-f]{64}$ ]] || \
+    fail "Invalid dependency stage input closure: ${stage}"
+  [[ "${source_execution_head}" =~ ^[0-9a-f]{40}$ &&
+    "${source_tracked_clean}" == true ]] || \
+    fail "Dependency source did not retain its exact checkout: ${stage}"
+  [[ "${receipt_artifact_count}" == 1 && "${receipt_exit}" == 0 ]] || \
+    fail "Dependency receipt did not record exact success: ${stage}"
+  expected_receipt_sha256="$(/usr/bin/shasum -a 256 "${receipt}" | \
+    /usr/bin/awk '{ print $1 }')"
   [[ "$(/usr/bin/shasum -a 256 "${archive}" | /usr/bin/awk '{ print $1 }')" == \
     "${expected_archive_sha256}" ]] || \
     fail "Dependency archive digest changed: ${stage}"
@@ -65,6 +96,18 @@ for receipt in *.receipt.tsv; do
   [[ "$(/usr/bin/awk -F '\t' '$1 == "artifact-count" { print $2 }' \
     "${manifest}")" == 1 ]] || \
     fail "Dependency manifest has the wrong artifact count: ${stage}"
+  [[ "$(/usr/bin/awk -F '\t' '$1 == "schema" { print $2 }' \
+    "${manifest}")" == 1 ]] || \
+    fail "Dependency manifest has the wrong schema: ${stage}"
+  [[ "$(/usr/bin/awk -F '\t' '$1 == "stage" { print $2 }' \
+    "${manifest}")" == "${stage}" ]] || \
+    fail "Dependency manifest has the wrong stage: ${stage}"
+  [[ "$(/usr/bin/awk -F '\t' '$1 == "repository" { print $2 }' \
+    "${manifest}")" == container-compose ]] || \
+    fail "Dependency manifest has the wrong repository: ${stage}"
+  [[ "$(/usr/bin/awk -F '\t' '$1 == "archive-sha256" { print $2 }' \
+    "${manifest}")" == "${expected_archive_sha256}" ]] || \
+    fail "Dependency manifest did not bind its archive: ${stage}"
   artifact_path="$(/usr/bin/awk -F '\t' '$1 == "artifact" { print $2 }' \
     "${manifest}")"
   case "${stage}" in
@@ -77,6 +120,18 @@ for receipt in *.receipt.tsv; do
     fail "Dependency manifest has the wrong artifact: ${stage}"
   /bin/cp "${receipt}" "${archive}" "${manifest}" \
     compose-package-dependencies/ || fail "Could not collect dependency: ${stage}"
+  [[ "$(/usr/bin/shasum -a 256 \
+    "compose-package-dependencies/${receipt}" | /usr/bin/awk '{ print $1 }')" == \
+    "${expected_receipt_sha256}" ]] || \
+    fail "Collected dependency receipt changed: ${stage}"
+  [[ "$(/usr/bin/shasum -a 256 \
+    "compose-package-dependencies/${archive}" | /usr/bin/awk '{ print $1 }')" == \
+    "${expected_archive_sha256}" ]] || \
+    fail "Collected dependency archive changed: ${stage}"
+  [[ "$(/usr/bin/shasum -a 256 \
+    "compose-package-dependencies/${manifest}" | /usr/bin/awk '{ print $1 }')" == \
+    "${expected_manifest_sha256}" ]] || \
+    fail "Collected dependency manifest changed: ${stage}"
   observed_stages="${observed_stages}${stage},"
   ((observed_count += 1))
 done

--- a/Tools/ci/materialize-pipeline-package.py
+++ b/Tools/ci/materialize-pipeline-package.py
@@ -96,15 +96,39 @@ def verify_evidence(
     """Verify the complete package receipt, manifest and archive closure."""
     receipt_rows = read_tsv(receipt)
     manifest_rows = read_tsv(manifest)
+    if one(receipt_rows, "schema") != "4":
+        raise MaterializationError("package receipt has the wrong schema")
     if one(receipt_rows, "stage") != "compose-package":
         raise MaterializationError("package receipt has the wrong stage")
     if one(receipt_rows, "repository") != "container-compose":
         raise MaterializationError("package receipt has the wrong repository")
+    if one(receipt_rows, "source-format") != "git-tree-archive":
+        raise MaterializationError("package receipt has the wrong source format")
     source_commit = one(receipt_rows, "source-commit")
     if len(source_commit) != 40 or any(
         character not in "0123456789abcdef" for character in source_commit
     ):
         raise MaterializationError("package receipt has an invalid source commit")
+    source_execution_head = one(receipt_rows, "source-execution-head")
+    if len(source_execution_head) != 40 or any(
+        character not in "0123456789abcdef"
+        for character in source_execution_head
+    ):
+        raise MaterializationError("package receipt has an invalid execution head")
+    if one(receipt_rows, "source-tracked-clean") != "true":
+        raise MaterializationError("package receipt source was not clean")
+    for key, label in (
+        ("source-payload-sha256", "source payload digest"),
+        ("source-metadata-sha256", "source metadata digest"),
+        ("command-sha256", "command digest"),
+        ("stage-tools-sha256", "stage tools digest"),
+        ("stage-inputs-sha256", "stage input digest"),
+    ):
+        require_sha256(one(receipt_rows, key), label)
+    if one(receipt_rows, "artifact-count") != str(len(EXPECTED_ARTIFACTS)):
+        raise MaterializationError("package receipt has the wrong artifact count")
+    if one(receipt_rows, "exit") != "0":
+        raise MaterializationError("package receipt did not record success")
     archive_digest = require_sha256(
         one(receipt_rows, "artifact-archive-sha256"), "archive digest"
     )
@@ -115,6 +139,12 @@ def verify_evidence(
         raise MaterializationError("package artifact archive digest does not match")
     if sha256(manifest) != manifest_digest:
         raise MaterializationError("package artifact manifest digest does not match")
+    if one(manifest_rows, "schema") != "1":
+        raise MaterializationError("package manifest has the wrong schema")
+    if one(manifest_rows, "stage") != "compose-package":
+        raise MaterializationError("package manifest has the wrong stage")
+    if one(manifest_rows, "repository") != "container-compose":
+        raise MaterializationError("package manifest has the wrong repository")
     if one(manifest_rows, "archive-sha256") != archive_digest:
         raise MaterializationError("package manifest does not bind its archive")
     if one(manifest_rows, "artifact-count") != str(len(EXPECTED_ARTIFACTS)):

--- a/Tools/ci/run-release-checkpoint.py
+++ b/Tools/ci/run-release-checkpoint.py
@@ -35,7 +35,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 FAILURE_TAIL_BYTES = 32 * 1024
 FAILURE_TAIL_LINES = 80
 DEADLINE_RUNNER = Path(__file__).with_name("run-command-with-deadline.py")
@@ -296,6 +296,8 @@ def run_supervised(options: argparse.Namespace) -> int:
         if fingerprint_status != 0:
             return fingerprint_status
     assert fingerprint is not None
+    fingerprint_before = fingerprint
+    fingerprint_after = fingerprint_before
 
     digest = stage_digest(
         options.stage, fingerprint, options.seconds, options.command
@@ -394,6 +396,27 @@ def run_supervised(options: argparse.Namespace) -> int:
             )
             if status == 0:
                 status = 74
+    if status == 0 and options.fingerprint_command is not None:
+        fingerprint_status, resolved_fingerprint = run_fingerprint_command(
+            options.fingerprint_command
+        )
+        if fingerprint_status != 0:
+            print(
+                "could not re-resolve release checkpoint inputs after stage "
+                f"completion: {options.stage}",
+                file=sys.stderr,
+            )
+            status = fingerprint_status
+        else:
+            assert resolved_fingerprint is not None
+            fingerprint_after = resolved_fingerprint
+            if fingerprint_after != fingerprint_before:
+                print(
+                    "release checkpoint inputs changed while stage ran; "
+                    f"refusing stale success: {options.stage}",
+                    file=sys.stderr,
+                )
+                status = 75
     result: dict[str, object] = {
         "command_sha256": hashlib.sha256(
             json.dumps(options.command, separators=(",", ":")).encode("utf-8")
@@ -402,7 +425,9 @@ def run_supervised(options: argparse.Namespace) -> int:
         "duration_seconds": round(time.monotonic() - started, 6),
         "executable": options.command[0],
         "finished_at": utc_timestamp(),
-        "fingerprint": fingerprint,
+        "fingerprint": fingerprint_before,
+        "fingerprint_after": fingerprint_after,
+        "fingerprint_before": fingerprint_before,
         "schema": SCHEMA_VERSION,
         "seconds": options.seconds,
         "stage": options.stage,

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -385,6 +385,20 @@ fi
 # and versions; this live identity catches a changed checkout, tool executable,
 # Docker CLI plugin, runtime, or init archive before a stale success is reused
 # or recorded.
+# Print a portable metadata identity for one resolved file.
+file_identity() {
+  local path="$1"
+  case "$(/usr/bin/uname -s)" in
+    Darwin)
+      /usr/bin/stat -L -f '%d:%i:%z:%m:%c' "${path}"
+      ;;
+    *)
+      /usr/bin/stat -L -c '%d:%i:%s:%Y:%Z' "${path}"
+      ;;
+  esac
+}
+
+# Re-resolve the mutable input closure for one stack-validation stage.
 live_validation_identity_for_stage() {
   local stage="$1"
   local repository label formula_sha256
@@ -441,11 +455,7 @@ live_validation_identity_for_stage() {
     printf 'tree=%s\n' "${tree}"
     printf 'describe=%s\n' "${describe}"
     printf 'init_archive=%s\n' "${init_archive_fingerprint}"
-    printf 'runtime_cli=%s\n' "${runtime_cli}"
-    if [[ -n "${runtime_cli}" && -f "${runtime_cli}" ]]; then
-      printf 'runtime_cli_sha256=%s\n' \
-        "$(shasum -a 256 "${runtime_cli}" | awk '{print $1}')"
-    fi
+    printf 'runtime_cli=%s\n' "${runtime_cli_fingerprint}"
     if [[ "${label}" == homebrew ]]; then
       formula_sha256=$(shasum -a 256 \
         "${homebrew_tap_repo}/Formula/container-compose.rb" | awk '{print $1}')
@@ -457,7 +467,7 @@ live_validation_identity_for_stage() {
       printf 'tool=%s:path=%s\n' "${tool_name}" "${tool_path:-missing}"
       if [[ -n "${tool_path}" && -f "${tool_path}" ]]; then
         printf 'tool=%s:identity=%s\n' "${tool_name}" \
-          "$(/usr/bin/stat -L -f '%d:%i:%z:%m:%c' "${tool_path}")"
+          "$(file_identity "${tool_path}")"
       fi
     done
     local docker_config_file="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
@@ -479,7 +489,7 @@ live_validation_identity_for_stage() {
         if [[ -e "${plugin_path}" ]]; then
           printf 'docker:plugin=%s:path=%s:identity=%s\n' \
             "${plugin_name}" "${plugin_path}" \
-            "$(/usr/bin/stat -L -f '%d:%i:%z:%m:%c' "${plugin_path}")"
+            "$(file_identity "${plugin_path}")"
         fi
       done
     done

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -380,10 +380,117 @@ if [[ -n "${checkpoint_directory}" ]]; then
   )
 fi
 
+# Re-resolve the mutable input closure at every independently resumable stage
+# boundary. The component fingerprints above declare the initial environment
+# and versions; this live identity catches a changed checkout, tool executable,
+# Docker CLI plugin, runtime, or init archive before a stale success is reused
+# or recorded.
+live_validation_identity_for_stage() {
+  local stage="$1"
+  local repository label formula_sha256
+  case "${stage}" in
+    builder-*)
+      repository="${builder_repo}"
+      label=builder
+      ;;
+    containerization-*)
+      repository="${containerization_repo}"
+      label=containerization
+      ;;
+    container-*)
+      repository="${container_repo}"
+      label=container
+      ;;
+    homebrew-*)
+      repository="${homebrew_tap_repo}"
+      label=homebrew
+      ;;
+    *)
+      printf 'unknown stack validation checkpoint stage: %s\n' "${stage}" >&2
+      return 2
+      ;;
+  esac
+
+  local head=fixture
+  local tree=fixture
+  local describe=fixture
+  if git -C "${repository}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if ! git -C "${repository}" diff --quiet --ignore-submodules=none HEAD --; then
+      printf 'tracked stack input changed at a stage boundary: %s\n' \
+        "${label}" >&2
+      return 75
+    fi
+    head=$(git -C "${repository}" rev-parse HEAD)
+    tree=$(git -C "${repository}" rev-parse 'HEAD^{tree}')
+    describe=$(git -C "${repository}" describe --tags --always --dirty)
+  fi
+
+  local init_archive_fingerprint=unset
+  if [[ -n "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}" ]]; then
+    if [[ -f "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" ]]; then
+      init_archive_fingerprint=$(shasum -a 256 \
+        "${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}" | awk '{print $1}')
+    else
+      init_archive_fingerprint="missing:${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE}"
+    fi
+  fi
+
+  {
+    printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
+    printf 'head=%s\n' "${head}"
+    printf 'tree=%s\n' "${tree}"
+    printf 'describe=%s\n' "${describe}"
+    printf 'init_archive=%s\n' "${init_archive_fingerprint}"
+    printf 'runtime_cli=%s\n' "${runtime_cli}"
+    if [[ -n "${runtime_cli}" && -f "${runtime_cli}" ]]; then
+      printf 'runtime_cli_sha256=%s\n' \
+        "$(shasum -a 256 "${runtime_cli}" | awk '{print $1}')"
+    fi
+    if [[ "${label}" == homebrew ]]; then
+      formula_sha256=$(shasum -a 256 \
+        "${homebrew_tap_repo}/Formula/container-compose.rb" | awk '{print $1}')
+      printf 'formula=%s\n' "${formula_sha256}"
+    fi
+    local tool_name tool_path
+    for tool_name in git make swift clang go ruby python3 docker hawkeye shellcheck xcodebuild; do
+      tool_path=$(command -v "${tool_name}" 2>/dev/null || true)
+      printf 'tool=%s:path=%s\n' "${tool_name}" "${tool_path:-missing}"
+      if [[ -n "${tool_path}" && -f "${tool_path}" ]]; then
+        printf 'tool=%s:identity=%s\n' "${tool_name}" \
+          "$(/usr/bin/stat -L -f '%d:%i:%z:%m:%c' "${tool_path}")"
+      fi
+    done
+    local docker_config_file="${DOCKER_CONFIG:-${HOME}/.docker}/config.json"
+    if [[ -f "${docker_config_file}" ]]; then
+      printf 'docker:config=%s\n' \
+        "$(shasum -a 256 "${docker_config_file}" | awk '{print $1}')"
+    else
+      printf 'docker:config=missing:%s\n' "${docker_config_file}"
+    fi
+    local plugin_name plugin_path
+    for plugin_name in buildx compose; do
+      for plugin_path in \
+        "${DOCKER_CONFIG:-${HOME}/.docker}/cli-plugins/docker-${plugin_name}" \
+        "/usr/local/lib/docker/cli-plugins/docker-${plugin_name}" \
+        "/usr/local/libexec/docker/cli-plugins/docker-${plugin_name}" \
+        "/opt/homebrew/lib/docker/cli-plugins/docker-${plugin_name}" \
+        "/opt/homebrew/libexec/docker/cli-plugins/docker-${plugin_name}" \
+        "/Applications/Docker.app/Contents/Resources/cli-plugins/docker-${plugin_name}"; do
+        if [[ -e "${plugin_path}" ]]; then
+          printf 'docker:plugin=%s:path=%s:identity=%s\n' \
+            "${plugin_name}" "${plugin_path}" \
+            "$(/usr/bin/stat -L -f '%d:%i:%z:%m:%c' "${plugin_path}")"
+        fi
+      done
+    done
+    uname -a
+  } | shasum -a 256 | awk '{print $1}'
+}
+
 # Returns the exact-input fingerprint for one independently validated stage.
 validation_fingerprint_for_stage() {
   local stage="$1"
-  local base_fingerprint
+  local base_fingerprint live_identity
   case "${stage}" in
     builder-*)
       base_fingerprint="${builder_validation_fingerprint}"
@@ -402,8 +509,10 @@ validation_fingerprint_for_stage() {
       return 2
       ;;
   esac
+  live_identity=$(live_validation_identity_for_stage "${stage}")
   {
     printf 'base=%s\n' "${base_fingerprint}"
+    printf 'live=%s\n' "${live_identity}"
     printf 'stage=%s\n' "${stage}"
   } | shasum -a 256 | awk '{print $1}'
 }
@@ -421,13 +530,13 @@ run_checkpointed() {
 
   mkdir -p "${checkpoint_directory}"
   local stamp="${checkpoint_directory}/${mode}-${stage}.sha256"
-  local expected
-  expected="$(validation_fingerprint_for_stage "${stage}"):${stage}"
+  local expected_before
+  expected_before="$(validation_fingerprint_for_stage "${stage}"):${stage}"
   local actual=""
   if [[ -f "${stamp}" ]]; then
     IFS= read -r actual <"${stamp}" || true
   fi
-  if [[ "${actual}" == "${expected}" ]]; then
+  if [[ "${actual}" == "${expected_before}" ]]; then
     printf 'reusing exact-input validation checkpoint: %s\n' "${stage}"
     verify_runtime_cli_identity
     return
@@ -435,9 +544,16 @@ run_checkpointed() {
 
   "$@"
   verify_runtime_cli_identity
+  local expected_after
+  expected_after="$(validation_fingerprint_for_stage "${stage}"):${stage}"
+  if [[ "${expected_after}" != "${expected_before}" ]]; then
+    printf 'stack validation inputs changed while stage ran; refusing stale success: %s\n' \
+      "${stage}" >&2
+    return 75
+  fi
   local temporary_stamp
   temporary_stamp=$(mktemp "${checkpoint_directory}/.${mode}-${stage}.XXXXXX")
-  printf '%s\n' "${expected}" >"${temporary_stamp}"
+  printf '%s\n' "${expected_after}" >"${temporary_stamp}"
   mv -f "${temporary_stamp}" "${stamp}"
 }
 

--- a/Tools/ci/test_collect_compose_package_dependencies.py
+++ b/Tools/ci/test_collect_compose_package_dependencies.py
@@ -61,10 +61,16 @@ class ComposePackageDependencyCollectionTests(unittest.TestCase):
         (root / f"{stage}.receipt.tsv").write_text(
             "\n".join(
                 (
-                    "schema\t3",
+                    "schema\t4",
                     f"stage\t{stage}",
                     "repository\tcontainer-compose",
+                    "source-format\tgit-tree-archive",
                     f"source-payload-sha256\t{payload}",
+                    f"stage-inputs-sha256\t{'e' * 64}",
+                    f"source-execution-head\t{'f' * 40}",
+                    "source-tracked-clean\ttrue",
+                    "artifact-count\t1",
+                    "exit\t0",
                     f"artifact-archive-sha256\t{sha256(archive)}",
                     f"artifact-manifest-sha256\t{sha256(manifest)}",
                 )
@@ -122,6 +128,24 @@ class ComposePackageDependencyCollectionTests(unittest.TestCase):
             root = Path(directory)
             self.write_evidence(root, "compose-release-build", "a" * 64)
             self.write_evidence(root, "compose-go-validation", "not-a-digest")
+
+            result = self.run_collector(root)
+
+            self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_a_legacy_receipt_without_closed_stage_inputs(self) -> None:
+        """A cached pre-contract receipt cannot enter the package stage."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            for stage in ARTIFACTS:
+                self.write_evidence(root, stage, "a" * 64)
+            receipt = root / "compose-release-build.receipt.tsv"
+            receipt.write_text(
+                receipt.read_text(encoding="utf-8").replace(
+                    "schema\t4", "schema\t3", 1
+                ),
+                encoding="utf-8",
+            )
 
             result = self.run_collector(root)
 

--- a/Tools/ci/test_materialize_pipeline_package.py
+++ b/Tools/ci/test_materialize_pipeline_package.py
@@ -84,10 +84,20 @@ class PipelinePackageMaterializationTests(unittest.TestCase):
         receipt.write_text(
             "\n".join(
                 (
-                    "schema\t3",
+                    "schema\t4",
                     "stage\tcompose-package",
                     "repository\tcontainer-compose",
+                    "source-format\tgit-tree-archive",
                     f"source-commit\t{commit}",
+                    f"source-payload-sha256\t{'a' * 64}",
+                    f"source-metadata-sha256\t{'b' * 64}",
+                    f"command-sha256\t{'c' * 64}",
+                    f"stage-tools-sha256\t{'f' * 64}",
+                    f"stage-inputs-sha256\t{'d' * 64}",
+                    f"source-execution-head\t{'e' * 40}",
+                    "source-tracked-clean\ttrue",
+                    f"artifact-count\t{len(materializer.EXPECTED_ARTIFACTS)}",
+                    "exit\t0",
                     f"artifact-archive-sha256\t{materializer.sha256(archive)}",
                     f"artifact-manifest-sha256\t{materializer.sha256(manifest)}",
                 )
@@ -171,6 +181,31 @@ class PipelinePackageMaterializationTests(unittest.TestCase):
                 )
 
             self.assertEqual(existing.read_bytes(), b"existing")
+            self.assertFalse((destination / "dist").exists())
+
+    def test_rejects_a_legacy_receipt_without_closed_stage_inputs(self) -> None:
+        """Recovered pre-contract package evidence cannot reach the checkout."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            destination, commit = self.destination(root)
+            receipt, manifest, archive = self.evidence(root, commit)
+            receipt.write_text(
+                receipt.read_text(encoding="utf-8").replace(
+                    "schema\t4", "schema\t3", 1
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                materializer.MaterializationError, "wrong schema"
+            ):
+                materializer.materialize(
+                    receipt=receipt,
+                    manifest=manifest,
+                    archive=archive,
+                    destination=destination,
+                )
+
             self.assertFalse((destination / "dist").exists())
 
     def test_failed_replacement_restores_every_existing_output(self) -> None:

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -221,6 +221,22 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
             REPOSITORY_STAGE,
         )
 
+    def test_stage_rechecks_inputs_and_tracked_source_before_success(self) -> None:
+        """A stage cannot publish a receipt for inputs it changed while running."""
+        command_start = REPOSITORY_STAGE.index("set +e\n    (")
+        command_end = REPOSITORY_STAGE.index("verify_tool_closure", command_start)
+        command_boundary = REPOSITORY_STAGE[command_start:command_end]
+
+        self.assertIn("stage_input_sha256_before", REPOSITORY_STAGE[:command_start])
+        self.assertIn("source_head_before", REPOSITORY_STAGE[:command_start])
+        self.assertIn("stage_input_sha256_after", command_boundary)
+        self.assertIn("source_head_after", command_boundary)
+        self.assertIn("stage changed tracked source after preflight", command_boundary)
+        self.assertIn("stage inputs changed while command ran", command_boundary)
+        self.assertIn("printf 'schema\\t4\\n'", REPOSITORY_STAGE)
+        self.assertIn("stage-inputs-sha256", REPOSITORY_STAGE)
+        self.assertIn("source-tracked-clean", REPOSITORY_STAGE)
+
     def test_history_sensitive_release_stages_request_commit_metadata(self) -> None:
         expected_declarations = (
             "'make,go,hawkeye', '.', 'commit,describe'",

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -118,7 +118,8 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
         )[1].split("['container-compose', 'compose-tool-validation'", 1)[0]
         self.assertTrue(go_build_stage.rstrip().endswith("'none'],"))
         self.assertIn("source-payload-sha256", PACKAGE_DEPENDENCY_COLLECTOR)
-        self.assertNotIn("source-commit", PACKAGE_DEPENDENCY_COLLECTOR)
+        self.assertIn("source-execution-head", PACKAGE_DEPENDENCY_COLLECTOR)
+        self.assertIn("stage-inputs-sha256", PACKAGE_DEPENDENCY_COLLECTOR)
         self.assertIn(
             "Tools/release/runtime-capabilities.json", package_stage
         )
@@ -236,6 +237,15 @@ class ReleaseStageGitHistoryTests(unittest.TestCase):
         self.assertIn("printf 'schema\\t4\\n'", REPOSITORY_STAGE)
         self.assertIn("stage-inputs-sha256", REPOSITORY_STAGE)
         self.assertIn("source-tracked-clean", REPOSITORY_STAGE)
+
+    def test_every_cached_receipt_consumer_requires_closed_stage_inputs(self) -> None:
+        """Legacy stage success cannot enter dependencies or the summary."""
+        self.assertIn('[[ "$dependency_receipt_schema" != 4 ]]', REPOSITORY_STAGE)
+        self.assertIn("dependency_stage_inputs_sha256", REPOSITORY_STAGE)
+        self.assertIn("dependency_source_execution_head", REPOSITORY_STAGE)
+        self.assertIn('[[ "$receipt_schema" == 4 ]]', PIPELINE_SOURCE)
+        self.assertIn("receipt_stage_inputs_sha256", PIPELINE_SOURCE)
+        self.assertIn("receipt_source_execution_head", PIPELINE_SOURCE)
 
     def test_history_sensitive_release_stages_request_commit_metadata(self) -> None:
         expected_declarations = (

--- a/Tools/ci/test_run_release_checkpoint.py
+++ b/Tools/ci/test_run_release_checkpoint.py
@@ -720,6 +720,202 @@ class RunReleaseCheckpointTest(unittest.TestCase):
             self.assertTrue(fingerprint_started.exists())
             self.assertFalse(stage_started.exists())
 
+    def test_fingerprint_command_rejects_inputs_changed_by_the_stage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoints = root / "checkpoints"
+            fingerprint_value = root / "fingerprint-value"
+            fingerprint_value.write_text("before\n", encoding="utf-8")
+            fingerprint_command = root / "fingerprint"
+            fingerprint_command.write_text(
+                "#!/bin/sh\n"
+                f"cat '{fingerprint_value}'\n",
+                encoding="utf-8",
+            )
+            fingerprint_command.chmod(0o755)
+
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--checkpoint-dir",
+                    str(checkpoints),
+                    "--stage",
+                    "compose-ci",
+                    "--fingerprint-command",
+                    str(fingerprint_command),
+                    "--seconds",
+                    "5",
+                    "--",
+                    "/bin/sh",
+                    "-c",
+                    f"printf 'after\\n' >'{fingerprint_value}'",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 75, completed.stderr)
+            self.assertIn("inputs changed while stage ran", completed.stderr)
+            self.assertFalse((checkpoints / "compose-ci.success.json").exists())
+            result = json.loads(
+                (checkpoints / "compose-ci.last.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(result["fingerprint_before"], "before")
+            self.assertEqual(result["fingerprint_after"], "after")
+            self.assertEqual(result["status"], 75)
+
+    def test_unchanged_fingerprint_command_success_is_reusable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoints = root / "checkpoints"
+            run_log = root / "runs.log"
+            fingerprint_command = root / "fingerprint"
+            fingerprint_command.write_text(
+                "#!/bin/sh\nprintf 'stable\\n'\n",
+                encoding="utf-8",
+            )
+            fingerprint_command.chmod(0o755)
+            arguments = [
+                sys.executable,
+                str(SCRIPT),
+                "--checkpoint-dir",
+                str(checkpoints),
+                "--stage",
+                "compose-ci",
+                "--fingerprint-command",
+                str(fingerprint_command),
+                "--seconds",
+                "5",
+                "--",
+                "/bin/sh",
+                "-c",
+                f"printf 'run\\n' >>'{run_log}'",
+            ]
+
+            first = subprocess.run(
+                arguments, capture_output=True, text=True, check=False
+            )
+            repeated = subprocess.run(
+                arguments, capture_output=True, text=True, check=False
+            )
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(repeated.returncode, 0, repeated.stderr)
+            self.assertEqual(run_log.read_text(encoding="utf-8"), "run\n")
+            self.assertIn("reusing exact-input release checkpoint", repeated.stdout)
+            checkpoint = json.loads(
+                (checkpoints / "compose-ci.success.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(checkpoint["fingerprint_before"], "stable")
+            self.assertEqual(checkpoint["fingerprint_after"], "stable")
+
+    def test_stack_stage_refuses_success_if_tracked_source_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            repositories = [
+                root / name
+                for name in ("compose", "builder", "containerization", "container")
+            ]
+            for repository in repositories:
+                repository.mkdir()
+                (repository / "Makefile").touch()
+            builder = repositories[1]
+            (builder / "input.txt").write_text("original\n", encoding="utf-8")
+            subprocess.run(["git", "-C", str(builder), "init", "--quiet"], check=True)
+            subprocess.run(
+                ["git", "-C", str(builder), "add", "Makefile", "input.txt"],
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "-C",
+                    str(builder),
+                    "-c",
+                    "user.name=Release Test",
+                    "-c",
+                    "user.email=release-test@example.invalid",
+                    "-c",
+                    "commit.gpgsign=false",
+                    "commit",
+                    "--quiet",
+                    "-m",
+                    "fixture",
+                ],
+                check=True,
+            )
+            tap = root / "tap"
+            (tap / "Formula").mkdir(parents=True)
+            (tap / "Formula" / "container-compose.rb").touch()
+            fake_bin = root / "bin"
+            fake_bin.mkdir()
+            fake_tool = "#!/bin/sh\nprintf 'fixture tool\\n'\n"
+            for name in (
+                "swift",
+                "clang",
+                "go",
+                "ruby",
+                "python3",
+                "docker",
+                "hawkeye",
+                "shellcheck",
+                "xcodebuild",
+            ):
+                path = fake_bin / name
+                path.write_text(fake_tool, encoding="utf-8")
+                path.chmod(0o755)
+            fake_make = fake_bin / "make"
+            fake_make.write_text(
+                "#!/bin/sh\n"
+                "if [ \"${1:-}\" = --version ]; then\n"
+                "  printf 'fixture make\\n'\n"
+                "  exit 0\n"
+                "fi\n"
+                "if [ \"${1:-}\" = -C ] && "
+                "[ \"${2:-}\" = \"${STACK_MUTATION_REPO:?}\" ]; then\n"
+                "  printf 'changed\\n' >>\"${STACK_MUTATION_REPO}/input.txt\"\n"
+                "fi\n",
+                encoding="utf-8",
+            )
+            fake_make.chmod(0o755)
+            checkpoints = root / "checkpoints"
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR": str(checkpoints),
+                    "CONTAINER_STACK_VALIDATION_SCRATCH_ROOT": str(root / "scratch"),
+                    "BASH_ENV": "/dev/null",
+                    "ENV": "/dev/null",
+                    "PATH": f"{fake_bin}:/opt/homebrew/bin:/usr/bin:/bin",
+                    "STACK_MUTATION_REPO": str(builder),
+                }
+            )
+
+            completed = subprocess.run(
+                [
+                    str(STACK_SCRIPT),
+                    "hosted",
+                    *(str(repository) for repository in repositories),
+                    str(tap),
+                ],
+                cwd=ROOT,
+                env=environment,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(completed.returncode, 75, completed.stderr)
+            self.assertIn(
+                "tracked stack input changed at a stage boundary: builder",
+                completed.stderr,
+            )
+            self.assertFalse(
+                (checkpoints / "hosted-builder-check.sha256").exists()
+            )
+
     def test_release_gate_starts_deadline_before_make_fingerprinting(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/Tools/parity/benchmark-authority.py
+++ b/Tools/parity/benchmark-authority.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify benchmark controls and release authority through report publication."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+
+REPOSITORY_PATTERN = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?/"
+    r"[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?"
+)
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+TAG_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def run_command(arguments: Sequence[str], cwd: Path | None = None) -> str:
+    completed = subprocess.run(
+        arguments,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"authority command failed ({completed.returncode}): "
+            f"{' '.join(arguments)}\n{completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def resolve_remote_ref(repository: str, ref: str, ref_type: str) -> str:
+    output = run_command(
+        (
+            "git",
+            "ls-remote",
+            f"--{ref_type}",
+            f"https://github.com/{repository}.git",
+            f"refs/{ref_type}/{ref}",
+            *(
+                (f"refs/{ref_type}/{ref}^{{}}",)
+                if ref_type == "tags"
+                else ()
+            ),
+        )
+    )
+    direct = ""
+    peeled = ""
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        if fields[1] == f"refs/{ref_type}/{ref}^{{}}":
+            peeled = fields[0]
+        elif fields[1] == f"refs/{ref_type}/{ref}":
+            direct = fields[0]
+    resolved = peeled or direct
+    if SHA_PATTERN.fullmatch(resolved) is None:
+        raise ValueError(f"remote ref is missing or invalid: {repository}@{ref}")
+    return resolved
+
+
+def parse_release(declaration: str) -> tuple[str, str, int, str]:
+    fields = declaration.split("|")
+    if len(fields) != 4:
+        raise ValueError(f"invalid benchmark release declaration: {declaration}")
+    repository, tag, release_id_text, sha = fields
+    if (
+        REPOSITORY_PATTERN.fullmatch(repository) is None
+        or TAG_PATTERN.fullmatch(tag) is None
+        or not release_id_text.isdigit()
+        or SHA_PATTERN.fullmatch(sha) is None
+    ):
+        raise ValueError(f"invalid benchmark release declaration: {declaration}")
+    return repository, tag, int(release_id_text), sha
+
+
+def verify_release(declaration: str) -> dict[str, object]:
+    repository, tag, expected_id, expected_sha = parse_release(declaration)
+    release = json.loads(
+        run_command(("gh", "api", f"repos/{repository}/releases/tags/{tag}"))
+    )
+    if (
+        release.get("id") != expected_id
+        or release.get("tag_name") != tag
+        or release.get("draft") is not False
+        or release.get("prerelease") is not False
+    ):
+        raise ValueError(f"benchmark release authority changed: {repository}@{tag}")
+    actual_sha = resolve_remote_ref(repository, tag, "tags")
+    if actual_sha != expected_sha:
+        raise ValueError(
+            f"benchmark release tag moved: {repository}@{tag} "
+            f"(expected {expected_sha}, got {actual_sha})"
+        )
+    return {
+        "id": expected_id,
+        "repository": repository,
+        "sha": actual_sha,
+        "tag": tag,
+    }
+
+
+def parse_checkout(declaration: str) -> tuple[Path, str]:
+    fields = declaration.split("|")
+    if len(fields) != 2:
+        raise ValueError(f"invalid benchmark checkout declaration: {declaration}")
+    path_text, sha = fields
+    path = Path(path_text)
+    if (
+        not path_text
+        or path.is_absolute()
+        or ".." in path.parts
+        or SHA_PATTERN.fullmatch(sha) is None
+    ):
+        raise ValueError(f"invalid benchmark checkout declaration: {declaration}")
+    return path, sha
+
+
+def verify_checkout(source: Path, declaration: str) -> dict[str, str]:
+    relative_path, expected_sha = parse_checkout(declaration)
+    repository = source / relative_path
+    actual_sha = run_command(("git", "rev-parse", "HEAD"), cwd=repository)
+    if actual_sha != expected_sha:
+        raise ValueError(
+            f"benchmark checkout authority changed: {relative_path} "
+            f"(expected {expected_sha}, got {actual_sha})"
+        )
+    tracked_status = run_command(
+        ("git", "status", "--porcelain", "--untracked-files=no"), cwd=repository
+    )
+    if tracked_status:
+        raise ValueError(f"benchmark checkout has tracked changes: {relative_path}")
+    return {"path": str(relative_path), "sha": actual_sha}
+
+
+def changed_paths(repository: Path, controls_ref: str) -> set[str]:
+    committed = run_command(
+        ("git", "diff", "--name-only", f"{controls_ref}..HEAD"), cwd=repository
+    )
+    working = run_command(
+        ("git", "diff", "--name-only", "HEAD"), cwd=repository
+    )
+    paths = set(filter(None, committed.splitlines()))
+    paths.update(filter(None, working.splitlines()))
+    return paths
+
+
+def verify_controls(
+    repository: Path, controls_ref: str, allowed_outputs: Sequence[str]
+) -> dict[str, object]:
+    run_command(("git", "cat-file", "-e", f"{controls_ref}^{{commit}}"), cwd=repository)
+    allowed = set(allowed_outputs)
+    unexpected = sorted(changed_paths(repository, controls_ref) - allowed)
+    if unexpected:
+        raise ValueError(
+            "benchmark controls changed during execution: " + ", ".join(unexpected)
+        )
+    return {"allowedOutputs": sorted(allowed), "sha": controls_ref}
+
+
+def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--controls-ref", required=True)
+    parser.add_argument("--allow-output", action="append", default=[])
+    parser.add_argument("--release", action="append", default=[])
+    parser.add_argument("--checkout", action="append", default=[])
+    options = parser.parse_args(arguments)
+    if SHA_PATTERN.fullmatch(options.controls_ref) is None:
+        parser.error(f"controls ref is not an immutable SHA: {options.controls_ref}")
+    if not options.release:
+        parser.error("at least one release authority is required")
+    for output in options.allow_output:
+        if not output or Path(output).is_absolute() or ".." in Path(output).parts:
+            parser.error(f"allowed output is not repository-relative: {output}")
+    return options
+
+
+def authority_digest(options: argparse.Namespace) -> str:
+    source = options.source.resolve()
+    authority = {
+        "checkouts": sorted(
+            (verify_checkout(source, declaration) for declaration in options.checkout),
+            key=lambda item: item["path"],
+        ),
+        "controls": verify_controls(
+            source, options.controls_ref, options.allow_output
+        ),
+        "releases": sorted(
+            (verify_release(declaration) for declaration in options.release),
+            key=lambda item: (item["repository"], item["tag"]),
+        ),
+        "schema": 1,
+    }
+    encoded = json.dumps(
+        authority, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def main(arguments: Sequence[str]) -> int:
+    try:
+        print(authority_digest(parse_arguments(arguments)))
+    except (json.JSONDecodeError, OSError, RuntimeError, ValueError) as error:
+        print(
+            f"benchmark authority verification failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Tools/parity/historical_reconstruction_benchmark.py
+++ b/Tools/parity/historical_reconstruction_benchmark.py
@@ -228,9 +228,15 @@ def extract_cctl(
         or len(artifact_rows[0]) != 4
         or SHA256.fullmatch(artifact_rows[0][2]) is None
         or records.get("archive-sha256") != [archive_digest]
-        or receipt_records.get("schema") != ["3"]
+        or receipt_records.get("schema") != ["4"]
         or receipt_records.get("stage") != ["containerization-benchmark-cctl"]
         or receipt_records.get("repository") != ["containerization"]
+        or receipt_records.get("source-format") != ["git-tree-archive"]
+        or len(receipt_records.get("source-commit", [])) != 1
+        or COMMIT.fullmatch(receipt_records["source-commit"][0]) is None
+        or len(receipt_records.get("source-execution-head", [])) != 1
+        or COMMIT.fullmatch(receipt_records["source-execution-head"][0]) is None
+        or receipt_records.get("source-tracked-clean") != ["true"]
         or receipt_records.get("artifact-archive-sha256") != [archive_digest]
         or receipt_records.get("artifact-manifest-sha256") != [manifest_digest]
         or receipt_records.get("artifact-count") != ["1"]
@@ -245,6 +251,7 @@ def extract_cctl(
         "source-metadata-sha256",
         "command-sha256",
         "stage-tools-sha256",
+        "stage-inputs-sha256",
     )
     if any(
         len(receipt_records.get(key, [])) != 1
@@ -273,10 +280,15 @@ def extract_cctl(
     return {
         "cctlArtifactSha256": archive_digest,
         "cctlBuildCommandSha256": receipt_records["command-sha256"][0],
+        "cctlBuildInputsSha256": receipt_records["stage-inputs-sha256"][0],
+        "cctlBuildSourceCommit": receipt_records["source-commit"][0],
+        "cctlBuildSourceFormat": receipt_records["source-format"][0],
         "cctlBuildSourceMetadataSha256": receipt_records[
             "source-metadata-sha256"
         ][0],
+        "cctlBuildSourceHead": receipt_records["source-execution-head"][0],
         "cctlBuildSourceSha256": receipt_records["source-payload-sha256"][0],
+        "cctlBuildSourceTrackedClean": True,
         "cctlBuildToolsSha256": receipt_records["stage-tools-sha256"][0],
         "cctlReceiptSha256": receipt_digest,
         "cctlSha256": artifact_rows[0][2],
@@ -299,8 +311,13 @@ def prepare_reconstruction(
         "artifactId",
         "cctlArtifactSha256",
         "cctlBuildCommandSha256",
+        "cctlBuildInputsSha256",
         "cctlBuildSourceMetadataSha256",
+        "cctlBuildSourceHead",
+        "cctlBuildSourceCommit",
+        "cctlBuildSourceFormat",
         "cctlBuildSourceSha256",
+        "cctlBuildSourceTrackedClean",
         "cctlBuildToolsSha256",
         "cctlReceiptSha256",
         "cctlSha256",
@@ -311,6 +328,12 @@ def prepare_reconstruction(
         raise ReconstructionInputError("guest reconstruction provenance is incomplete")
     if (
         COMMIT.fullmatch(str(provenance["containerizationRef"])) is None
+        or COMMIT.fullmatch(str(provenance["cctlBuildSourceCommit"])) is None
+        or COMMIT.fullmatch(str(provenance["cctlBuildSourceHead"])) is None
+        or provenance["cctlBuildSourceCommit"]
+        != provenance["containerizationRef"]
+        or provenance["cctlBuildSourceFormat"] != "git-tree-archive"
+        or provenance["cctlBuildSourceTrackedClean"] is not True
         or SHA256.fullmatch(str(provenance["cctlArtifactSha256"])) is None
         or any(
             SHA256.fullmatch(str(provenance[key])) is None

--- a/Tools/parity/test_benchmark_authority.py
+++ b/Tools/parity/test_benchmark_authority.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Sequence
+import importlib.util
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+MODULE_PATH = Path(__file__).with_name("benchmark-authority.py")
+SPEC = importlib.util.spec_from_file_location("benchmark_authority", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+AUTHORITY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUTHORITY)
+
+
+class BenchmarkAuthorityTests(unittest.TestCase):
+    controls_ref = "a" * 40
+    release_ref = "b" * 40
+
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.repository = Path(self.temporary_directory.name)
+        subprocess.run(["git", "init", "-q", self.repository], check=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Tests"], cwd=self.repository, check=True
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "tests@example.com"],
+            cwd=self.repository,
+            check=True,
+        )
+        (self.repository / "controls.txt").write_text("exact\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=self.repository, check=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "test: add controls"],
+            cwd=self.repository,
+            check=True,
+        )
+        self.controls_ref = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=self.repository,
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def options(self, *extra: str) -> argparse.Namespace:
+        return AUTHORITY.parse_arguments(
+            (
+                "--source",
+                str(self.repository),
+                "--controls-ref",
+                self.controls_ref,
+                "--release",
+                f"owner/compose|1.2.3|12|{self.release_ref}",
+                *extra,
+            )
+        )
+
+    def remote_result(
+        self,
+        original: Callable[[Sequence[str], Path | None], str],
+        arguments: Sequence[str],
+        cwd: Path | None = None,
+    ) -> str:
+        if cwd is not None:
+            return original(arguments, cwd)
+        joined = " ".join(arguments)
+        if "releases/tags/1.2.3" in joined:
+            return (
+                '{"id":12,"tag_name":"1.2.3",'
+                '"draft":false,"prerelease":false}'
+            )
+        if "--tags" in arguments:
+            return f"{self.release_ref}\trefs/tags/1.2.3"
+        raise AssertionError(arguments)
+
+    def test_allowed_report_output_preserves_a_stable_authority(self) -> None:
+        report = self.repository / "docs" / "benchmarks" / "report.md"
+        report.parent.mkdir(parents=True)
+        report.write_text("evidence\n", encoding="utf-8")
+        original = AUTHORITY.run_command
+
+        with mock.patch.object(
+            AUTHORITY,
+            "run_command",
+            side_effect=lambda arguments, cwd=None: self.remote_result(
+                original, arguments, cwd
+            ),
+        ):
+            first = AUTHORITY.authority_digest(
+                self.options("--allow-output", "docs/benchmarks/report.md")
+            )
+            second = AUTHORITY.authority_digest(
+                self.options("--allow-output", "docs/benchmarks/report.md")
+            )
+
+        self.assertRegex(first, r"^[0-9a-f]{64}$")
+        self.assertEqual(first, second)
+
+    def test_changed_controls_are_rejected(self) -> None:
+        (self.repository / "controls.txt").write_text("changed\n", encoding="utf-8")
+        original = AUTHORITY.run_command
+
+        with mock.patch.object(
+            AUTHORITY,
+            "run_command",
+            side_effect=lambda arguments, cwd=None: self.remote_result(
+                original, arguments, cwd
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "controls changed"):
+                AUTHORITY.authority_digest(self.options())
+
+    def test_moved_release_tag_is_rejected(self) -> None:
+        original = AUTHORITY.run_command
+
+        def changed(arguments: Sequence[str], cwd: Path | None = None) -> str:
+            result = self.remote_result(original, arguments, cwd)
+            if cwd is None and "--tags" in arguments:
+                return result.replace(self.release_ref, "d" * 40)
+            return result
+
+        with mock.patch.object(AUTHORITY, "run_command", side_effect=changed):
+            with self.assertRaisesRegex(ValueError, "release tag moved"):
+                AUTHORITY.authority_digest(self.options())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -168,13 +168,18 @@ class HistoricalReconstructionTests(unittest.TestCase):
             manifest_digest = hashlib.sha256(manifest.read_bytes()).hexdigest()
             receipt = root / "containerization-benchmark-cctl.receipt.tsv"
             receipt.write_text(
-                "schema\t3\n"
+                "schema\t4\n"
                 "stage\tcontainerization-benchmark-cctl\n"
                 "repository\tcontainerization\n"
+                "source-format\tgit-tree-archive\n"
+                f"source-commit\t{'6' * 40}\n"
                 f"source-payload-sha256\t{'1' * 64}\n"
                 f"source-metadata-sha256\t{'2' * 64}\n"
                 f"command-sha256\t{'3' * 64}\n"
                 f"stage-tools-sha256\t{'4' * 64}\n"
+                f"stage-inputs-sha256\t{'5' * 64}\n"
+                f"source-execution-head\t{'7' * 40}\n"
+                "source-tracked-clean\ttrue\n"
                 f"artifact-archive-sha256\t{archive_digest}\n"
                 f"artifact-manifest-sha256\t{manifest_digest}\n"
                 "artifact-count\t1\n"
@@ -200,6 +205,11 @@ class HistoricalReconstructionTests(unittest.TestCase):
             )
             self.assertEqual(output.read_bytes(), payload)
             self.assertEqual(result["cctlArtifactSha256"], archive_digest)
+            self.assertEqual(result["cctlBuildInputsSha256"], "5" * 64)
+            self.assertEqual(result["cctlBuildSourceCommit"], "6" * 40)
+            self.assertEqual(result["cctlBuildSourceFormat"], "git-tree-archive")
+            self.assertEqual(result["cctlBuildSourceHead"], "7" * 40)
+            self.assertIs(result["cctlBuildSourceTrackedClean"], True)
             self.assertEqual(result["cctlReceiptSha256"], receipt_digest)
 
     def test_prepare_reconstruction_requires_complete_provenance(self) -> None:

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -1017,7 +1017,8 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
         for job in (resolve, benchmark):
             self.assertIn("github.repository == 'stephenlclarke/container-compose'", job)
             self.assertIn("github.ref == 'refs/heads/main'", job)
-            self.assertIn("ref: main", job)
+        self.assertIn("ref: ${{ github.sha }}", resolve)
+        self.assertIn("ref: ${{ needs.resolve.outputs.controls_ref }}", benchmark)
 
     def test_workflow_reruns_use_a_fresh_publication_branch(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")

--- a/Tools/release/documentation-authority.py
+++ b/Tools/release/documentation-authority.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify the immutable authority used by one documentation deployment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+TAG_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+REPOSITORY_PATTERN = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?/"
+    r"[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?"
+)
+
+
+def run_command(arguments: Sequence[str]) -> str:
+    completed = subprocess.run(
+        arguments,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"authority command failed ({completed.returncode}): "
+            f"{' '.join(arguments)}\n{completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def resolve_tag(repository: str, tag: str) -> str:
+    output = run_command(
+        (
+            "git",
+            "ls-remote",
+            "--tags",
+            f"https://github.com/{repository}.git",
+            f"refs/tags/{tag}",
+            f"refs/tags/{tag}^{{}}",
+        )
+    )
+    direct = ""
+    peeled = ""
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        if fields[1] == f"refs/tags/{tag}^{{}}":
+            peeled = fields[0]
+        elif fields[1] == f"refs/tags/{tag}":
+            direct = fields[0]
+    resolved = peeled or direct
+    if SHA_PATTERN.fullmatch(resolved) is None:
+        raise ValueError(f"published tag is missing or invalid: {repository}@{tag}")
+    return resolved
+
+
+def verify_release(
+    repository: str, tag: str, expected_id: int, expected_sha: str
+) -> dict[str, object]:
+    release = json.loads(
+        run_command(("gh", "api", f"repos/{repository}/releases/tags/{tag}"))
+    )
+    actual_id = release.get("id")
+    if (
+        actual_id != expected_id
+        or release.get("tag_name") != tag
+        or release.get("draft") is not False
+        or release.get("prerelease") is not False
+    ):
+        raise ValueError(f"published release authority changed: {repository}@{tag}")
+    actual_sha = resolve_tag(repository, tag)
+    if actual_sha != expected_sha:
+        raise ValueError(
+            f"published tag moved: {repository}@{tag} "
+            f"(expected {expected_sha}, got {actual_sha})"
+        )
+    return {
+        "id": actual_id,
+        "repository": repository,
+        "sha": actual_sha,
+        "tag": tag,
+    }
+
+
+def verify_commit(repository: str, expected_sha: str) -> dict[str, str]:
+    actual_sha = run_command(
+        ("gh", "api", f"repos/{repository}/commits/{expected_sha}", "--jq", ".sha")
+    )
+    if actual_sha != expected_sha:
+        raise ValueError(
+            f"released component commit changed: {repository} "
+            f"(expected {expected_sha}, got {actual_sha})"
+        )
+    return {"repository": repository, "sha": actual_sha}
+
+
+def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--compose-repository", required=True)
+    parser.add_argument("--compose-tag", required=True)
+    parser.add_argument("--compose-release-id", required=True, type=int)
+    parser.add_argument("--compose-ref", required=True)
+    parser.add_argument("--component", action="append", default=[])
+    parser.add_argument("--k8s-repository", required=True)
+    parser.add_argument("--k8s-tag", required=True)
+    parser.add_argument("--k8s-release-id", required=True, type=int)
+    parser.add_argument("--k8s-ref", required=True)
+    options = parser.parse_args(arguments)
+    for name, value in (
+        ("compose repository", options.compose_repository),
+        ("k8s repository", options.k8s_repository),
+    ):
+        if REPOSITORY_PATTERN.fullmatch(value) is None:
+            parser.error(f"{name} is invalid: {value}")
+    for name, value in (
+        ("compose tag", options.compose_tag),
+        ("k8s tag", options.k8s_tag),
+    ):
+        if TAG_PATTERN.fullmatch(value) is None:
+            parser.error(f"{name} is invalid: {value}")
+    for name, value in (
+        ("compose ref", options.compose_ref),
+        ("k8s ref", options.k8s_ref),
+    ):
+        if SHA_PATTERN.fullmatch(value) is None:
+            parser.error(f"{name} is not an immutable SHA: {value}")
+    return options
+
+
+def authority_digest(options: argparse.Namespace) -> str:
+    components = []
+    for declaration in options.component:
+        repository, separator, sha = declaration.partition("=")
+        if (
+            not separator
+            or REPOSITORY_PATTERN.fullmatch(repository) is None
+            or SHA_PATTERN.fullmatch(sha) is None
+        ):
+            raise ValueError(f"invalid released component declaration: {declaration}")
+        components.append(verify_commit(repository, sha))
+    authority = {
+        "compose": verify_release(
+            options.compose_repository,
+            options.compose_tag,
+            options.compose_release_id,
+            options.compose_ref,
+        ),
+        "components": sorted(components, key=lambda item: item["repository"]),
+        "k8s": verify_release(
+            options.k8s_repository,
+            options.k8s_tag,
+            options.k8s_release_id,
+            options.k8s_ref,
+        ),
+        "schema": 1,
+    }
+    encoded = json.dumps(
+        authority, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def main(arguments: Sequence[str]) -> int:
+    try:
+        print(authority_digest(parse_arguments(arguments)))
+    except (json.JSONDecodeError, RuntimeError, ValueError) as error:
+        print(
+            f"documentation authority verification failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Tools/release/package-publication-authority.py
+++ b/Tools/release/package-publication-authority.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify one published release and its optional Homebrew output closure."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import subprocess
+import sys
+from collections.abc import Sequence
+from urllib.parse import urlparse
+
+REPOSITORY_PATTERN = re.compile(
+    r"[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?/"
+    r"[A-Za-z0-9](?:[A-Za-z0-9_.-]*[A-Za-z0-9])?"
+)
+SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
+SHA256_PATTERN = re.compile(r"[0-9a-f]{64}")
+TAG_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def run_command(arguments: Sequence[str], cwd: Path | None = None) -> str:
+    completed = subprocess.run(
+        arguments,
+        cwd=cwd,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"authority command failed ({completed.returncode}): "
+            f"{' '.join(arguments)}\n{completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def resolve_tag(repository: str, tag: str) -> str:
+    output = run_command(
+        (
+            "git",
+            "ls-remote",
+            "--tags",
+            f"https://github.com/{repository}.git",
+            f"refs/tags/{tag}",
+            f"refs/tags/{tag}^{{}}",
+        )
+    )
+    direct = ""
+    peeled = ""
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        if fields[1] == f"refs/tags/{tag}^{{}}":
+            peeled = fields[0]
+        elif fields[1] == f"refs/tags/{tag}":
+            direct = fields[0]
+    resolved = peeled or direct
+    if SHA_PATTERN.fullmatch(resolved) is None:
+        raise ValueError(f"published tag is missing or invalid: {repository}@{tag}")
+    return resolved
+
+
+def parse_formula(path: Path) -> tuple[str, str]:
+    text = path.read_text(encoding="utf-8")
+    url_match = re.search(r'^\s*url\s+"([^"]+)"\s*$', text, re.MULTILINE)
+    sha_match = re.search(
+        r'^\s*sha256\s+"([0-9a-f]{64})"\s*$', text, re.MULTILINE
+    )
+    if url_match is None or sha_match is None:
+        raise ValueError(f"formula must declare one URL and SHA-256: {path}")
+    run_command(("ruby", "-c", str(path)))
+    return url_match.group(1), sha_match.group(1)
+
+
+def parse_expected_assets(declarations: Sequence[str]) -> dict[str, str]:
+    assets: dict[str, str] = {}
+    for declaration in declarations:
+        name, separator, digest = declaration.partition("=")
+        if (
+            not separator
+            or not name
+            or Path(name).name != name
+            or SHA256_PATTERN.fullmatch(digest) is None
+        ):
+            raise ValueError(f"invalid release asset declaration: {declaration}")
+        if name in assets:
+            raise ValueError(f"duplicate release asset declaration: {name}")
+        assets[name] = digest
+    return assets
+
+
+def verify_formula(
+    path: Path,
+    repository: str,
+    tag: str,
+    release_assets: dict[str, str],
+) -> dict[str, str]:
+    url, expected_digest = parse_formula(path)
+    parsed = urlparse(url)
+    prefix = f"/{repository}/releases/download/{tag}/"
+    asset = Path(parsed.path).name
+    if parsed.scheme != "https" or parsed.netloc != "github.com":
+        raise ValueError(f"formula URL is not an HTTPS GitHub release asset: {path}")
+    if not parsed.path.startswith(prefix) or not asset:
+        raise ValueError(f"formula URL does not use {repository}@{tag}: {path}")
+    actual_digest = release_assets.get(asset)
+    if actual_digest != expected_digest:
+        raise ValueError(
+            f"formula digest does not match published asset {asset}: "
+            f"expected {expected_digest}, got {actual_digest or 'missing'}"
+        )
+    return {"asset": asset, "path": str(path), "sha256": expected_digest}
+
+
+def verify_tap(
+    tap: Path,
+    expected_ref: str,
+    formulae: Sequence[Path],
+    repository: str,
+    tag: str,
+    release_assets: dict[str, str],
+) -> dict[str, object]:
+    actual_ref = run_command(("git", "rev-parse", "HEAD"), cwd=tap)
+    remote_ref = run_command(
+        ("git", "ls-remote", "--heads", "origin", "refs/heads/main"), cwd=tap
+    ).partition("\t")[0]
+    if actual_ref != expected_ref or remote_ref != expected_ref:
+        raise ValueError(
+            "Homebrew tap authority changed: "
+            f"expected {expected_ref}, local {actual_ref}, remote {remote_ref}"
+        )
+    relative_formulae = [str(path.relative_to(tap)) for path in formulae]
+    status = run_command(
+        ("git", "status", "--porcelain", "--", *relative_formulae), cwd=tap
+    )
+    if status:
+        raise ValueError("Homebrew formula output is not committed")
+    return {
+        "formulae": [
+            verify_formula(path, repository, tag, release_assets)
+            for path in formulae
+        ],
+        "ref": actual_ref,
+    }
+
+
+def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--release-ref", required=True)
+    parser.add_argument(
+        "--release-prerelease", choices=("true", "false"), required=True
+    )
+    parser.add_argument("--asset", action="append", default=[])
+    parser.add_argument("--tap", type=Path)
+    parser.add_argument("--tap-ref")
+    parser.add_argument("--formula", action="append", type=Path, default=[])
+    options = parser.parse_args(arguments)
+    if REPOSITORY_PATTERN.fullmatch(options.repository) is None:
+        parser.error(f"repository is invalid: {options.repository}")
+    if TAG_PATTERN.fullmatch(options.release_tag) is None:
+        parser.error(f"release tag is invalid: {options.release_tag}")
+    if SHA_PATTERN.fullmatch(options.release_ref) is None:
+        parser.error(f"release ref is not an immutable SHA: {options.release_ref}")
+    tap_arguments = (
+        options.tap is not None,
+        options.tap_ref is not None,
+        bool(options.formula),
+    )
+    if any(tap_arguments) and not all(tap_arguments):
+        parser.error("tap, tap-ref, and at least one formula must be provided together")
+    if options.tap_ref is not None and SHA_PATTERN.fullmatch(options.tap_ref) is None:
+        parser.error(f"tap ref is not an immutable SHA: {options.tap_ref}")
+    return options
+
+
+def authority_digest(options: argparse.Namespace) -> str:
+    expected_assets = parse_expected_assets(options.asset)
+    release = json.loads(
+        run_command(
+            (
+                "gh",
+                "api",
+                f"repos/{options.repository}/releases/tags/{options.release_tag}",
+            )
+        )
+    )
+    expected_prerelease = options.release_prerelease == "true"
+    if (
+        release.get("tag_name") != options.release_tag
+        or release.get("draft") is not False
+        or release.get("prerelease") is not expected_prerelease
+        or not isinstance(release.get("id"), int)
+    ):
+        raise ValueError(
+            f"published release state changed: {options.repository}@{options.release_tag}"
+        )
+    if resolve_tag(options.repository, options.release_tag) != options.release_ref:
+        raise ValueError(
+            f"published release tag moved: {options.repository}@{options.release_tag}"
+        )
+    published_assets = {
+        asset.get("name"): str(asset.get("digest", "")).removeprefix("sha256:")
+        for asset in release.get("assets", [])
+        if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+    }
+    for name, expected_digest in expected_assets.items():
+        actual_digest = published_assets.get(name)
+        if actual_digest != expected_digest:
+            raise ValueError(
+                f"published asset changed: {name} "
+                f"(expected {expected_digest}, got {actual_digest or 'missing'})"
+            )
+    authority: dict[str, object] = {
+        "assets": expected_assets,
+        "release": {
+            "id": release.get("id"),
+            "prerelease": expected_prerelease,
+            "repository": options.repository,
+            "sha": options.release_ref,
+            "tag": options.release_tag,
+        },
+        "schema": 1,
+    }
+    if options.tap is not None:
+        authority["tap"] = verify_tap(
+            options.tap.resolve(),
+            options.tap_ref,
+            [path.resolve() for path in options.formula],
+            options.repository,
+            options.release_tag,
+            published_assets,
+        )
+    encoded = json.dumps(
+        authority, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def main(arguments: Sequence[str]) -> int:
+    try:
+        print(authority_digest(parse_arguments(arguments)))
+    except (json.JSONDecodeError, OSError, RuntimeError, ValueError) as error:
+        print(
+            f"package publication authority verification failed: {error}",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3307,7 +3307,7 @@ github_cli() {{
         self.assertIn('printf \'publish=%s\\n\' "${publish}" >> "$GITHUB_OUTPUT"', freshness)
         self.assertEqual(
             workflow.count("steps.current-freshness.outputs.publish == 'true'"),
-            8,
+            9,
         )
 
     def test_package_publication_closes_exact_inputs_and_outputs(self) -> None:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2938,6 +2938,11 @@ github_cli() {{
             "PUBLISH_SHA: ${{ needs.resolve-current.outputs.sha }}", publish_step
         )
         self.assertIn("current_release_matches()", publish_step)
+        self.assertIn('checkout_sha="$(git rev-parse HEAD)"', publish_step)
+        self.assertIn(
+            'tracked_status="$(git status --porcelain --untracked-files=no)"',
+            publish_step,
+        )
         self.assertGreaterEqual(
             publish_step.count("if ! current_release_matches"), 4
         )
@@ -2952,6 +2957,14 @@ github_cli() {{
         )
         self.assertIn(
             'replace_release_asset "${publication_release_id}" "${DEMO_OUTPUT}"',
+            publish_step,
+        )
+        self.assertIn(
+            "Current demo output verified against release %s.",
+            publish_step,
+        )
+        self.assertIn(
+            "Current demo upload returned success without the exact published output.",
             publish_step,
         )
         self.assertIn(
@@ -3093,6 +3106,17 @@ github_cli() {{
         self.assertIn("needs: build-sites", workflow)
         self.assertIn("merge-multiple: true", workflow)
         self.assertIn("Assemble DocC portal", workflow)
+        self.assertIn("Re-resolve documentation authority before deployment", workflow)
+        self.assertIn("Verify documentation authority after deployment", workflow)
+        self.assertEqual(workflow.count("documentation-authority.py"), 2)
+        self.assertLess(
+            workflow.index("Re-resolve documentation authority before deployment"),
+            workflow.index("Deploy to GitHub Pages"),
+        )
+        self.assertLess(
+            workflow.index("Deploy to GitHub Pages"),
+            workflow.index("Verify documentation authority after deployment"),
+        )
         self.assertNotIn("scripts/add-upstream-docc-sites.sh", workflow)
         self.assertNotIn("      - Makefile", workflow)
 
@@ -3286,6 +3310,34 @@ github_cli() {{
             8,
         )
 
+    def test_package_publication_closes_exact_inputs_and_outputs(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        publication = workflow[
+            workflow.index("- name: Retain active and stable benchmark assets") :
+            workflow.index("  repair-stable-tap:")
+        ]
+        repair = workflow[workflow.index("  repair-stable-tap:") :]
+
+        self.assertIn("Verify exact published output closure", publication)
+        self.assertIn("package-publication-authority.py", publication)
+        self.assertIn(
+            'verify_checkout release-tools "${RELEASE_CONTROL_SHA}"', publication
+        )
+        self.assertIn('verify_checkout container "${CONTAINER_REF}"', publication)
+        self.assertIn(
+            "Current release dependency changed during publication", publication
+        )
+        self.assertLess(
+            publication.index("Retain active and stable benchmark assets"),
+            publication.index("Verify exact published output closure"),
+        )
+        self.assertIn("Verify repaired stable Homebrew output closure", repair)
+        self.assertIn("package-publication-authority.py", repair)
+        self.assertLess(
+            repair.index("Commit repaired stable Homebrew stack"),
+            repair.index("Verify repaired stable Homebrew output closure"),
+        )
+
     def test_current_package_workflow_only_follows_successful_main_ci(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn("workflow_run:", workflow)
@@ -3391,6 +3443,9 @@ github_cli() {{
         self.assertNotIn("branches:\n      - main", codeql)
         self.assertIn("release_ref:", codeql)
         self.assertIn("Require an immutable published release", codeql)
+        self.assertIn("release_id:", codeql)
+        self.assertIn("Verify release source remained exact", codeql)
+        self.assertIn("CodeQL release authority changed while analysis ran", codeql)
         self.assertIn("name: CodeQL", codeql)
         self.assertIn("needs.analyze.result", codeql)
         self.assertIn("codeql-release:", package)
@@ -3407,7 +3462,58 @@ github_cli() {{
             package_job,
         )
         self.assertIn("needs.codeql-release.result == 'success'", package_job)
+        self.assertIn("Verify CodeQL release authority after analysis", release_codeql)
+        self.assertLess(
+            release_codeql.index("Analyze CodeQL release source"),
+            release_codeql.index("Verify CodeQL release authority after analysis"),
+        )
         self.assertNotIn("workflow run codeql.yml", benchmark)
+
+    def test_benchmark_publication_rechecks_exact_release_authority(self) -> None:
+        for path in (
+            ROOT / ".github" / "workflows" / "published-benchmark.yml",
+            ROOT / ".github" / "workflows" / "historical-benchmark.yml",
+        ):
+            workflow = path.read_text(encoding="utf-8")
+            publication = workflow[
+                workflow.index("- name: Open documentation pull request") :
+            ]
+
+            self.assertIn("ref: ${{ github.sha }}", workflow)
+            self.assertIn("benchmark-authority.py", publication)
+            self.assertIn('expected_authority="$(verify_authority)"', publication)
+            self.assertIn('current_authority="$(verify_authority)"', publication)
+            self.assertIn(
+                "benchmark authority changed during report publication", publication
+            )
+            self.assertIn(
+                "benchmark report pull request is not bound to its exact output commit",
+                publication,
+            )
+            self.assertIn(
+                "--json baseRefName,headRefName,headRefOid,state,url", publication
+            )
+            self.assertLess(
+                publication.index('expected_authority="$(verify_authority)"'),
+                publication.index("gh pr create"),
+            )
+            self.assertLess(
+                publication.index("gh pr create"),
+                publication.index('current_authority="$(verify_authority)"'),
+            )
+
+    def test_stable_authority_check_verifies_its_created_output(self) -> None:
+        workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        record = workflow[workflow.index("  record-release-authority:") :]
+
+        self.assertIn('check_run="$(', record)
+        self.assertIn("repos/${GITHUB_REPOSITORY}/check-runs", record)
+        self.assertIn(".head_sha == $sha", record)
+        self.assertIn(".external_id == $run", record)
+        self.assertIn(
+            "stable release authority check output does not match its exact candidate",
+            record,
+        )
 
     def test_release_sonar_step_preserves_and_restores_canonical_main(self) -> None:
         ci = CI_WORKFLOW.read_text(encoding="utf-8")

--- a/Tools/release/test_documentation_authority.py
+++ b/Tools/release/test_documentation_authority.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest import mock
+
+MODULE_PATH = Path(__file__).with_name("documentation-authority.py")
+SPEC = importlib.util.spec_from_file_location("documentation_authority", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+AUTHORITY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUTHORITY)
+
+
+class DocumentationAuthorityTests(unittest.TestCase):
+    def options(self) -> argparse.Namespace:
+        return AUTHORITY.parse_arguments(
+            (
+                "--compose-repository",
+                "owner/compose",
+                "--compose-tag",
+                "1.2.3",
+                "--compose-release-id",
+                "12",
+                "--compose-ref",
+                "a" * 40,
+                "--component",
+                f"owner/container={'b' * 40}",
+                "--k8s-repository",
+                "owner/k8s",
+                "--k8s-tag",
+                "4.5.6",
+                "--k8s-release-id",
+                "34",
+                "--k8s-ref",
+                "c" * 40,
+            )
+        )
+
+    @staticmethod
+    def command_result(arguments: Sequence[str]) -> str:
+        joined = " ".join(arguments)
+        if "releases/tags/1.2.3" in joined:
+            return (
+                '{"id":12,"tag_name":"1.2.3",'
+                '"draft":false,"prerelease":false}'
+            )
+        if "releases/tags/4.5.6" in joined:
+            return (
+                '{"id":34,"tag_name":"4.5.6",'
+                '"draft":false,"prerelease":false}'
+            )
+        if "commits/" in joined:
+            return "b" * 40
+        if "owner/compose.git" in joined:
+            return f"{'a' * 40}\trefs/tags/1.2.3"
+        if "owner/k8s.git" in joined:
+            return f"{'c' * 40}\trefs/tags/4.5.6"
+        raise AssertionError(arguments)
+
+    def test_unchanged_authority_has_a_stable_digest(self) -> None:
+        with mock.patch.object(
+            AUTHORITY, "run_command", side_effect=self.command_result
+        ):
+            first = AUTHORITY.authority_digest(self.options())
+            second = AUTHORITY.authority_digest(self.options())
+
+        self.assertRegex(first, r"^[0-9a-f]{64}$")
+        self.assertEqual(first, second)
+
+    def test_changed_release_identity_is_rejected(self) -> None:
+        def changed(arguments):
+            if "releases/tags/1.2.3" in " ".join(arguments):
+                return (
+                    '{"id":99,"tag_name":"1.2.3",'
+                    '"draft":false,"prerelease":false}'
+                )
+            return self.command_result(arguments)
+
+        with mock.patch.object(AUTHORITY, "run_command", side_effect=changed):
+            with self.assertRaisesRegex(ValueError, "release authority changed"):
+                AUTHORITY.authority_digest(self.options())
+
+    def test_moved_tag_is_rejected(self) -> None:
+        def moved(arguments):
+            if "owner/compose.git" in " ".join(arguments):
+                return f"{'d' * 40}\trefs/tags/1.2.3"
+            return self.command_result(arguments)
+
+        with mock.patch.object(AUTHORITY, "run_command", side_effect=moved):
+            with self.assertRaisesRegex(ValueError, "published tag moved"):
+                AUTHORITY.authority_digest(self.options())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/test_package_publication_authority.py
+++ b/Tools/release/test_package_publication_authority.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+import importlib.util
+from pathlib import Path
+import tempfile
+import unittest
+from unittest import mock
+
+MODULE_PATH = Path(__file__).with_name("package-publication-authority.py")
+SPEC = importlib.util.spec_from_file_location("package_publication_authority", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+AUTHORITY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUTHORITY)
+
+
+class PackagePublicationAuthorityTests(unittest.TestCase):
+    release_ref = "a" * 40
+    asset_digest = "b" * 64
+    tap_ref = "c" * 40
+
+    def options(self, *extra: str) -> argparse.Namespace:
+        return AUTHORITY.parse_arguments(
+            (
+                "--repository",
+                "owner/compose",
+                "--release-tag",
+                "1.2.3",
+                "--release-ref",
+                self.release_ref,
+                "--release-prerelease",
+                "false",
+                "--asset",
+                f"compose.tar.gz={self.asset_digest}",
+                *extra,
+            )
+        )
+
+    def command_result(
+        self, arguments: Sequence[str], cwd: Path | None = None
+    ) -> str:
+        del cwd
+        joined = " ".join(arguments)
+        if "releases/tags/1.2.3" in joined:
+            return (
+                '{"id":12,"tag_name":"1.2.3","draft":false,'
+                '"prerelease":false,"assets":['
+                f'{{"name":"compose.tar.gz","digest":"sha256:{self.asset_digest}"}}]}}'
+            )
+        if "https://github.com/owner/compose.git" in joined:
+            return f"{self.release_ref}\trefs/tags/1.2.3"
+        if arguments[:3] == ("git", "rev-parse", "HEAD"):
+            return self.tap_ref
+        if arguments[:3] == ("git", "ls-remote", "--heads"):
+            return f"{self.tap_ref}\trefs/heads/main"
+        if arguments[:3] == ("git", "status", "--porcelain"):
+            return ""
+        if arguments[:2] == ("ruby", "-c"):
+            return "Syntax OK"
+        raise AssertionError(arguments)
+
+    def test_unchanged_release_and_tap_have_a_stable_digest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            tap = Path(directory)
+            formula = tap / "Formula" / "container-compose.rb"
+            formula.parent.mkdir()
+            formula.write_text(
+                "class ContainerCompose < Formula\n"
+                '  url "https://github.com/owner/compose/releases/download/'
+                '1.2.3/compose.tar.gz"\n'
+                f'  sha256 "{self.asset_digest}"\n'
+                "end\n",
+                encoding="utf-8",
+            )
+            options = self.options(
+                "--tap",
+                str(tap),
+                "--tap-ref",
+                self.tap_ref,
+                "--formula",
+                str(formula),
+            )
+
+            with mock.patch.object(
+                AUTHORITY, "run_command", side_effect=self.command_result
+            ):
+                first = AUTHORITY.authority_digest(options)
+                second = AUTHORITY.authority_digest(options)
+
+        self.assertRegex(first, r"^[0-9a-f]{64}$")
+        self.assertEqual(first, second)
+
+    def test_changed_published_asset_is_rejected(self) -> None:
+        def changed(arguments: Sequence[str]) -> str:
+            result = self.command_result(arguments)
+            if "releases/tags/1.2.3" in " ".join(arguments):
+                return result.replace(self.asset_digest, "d" * 64)
+            return result
+
+        with mock.patch.object(AUTHORITY, "run_command", side_effect=changed):
+            with self.assertRaisesRegex(ValueError, "published asset changed"):
+                AUTHORITY.authority_digest(self.options())
+
+    def test_moved_release_tag_is_rejected(self) -> None:
+        def changed(arguments: Sequence[str]) -> str:
+            if "https://github.com/owner/compose.git" in " ".join(arguments):
+                return f"{'d' * 40}\trefs/tags/1.2.3"
+            return self.command_result(arguments)
+
+        with mock.patch.object(AUTHORITY, "run_command", side_effect=changed):
+            with self.assertRaisesRegex(ValueError, "release tag moved"):
+                AUTHORITY.authority_digest(self.options())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/build-pipeline/modules/repository-stage.nf
+++ b/build-pipeline/modules/repository-stage.nf
@@ -792,6 +792,42 @@ process RUN_REPOSITORY_STAGE {
     } >"$stage_command"
     /bin/chmod 0700 "$stage_command"
 
+    compute_stage_input_closure() {
+        unexpected_input_entry="$(/usr/bin/find -P "$dependencies_root" \
+            -mindepth 1 -maxdepth 1 ! -type f -print -quit)"
+        if [[ -n "$unexpected_input_entry" ]]; then
+            printf 'stage dependency closure contains an unsupported entry: %s\n' \
+                "$unexpected_input_entry" >&2
+            return 75
+        fi
+        {
+            for input_file in "$source_payload" "$source_metadata" \
+                "$stage_tools" "$staged_deadline_runner" \
+                "$dependency_installer" "$stage_command"; do
+                printf 'input\t%s\t%s\n' "$(/usr/bin/basename "$input_file")" \
+                    "$(/usr/bin/shasum -a 256 "$input_file" | \
+                        /usr/bin/awk '{ print $1 }')"
+            done
+            while IFS= read -r dependency_input; do
+                [[ -n "$dependency_input" ]] || continue
+                printf 'dependency-input\t%s\t%s\n' \
+                    "$(/usr/bin/basename "$dependency_input")" \
+                    "$(/usr/bin/shasum -a 256 "$dependency_input" | \
+                        /usr/bin/awk '{ print $1 }')"
+            done < <(/usr/bin/find -P "$dependencies_root" \
+                -mindepth 1 -maxdepth 1 -type f -print | LC_ALL=C /usr/bin/sort)
+        } | /usr/bin/shasum -a 256 | /usr/bin/awk '{ print $1 }'
+    }
+
+    source_head_before="$(run_clean /usr/bin/git -C \
+        "$execution_root/source" rev-parse HEAD)"
+    if ! run_clean /usr/bin/git -C "$execution_root/source" diff \
+        --quiet --ignore-submodules=none HEAD --; then
+        printf 'stage source is dirty before execution: %s\n' "$stage_name" >&2
+        exit 75
+    fi
+    stage_input_sha256_before="$(compute_stage_input_closure)"
+
     set +e
     (
         cd "$execution_root/source"
@@ -808,6 +844,20 @@ process RUN_REPOSITORY_STAGE {
     /bin/cat "$stderr_log" >&2
     if ((stage_status != 0)); then
         exit "$stage_status"
+    fi
+    source_head_after="$(run_clean /usr/bin/git -C \
+        "$execution_root/source" rev-parse HEAD)"
+    if [[ "$source_head_after" != "$source_head_before" ]] || \
+        ! run_clean /usr/bin/git -C "$execution_root/source" diff \
+            --quiet --ignore-submodules=none HEAD --; then
+        printf 'stage changed tracked source after preflight: %s\n' \
+            "$stage_name" >&2
+        exit 75
+    fi
+    stage_input_sha256_after="$(compute_stage_input_closure)"
+    if [[ "$stage_input_sha256_after" != "$stage_input_sha256_before" ]]; then
+        printf 'stage inputs changed while command ran: %s\n' "$stage_name" >&2
+        exit 75
     fi
     verify_tool_closure
 
@@ -874,7 +924,7 @@ process RUN_REPOSITORY_STAGE {
     artifact_manifest_sha256="$(/usr/bin/shasum -a 256 \
         "$artifact_manifest" | /usr/bin/awk '{ print $1 }')"
     {
-        printf 'schema\t3\n'
+        printf 'schema\t4\n'
         printf 'stage\t%s\n' "$stage_name"
         printf 'repository\t%s\n' "$repository_name"
         printf 'source-format\t%s\n' "$source_format"
@@ -888,6 +938,9 @@ process RUN_REPOSITORY_STAGE {
         printf 'deadline-seconds\t%s\n' "$deadline_seconds"
         printf 'command-sha256\t%s\n' "$command_sha256"
         printf 'stage-tools-sha256\t%s\n' "$tools_sha256"
+        printf 'stage-inputs-sha256\t%s\n' "$stage_input_sha256_after"
+        printf 'source-execution-head\t%s\n' "$source_head_after"
+        printf 'source-tracked-clean\ttrue\n'
         printf 'stdout-sha256\t%s\n' "$stdout_sha256"
         printf 'stderr-sha256\t%s\n' "$stderr_sha256"
         printf 'artifact-archive-sha256\t%s\n' \

--- a/build-pipeline/modules/repository-stage.nf
+++ b/build-pipeline/modules/repository-stage.nf
@@ -737,6 +737,26 @@ process RUN_REPOSITORY_STAGE {
         expected_dependency_manifest_sha256="$(/usr/bin/awk -F '\t' \
             '$1 == "artifact-manifest-sha256" { print $2 }' \
             "$dependency_receipt")"
+        dependency_receipt_schema="$(/usr/bin/awk -F '\t' \
+            '$1 == "schema" { print $2 }' "$dependency_receipt")"
+        dependency_source_format="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-format" { print $2 }' "$dependency_receipt")"
+        dependency_source_payload_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-payload-sha256" { print $2 }' \
+            "$dependency_receipt")"
+        dependency_stage_inputs_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "stage-inputs-sha256" { print $2 }' \
+            "$dependency_receipt")"
+        dependency_source_execution_head="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-execution-head" { print $2 }' \
+            "$dependency_receipt")"
+        dependency_source_tracked_clean="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-tracked-clean" { print $2 }' \
+            "$dependency_receipt")"
+        dependency_exit="$(/usr/bin/awk -F '\t' \
+            '$1 == "exit" { print $2 }' "$dependency_receipt")"
+        expected_dependency_artifact_count="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-count" { print $2 }' "$dependency_receipt")"
         actual_dependency_archive_sha256="$(/usr/bin/shasum -a 256 \
             "$dependency_archive" | /usr/bin/awk '{ print $1 }')"
         actual_dependency_manifest_sha256="$(/usr/bin/shasum -a 256 \
@@ -745,7 +765,14 @@ process RUN_REPOSITORY_STAGE {
             '$1 == "archive-sha256" { print $2 }' "$dependency_manifest")"
         manifest_dependency_count="$(/usr/bin/awk -F '\t' \
             '$1 == "artifact-count" { print $2 }' "$dependency_manifest")"
-        if ! [[ "$expected_dependency_archive_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+        if [[ "$dependency_receipt_schema" != 4 ]] ||
+            ! [[ "$dependency_source_format" =~ ^(git-bundle|git-tree-archive)$ ]] ||
+            ! [[ "$dependency_source_payload_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+            ! [[ "$dependency_stage_inputs_sha256" =~ ^[0-9a-f]{64}$ ]] ||
+            ! [[ "$dependency_source_execution_head" =~ ^[0-9a-f]{40}$ ]] ||
+            [[ "$dependency_source_tracked_clean" != true ]] ||
+            [[ "$dependency_exit" != 0 ]] ||
+            ! [[ "$expected_dependency_archive_sha256" =~ ^[0-9a-f]{64}$ ]] ||
             ! [[ "$expected_dependency_manifest_sha256" =~ ^[0-9a-f]{64}$ ]] ||
             [[ "$actual_dependency_archive_sha256" != \
                 "$expected_dependency_archive_sha256" ]] ||
@@ -753,7 +780,9 @@ process RUN_REPOSITORY_STAGE {
                 "$expected_dependency_manifest_sha256" ]] ||
             [[ "$manifest_dependency_archive_sha256" != \
                 "$expected_dependency_archive_sha256" ]] ||
-            ! [[ "$manifest_dependency_count" =~ ^[1-9][0-9]*$ ]]; then
+            ! [[ "$manifest_dependency_count" =~ ^[1-9][0-9]*$ ]] ||
+            [[ "$expected_dependency_artifact_count" != \
+                "$manifest_dependency_count" ]]; then
             printf 'stage dependency digest is invalid: %s\n' \
                 "$dependency_stage" >&2
             exit 2

--- a/main.nf
+++ b/main.nf
@@ -1583,7 +1583,31 @@ process PIPELINE_SUMMARY {
         test -s "$receipt"
         receipt_stage="$(/usr/bin/awk -F '\t' '$1 == "stage" { print $2 }' \
             "$receipt")"
+        receipt_schema="$(/usr/bin/awk -F '\t' '$1 == "schema" { print $2 }' \
+            "$receipt")"
+        receipt_repository="$(/usr/bin/awk -F '\t' \
+            '$1 == "repository" { print $2 }' "$receipt")"
+        receipt_source_format="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-format" { print $2 }' "$receipt")"
+        receipt_source_payload_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-payload-sha256" { print $2 }' "$receipt")"
+        receipt_stage_inputs_sha256="$(/usr/bin/awk -F '\t' \
+            '$1 == "stage-inputs-sha256" { print $2 }' "$receipt")"
+        receipt_source_execution_head="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-execution-head" { print $2 }' "$receipt")"
+        receipt_source_tracked_clean="$(/usr/bin/awk -F '\t' \
+            '$1 == "source-tracked-clean" { print $2 }' "$receipt")"
+        receipt_exit="$(/usr/bin/awk -F '\t' '$1 == "exit" { print $2 }' \
+            "$receipt")"
+        [[ "$receipt_schema" == 4 ]]
         [[ "$receipt_stage" =~ ^[a-z0-9][a-z0-9-]*$ ]]
+        [[ "$receipt_repository" =~ ^[a-z0-9][a-z0-9-]*$ ]]
+        [[ "$receipt_source_format" =~ ^(git-bundle|git-tree-archive)$ ]]
+        [[ "$receipt_source_payload_sha256" =~ ^[0-9a-f]{64}$ ]]
+        [[ "$receipt_stage_inputs_sha256" =~ ^[0-9a-f]{64}$ ]]
+        [[ "$receipt_source_execution_head" =~ ^[0-9a-f]{40}$ ]]
+        [[ "$receipt_source_tracked_clean" == true ]]
+        [[ "$receipt_exit" == 0 ]]
         [[ "$(/usr/bin/basename "$receipt")" == \
             "${receipt_stage}.receipt.tsv" ]]
         case "$observed_stage_names" in
@@ -1607,10 +1631,22 @@ process PIPELINE_SUMMARY {
             '$1 == "artifact-archive-sha256" { print $2 }' "$receipt")"
         expected_artifact_manifest_sha256="$(/usr/bin/awk -F '\t' \
             '$1 == "artifact-manifest-sha256" { print $2 }' "$receipt")"
+        expected_artifact_count="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-count" { print $2 }' "$receipt")"
+        manifest_stage="$(/usr/bin/awk -F '\t' \
+            '$1 == "stage" { print $2 }' "$artifact_manifest")"
+        manifest_repository="$(/usr/bin/awk -F '\t' \
+            '$1 == "repository" { print $2 }' "$artifact_manifest")"
+        manifest_artifact_count="$(/usr/bin/awk -F '\t' \
+            '$1 == "artifact-count" { print $2 }' "$artifact_manifest")"
         [[ "$expected_stdout_sha256" =~ ^[0-9a-f]{64}$ ]]
         [[ "$expected_stderr_sha256" =~ ^[0-9a-f]{64}$ ]]
         [[ "$expected_artifact_archive_sha256" =~ ^[0-9a-f]{64}$ ]]
         [[ "$expected_artifact_manifest_sha256" =~ ^[0-9a-f]{64}$ ]]
+        [[ "$expected_artifact_count" =~ ^[0-9]+$ ]]
+        [[ "$manifest_stage" == "$receipt_stage" ]]
+        [[ "$manifest_repository" == "$receipt_repository" ]]
+        [[ "$manifest_artifact_count" == "$expected_artifact_count" ]]
         [[ "$(/usr/bin/shasum -a 256 "$stdout_log" | \
             /usr/bin/awk '{ print $1 }')" == "$expected_stdout_sha256" ]]
         [[ "$(/usr/bin/shasum -a 256 "$stderr_log" | \


### PR DESCRIPTION
Closes #573

## What changed

- re-resolve command-backed fingerprints before recording every outer release checkpoint
- close all sibling and all 31 Nextflow repository-stage inputs after execution
- carry immutable release identities through package, CodeQL, documentation, and benchmark workflows
- verify exact outputs for release assets, Homebrew formulae, Pages authority, benchmark pull requests, Current demo, and the stable authority check
- reject legacy stage receipts at every cached consumer and preserve the distinct captured-source and isolated-execution identities for archive-backed stages
- preserve reuse for unchanged exact-input retries while invalidating only a changed stage and its downstream closure

## Validation

- 19 focused exact-authority regressions
- 48 focused receipt-consumer and stage-policy tests
- actionlint across all workflows
- shellcheck and Homebrew Bash syntax validation for the stack validator and package collector
- Python compile checks and `git diff --check`

No runtime implementation changed. The retained 66/66 socket parity result remains authoritative and was not rerun.
