### PR TITLE
fix(release): bootstrap retained recovery

### DIFF
--- a/.github/workflows/scheduled-stable-release.yml
+++ b/.github/workflows/scheduled-stable-release.yml
@@ -152,6 +152,69 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # This inline workflow step is the trust root for unattended recovery.
+      # It must run before Make, Bash, or Python consumes any checked-out file;
+      # the controller repeats the check later only as defence in depth.
+      - name: Verify exact release bootstrap closure
+        shell: bash
+        working-directory: release-controls/container-compose
+        env:
+          EXPECTED_HEAD: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          bootstrap_closure=(
+            Makefile
+            scripts/CONTAINER_STACK_RELEASE.sh
+            Tools/ci/container-runtime-lock.sh
+            Tools/release/release-host-state.py
+            Tools/release/release-workspace.py
+          )
+          origin_url="$(git remote get-url origin)"
+          case "${origin_url}" in
+            https://github.com/stephenlclarke/container-compose|https://github.com/stephenlclarke/container-compose.git|git@github.com:stephenlclarke/container-compose|git@github.com:stephenlclarke/container-compose.git) ;;
+            *)
+              printf 'release bootstrap origin is not stephenlclarke/container-compose: %s\n' \
+                "${origin_url:-missing}" >&2
+              exit 1
+              ;;
+          esac
+          local_head="$(git rev-parse HEAD)"
+          remote_head="$(git ls-remote --heads origin refs/heads/main | awk '{print $1}' | tail -n 1)"
+          if [[ ! "${EXPECTED_HEAD}" =~ ^[0-9a-f]{40}$ ]] ||
+            [[ "${local_head}" != "${EXPECTED_HEAD}" ]] ||
+            [[ "${remote_head}" != "${EXPECTED_HEAD}" ]]; then
+            printf 'unattended release bootstrap is not exact reviewed main: workflow %s, local %s, remote %s\n' \
+              "${EXPECTED_HEAD:-missing}" "${local_head:-missing}" \
+              "${remote_head:-missing}" >&2
+            exit 1
+          fi
+          if [[ -n "$(git status --short)" ]]; then
+            printf 'unattended release bootstrap checkout is dirty\n' >&2
+            exit 1
+          fi
+          for relative_path in "${bootstrap_closure[@]}"; do
+            if [[ ! -f "${relative_path}" || -L "${relative_path}" ]]; then
+              printf 'release bootstrap closure file is missing or unsafe: %s\n' \
+                "${relative_path}" >&2
+              exit 1
+            fi
+            index_entry="$(git ls-files -v -- "${relative_path}")"
+            if [[ -z "${index_entry}" || "${index_entry}" == S\ * ||
+              "${index_entry:0:1}" =~ [a-z] ]]; then
+              printf 'release bootstrap closure has hidden index state: %s\n' \
+                "${relative_path}" >&2
+              exit 1
+            fi
+            expected_blob="$(git rev-parse "HEAD:${relative_path}")"
+            actual_blob="$(git hash-object --no-filters "${relative_path}")"
+            if [[ ! "${expected_blob}" =~ ^[0-9a-f]{40}$ ]] ||
+              [[ "${actual_blob}" != "${expected_blob}" ]]; then
+              printf 'release bootstrap closure differs from reviewed HEAD: %s\n' \
+                "${relative_path}" >&2
+              exit 1
+            fi
+          done
+
       - name: Configure isolated release controller
         shell: bash
         run: |

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -72,14 +72,15 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
 
     def test_existing_stable_tags_resume_without_changing_identity(self) -> None:
         release = self.script[self.script.index("release_current_stack() {") :]
-        self.assertIn('if stable_tag_exists "${version}"', release)
-        self.assertIn('resume_stable_release "${version}"', release)
+        ordinary = release[release.index('if stable_tag_exists "${version}"') :]
+        self.assertIn('if stable_tag_exists "${version}"', ordinary)
+        self.assertIn('resume_stable_release "${version}"', ordinary)
         self.assertIn('ensure_latest_stable_retry "${version}"', self.script)
         self.assertIn('ensure_stable_retry_source_authority "${version}"', self.script)
-        self.assertIn("ensure_new_stable_release \"${version}\"", release)
+        self.assertIn("ensure_new_stable_release \"${version}\"", ordinary)
         self.assertLess(
-            release.index('resume_stable_release "${version}"'),
-            release.index("ensure_new_stable_release \"${version}\""),
+            ordinary.index('resume_stable_release "${version}"'),
+            ordinary.index("ensure_new_stable_release \"${version}\""),
         )
         self.assertIn("ensure_stable_release_is_unpublished() {", self.script)
         self.assertIn("stable_release_is_published() {", self.script)
@@ -98,6 +99,7 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
     def test_release_helper_owns_an_isolated_transaction_root(self) -> None:
         self.assertIn("run_isolated_release() {", self.script)
         self.assertIn("CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE=1", self.script)
+        self.assertIn("CONTAINER_STACK_RELEASE_BOOTSTRAP=1", self.script)
         self.assertIn("release transaction retained for exact recovery", self.script)
         self.assertIn('RELEASE_BUILD_ROOT="${CONTAINER_STACK_RELEASE_BUILD_ROOT:', self.script)
         self.assertIn('"${RELEASE_WORKSPACE_TOOL}" execute', self.script)
@@ -106,6 +108,30 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('--pid "${child_pid}"', self.script)
         self.assertNotIn('--pid "$$"', self.script)
         self.assertNotIn("Local source checkout layout expected", self.script)
+        isolated = self.script[
+            self.script.index("require_release_bootstrap_authority() {") :
+            self.script.index("\nmain() {")
+        ]
+        self.assertIn('status --short', isolated)
+        self.assertIn("stephenlclarke/container-compose", isolated)
+        self.assertIn('"Tools/ci/container-runtime-lock.sh"', isolated)
+        self.assertIn('"Tools/release/release-host-state.py"', isolated)
+        self.assertIn('"Tools/release/release-workspace.py"', isolated)
+        self.assertIn('ls-files -v -- "${relative_path}"', isolated)
+        self.assertIn('"${index_entry}" == S\\ *', isolated)
+        self.assertIn('"${index_entry:0:1}" =~ [a-z]', isolated)
+        self.assertIn('hash-object --no-filters', isolated)
+        self.assertIn('rev-parse "HEAD:${relative_path}"', isolated)
+        self.assertIn('ls-remote --heads origin refs/heads/main', isolated)
+        self.assertIn('"${source_head}" != "${remote_head}"', isolated)
+        self.assertIn('RELEASE_BOOTSTRAP_HEAD="${source_head}"', isolated)
+        self.assertIn(
+            'CONTAINER_STACK_RELEASE_BOOTSTRAP_HEAD="${RELEASE_BOOTSTRAP_HEAD}"',
+            isolated,
+        )
+        self.assertIn('[[ ! -f "${child}" || -L "${child}" ]]', isolated)
+        self.assertIn('/bin/bash "${bootstrap}" release', isolated)
+        self.assertNotIn('/bin/bash "${child}" release', isolated)
         active = self.script.split(
             'elif [[ "${CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE:-0}" == "1" ]]',
             1,
@@ -118,6 +144,40 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             active.index("recover_release_host_state_on_startup"),
             active.index("release_current_stack"),
         )
+        outer = self.script[
+            self.script.index('      else\n        require_release_bootstrap_authority') :
+            self.script.index("      fi\n      CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=1")
+        ]
+        self.assertLess(
+            outer.index("require_release_bootstrap_authority"),
+            outer.index("recover_release_host_state_on_startup"),
+        )
+
+    def test_release_bootstrap_recovers_then_hands_off_before_readiness(self) -> None:
+        release = self.script[self.script.index("release_current_stack() {") :]
+        bootstrap = release[
+            release.index('if [[ "${CONTAINER_STACK_RELEASE_BOOTSTRAP:-0}" == "1" ]]') :
+            release.index('if stable_tag_exists "${version}"; then')
+        ]
+
+        self.assertIn('recover_unpublished_release_candidate "${version}"', bootstrap)
+        self.assertIn("RELEASE_CONTROLLER_RESTART_REQUIRED=1", bootstrap)
+        self.assertIn("restart_refreshed_release_controller", bootstrap)
+        self.assertNotIn("ensure_current_build_release_readiness", bootstrap)
+        self.assertLess(
+            release.index("restart_refreshed_release_controller", release.index("bootstrap")),
+            release.index("ensure_current_build_release_readiness"),
+        )
+
+        recovery = self.script[
+            self.script.index("recover_unpublished_release_candidate() {") :
+            self.script.index("# A retained candidate can acquire newer release-controller")
+        ]
+        self.assertIn("CONTAINER_STACK_RELEASE_BOOTSTRAP_HEAD", recovery)
+        self.assertLess(
+            recovery.index("reviewed release bootstrap moved"),
+            recovery.index('if [[ "${local_head}" == "${remote_head}" ]]'),
+        )
 
     def test_scheduled_release_delegates_checkout_ownership_to_controller(self) -> None:
         workflow = SCHEDULED_STABLE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
@@ -128,6 +188,24 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("CONTAINER_STACK_RELEASE_BUILD_ROOT:", release)
         self.assertNotIn("CONTAINER_STACK_RELEASE_ROOT:", release)
         self.assertNotIn("Checkout builder-shim source", release)
+        checkout = release.index("Checkout container-compose release controls")
+        authority = release.index("Verify exact release bootstrap closure")
+        configure = release.index("Configure isolated release controller")
+        promote = release.index("Promote the selected stable release")
+        self.assertLess(checkout, authority)
+        self.assertLess(authority, configure)
+        self.assertLess(authority, promote)
+        preflight = release[authority:configure]
+        self.assertIn("EXPECTED_HEAD: ${{ github.sha }}", preflight)
+        self.assertIn("scripts/CONTAINER_STACK_RELEASE.sh", preflight)
+        self.assertIn("Tools/ci/container-runtime-lock.sh", preflight)
+        self.assertIn("Tools/release/release-host-state.py", preflight)
+        self.assertIn("Tools/release/release-workspace.py", preflight)
+        self.assertIn('git ls-files -v -- "${relative_path}"', preflight)
+        self.assertIn('git hash-object --no-filters "${relative_path}"', preflight)
+        self.assertNotIn("make ", preflight)
+        self.assertNotIn("./scripts/", preflight)
+        self.assertNotIn("python3 Tools/", preflight)
         self.assertNotIn("Checkout containerization source", release)
         self.assertNotIn("Checkout container runtime source", release)
         self.assertNotIn("Checkout Homebrew tap", release)
@@ -7826,6 +7904,49 @@ esac
             self.assertIn("restart=0", repeated.stdout)
             self.assertEqual(self.git(local, "rev-parse", "main"), refreshed_head)
 
+    def test_release_bootstrap_rejects_main_moving_before_candidate_recovery(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote, local = self.create_compose_checkout(root)
+            reviewed_bootstrap_head = self.git(local, "rev-parse", "main")
+            self.enable_ssh_signing(root, local)
+            self.commit_signed_files(
+                local,
+                {"Makefile": "COMPOSE_VERSION ?= 0.6.71\n"},
+                "chore(release): prepare 0.6.71",
+            )
+            candidate_head = self.git(local, "rev-parse", "main")
+
+            updater = root / "updater"
+            self.run_command(
+                "git", "clone", "--branch", "main", str(remote), str(updater)
+            )
+            self.configure_repo(updater)
+            self.commit_file(
+                updater,
+                "REPAIR.md",
+                "newer reviewed main\n",
+                "fix: advance reviewed main",
+            )
+            self.run_command("git", "-C", str(updater), "push", "origin", "main")
+
+            result = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71",
+                shell_setup=(
+                    "export CONTAINER_STACK_RELEASE_BOOTSTRAP=1\n"
+                    "export CONTAINER_STACK_RELEASE_BOOTSTRAP_HEAD="
+                    f"{reviewed_bootstrap_head}"
+                ),
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("reviewed release bootstrap moved", result.stderr)
+            self.assertEqual(self.git(local, "rev-parse", "main"), candidate_head)
+            self.assertEqual(self.git(local, "status", "--short"), "")
+
     def test_release_helper_reexecutes_the_refreshed_controller(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -7834,8 +7955,9 @@ esac
             controller = scripts / "CONTAINER_STACK_RELEASE.sh"
             controller.write_text(
                 "#!/bin/bash\n"
-                "printf 'args=%s|%s|%s library=%s\\n' "
-                '"$1" "$2" "$3" "${CONTAINER_STACK_RELEASE_LIBRARY}"\n',
+                "printf 'args=%s|%s|%s library=%s bootstrap=%s\\n' "
+                '"$1" "$2" "$3" "${CONTAINER_STACK_RELEASE_LIBRARY}" '
+                '"${CONTAINER_STACK_RELEASE_BOOTSTRAP}"\n',
                 encoding="utf-8",
             )
 
@@ -7848,7 +7970,10 @@ esac
 
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("restarting from refreshed release controller", result.stdout)
-            self.assertIn("args=release|0.6.71|--execute library=0", result.stdout)
+            self.assertIn(
+                "args=release|0.6.71|--execute library=0 bootstrap=0",
+                result.stdout,
+            )
 
     def test_release_helper_refreshes_the_same_candidate_after_main_advances_twice(
         self,

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -292,6 +292,7 @@ MAINTENANCE_REASON="${CONTAINER_STACK_MAINTENANCE_REASON:-}"
 MILESTONE_SOAK_OVERRIDE_REASON="${CONTAINER_STACK_MILESTONE_SOAK_OVERRIDE_REASON:-}"
 RECOVERED_UNPUBLISHED_RELEASE_BASE=""
 RELEASE_CONTROLLER_RESTART_REQUIRED=0
+RELEASE_BOOTSTRAP_HEAD=""
 CURRENT_INIT_IMAGE_AUTHORITY_ROOT=""
 CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=0
 RELEASE_INIT_AUTHORITY_CACHE_ROOT="${CONTAINER_STACK_RELEASE_INIT_AUTHORITY_CACHE_ROOT:-$({ getconf DARWIN_USER_CACHE_DIR 2>/dev/null || printf '/private/tmp/'; })container-compose-release-authorities}"
@@ -1040,6 +1041,16 @@ recover_unpublished_release_candidate() {
   local_head="$(git -C "${path}" rev-parse main)"
   remote_head="$(remote_main_commit "${COMPOSE_REPO}")"
 
+  if [[ "${CONTAINER_STACK_RELEASE_BOOTSTRAP:-0}" == "1" ]]; then
+    if [[ ! "${CONTAINER_STACK_RELEASE_BOOTSTRAP_HEAD:-}" =~ ^[0-9a-f]{40}$ ]] ||
+      [[ "${remote_head}" != "${CONTAINER_STACK_RELEASE_BOOTSTRAP_HEAD}" ]]; then
+      printf 'reviewed release bootstrap moved before candidate recovery: expected %s, got %s\n' \
+        "${CONTAINER_STACK_RELEASE_BOOTSTRAP_HEAD:-missing}" \
+        "${remote_head:-missing}" >&2
+      exit 1
+    fi
+  fi
+
   if [[ "${local_head}" == "${remote_head}" ]]; then
     return 0
   fi
@@ -1115,9 +1126,11 @@ recover_unpublished_release_candidate() {
 }
 
 # A retained candidate can acquire newer release-controller code and version
-# metadata when it is refreshed from canonical main. Replace this process so
-# no state computed by the old controller survives past that boundary. exec
-# preserves the marker-protected workspace lease because its PID is unchanged.
+# metadata when it is refreshed from canonical main. The outer bootstrap also
+# enters here after it has recovered an older candidate with reviewed main.
+# Replace either process so no state computed by the bootstrap or old controller
+# survives past that boundary. exec preserves the marker-protected workspace
+# lease because its PID is unchanged.
 restart_refreshed_release_controller() {
   local path controller
   if [[ "${RELEASE_CONTROLLER_RESTART_REQUIRED}" != "1" ]]; then
@@ -1132,7 +1145,9 @@ restart_refreshed_release_controller() {
   fi
   printf 'restarting from refreshed release controller: %s\n' "${controller}"
   CONTAINER_STACK_RELEASE_LIBRARY=0
+  CONTAINER_STACK_RELEASE_BOOTSTRAP=0
   export CONTAINER_STACK_RELEASE_LIBRARY
+  export CONTAINER_STACK_RELEASE_BOOTSTRAP
   exec /bin/bash "${controller}" release "${VERSION_SELECTOR}" --execute
 }
 
@@ -6415,6 +6430,19 @@ release_current_stack() {
   fi
   current="$(current_compose_version)"
   version="$(resolve_release_version "${VERSION_SELECTOR}")"
+  if [[ "${CONTAINER_STACK_RELEASE_BOOTSTRAP:-0}" == "1" ]]; then
+    if ! stable_tag_exists "${version}"; then
+      ensure_release_version_is_valid "${latest}" "${current}" "${version}"
+      ensure_new_stable_release "${version}"
+      ensure_release_intent
+      recover_unpublished_release_candidate "${version}"
+    fi
+    # No build, test, package, or publication step may use controller or tool
+    # files outside the signed transaction. Even an unchanged candidate must
+    # therefore replace the reviewed-main bootstrap before proceeding.
+    RELEASE_CONTROLLER_RESTART_REQUIRED=1
+    restart_refreshed_release_controller
+  fi
   if stable_tag_exists "${version}"; then
     printf 'resuming stable tag: %s\n' "${version}"
     resume_stable_release "${version}"
@@ -6523,11 +6551,88 @@ Process:
 EOF
 }
 
+# Require the one controller allowed to bootstrap a retained transaction to be
+# the clean, exact reviewed main checkout. The bootstrap may recover an
+# unpublished candidate, but it must re-exec the signed transaction controller
+# before any release stage runs.
+require_release_bootstrap_authority() {
+  local source_root source_head source_origin remote_head bootstrap_controller
+  local relative_path absolute_path index_entry expected_blob actual_blob
+  local -a bootstrap_closure=(
+    "Makefile"
+    "scripts/${SCRIPT_NAME}"
+    "Tools/ci/container-runtime-lock.sh"
+    "Tools/release/release-host-state.py"
+    "Tools/release/release-workspace.py"
+  )
+  source_root="$(cd "${SELF_DIRECTORY}/.." && pwd -P)"
+  bootstrap_controller="${SELF_DIRECTORY}/${SCRIPT_NAME}"
+  if [[ ! -f "${bootstrap_controller}" || -L "${bootstrap_controller}" ]]; then
+    printf 'release bootstrap controller is missing or unsafe: %s\n' \
+      "${bootstrap_controller}" >&2
+    return 1
+  fi
+  if ! git -C "${source_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf 'release bootstrap source is not a Git checkout: %s\n' \
+      "${source_root}" >&2
+    return 1
+  fi
+  if [[ -n "$(git -C "${source_root}" status --short)" ]]; then
+    printf 'dirty release bootstrap source is not reviewed authority: %s\n' \
+      "${source_root}" >&2
+    return 1
+  fi
+  for relative_path in "${bootstrap_closure[@]}"; do
+    absolute_path="${source_root}/${relative_path}"
+    if [[ ! -f "${absolute_path}" || -L "${absolute_path}" ]]; then
+      printf 'release bootstrap closure file is missing or unsafe: %s\n' \
+        "${absolute_path}" >&2
+      return 1
+    fi
+    index_entry="$(git -C "${source_root}" ls-files -v -- "${relative_path}")"
+    if [[ -z "${index_entry}" || "${index_entry}" == S\ * ||
+      "${index_entry:0:1}" =~ [a-z] ]]; then
+      printf 'release bootstrap closure has hidden index state: %s\n' \
+        "${relative_path}" >&2
+      return 1
+    fi
+    expected_blob="$(git -C "${source_root}" rev-parse "HEAD:${relative_path}" \
+      2>/dev/null || true)"
+    actual_blob="$(git -C "${source_root}" hash-object --no-filters \
+      "${absolute_path}" 2>/dev/null || true)"
+    if [[ ! "${expected_blob}" =~ ^[0-9a-f]{40}$ ]] ||
+      [[ "${actual_blob}" != "${expected_blob}" ]]; then
+      printf 'release bootstrap closure differs from reviewed HEAD: %s\n' \
+        "${relative_path}" >&2
+      return 1
+    fi
+  done
+  source_origin="$(git -C "${source_root}" remote get-url origin 2>/dev/null || true)"
+  case "${source_origin}" in
+    https://github.com/stephenlclarke/container-compose|https://github.com/stephenlclarke/container-compose.git|git@github.com:stephenlclarke/container-compose|git@github.com:stephenlclarke/container-compose.git) ;;
+    *)
+      printf 'release bootstrap origin is not stephenlclarke/container-compose: %s\n' \
+        "${source_origin:-missing}" >&2
+      return 1
+      ;;
+  esac
+  source_head="$(git -C "${source_root}" rev-parse HEAD)"
+  remote_head="$(git -C "${source_root}" ls-remote --heads origin refs/heads/main \
+    | awk '{print $1}' | tail -n 1)"
+  if [[ ! "${source_head}" =~ ^[0-9a-f]{40}$ ]] ||
+    [[ "${source_head}" != "${remote_head}" ]]; then
+    printf 'release bootstrap is not exact reviewed origin/main: local %s, remote %s\n' \
+      "${source_head:-missing}" "${remote_head:-missing}" >&2
+    return 1
+  fi
+  RELEASE_BOOTSTRAP_HEAD="${source_head}"
+}
+
 # Run a stable release only inside the exact marker-protected transaction
 # created by the release workspace controller. A failed child is retained for
 # the next invocation; only a completely successful publication is removed.
 run_isolated_release() {
-  local workspace child child_pid status claim_status
+  local workspace bootstrap child child_pid status claim_status
   if [[ "${EXECUTE}" != "1" ]]; then
     python3 "${RELEASE_WORKSPACE_TOOL}" plan
     printf 'would materialize and retain an exact isolated release workspace for %s\n' \
@@ -6537,6 +6642,7 @@ run_isolated_release() {
 
   workspace="$(python3 "${RELEASE_WORKSPACE_TOOL}" materialize \
     --build-root "${RELEASE_BUILD_ROOT}" -- "${VERSION_SELECTOR}")"
+  bootstrap="${SELF_DIRECTORY}/${SCRIPT_NAME}"
   child="${workspace}/container-compose/scripts/${SCRIPT_NAME}"
   if [[ ! -f "${child}" || -L "${child}" ]]; then
     printf 'isolated release controller is missing or unsafe: %s\n' "${child}" >&2
@@ -6546,9 +6652,11 @@ run_isolated_release() {
   CONTAINER_STACK_RELEASE_ROOT="${workspace}" \
   CONTAINER_STACK_RELEASE_BUILD_ROOT="${RELEASE_BUILD_ROOT}" \
   CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE=1 \
+  CONTAINER_STACK_RELEASE_BOOTSTRAP=1 \
+  CONTAINER_STACK_RELEASE_BOOTSTRAP_HEAD="${RELEASE_BOOTSTRAP_HEAD}" \
     python3 "${RELEASE_WORKSPACE_TOOL}" execute \
       --build-root "${RELEASE_BUILD_ROOT}" "${workspace}" \
-      /bin/bash "${child}" release "${VERSION_SELECTOR}" --execute &
+      /bin/bash "${bootstrap}" release "${VERSION_SELECTOR}" --execute &
   child_pid=$!
   wait "${child_pid}" || status=$?
   claim_status=0
@@ -6589,6 +6697,7 @@ main() {
         done
         release_current_stack
       else
+        require_release_bootstrap_authority
         recover_release_host_state_on_startup
         run_isolated_release
       fi


### PR DESCRIPTION
Closes #579.

## What changed

- require the release launcher to be a clean, regular-file checkout at the exact `stephenlclarke/container-compose` remote `main` head;
- execute that reviewed controller only as a bootstrap inside the verified retained transaction;
- bind recovery to the exact bootstrap SHA and reject a remote-main movement before candidate mutation;
- unconditionally re-exec the signed transaction controller before readiness, build, test, packaging, or publication;
- retain the existing signed candidate and exact-input recovery checks.

## Proof

- 7 focused recovery/bootstrap regressions pass;
- Bash syntax and ShellCheck pass;
- the live 0.14.3 retained transaction reproduced the old-controller deadlock in 5 seconds before any build or test, providing the exact post-merge recovery proof target.

No parity, CodeQL, documentation, packaging, or benchmark work was run.