### PR TITLE
fix(build): pin Hawkeye CLI contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ CODESIGN_OPTS ?= --force --sign - --timestamp=none
 CONTAINER_RUNTIME_CODESIGN_IDENTITY ?= $(shell security find-identity -v -p codesigning 2>/dev/null | awk '/"Developer ID Application:/{print $$2; exit}')
 PYTHON ?= python3
 MARKDOWNLINT ?= markdownlint
-HAWKEYE ?= $(shell command -v hawkeye 2>/dev/null || printf '%s' .local/bin/hawkeye)
+HAWKEYE ?= .local/bin/hawkeye
 CODEQL_CACHE_ROOT ?= .local/share/codeql
 CODEQL_ARTIFACT_ROOT ?= .build/codeql
 CODEQL_UPLOAD_REPOSITORY ?= stephenlclarke/container-compose
@@ -3004,11 +3004,11 @@ format: update-licenses swift-style-format
 	cd Tools/compose-normalizer && $(GO) fmt ./...
 
 check-licenses:
-	@./scripts/ensure-hawkeye-exists.sh
+	@HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh
 	@$(HAWKEYE) check --fail-if-unknown
 
 update-licenses:
-	@./scripts/ensure-hawkeye-exists.sh
+	@HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh
 	@$(HAWKEYE) format --fail-if-unknown --fail-if-updated false
 
 pre-commit:
@@ -3019,7 +3019,7 @@ pre-commit:
 	printf 'PRECOMMIT_NOFMT=$${PRECOMMIT_NOFMT} "$$(git rev-parse --git-path hooks/pre-commit.fmt)"\n' >> /tmp/container-compose-pre-commit.new
 	mv /tmp/container-compose-pre-commit.new "$(HOOKS_DIR)/pre-commit"
 	chmod +x "$(HOOKS_DIR)/pre-commit"
-	@./scripts/ensure-hawkeye-exists.sh
+	@HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh
 
 clean: local-swift-stack-clean
 	$(SWIFT) package clean

--- a/Tools/ci/test_makefile_fail_fast.py
+++ b/Tools/ci/test_makefile_fail_fast.py
@@ -65,6 +65,23 @@ class MakefileFailFastTests(unittest.TestCase):
             ],
         )
 
+    def test_license_check_uses_repository_pinned_hawkeye_by_default(self) -> None:
+        self.assertIn("HAWKEYE ?= .local/bin/hawkeye", self.makefile)
+        recipe = self.makefile.split("check-licenses:", 1)[1].split(
+            "update-licenses:", 1
+        )[0]
+        self.assertIn(
+            'HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh', recipe
+        )
+
+    def test_license_update_validates_the_selected_hawkeye(self) -> None:
+        recipe = self.makefile.split("update-licenses:", 1)[1].split(
+            "pre-commit:", 1
+        )[0]
+        self.assertIn(
+            'HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh', recipe
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ensure-hawkeye-exists.sh
+++ b/scripts/ensure-hawkeye-exists.sh
@@ -18,6 +18,17 @@
 set -euo pipefail
 
 auto_install=0
+hawkeye="${HAWKEYE:-.local/bin/hawkeye}"
+
+hawkeye_is_compatible() {
+    local check_help format_help
+    [[ -f "${hawkeye}" && -x "${hawkeye}" && ! -L "${hawkeye}" ]] || return 1
+    check_help="$("${hawkeye}" check --help 2>&1)" || return 1
+    format_help="$("${hawkeye}" format --help 2>&1)" || return 1
+    [[ "${check_help}" == *--fail-if-unknown* ]] || return 1
+    [[ "${format_help}" == *--fail-if-unknown* ]] || return 1
+    [[ "${format_help}" == *--fail-if-updated* ]]
+}
 
 for arg in "$@"; do
     case "${arg}" in
@@ -28,9 +39,10 @@ for arg in "$@"; do
             cat <<EOF
 Usage: $(basename "$0") [--auto-install|-y]
 
-Checks first for a working system-wide hawkeye installation, then for the
-repository-local .local/bin fallback. If hawkeye is missing, prompts before
-running scripts/install-hawkeye.sh.
+Checks the selected Hawkeye executable against the pinned CLI contract. The
+default is the repository-local .local/bin/hawkeye; system installations are
+used only when HAWKEYE explicitly selects one. If the default is missing or
+incompatible, prompts before running scripts/install-hawkeye.sh.
 
 Skip the prompt non-interactively in either of two ways:
   --auto-install, -y      pass on the command line
@@ -50,19 +62,20 @@ if [[ "${HAWKEYE_AUTO_INSTALL:-}" == "1" ]]; then
     auto_install=1
 fi
 
-if command -v hawkeye >/dev/null 2>&1; then
-    printf 'hawkeye found at %s\n' "$(command -v hawkeye)"
+if hawkeye_is_compatible; then
+    printf 'compatible hawkeye found at %s\n' "${hawkeye}"
     exit 0
 fi
 
-if command -v .local/bin/hawkeye >/dev/null 2>&1; then
-    printf 'repository-local hawkeye found at .local/bin/hawkeye\n'
-    exit 0
+if [[ "${hawkeye}" != ".local/bin/hawkeye" ]]; then
+    printf 'selected Hawkeye does not satisfy the pinned CLI contract: %s\n' \
+        "${hawkeye}" >&2
+    exit 1
 fi
 
 cat <<EOF
 
-hawkeye is not installed system-wide or in this checkout.
+the repository-pinned Hawkeye is missing or incompatible in this checkout.
 
 scripts/install-hawkeye.sh will install a repository-local fallback by running:
 


### PR DESCRIPTION
## Summary

Make local, hosted, and release source checks use the repository-pinned Hawkeye 6.5.1 contract by default. Homebrew 7.0.1 changed both CLI flags and the configuration schema, so an ambient system installation is no longer accepted silently. Explicit overrides are validated and fail before source scanning when incompatible.

Fixes #590.

## Validation

- Default pinned install and licence check pass.
- Existing pinned release binary passes.
- Homebrew 7.0.1 is rejected before scanning.
- Full source-only checks pass in 16.6 seconds: 114 harness tests plus static, licence, stack-consistency, and runtime-neutrality checks.
- Focused Makefile contract tests pass.