### PR TITLE
fix(deps): correct retained VSOCK stack metadata

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c9c5c652da39f98b362c2025eb73f1fde9632a46b69389625008c7553c047be0",
+  "originHash" : "dbbfc4a6208c38bdf34b735ce957f4b457f8b26bf84581102d1e0531580845cb",
   "pins" : [
     {
       "identity" : "async-http-client",

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "7ed777a171554cd6309ca96d3d2a4e7135c910c5",
+      "ref": "24dec751bd12e3cbaca8e954075f534a2be53586",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "9e0626e1171cee5c09b0adecb886f1b24784320c",
+      "ref": "a4abc86ce7f2c4169c805ff38b018297b166880a",
       "repository": "stephenlclarke/containerization"
     }
   },


### PR DESCRIPTION
## Summary

Correct the metadata omitted from PR #588: regenerate the Package.resolved origin hash and align the checked-in release stack authority with the merged Container and Containerization revisions.

Fixes #587.

## Validation

- Exact stack consistency check passes.
- Full source-only checks pass: 114 focused Python/harness tests plus static, licence, and runtime-neutrality checks.
- No build or runtime integration cycle was run for this metadata-only correction.