### PR TITLE
docs(release): classify 0.14.3 Container fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 8 September 2026 snapshot, the three support forks are **1155 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 8 September 2026 snapshot, the three support forks are **1159 commits ahead of Apple upstream**:
 >
 > - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 304 ahead** at [`9e0626e1171c`](https://github.com/stephenlclarke/containerization/commit/9e0626e1171cee5c09b0adecb886f1b24784320c).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 796 ahead** at [`0eb4a7e9df9b`](https://github.com/stephenlclarke/container/commit/0eb4a7e9df9bda860e48b809d777a8ba4e28b7df).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 800 ahead** at [`7ed777a17155`](https://github.com/stephenlclarke/container/commit/7ed777a171554cd6309ca96d3d2a4e7135c910c5).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 55 ahead** at [`f99e66b89402`](https://github.com/stephenlclarke/container-builder-shim/commit/f99e66b8940242d6ea8bed448619ba61f3f6f1a5).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "eee7ad097079cc3b02d5309ec10160143f2d0c6a",
-      "forkHead": "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
+      "forkHead": "7ed777a171554cd6309ca96d3d2a4e7135c910c5",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -505,7 +505,9 @@
             "25399784a692d5d5933ab3db67d385e0e82b5fad",
             "8372b65b66f1453d0ac3d9d78bdc532a49e12aab",
             "7601ceca01d4a221a6724e78a6d6738576f22b60",
-            "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df"
+            "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
+            "fed883357d578cc3701c2dcc76a7b8a65a8f3fcf",
+            "6cac63afeadd0378baaf5eed3175c0533e025a8a"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `0eb4a7e9df9bda860e48b809d777a8ba4e28b7df` | 0 | 796 | 670 |
+| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `7ed777a171554cd6309ca96d3d2a4e7135c910c5` | 0 | 800 | 672 |
 | `containerization` | `847655d373a27b8b8d0c3a9747f04f16b5de1206` | `9e0626e1171cee5c09b0adecb886f1b24784320c` | 0 | 304 | 240 |
 | `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `f99e66b8940242d6ea8bed448619ba61f3f6f1a5` | 0 | 55 | 45 |
-| **Total** | | | **0** | **1155** | **955** |
+| **Total** | | | **0** | **1159** | **957** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 699 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 701 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 231 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -318,3 +318,12 @@ through `9e0626e1171c` and Container through `0eb4a7e9df9b`. The runtime fix
 redials an available VM only when an exited process retained an already-stopped
 gRPC client; the Container change pins that reviewed correction. Both are
 support maintenance and add no Compose policy or new public runtime primitive.
+
+The 8 September 2026 release-gate correction advances Container through
+`7ed777a17155` and classifies two reviewed support-maintenance commits. The
+runtime change makes `system stop` clean an unhealthy Kubernetes API server
+and every namespace service; its focused regression proves that cleanup and
+error propagation. The companion Kubernetes test proves that a retained
+cluster restarts on its configured address without preserving the obsolete
+address-rotation expectation. Neither commit adds a fork-only capability or
+temporary upstream port.


### PR DESCRIPTION
## Summary

- classify the two reviewed Container release-gate commits as support maintenance
- advance the reviewed Container fork head and exact totals
- refresh the README snapshot from current remotes

## Verification

- `python3.12 Tools/ci/upstream-divergence-report.py --repo-root /Users/sclarke/github --fetch --classifications-only ...`
- `python3.12 Tools/ci/update-readme-upstream-metrics.py --repo-root /Users/sclarke/github --fetch --check`
- `python3.12 -m unittest Tools.ci.test_upstream_divergence_report Tools.ci.test_update_readme_upstream_metrics` (17 passed)
- `git diff --check`

Closes #585