### PR TITLE
[Build] Refresh process-deletion recovery authority

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 7 September 2026 snapshot, the three support forks are **1150 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 8 September 2026 snapshot, the three support forks are **1155 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 303 ahead** at [`f9d57ad1c809`](https://github.com/stephenlclarke/containerization/commit/f9d57ad1c80944c43bec6fc74afe1bfac3956480).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 792 ahead** at [`d8ccda0fd6f3`](https://github.com/stephenlclarke/container/commit/d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 304 ahead** at [`9e0626e1171c`](https://github.com/stephenlclarke/containerization/commit/9e0626e1171cee5c09b0adecb886f1b24784320c).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 796 ahead** at [`0eb4a7e9df9b`](https://github.com/stephenlclarke/container/commit/0eb4a7e9df9bda860e48b809d777a8ba4e28b7df).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 55 ahead** at [`f99e66b89402`](https://github.com/stephenlclarke/container-builder-shim/commit/f99e66b8940242d6ea8bed448619ba61f3f6f1a5).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-09-07",
+  "reviewedAt": "2026-09-08",
   "repositories": {
     "container": {
       "upstreamHead": "eee7ad097079cc3b02d5309ec10160143f2d0c6a",
-      "forkHead": "d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a",
+      "forkHead": "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -502,7 +502,10 @@
             "6f4c232563ba812404282471bdea4d32a143e745",
             "228897171d71975988ccdc690f1982e7433952af",
             "09acdc2f1df2d8a15a37e6dbce19dbf94ed2a607",
-            "25399784a692d5d5933ab3db67d385e0e82b5fad"
+            "25399784a692d5d5933ab3db67d385e0e82b5fad",
+            "8372b65b66f1453d0ac3d9d78bdc532a49e12aab",
+            "7601ceca01d4a221a6724e78a6d6738576f22b60",
+            "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df"
           ]
         },
         {
@@ -749,7 +752,7 @@
     },
     "containerization": {
       "upstreamHead": "847655d373a27b8b8d0c3a9747f04f16b5de1206",
-      "forkHead": "f9d57ad1c80944c43bec6fc74afe1bfac3956480",
+      "forkHead": "9e0626e1171cee5c09b0adecb886f1b24784320c",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -927,7 +930,8 @@
             "793b35fa246caafcae796771a821ee1d776b8dea",
             "c40599fadb6a14e934c4cc1b997fd133bf416df2",
             "6ad1113465f105a5e3bb18c00582fdfdc275f946",
-            "1044451748d8f2614dbb7289d99329577c13c7e6"
+            "1044451748d8f2614dbb7289d99329577c13c7e6",
+            "9e0626e1171cee5c09b0adecb886f1b24784320c"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 7 September 2026
+Updated: 8 September 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `d8ccda0fd6f3c24ecfb399f40b50850ce2fa136a` | 0 | 792 | 667 |
-| `containerization` | `847655d373a27b8b8d0c3a9747f04f16b5de1206` | `f9d57ad1c80944c43bec6fc74afe1bfac3956480` | 0 | 303 | 239 |
+| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `0eb4a7e9df9bda860e48b809d777a8ba4e28b7df` | 0 | 796 | 670 |
+| `containerization` | `847655d373a27b8b8d0c3a9747f04f16b5de1206` | `9e0626e1171cee5c09b0adecb886f1b24784320c` | 0 | 304 | 240 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `f99e66b8940242d6ea8bed448619ba61f3f6f1a5` | 0 | 55 | 45 |
-| **Total** | | | **0** | **1150** | **951** |
+| **Total** | | | **0** | **1155** | **955** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 695 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 699 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 231 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -305,3 +305,16 @@ pin at `25399784a692` and the builder shim's module-derived Go toolchain fix at
 `8538b2e7931f` are support maintenance. They make the matched build
 reproducible without adding runtime behaviour or changing any temporary port,
 generic primitive, or rejected Compose-policy disposition.
+
+The machine-runtime release repair advances Container through
+`24c4726d1048`. Numeric user resolution at `8372b65b66f1` and serialized
+completed-exec cleanup at `7601ceca01d4` are independently reviewed bug fixes,
+so both are support maintenance. They restore existing runtime behaviour
+without adding a generic primitive or changing any temporary port or rejected
+Compose-policy disposition.
+
+The 8 September 2026 process-deletion recovery advances Containerization
+through `9e0626e1171c` and Container through `0eb4a7e9df9b`. The runtime fix
+redials an available VM only when an exited process retained an already-stopped
+gRPC client; the Container change pins that reviewed correction. Both are
+support maintenance and add no Compose policy or new public runtime primitive.


### PR DESCRIPTION
## Summary

- classify the reviewed Containerization process-deletion recovery and matched Container dependency pin
- include the intervening numeric-user and completed-exec cleanup fixes in the exact fork authority
- refresh the README support-fork snapshot to the release transaction heads

## Why

The retained 0.14.3 controller correctly stopped before builds or tests when its strict divergence gate found the fork authority one reviewed merge behind both lower repositories. This refresh makes that authority exact without weakening the gate or restarting the release transaction.

## Validation

- `make fork-classifications-check`
- `make upstream-handoff-registry-check`
- strict fetched divergence check against the retained 0.14.3 transaction repository root
- README metrics check
- Markdown lint
- JSON parse and `git diff --check`

Fixes #575