### PR TITLE
fix(release): quiesce runtime for container integration

### DIFF
--- a/Tools/ci/manage-release-gate-runtime.sh
+++ b/Tools/ci/manage-release-gate-runtime.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#===----------------------------------------------------------------------===#
+# Copyright © 2026 container-compose project authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#===----------------------------------------------------------------------===#
+
+# Quiesce and resume only the exact marker-protected Container candidate that
+# owns the local release gate. Container's isolated integration suite may then
+# use the host's virtualization resources without competing with the candidate
+# shared sandbox or BuildKit VM.
+set -euo pipefail
+
+if (($# != 4)); then
+  printf 'usage: %s {validate|quiesce|resume} CONTAINER_CLI APP_ROOT SERVICE_NAMESPACE\n' "$0" >&2
+  exit 2
+fi
+
+action="$1"
+container_cli="$2"
+app_root="${3%/}"
+service_namespace="$4"
+script_directory="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+compose_root="$(cd "${script_directory}/../.." && pwd -P)"
+deadline_runner="${script_directory}/run-command-with-deadline.py"
+runtime_wrapper="${compose_root}/scripts/run-with-container-runtime.sh"
+launchctl_bin=/bin/launchctl
+ps_bin=/bin/ps
+sleep_bin=/bin/sleep
+wait_attempts=100
+wait_interval=0.1
+
+if [[ "${CONTAINER_RELEASE_RUNTIME_TESTING:-0}" == 1 ]]; then
+  launchctl_bin="${CONTAINER_RELEASE_RUNTIME_LAUNCHCTL:-${launchctl_bin}}"
+  ps_bin="${CONTAINER_RELEASE_RUNTIME_PS:-${ps_bin}}"
+  sleep_bin="${CONTAINER_RELEASE_RUNTIME_SLEEP:-${sleep_bin}}"
+  deadline_runner="${CONTAINER_RELEASE_RUNTIME_DEADLINE_RUNNER:-${deadline_runner}}"
+  runtime_wrapper="${CONTAINER_RELEASE_RUNTIME_WRAPPER:-${runtime_wrapper}}"
+  wait_attempts="${CONTAINER_RELEASE_RUNTIME_WAIT_ATTEMPTS:-${wait_attempts}}"
+  wait_interval="${CONTAINER_RELEASE_RUNTIME_WAIT_INTERVAL:-${wait_interval}}"
+fi
+
+case "${action}" in
+  validate | quiesce | resume) ;;
+  *)
+    printf 'unknown release runtime action: %s\n' "${action}" >&2
+    exit 2
+    ;;
+esac
+if [[ ! "${app_root}" =~ ^(/private)?/tmp/c\.[^/]+/app$ ]] ||
+  [[ -L "${app_root}" || ! -d "${app_root}" ]]; then
+  printf 'release runtime application root is not the exact protected path: %s\n' \
+    "${app_root:-unset}" >&2
+  exit 2
+fi
+runtime_marker="${app_root}/.container-compose-runtime-root"
+if [[ ! -f "${runtime_marker}" || -L "${runtime_marker}" ]] ||
+  [[ "$(<"${runtime_marker}")" != 'container-compose isolated runtime state v1' ]]; then
+  printf 'release runtime application root has no valid ownership marker: %s\n' \
+    "${app_root}" >&2
+  exit 2
+fi
+if [[ ! "${service_namespace}" =~ ^io\.github\.stephenlclarke\.container-compose\.runtime\.[A-Za-z0-9_-]+$ ]]; then
+  printf 'release runtime namespace is invalid: %s\n' \
+    "${service_namespace:-unset}" >&2
+  exit 2
+fi
+if [[ "${container_cli}" != /* || ! -f "${container_cli}" ||
+  -L "${container_cli}" || ! -x "${container_cli}" ]]; then
+  printf 'release runtime CLI is not an exact executable file: %s\n' \
+    "${container_cli:-unset}" >&2
+  exit 2
+fi
+candidate_root="$(cd "$(dirname "${container_cli}")/.." && pwd -P)"
+runtime_user_id="$(id -u)"
+candidate_marker_valid=false
+candidate_marker_value=""
+if [[ "${candidate_root}" =~ ^(/private)?/tmp/container-compose-runtime-${runtime_user_id}/candidate-[0-9a-f]{16}$ ]]; then
+  candidate_marker="${candidate_root}/.container-compose-runtime-candidate-staging"
+  if [[ -f "${candidate_marker}" && ! -L "${candidate_marker}" ]]; then
+    IFS= read -r candidate_marker_value <"${candidate_marker}" || true
+    if [[ "${candidate_marker_value}" =~ ^container-compose\ runtime\ candidate\ staging\ v1\ [0-9a-f]{64}$ ]]; then
+      candidate_marker_valid=true
+    fi
+  fi
+elif [[ "${candidate_root}" =~ ^(/private)?/tmp/container-compose-runtime-candidate\.([0-9a-f]{40})\.[A-Za-z0-9]{6}$ ]]; then
+  candidate_head="${BASH_REMATCH[2]}"
+  candidate_marker="${candidate_root}/.container-compose-runtime-candidate-run"
+  if [[ -f "${candidate_marker}" && ! -L "${candidate_marker}" ]]; then
+    IFS= read -r candidate_marker_value <"${candidate_marker}" || true
+    if [[ "${candidate_marker_value}" =~ ^container-compose\ runtime\ candidate\ run\ v1\ ${candidate_head}\ [0-9a-f]{64}$ ]]; then
+      candidate_marker_valid=true
+    fi
+  fi
+else
+  printf 'release runtime CLI is outside protected candidate storage: %s\n' \
+    "${container_cli}" >&2
+  exit 2
+fi
+if [[ "${candidate_marker_valid}" != true ]]; then
+  printf 'release runtime CLI has no valid candidate marker: %s\n' \
+    "${candidate_root}" >&2
+  exit 2
+fi
+for tool in "${deadline_runner}" "${launchctl_bin}" "${ps_bin}" "${sleep_bin}"; do
+  if [[ ! -x "${tool}" ]]; then
+    printf 'release runtime lifecycle tool is not executable: %s\n' "${tool}" >&2
+    exit 2
+  fi
+done
+if ! [[ "${wait_attempts}" =~ ^[1-9][0-9]*$ ]] ||
+  ! [[ "${wait_interval}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+  printf 'release runtime lifecycle wait policy is invalid\n' >&2
+  exit 2
+fi
+
+if [[ "${action}" == validate ]]; then
+  printf 'validated exact release runtime namespace: %s\n' "${service_namespace}"
+  exit 0
+fi
+
+runtime_services() {
+  "${launchctl_bin}" list | /usr/bin/awk -v prefix="${service_namespace}." \
+    'index($3, prefix) == 1 { print $3 }'
+}
+
+runtime_processes() {
+  local process_id process_uid executable process_snapshot
+  if ! process_snapshot="$("${ps_bin}" -axo pid=,uid=,command=)"; then
+    printf 'failed to inspect release runtime processes\n' >&2
+    return 1
+  fi
+  while read -r process_id process_uid executable _; do
+    case "${executable}" in
+      "${candidate_root}"/*)
+        if [[ "${process_uid}" == "$(id -u)" ]]; then
+          printf '%s\n' "${process_id}"
+        fi
+        ;;
+    esac
+  done <<<"${process_snapshot}"
+}
+
+if [[ "${action}" == quiesce ]]; then
+  env CONTAINER_APP_ROOT="${app_root}" \
+    CONTAINER_SERVICE_NAMESPACE="${service_namespace}" \
+    "${deadline_runner}" --seconds 60 --grace-seconds 0 -- \
+      "${container_cli}" system stop
+
+  remaining_services=""
+  remaining_processes=""
+  for ((attempt = 1; attempt <= wait_attempts; attempt++)); do
+    remaining_services="$(runtime_services)"
+    remaining_processes="$(runtime_processes)"
+    if [[ -z "${remaining_services}" && -z "${remaining_processes}" ]]; then
+      printf 'quiesced exact release runtime namespace: %s\n' \
+        "${service_namespace}"
+      exit 0
+    fi
+    if ((attempt < wait_attempts)); then
+      "${sleep_bin}" "${wait_interval}"
+    fi
+  done
+  if [[ -n "${remaining_services}" ]]; then
+    printf 'release runtime services survived quiescence: %s\n' \
+      "$(tr '\n' ' ' <<<"${remaining_services}" | sed 's/[[:space:]]*$//')" >&2
+  fi
+  if [[ -n "${remaining_processes}" ]]; then
+    printf 'release runtime processes survived quiescence: %s\n' \
+      "$(tr '\n' ' ' <<<"${remaining_processes}" | sed 's/[[:space:]]*$//')" >&2
+  fi
+  exit 1
+fi
+
+if [[ ! -x "${runtime_wrapper}" ]]; then
+  printf 'release runtime wrapper is not executable: %s\n' \
+    "${runtime_wrapper}" >&2
+  exit 2
+fi
+env CONTAINER_RUNTIME_MANAGED=1 \
+  CONTAINER_RUNTIME_APP_ROOT="${app_root}" \
+  CONTAINER_RUNTIME_SERVICE_NAMESPACE="${service_namespace}" \
+  CONTAINER_APP_ROOT="${app_root}" \
+  CONTAINER_SERVICE_NAMESPACE="${service_namespace}" \
+  "${deadline_runner}" --seconds 120 --grace-seconds 0 -- \
+    "${runtime_wrapper}" "${container_cli}" /usr/bin/true
+env CONTAINER_APP_ROOT="${app_root}" \
+  CONTAINER_SERVICE_NAMESPACE="${service_namespace}" \
+  "${deadline_runner}" --seconds 30 --grace-seconds 0 -- \
+    "${container_cli}" list --all --format json >/dev/null
+printf 'resumed exact release runtime namespace: %s\n' "${service_namespace}"

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -158,6 +158,10 @@ runtime_codesign_identity=${CONTAINER_RUNTIME_CODESIGN_IDENTITY:-}
 validation_environment_path=${PATH}
 runtime_make_args=()
 container_codesign_make_args=()
+managed_runtime_manager="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/manage-release-gate-runtime.sh"
+managed_runtime_app_root=${CONTAINER_APP_ROOT:-}
+managed_runtime_namespace=${CONTAINER_SERVICE_NAMESPACE:-}
+managed_runtime_enabled=false
 if [[ "${mode}" == "full" ]]; then
   if [[ -z "${runtime_cli}" ]]; then
     printf 'full stack validation requires an executable CONTAINER_RUNTIME_CLI: %s\n' \
@@ -251,6 +255,16 @@ PY
   container_codesign_make_args+=(
     "CODESIGN_OPTS=--force --sign ${runtime_codesign_identity} --timestamp=none"
   )
+  if [[ "${CONTAINER_RUNTIME_MANAGED:-0}" == 1 ]]; then
+    managed_runtime_enabled=true
+    if [[ ! -x "${managed_runtime_manager}" ]]; then
+      printf 'full stack validation requires its managed runtime lifecycle helper: %s\n' \
+        "${managed_runtime_manager}" >&2
+      exit 2
+    fi
+    "${managed_runtime_manager}" validate "${runtime_cli}" \
+      "${managed_runtime_app_root}" "${managed_runtime_namespace}"
+  fi
 fi
 
 # The full gate owns one namespace-scoped Container candidate. Pin PATH as a
@@ -287,6 +301,8 @@ if [[ -n "${checkpoint_directory}" ]]; then
     {
       printf 'mode=%s\n' "${mode}"
       printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
+      printf 'runtime_manager=%s\n' \
+        "$(shasum -a 256 "${managed_runtime_manager}" | awk '{print $1}')"
       printf 'environment=PATH=%s\n' "${validation_environment_path}"
       printf 'environment=DEVELOPER_DIR=%s\n' "${DEVELOPER_DIR:-}"
       printf 'environment=SDKROOT=%s\n' "${SDKROOT:-}"
@@ -451,6 +467,8 @@ live_validation_identity_for_stage() {
 
   {
     printf 'validator=%s\n' "$(shasum -a 256 "$0" | awk '{print $1}')"
+    printf 'runtime_manager=%s\n' \
+      "$(shasum -a 256 "${managed_runtime_manager}" | awk '{print $1}')"
     printf 'head=%s\n' "${head}"
     printf 'tree=%s\n' "${tree}"
     printf 'describe=%s\n' "${describe}"
@@ -593,6 +611,15 @@ fi
 run_checkpointed_make_targets builder "${builder_repo}" "${builder_targets[@]}"
 run_checkpointed_make_targets containerization "${containerization_repo}" \
   "${containerization_targets[@]}"
+# Containerization's macOS build uses the managed candidate for Linux build
+# containers. Quiesce that exact runtime before Container's independent
+# integration namespace starts its own VMs, then resume it for the remaining
+# Compose release gate. This lifecycle boundary is deliberately not
+# checkpointed: every resumed run must prove the host is uncontaminated again.
+if [[ "${managed_runtime_enabled}" == true ]]; then
+  "${managed_runtime_manager}" quiesce "${runtime_cli}" \
+    "${managed_runtime_app_root}" "${managed_runtime_namespace}"
+fi
 # The outer stable gate may select an already-running isolated runtime for
 # Containerization's image build. Container's unit tests exercise their own
 # default namespace contract, so do not let that selector rewrite the expected
@@ -606,5 +633,9 @@ for target in "${container_targets[@]}"; do
       make -C "${container_repo}" "${runtime_make_args[@]}" \
         "${container_codesign_make_args[@]}" "${container_make_args[@]}" "${target}"
 done
+if [[ "${managed_runtime_enabled}" == true ]]; then
+  "${managed_runtime_manager}" resume "${runtime_cli}" \
+    "${managed_runtime_app_root}" "${managed_runtime_namespace}"
+fi
 run_checkpointed homebrew-formula \
   ruby -c "${homebrew_tap_repo}/Formula/container-compose.rb"

--- a/Tools/ci/test_manage_release_gate_runtime.py
+++ b/Tools/ci/test_manage_release_gate_runtime.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import textwrap
+import unittest
+import uuid
+
+
+SCRIPT = Path(__file__).with_name("manage-release-gate-runtime.sh")
+
+
+class ManageReleaseGateRuntimeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="c.", dir="/tmp")
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name).resolve()
+        self.app_root = self.root / "app"
+        self.app_root.mkdir()
+        (self.app_root / ".container-compose-runtime-root").write_text(
+            "container-compose isolated runtime state v1\n", encoding="utf-8"
+        )
+        self.namespace = "io.github.stephenlclarke.container-compose.runtime.fixture"
+
+        candidate_parent = self.root.parent / f"container-compose-runtime-{os.getuid()}"
+        candidate_parent_created = not candidate_parent.exists()
+        candidate_parent.mkdir(mode=0o700, exist_ok=True)
+        if candidate_parent_created:
+            self.addCleanup(candidate_parent.rmdir)
+        self.candidate_root = candidate_parent / (
+            "candidate-" + uuid.uuid4().hex[:16]
+        )
+        self.addCleanup(
+            lambda: subprocess.run(
+                ["/bin/rm", "-rf", str(self.candidate_root)], check=False
+            )
+        )
+        (self.candidate_root / "bin").mkdir(parents=True)
+        (self.candidate_root / "libexec").mkdir()
+        (self.candidate_root / ".container-compose-runtime-candidate-staging").write_text(
+            "container-compose runtime candidate staging v1 " + "a" * 64 + "\n",
+            encoding="utf-8",
+        )
+        self.command_log = self.root / "commands.log"
+        self.service_state = self.root / "services"
+        self.process_state = self.root / "processes"
+        self.ready_state = self.root / "ready"
+        self.service_state.touch()
+        self.process_state.touch()
+
+        self.container_cli = self.candidate_root / "bin" / "container"
+        self._write_executable(
+            self.container_cli,
+            """
+            printf 'container:%s\n' "$*" >>"${LIFECYCLE_COMMAND_LOG:?}"
+            if [[ "$*" == "system stop" ]]; then
+              if [[ "${LEAVE_RUNTIME_STATE:-0}" != 1 ]]; then
+                : >"${LIFECYCLE_SERVICE_STATE:?}"
+                : >"${LIFECYCLE_PROCESS_STATE:?}"
+              fi
+              exit 0
+            fi
+            if [[ "${1:-}" == list ]]; then
+              [[ -f "${LIFECYCLE_READY_STATE:?}" ]]
+              exit
+            fi
+            exit 64
+            """,
+        )
+        self.launchctl = self.root / "launchctl"
+        self._write_executable(
+            self.launchctl,
+            """
+            if [[ "${1:-}" == list ]]; then
+              while IFS= read -r label; do
+                [[ -n "$label" ]] && printf -- '-\t0\t%s\n' "$label"
+              done <"${LIFECYCLE_SERVICE_STATE:?}"
+              exit 0
+            fi
+            exit 64
+            """,
+        )
+        self.ps = self.root / "ps"
+        self._write_executable(
+            self.ps,
+            """
+            if [[ "$*" == '-axo pid=,uid=,command=' ]]; then
+              if [[ "${FAIL_PROCESS_SNAPSHOT:-0}" == 1 ]]; then exit 70; fi
+              while IFS= read -r executable; do
+                [[ -n "$executable" ]] && printf '991 %s %s --fixture\n' "$(id -u)" "$executable"
+              done <"${LIFECYCLE_PROCESS_STATE:?}"
+              exit 0
+            fi
+            exit 64
+            """,
+        )
+        self.deadline = self.root / "deadline"
+        self._write_executable(
+            self.deadline,
+            """
+            while (($#)); do
+              if [[ "$1" == -- ]]; then shift; break; fi
+              shift
+            done
+            exec "$@"
+            """,
+        )
+        self.wrapper = self.root / "runtime-wrapper"
+        self._write_executable(
+            self.wrapper,
+            """
+            printf 'wrapper:%s\n' "$*" >>"${LIFECYCLE_COMMAND_LOG:?}"
+            touch "${LIFECYCLE_READY_STATE:?}"
+            """,
+        )
+        self.sleep = self.root / "sleep"
+        self._write_executable(self.sleep, ":")
+
+        self.environment = os.environ.copy()
+        self.environment.update(
+            {
+                "BASH_ENV": "/dev/null",
+                "ENV": "/dev/null",
+                "CONTAINER_RELEASE_RUNTIME_TESTING": "1",
+                "CONTAINER_RELEASE_RUNTIME_LAUNCHCTL": str(self.launchctl),
+                "CONTAINER_RELEASE_RUNTIME_PS": str(self.ps),
+                "CONTAINER_RELEASE_RUNTIME_SLEEP": str(self.sleep),
+                "CONTAINER_RELEASE_RUNTIME_DEADLINE_RUNNER": str(self.deadline),
+                "CONTAINER_RELEASE_RUNTIME_WRAPPER": str(self.wrapper),
+                "CONTAINER_RELEASE_RUNTIME_WAIT_ATTEMPTS": "1",
+                "LIFECYCLE_COMMAND_LOG": str(self.command_log),
+                "LIFECYCLE_SERVICE_STATE": str(self.service_state),
+                "LIFECYCLE_PROCESS_STATE": str(self.process_state),
+                "LIFECYCLE_READY_STATE": str(self.ready_state),
+            }
+        )
+
+    def _write_executable(self, path: Path, body: str) -> None:
+        path.write_text(
+            "#!/usr/bin/env bash\nset -euo pipefail\n"
+            + textwrap.dedent(body).lstrip(),
+            encoding="utf-8",
+        )
+        path.chmod(0o755)
+
+    def _run(self, action: str, **environment: str) -> subprocess.CompletedProcess[str]:
+        merged_environment = self.environment.copy()
+        merged_environment.update(environment)
+        return subprocess.run(
+            [
+                str(SCRIPT),
+                action,
+                str(self.container_cli),
+                str(self.app_root),
+                self.namespace,
+            ],
+            check=False,
+            capture_output=True,
+            env=merged_environment,
+            text=True,
+        )
+
+    def test_validates_quiesces_and_resumes_exact_runtime(self) -> None:
+        validated = self._run("validate")
+        self.assertEqual(validated.returncode, 0, validated.stderr)
+
+        self.service_state.write_text(
+            f"{self.namespace}.apiserver\n", encoding="utf-8"
+        )
+        self.process_state.write_text(
+            f"{self.candidate_root}/libexec/container-apiserver\n",
+            encoding="utf-8",
+        )
+        quiesced = self._run("quiesce")
+        self.assertEqual(quiesced.returncode, 0, quiesced.stderr)
+        self.assertIn("quiesced exact release runtime namespace", quiesced.stdout)
+
+        resumed = self._run("resume")
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        self.assertIn("resumed exact release runtime namespace", resumed.stdout)
+        commands = self.command_log.read_text(encoding="utf-8")
+        self.assertIn("container:system stop", commands)
+        self.assertIn(f"wrapper:{self.container_cli} /usr/bin/true", commands)
+        self.assertIn("container:list --all --format json", commands)
+
+    def test_rejects_a_successful_stop_that_left_runtime_state(self) -> None:
+        self.service_state.write_text(
+            f"{self.namespace}.apiserver\n", encoding="utf-8"
+        )
+        self.process_state.write_text(
+            f"{self.candidate_root}/libexec/container-apiserver\n",
+            encoding="utf-8",
+        )
+        result = self._run("quiesce", LEAVE_RUNTIME_STATE="1")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("runtime services survived quiescence", result.stderr)
+        self.assertIn("runtime processes survived quiescence", result.stderr)
+
+    def test_rejects_a_failed_process_snapshot(self) -> None:
+        result = self._run("quiesce", FAIL_PROCESS_SNAPSHOT="1")
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("failed to inspect release runtime processes", result.stderr)
+
+    def test_rejects_an_unmarked_application_root(self) -> None:
+        (self.app_root / ".container-compose-runtime-root").unlink()
+        result = self._run("validate")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("no valid ownership marker", result.stderr)
+
+    def test_rejects_a_malformed_candidate_marker(self) -> None:
+        marker = self.candidate_root / ".container-compose-runtime-candidate-staging"
+        marker.write_text(
+            "container-compose runtime candidate staging v1 not-a-digest\n",
+            encoding="utf-8",
+        )
+        result = self._run("validate")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("no valid candidate marker", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -4129,6 +4129,11 @@ github_cli() {{
             "env -u CONTAINER_APP_ROOT -u CONTAINER_SERVICE_NAMESPACE",
             validation,
         )
+        quiesce_index = validation.index('"${managed_runtime_manager}" quiesce')
+        container_index = validation.index('for target in "${container_targets[@]}"')
+        resume_index = validation.index('"${managed_runtime_manager}" resume')
+        self.assertLess(quiesce_index, container_index)
+        self.assertLess(container_index, resume_index)
         self.assertIn(
             'CONTAINER_INIT_BOOTSTRAP_IMAGE_ARCHIVE="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"',
             validation,


### PR DESCRIPTION
## Summary

Quiesce the exact marker-protected release candidate after Containerization has used it and before Container starts its isolated integration runtime. Prove that its namespace and candidate processes are absent, then resume the same candidate for the remaining Compose release gate.

This prevents the outer shared sandbox and BuildKit VM from competing with the 6 GiB Kubernetes integration VM. It also rejects false-success cleanup, failed process snapshots, malformed ownership markers, and candidate paths outside the exact owned layouts.

Closes #581.

## Focused proof

- 5 managed runtime lifecycle tests passed
- existing candidate-staging compatibility proof passed
- release-stage ordering policy passed
- Bash syntax and ShellCheck passed
- diff hygiene passed

The lifecycle boundary is deliberately re-proved on every recovery rather than checkpointed.