### PR TITLE
fix(deps): pin retained VSOCK owner stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "7ed777a171554cd6309ca96d3d2a4e7135c910c5"
+        "revision" : "24dec751bd12e3cbaca8e954075f534a2be53586"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "9e0626e1171cee5c09b0adecb886f1b24784320c"
+        "revision" : "a4abc86ce7f2c4169c805ff38b018297b166880a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -19,12 +19,12 @@ import PackageDescription
 
 let containerDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/container.git",
-    revision: "7ed777a171554cd6309ca96d3d2a4e7135c910c5",
+    revision: "24dec751bd12e3cbaca8e954075f534a2be53586",
 )
 
 let containerizationDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/containerization.git",
-    revision: "9e0626e1171cee5c09b0adecb886f1b24784320c",
+    revision: "a4abc86ce7f2c4169c805ff38b018297b166880a",
 )
 
 let nioSSLDependency: Package.Dependency = .package(


### PR DESCRIPTION
## Summary

Advance the matched Compose runtime stack to the merged VSOCK lifetime fix. Container now pins Containerization PR #81, and Compose pins both resulting immutable main revisions.

Fixes #587.

## Validation

- Swift manifest parses successfully.
- Forced resolved-version validation succeeds.
- Package.swift and Package.resolved identify the same immutable Container and Containerization commits.
- Both pins match their current fork main authorities.
- The release checkpoint will revalidate the affected sibling-stack closure.