### PR TITLE
build(deps): pin Container release fixes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1bf517a669e892e339e67a2b457e47590d5176bfb0addefec90b9b75a65e4906",
+  "originHash" : "c9c5c652da39f98b362c2025eb73f1fde9632a46b69389625008c7553c047be0",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df"
+        "revision" : "7ed777a171554cd6309ca96d3d2a4e7135c910c5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 
 let containerDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/container.git",
-    revision: "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
+    revision: "7ed777a171554cd6309ca96d3d2a4e7135c910c5",
 )
 
 let containerizationDependency: Package.Dependency = .package(

--- a/Tools/ci/check-stack-consistency.py
+++ b/Tools/ci/check-stack-consistency.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import re
@@ -162,6 +163,13 @@ def container_pin() -> dict[str, Any]:
     raise SystemExit(f"{package_resolved} is missing a container pin")
 
 
+def validate_compose_resolved_origin_hash() -> None:
+    resolved = load_json(COMPOSE_RESOLVED)
+    actual = str(resolved.get("originHash", ""))
+    expected = hashlib.sha256(COMPOSE_PACKAGE.read_bytes()).hexdigest()
+    require_match("Package.resolved originHash", actual, expected)
+
+
 def require_match(label: str, actual: str, expected: str) -> None:
     if actual != expected:
         raise SystemExit(f"{label} mismatch: expected {expected}, got {actual}")
@@ -295,6 +303,7 @@ def validate_builder_image(stack_refs: dict[str, Any]) -> None:
 
 def main() -> int:
     stack_refs = load_json(STACK_REFS)
+    validate_compose_resolved_origin_hash()
     validate_runtime_capabilities()
     validate_builder_image(stack_refs)
     components = stack_refs.get("components", {})

--- a/Tools/ci/test_check_stack_consistency.py
+++ b/Tools/ci/test_check_stack_consistency.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import tempfile
@@ -181,6 +182,9 @@ def write_resolved(
     path.write_text(
         json.dumps(
             {
+                "originHash": hashlib.sha256(
+                    path.with_name("Package.swift").read_bytes()
+                ).hexdigest(),
                 "pins": pins
             }
         ),
@@ -318,6 +322,34 @@ class StackConsistencyTests(unittest.TestCase):
             write_resolved(root / "container" / "Package.resolved")
 
             self.assertEqual(self.run_checker(root), 0)
+
+    def test_rejects_stale_compose_resolved_origin_hash(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "compose").mkdir()
+            (root / "container").mkdir()
+            write_stack_refs(root / "stack-refs.json")
+            write_package(
+                root / "compose" / "Package.swift",
+                "revision",
+                CONTAINERIZATION_REF,
+                include_container=True,
+            )
+            write_package(
+                root / "container" / "Package.swift",
+                "revision",
+                CONTAINERIZATION_REF,
+                requirement_constant="containerizationRevision",
+            )
+            compose_resolved = root / "compose" / "Package.resolved"
+            write_resolved(compose_resolved, include_container=True)
+            resolved = json.loads(compose_resolved.read_text(encoding="utf-8"))
+            resolved["originHash"] = "0" * 64
+            compose_resolved.write_text(json.dumps(resolved), encoding="utf-8")
+            write_resolved(root / "container" / "Package.resolved")
+
+            with self.assertRaisesRegex(SystemExit, "Package.resolved originHash mismatch"):
+                self.run_checker(root)
 
     def test_accepts_identity_preserving_local_override_with_remote_revision(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
+      "ref": "7ed777a171554cd6309ca96d3d2a4e7135c910c5",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {


### PR DESCRIPTION
## Summary

- pin Compose to exact reviewed Container main `7ed777a171554cd6309ca96d3d2a4e7135c910c5`
- keep Containerization, builder, and unrelated transitive package identities unchanged
- refresh the SwiftPM lockfile origin hash for the changed manifest
- make the fast stack-consistency gate reject stale origin hashes before builds
- let the normal Current lane certify the release-gate repairs from Container #225 and #226 before stable promotion

## Focused proof

- `Tools/ci/check-stack-consistency.py`
- `python3.12 -m unittest Tools.ci.test_check_stack_consistency` (11 passed)
- `swift package --disable-automatic-resolution describe --type json`
- fork-classification and README-metrics checks against live remotes
- `git diff --check`

Closes #583