### PR TITLE
fix(build): complete recoverable stack workflow

### DIFF
--- a/.github/workflows/scheduled-stable-release.yml
+++ b/.github/workflows/scheduled-stable-release.yml
@@ -15,7 +15,7 @@
 #===----------------------------------------------------------------------===#
 
 name: Scheduled Stable Release
-run-name: Scheduled Stable Release · ${{ inputs.version_selector || '-+-' }}
+run-name: Scheduled Stable Release · ${{ inputs.version_selector || 'auto' }}
 
 on:
   schedule:
@@ -24,11 +24,13 @@ on:
   workflow_dispatch:
     inputs:
       version_selector:
-        description: "Stable release bump, resolved from the latest semantic tag"
+        description: "Stable release bump; auto derives it from Conventional Commits"
         required: true
-        default: "-+-"
+        default: "auto"
         type: choice
         options:
+          - "auto"
+          - "--+"
           - "-+-"
           - "+--"
 
@@ -52,21 +54,39 @@ jobs:
       - name: Checkout release controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Select release increment
         id: selector
         env:
-          SELECTOR: ${{ inputs.version_selector || '-+-' }}
+          SELECTOR: ${{ inputs.version_selector || 'auto' }}
         shell: bash
         run: |
           set -euo pipefail
+          requested_selector="${SELECTOR}"
           case "${SELECTOR}" in
-            -+-|+--)
-              printf 'selector=%s\n' "${SELECTOR}" >> "$GITHUB_OUTPUT"
+            auto)
+              SELECTOR="$(python3 Tools/release/conventional-version.py \
+                --format selector --allow-no-release)"
+              ;;
+            --+|-+-|+--)
               ;;
             *)
-              printf 'scheduled stable releases only support -+- (minor) or +-- (major): %s\n' \
+              printf 'stable release selector must be auto, --+, -+-, or +--: %s\n' \
+                "${SELECTOR}" >&2
+              exit 2
+              ;;
+          esac
+          case "${SELECTOR}" in
+            --+|-+-|+--)
+              printf 'selector=%s\n' "${SELECTOR}" >> "$GITHUB_OUTPUT"
+              ;;
+            "")
+              [[ "${requested_selector}" == "auto" ]]
+              printf 'selector=\n' >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              printf 'conventional version resolver returned an invalid selector: %s\n' \
                 "${SELECTOR}" >&2
               exit 2
               ;;
@@ -76,6 +96,7 @@ jobs:
         id: decision
         env:
           GH_TOKEN: ${{ github.token }}
+          SELECTED_SELECTOR: ${{ steps.selector.outputs.selector }}
         shell: bash
         run: |
           set -euo pipefail
@@ -134,6 +155,10 @@ jobs:
             --latest-stable-sha "${latest_stable_sha}" > "${decision_file}"
           should_release="$(jq -r '.should_release' "${decision_file}")"
           reason="$(jq -r '.reason' "${decision_file}")"
+          if [[ "${should_release}" == "true" && -z "${SELECTED_SELECTOR}" ]]; then
+            should_release=false
+            reason="Current is newer, but Conventional Commit history contains no release-producing change."
+          fi
           printf 'should_release=%s\n' "${should_release}" >> "$GITHUB_OUTPUT"
           printf 'reason=%s\n' "${reason}" >> "$GITHUB_OUTPUT"
           printf '%s\n' "${reason}" >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ GO_COVERAGE_MIN ?= 85
 DIST_DIR ?= dist
 PLUGIN_ARCHIVE ?= container-compose-plugin-release-arm64.tar.gz
 PLUGIN_ICON ?= docs/images/container-compose-icon-octopus.png
+CONVENTIONAL_VERSION_TOOL := $(abspath Tools/release/conventional-version.py)
 DOCS_OUTPUT_DIR ?= _site
 DOCS_SERVER_DIR ?= _serve
 DOCS_HOSTING_BASE_PATH ?= container-compose
@@ -204,9 +205,18 @@ CONTAINER_RUNTIME_START_DEADLINE_SECONDS ?= 300
 # development volume is available. A local fallback keeps ordinary source
 # builds usable when that volume is intentionally disconnected.
 STACK_STATE_ROOT ?= $(if $(wildcard /Volumes/SSD/github/.),/Volumes/SSD/github/.container-compose-build,$(abspath .build/stack))
+# BEGIN RECOVERABLE STACK CONFIGURATION
 STACK_MARKER_VALUE := container-compose recoverable build v1
 STACK_PIN_TOOL := $(abspath Tools/build/stack-pin.py)
+STACK_BUILD_CONTRACT := $(abspath Tools/build/stack-build-contract.json)
+STACK_DEADLINE_TOOL := $(abspath Tools/ci/run-command-with-deadline.py)
+STACK_SWIFT_STACK_TOOL := $(abspath Tools/ci/run-with-local-swift-stack.py)
 STACK_CONFIGURATION ?= debug
+STACK_BUILD_STAGE_TIMEOUT_SECONDS ?= 3600
+STACK_BUILD_TIMEOUT_SECONDS ?= 14400
+STACK_LOCK_TOOL ?= /usr/bin/lockf
+STACK_TIMING_ROOT := $(STACK_STATE_ROOT)/timings
+STACK_TIMING_LOG ?= $(STACK_TIMING_ROOT)/direct-stage.jsonl
 STACK_PIN_DIR := $(STACK_STATE_ROOT)/pins/$(STACK_CONFIGURATION)
 STACK_SCRATCH_ROOT := $(STACK_STATE_ROOT)/scratch
 STACK_ARTIFACT_ROOT := $(STACK_STATE_ROOT)/artifacts/$(STACK_CONFIGURATION)
@@ -221,12 +231,18 @@ STACK_GO ?= $(GO)
 STACK_SWIFT_CONTRACT = $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--tool $(call SHELL_QUOTE,$(STACK_SWIFT)) \
 	--configuration $(call SHELL_QUOTE,$(STACK_CONFIGURATION)) \
-	--controller "$(abspath Makefile)" --controller "$(STACK_PIN_TOOL)" \
-	--controller "$(abspath Tools/ci/run-with-local-swift-stack.py)")
+	--controller "$(STACK_BUILD_CONTRACT)" --controller "$(STACK_PIN_TOOL)" \
+	--controller "$(STACK_DEADLINE_TOOL)" --controller "$(STACK_SWIFT_STACK_TOOL)" \
+	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK CONFIGURATION::END RECOVERABLE STACK CONFIGURATION" \
+	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK TARGETS::END RECOVERABLE STACK TARGETS")
 STACK_GO_CONTRACT = $(shell GOWORK=off "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--tool $(call SHELL_QUOTE,$(STACK_GO)) \
 	--configuration $(call SHELL_QUOTE,$(STACK_CONFIGURATION)) \
-	--controller "$(abspath Makefile)" --controller "$(STACK_PIN_TOOL)")
+	--controller "$(STACK_BUILD_CONTRACT)" --controller "$(STACK_PIN_TOOL)" \
+	--controller "$(STACK_DEADLINE_TOOL)" \
+	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK CONFIGURATION::END RECOVERABLE STACK CONFIGURATION" \
+	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK TARGETS::END RECOVERABLE STACK TARGETS")
+# END RECOVERABLE STACK CONFIGURATION
 RELEASE_GATE_CHECKPOINT_DIR = $(if $(CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR),$(CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR)/compose-release-gate,)
 PARITY_GATE_CHECKPOINT_DIR = $(if $(RELEASE_GATE_CHECKPOINT_DIR),$(RELEASE_GATE_CHECKPOINT_DIR)/parity,)
 RELEASE_GATE_INIT_ARCHIVE_FINGERPRINT = $(shell if [[ -z "$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" ]]; then printf unset; elif [[ -f "$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" ]]; then shasum -a 256 "$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" | awk '{print $$1}'; else printf missing; fi)
@@ -354,7 +370,7 @@ DOCKER_COMPOSE_PARITY_TARGETS := \
 SWIFT_TEST_FLAGS ?=
 SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -F -Xswiftc '$(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)' -Xlinker -rpath -Xlinker '$(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)' $(if $(strip $(SWIFT_TEST_RUNTIME_LIBRARY_PATH)),-Xlinker -rpath -Xlinker '$(SWIFT_TEST_RUNTIME_LIBRARY_PATH)'))
 
-.PHONY: all workflow ci ci-fast release-gate-environment-fingerprint-check release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-test-direct swift-runtime-test-build swift-runtime-test swift-coverage swift-coverage-check go-test go-coverage-check go-build go-release-check cli-smoke cli-smoke-built container-stack-build container-stack-build-if-needed docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-parity-stages docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-external-dockerfile-parity docker-compose-build-external-secret-parity docker-compose-build-isolation-parity docker-compose-build-no-cache-filter-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-image-volumes-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-cpu-limit-parity docker-compose-privileged-parity docker-compose-security-opt-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-memory-byte-precision-parity docker-compose-memory-swap-limit-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-service-discovery-parity docker-compose-links-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-state-status-parity docker-compose-rm-parity docker-compose-lifecycle-hooks-parity docker-compose-signal-log-reliability-parity docker-compose-restart-policy-parity docker-compose-userns-mode-parity coverage coverage-check sonar sonar-scan release release-plan package package-release package-debug package-built stack-consistency coverage-tools-syntax coverage-python-tools-test release-tools-test ci-tools-test coverage-tools-test source-checks lint format fmt check check-licenses update-licenses pre-commit swift-style-tools swift-style-paths swift-style-check swift-style-format local-swift-stack-clean
+.PHONY: all local-build workflow ci ci-fast release-gate-environment-fingerprint-check release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-test-direct swift-runtime-test-build swift-runtime-test swift-coverage swift-coverage-check go-test go-coverage-check go-build go-release-check cli-smoke cli-smoke-built container-stack-build container-stack-build-if-needed docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-parity-stages docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-external-dockerfile-parity docker-compose-build-external-secret-parity docker-compose-build-isolation-parity docker-compose-build-no-cache-filter-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-image-volumes-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-cpu-limit-parity docker-compose-privileged-parity docker-compose-security-opt-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-memory-byte-precision-parity docker-compose-memory-swap-limit-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-service-discovery-parity docker-compose-links-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-state-status-parity docker-compose-rm-parity docker-compose-lifecycle-hooks-parity docker-compose-signal-log-reliability-parity docker-compose-restart-policy-parity docker-compose-userns-mode-parity coverage coverage-check sonar sonar-scan release release-plan release-version package package-release package-debug package-built stack-consistency coverage-tools-syntax coverage-python-tools-test release-tools-test ci-tools-test coverage-tools-test source-checks lint format fmt check check-licenses update-licenses pre-commit swift-style-tools swift-style-paths swift-style-check swift-style-format local-swift-stack-clean
 
 .PHONY: print-release-gate-static-fingerprint print-release-gate-fingerprint
 .PHONY: worktree-audit worktree-audit-strict
@@ -368,16 +384,19 @@ SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -
 .PHONY: docker-terminal-session-oracle docker-terminal-session-oracle-update docker-terminal-session-candidate-oracle docker-rest-logging-oracle docker-rest-logging-candidate docker-rest-logging-parity docker-rest-discovery-oracle docker-rest-discovery-candidate docker-rest-discovery-parity docker-rest-image-discovery-oracle docker-rest-image-discovery-candidate docker-rest-image-discovery-parity docker-rest-image-mutation-oracle docker-rest-image-mutation-candidate docker-rest-image-mutation-parity
 .PHONY: stack-help stack-state-init stack-preflight stack-status stack-self-test stack-build stack-build-locked stack-containerization-build stack-engine-api-build stack-container-build stack-builder-build stack-compose-build
 
+# BEGIN RECOVERABLE STACK TARGETS
 STACK_REQUIRE_LOCK = @[[ "$(STACK_LOCK_HELD)" == 1 ]] || { printf 'stack stage requires the stack-build lock\n' >&2; exit 2; }
 
 stack-help:
 	@printf '%s\n' \
 		'Recoverable Container-family source build:' \
-		'  make                 Build Compose with SwiftPM and Go only.' \
+		'  make                 Build the complete source stack and publish exact pins.' \
+		'  make local-build     Build Compose with SwiftPM and Go only.' \
 		'  make stack-preflight Verify tools and clean sibling source repositories.' \
 		'  make stack-build     Build the complete source stack and publish exact pins.' \
 		'  make stack-status    Verify each retained build pin and artifact.' \
 		'  make stack-self-test Run the focused receipt/recovery regression tests.' \
+		'  Each full run writes durable JSONL stage timings under the state root.' \
 		'' \
 		'Stack build order:' \
 		'  containerization + container-engine-api + container-builder-shim (parallel)' \
@@ -424,7 +443,7 @@ stack-state-init:
 		/bin/mv "$$temporary" "$$marker"; \
 		trap - EXIT; \
 	fi; \
-	for managed in "$(STACK_PIN_DIR)" "$(STACK_SCRATCH_ROOT)" "$(STACK_ARTIFACT_ROOT)"; do \
+	for managed in "$(STACK_PIN_DIR)" "$(STACK_SCRATCH_ROOT)" "$(STACK_ARTIFACT_ROOT)" "$(STACK_TIMING_ROOT)"; do \
 		if [[ -L "$$managed" ]] || [[ -e "$$managed" && ! -d "$$managed" ]]; then \
 			printf 'build state path must be a direct directory: %s\n' "$$managed" >&2; \
 			exit 2; \
@@ -435,7 +454,7 @@ stack-state-init:
 	done
 
 stack-preflight: stack-state-init
-	@for tool in /usr/bin/git "$(STACK_SWIFT)" "$(STACK_GO)" "$(PYTHON)"; do \
+	@for tool in /usr/bin/git "$(STACK_LOCK_TOOL)" "$(STACK_SWIFT)" "$(STACK_GO)" "$(PYTHON)"; do \
 		if [[ "$$tool" == */* ]]; then [[ -x "$$tool" ]] || { printf 'required build tool is unavailable: %s\n' "$$tool" >&2; exit 2; }; \
 		else command -v "$$tool" >/dev/null 2>&1 || { printf 'required build tool is unavailable: %s\n' "$$tool" >&2; exit 2; }; fi; \
 	done; \
@@ -451,6 +470,12 @@ stack-preflight: stack-state-init
 	done; \
 	for contract in "$(STACK_SWIFT_CONTRACT)" "$(STACK_GO_CONTRACT)"; do \
 		[[ "$$contract" =~ ^[0-9a-f]{64}$$ ]] || { printf 'could not establish an exact build contract\n' >&2; exit 2; }; \
+	done; \
+	for timeout in "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" "$(STACK_BUILD_TIMEOUT_SECONDS)"; do \
+		awk 'BEGIN { exit !(ARGV[1] + 0 > 0) }' "$$timeout" || { \
+			printf 'stack build timeouts must be greater than zero: %s\n' "$$timeout" >&2; \
+			exit 2; \
+		}; \
 	done
 
 stack-status:
@@ -491,9 +516,16 @@ stack-self-test:
 	"$(PYTHON)" -m unittest discover Tools/build
 
 stack-build: stack-preflight
-	@/usr/bin/lockf -t 0 "$(STACK_STATE_ROOT)/stack-build.lock" \
+	@timing_log="$(STACK_TIMING_ROOT)/$$(date -u +%Y%m%dT%H%M%SZ)-$$$$.jsonl"; \
+	"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_TIMEOUT_SECONDS)" \
+		--timing-log "$$timing_log" --timing-label stack-total -- \
+		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_STATE_ROOT)/stack-build.lock" \
 		$(MAKE) --no-print-directory stack-build-locked STACK_LOCK_HELD=1 \
-			STACK_STATE_ROOT="$(STACK_STATE_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)"
+			STACK_STATE_ROOT="$(STACK_STATE_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)" \
+			STACK_TIMING_LOG="$$timing_log"; \
+	exit_status=$$?; \
+	printf 'Stack timing evidence: %s\n' "$$timing_log"; \
+	exit $$exit_status
 
 stack-build-locked:
 	@[[ "$(STACK_LOCK_HELD)" == 1 ]] || { printf 'stack-build-locked requires the stack-build lock\n' >&2; exit 2; }
@@ -522,9 +554,13 @@ stack-containerization-build:
 		scratch="$(STACK_SCRATCH_ROOT)/$(STACK_SWIFT_CONTRACT)/containerization"; \
 		started=$$SECONDS; \
 		cd "$(CONTAINERIZATION_STACK_REPO)"; \
-		"$(STACK_SWIFT)" build --disable-automatic-resolution \
+		"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label containerization-build -- \
+			"$(STACK_SWIFT)" build --disable-automatic-resolution \
 			--scratch-path "$$scratch" -c "$(STACK_CONFIGURATION)" --product cctl; \
-		bin_path="$$($(STACK_SWIFT) build --scratch-path "$$scratch" \
+		bin_path="$$($(PYTHON) "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label containerization-bin-path -- \
+			"$(STACK_SWIFT)" build --scratch-path "$$scratch" \
 			-c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository containerization \
 			--repository-path "$(CONTAINERIZATION_STACK_REPO)" \
@@ -548,9 +584,13 @@ stack-engine-api-build:
 		scratch="$(STACK_SCRATCH_ROOT)/$(STACK_SWIFT_CONTRACT)/container-engine-api"; \
 		started=$$SECONDS; \
 		cd "$(CONTAINER_ENGINE_API_STACK_REPO)"; \
-		"$(STACK_SWIFT)" build --disable-automatic-resolution \
+		"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label engine-api-build -- \
+			"$(STACK_SWIFT)" build --disable-automatic-resolution \
 			--scratch-path "$$scratch" -c "$(STACK_CONFIGURATION)" --product container-engine; \
-		bin_path="$$($(STACK_SWIFT) build --scratch-path "$$scratch" \
+		bin_path="$$($(PYTHON) "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label engine-api-bin-path -- \
+			"$(STACK_SWIFT)" build --scratch-path "$$scratch" \
 			-c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-engine-api \
 			--repository-path "$(CONTAINER_ENGINE_API_STACK_REPO)" \
@@ -578,10 +618,14 @@ stack-container-build: stack-containerization-build stack-engine-api-build
 		cd "$(CONTAINER_STACK_REPO)"; \
 		CONTAINERIZATION_PACKAGE_PATH="$(CONTAINERIZATION_STACK_REPO)" \
 		CONTAINER_ENGINE_API_PACKAGE_PATH="$(CONTAINER_ENGINE_API_STACK_REPO)" \
+			"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label container-build -- \
 			"$(STACK_SWIFT)" build --disable-automatic-resolution \
 			--scratch-path "$$scratch" -c "$(STACK_CONFIGURATION)" --product container; \
 		bin_path="$$(CONTAINERIZATION_PACKAGE_PATH="$(CONTAINERIZATION_STACK_REPO)" \
 			CONTAINER_ENGINE_API_PACKAGE_PATH="$(CONTAINER_ENGINE_API_STACK_REPO)" \
+			"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label container-bin-path -- \
 			"$(STACK_SWIFT)" build --scratch-path "$$scratch" \
 			-c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container \
@@ -608,7 +652,9 @@ stack-builder-build:
 		/usr/bin/install -d -m 0700 "$$(dirname "$$artifact")"; \
 		cd "$(CONTAINER_BUILDER_SHIM_STACK_REPO)"; \
 		started=$$SECONDS; \
-		GOWORK=off "$(STACK_GO)" build -trimpath -o "$$artifact" .; \
+		GOWORK=off "$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label builder-build -- \
+			"$(STACK_GO)" build -trimpath -o "$$artifact" .; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-builder-shim \
 			--repository-path "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" \
 			--output "$(STACK_BUILDER_PIN)" --artifact "$$artifact" \
@@ -628,29 +674,34 @@ stack-compose-build: stack-container-build
 	else \
 		source_commit="$$(/usr/bin/git -C "$(CURDIR)" rev-parse 'HEAD^{commit}')"; \
 		source_tree="$$(/usr/bin/git -C "$(CURDIR)" rev-parse 'HEAD^{tree}')"; \
-		container_commit="$$($(PYTHON) $(STACK_PIN_TOOL) value --receipt "$(STACK_CONTAINER_PIN)" --field source.commit)"; \
-		container_tree="$$($(PYTHON) $(STACK_PIN_TOOL) value --receipt "$(STACK_CONTAINER_PIN)" --field source.tree)"; \
-		containerization_commit="$$($(PYTHON) $(STACK_PIN_TOOL) value --receipt "$(STACK_CONTAINERIZATION_PIN)" --field source.commit)"; \
-		containerization_tree="$$($(PYTHON) $(STACK_PIN_TOOL) value --receipt "$(STACK_CONTAINERIZATION_PIN)" --field source.tree)"; \
-		engine_commit="$$($(PYTHON) $(STACK_PIN_TOOL) value --receipt "$(STACK_ENGINE_API_PIN)" --field source.commit)"; \
-		engine_tree="$$($(PYTHON) $(STACK_PIN_TOOL) value --receipt "$(STACK_ENGINE_API_PIN)" --field source.tree)"; \
+		scratch="$(STACK_SCRATCH_ROOT)/$(STACK_SWIFT_CONTRACT)/container-compose"; \
 		started=$$SECONDS; \
-		"$(PYTHON)" Tools/ci/run-with-local-swift-stack.py --swift "$(STACK_SWIFT)" --retain-edits \
-			--container "$(CONTAINER_STACK_REPO)" --container-commit "$$container_commit" --container-tree "$$container_tree" \
-			--containerization "$(CONTAINERIZATION_STACK_REPO)" --containerization-commit "$$containerization_commit" --containerization-tree "$$containerization_tree" \
-			--engine-api "$(CONTAINER_ENGINE_API_STACK_REPO)" --engine-api-commit "$$engine_commit" --engine-api-tree "$$engine_tree" \
-			-- "$(STACK_SWIFT)" build --disable-automatic-resolution -c "$(STACK_CONFIGURATION)" --product compose; \
+		CONTAINER_PACKAGE_PATH="$(CONTAINER_STACK_REPO)" \
+		CONTAINERIZATION_PACKAGE_PATH="$(CONTAINERIZATION_STACK_REPO)" \
+		CONTAINER_ENGINE_API_PACKAGE_PATH="$(CONTAINER_ENGINE_API_STACK_REPO)" \
+		"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+		--timing-log "$(STACK_TIMING_LOG)" --timing-label compose-build -- \
+		"$(STACK_SWIFT)" build --disable-automatic-resolution --scratch-path "$$scratch" -c "$(STACK_CONFIGURATION)" --product compose; \
+		bin_path="$$(CONTAINER_PACKAGE_PATH="$(CONTAINER_STACK_REPO)" \
+			CONTAINERIZATION_PACKAGE_PATH="$(CONTAINERIZATION_STACK_REPO)" \
+			CONTAINER_ENGINE_API_PACKAGE_PATH="$(CONTAINER_ENGINE_API_STACK_REPO)" \
+			"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label compose-bin-path -- \
+			"$(STACK_SWIFT)" build --scratch-path "$$scratch" -c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-compose \
 			--repository-path "$(CURDIR)" --output "$(STACK_COMPOSE_PIN)" \
 			--dependency "$(STACK_CONTAINERIZATION_PIN)" --dependency "$(STACK_ENGINE_API_PIN)" \
-			--dependency "$(STACK_CONTAINER_PIN)" --artifact "$(CURDIR)/.build/$(STACK_CONFIGURATION)/compose" \
+			--dependency "$(STACK_CONTAINER_PIN)" --artifact "$$bin_path/compose" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_SWIFT_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
 			--command-label 'swift build --product compose' >/dev/null; \
 	fi
+# END RECOVERABLE STACK TARGETS
 
-all: build go-build
+local-build: build go-build
+
+all: stack-build
 
 workflow: ci package
 
@@ -688,15 +739,24 @@ release-gate-hosted:
 ci-release: release-gate package-release
 
 release:
-	@test -n "$(VERSION_SELECTOR)" || { \
-		printf 'VERSION_SELECTOR is required, for example: make release VERSION_SELECTOR=--+\n' >&2; \
-		exit 2; \
-	}
+	@selector=$(call SHELL_QUOTE,$(VERSION_SELECTOR)); \
+	if [[ -z "$$selector" ]]; then \
+		selector="$$($(PYTHON) "$(CONVENTIONAL_VERSION_TOOL)" --format selector)"; \
+	fi; \
 	CONTAINER_RUNTIME_CODESIGN_IDENTITY="$(CONTAINER_RUNTIME_CODESIGN_IDENTITY)" \
-		./scripts/CONTAINER_STACK_RELEASE.sh release "$(VERSION_SELECTOR)" --execute
+		./scripts/CONTAINER_STACK_RELEASE.sh release "$$selector" --execute
 
 release-plan:
+	@selector=$(call SHELL_QUOTE,$(VERSION_SELECTOR)); \
+	if [[ -z "$$selector" ]]; then \
+		"$(PYTHON)" "$(CONVENTIONAL_VERSION_TOOL)"; \
+	else \
+		printf 'Explicit reviewed release selector: %s\n' "$$selector"; \
+	fi
 	./scripts/CONTAINER_STACK_RELEASE.sh plan
+
+release-version:
+	$(PYTHON) "$(CONVENTIONAL_VERSION_TOOL)" --format version
 
 resolve:
 	$(PYTHON) Tools/ci/run-with-local-swift-stack.py --swift "$(SWIFT)" -- \
@@ -2317,7 +2377,7 @@ package-built:
 	$(PYTHON) Tools/release/write-sha256-sidecar.py "$(PLUGIN_ARCHIVE)"
 
 coverage-tools-syntax:
-	$(PYTHON) -m py_compile Tools/coverage/*.py Tools/release/*.py Tools/ci/*.py
+	$(PYTHON) -m py_compile Tools/build/*.py Tools/coverage/*.py Tools/release/*.py Tools/ci/*.py
 
 coverage-python-tools-test: coverage-tools-syntax
 	$(PYTHON) -m unittest discover Tools/coverage

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dbbfc4a6208c38bdf34b735ce957f4b457f8b26bf84581102d1e0531580845cb",
+  "originHash" : "255429417efd5cd4ffc1bf02451349f78a3c67d6b9e5fb3f0d5092f5465a75c1",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "24dec751bd12e3cbaca8e954075f534a2be53586"
+        "revision" : "d9d0fd80d38db1f332c854d91f9a479f5e149431"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "a4abc86ce7f2c4169c805ff38b018297b166880a"
+        "revision" : "6702ebb6e17196d5b7b195b2de4b1d69b0251d01"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,17 +15,32 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
+import Foundation
 import PackageDescription
 
-let containerDependency: Package.Dependency = .package(
-    url: "https://github.com/stephenlclarke/container.git",
-    revision: "24dec751bd12e3cbaca8e954075f534a2be53586",
-)
+let containerDependency: Package.Dependency = {
+    if let path = ProcessInfo.processInfo.environment["CONTAINER_PACKAGE_PATH"],
+       !path.isEmpty
+    {
+        return .package(name: "container", path: path)
+    }
+    return .package(
+        url: "https://github.com/stephenlclarke/container.git",
+        revision: "d9d0fd80d38db1f332c854d91f9a479f5e149431",
+    )
+}()
 
-let containerizationDependency: Package.Dependency = .package(
-    url: "https://github.com/stephenlclarke/containerization.git",
-    revision: "a4abc86ce7f2c4169c805ff38b018297b166880a",
-)
+let containerizationDependency: Package.Dependency = {
+    if let path = ProcessInfo.processInfo.environment[
+        "CONTAINERIZATION_PACKAGE_PATH"
+    ], !path.isEmpty {
+        return .package(name: "containerization", path: path)
+    }
+    return .package(
+        url: "https://github.com/stephenlclarke/containerization.git",
+        revision: "6702ebb6e17196d5b7b195b2de4b1d69b0251d01",
+    )
+}()
 
 let nioSSLDependency: Package.Dependency = .package(
     url: "https://github.com/stephenlclarke/swift-nio-ssl.git",

--- a/README.md
+++ b/README.md
@@ -215,6 +215,14 @@ commands. The supported Homebrew install uses the matched `stephenlclarke`
 runtime stack; [BUILD.md](docs/guides/BUILD.md) covers repository roles, branch policy, and
 deterministic release promotion.
 
+From a clean source checkout, `make` builds the complete local Container-family
+stack, automatically consumes exact upstream pins, and retains recoverable
+native caches and timing evidence. Use `make local-build` for a quick
+Compose-only build, `make stack-status` to verify retained pins, and
+`make release-version` to preview the Conventional Commit semantic-version
+decision. The complete build, test, Actions, recovery, and release diagrams are
+in [Recoverable Container-family builds](docs/architecture/recoverable-container-family-builds.md).
+
 ## Plugin Recognition
 
 When installed correctly, `container help` lists `compose` under `PLUGINS`.
@@ -226,7 +234,7 @@ When installed correctly, `container help` lists `compose` under `PLUGINS`.
 - [Container developer API collection](https://stephenlclarke.github.io/api/): browse the unified documentation for `container-engine-api`, `container`, `containerization`, `container-k8s`, `container-builder-shim`, `container-compose`, and `devcontainer`.
 - [container-compose API reference](https://stephenlclarke.github.io/api/container-compose/): browse the Compose plugin API reference generated from the Swift source.
 - [INSTALL.md](docs/guides/INSTALL.md): install, upgrade, verify, uninstall, recover bad installs, and diagnose runtime issues.
-- [BUILD.md](docs/guides/BUILD.md): build, test, package, validate parity, and promote the current build to a stable release, including the weekly minor-release scheduler and manual major-release dispatch.
+- [BUILD.md](docs/guides/BUILD.md): build, test, package, validate parity, and promote the current build using automatic Conventional Commit versioning or an explicit reviewed override.
 - [DESIGN.md](docs/project/DESIGN.md): understand the Swift/Go boundary and runtime adapter ownership.
 - [STATUS.md](docs/project/STATUS.md): understand the functionality and explicit limitations in the current stable release and candidate.
 - [BACKLOG.md](docs/project/BACKLOG.md): understand the remaining parity contracts and follow their live GitHub issues.

--- a/Tools/build/stack-build-contract.json
+++ b/Tools/build/stack-build-contract.json
@@ -1,0 +1,19 @@
+{
+  "contract": "recoverable-container-family-build",
+  "controllers": [
+    "Make stack targets",
+    "Tools/build/stack-pin.py",
+    "Tools/ci/run-command-with-deadline.py",
+    "Tools/ci/run-with-local-swift-stack.py"
+  ],
+  "features": [
+    "bounded native build stages",
+    "durable per-operation and end-to-end timing evidence",
+    "durable external SwiftPM scratch paths",
+    "exact transitive source and artifact pins",
+    "parallel independent roots",
+    "verified final bundle"
+  ],
+  "revision": 3,
+  "schema": 1
+}

--- a/Tools/build/stack-pin.py
+++ b/Tools/build/stack-pin.py
@@ -119,6 +119,7 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
     contract.add_argument("--tool", required=True)
     contract.add_argument("--configuration", required=True)
     contract.add_argument("--controller", type=Path, action="append", default=[])
+    contract.add_argument("--controller-section", action="append", default=[])
 
     return parser.parse_args(arguments)
 
@@ -269,12 +270,16 @@ def effective_swift_build_environment(tool: Path) -> dict[str, Any]:
     developer_directory = ""
     sdk: dict[str, Any] = {}
     if platform.system() == "Darwin":
-        xcrun = Path("/usr/bin/xcrun").resolve(strict=True)
+        developer_selector = os.environ.get("DEVELOPER_DIR", "")
+        sdk_selector = os.environ.get("SDKROOT", "")
+        xcrun: Path | None = None
+        if tool == Path("/usr/bin/swift") or not sdk_selector:
+            xcrun = Path("/usr/bin/xcrun").resolve(strict=True)
         if tool == Path("/usr/bin/swift"):
+            assert xcrun is not None
             compiler = Path(
                 checked_output([str(xcrun), "--find", "swift"], "Swift compiler")
             ).resolve(strict=True)
-        developer_selector = os.environ.get("DEVELOPER_DIR", "")
         developer_directory = str(
             (
                 Path(developer_selector)
@@ -286,13 +291,17 @@ def effective_swift_build_environment(tool: Path) -> dict[str, Any]:
                 )
             ).resolve(strict=True)
         )
-        sdk_selector = os.environ.get("SDKROOT", "")
         sdk_path = (
             Path(sdk_selector)
             if sdk_selector
             else Path(
                 checked_output(
-                    [str(xcrun), "--sdk", "macosx", "--show-sdk-path"],
+                    [
+                        str(xcrun),
+                        "--sdk",
+                        "macosx",
+                        "--show-sdk-path",
+                    ],
                     "Swift SDK",
                 )
             )
@@ -384,6 +393,38 @@ def build_contract(options: argparse.Namespace) -> str:
             {
                 "path": str(resolved_controller),
                 "sha256": sha256_file(resolved_controller),
+            }
+        )
+    for specification in options.controller_section:
+        fields = specification.split("::", 2)
+        if len(fields) != 3 or not all(fields):
+            raise PinError(
+                "build controller section must be PATH::BEGIN-MARKER::END-MARKER"
+            )
+        path_value, begin_marker, end_marker = fields
+        section_path = Path(path_value)
+        if not section_path.is_absolute():
+            raise PinError(f"build controller path must be absolute: {section_path}")
+        resolved_section = section_path.resolve(strict=True)
+        try:
+            contents = regular_file_bytes(resolved_section).decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise PinError(
+                f"build controller section is not UTF-8: {resolved_section}"
+            ) from error
+        begin_token = begin_marker + "\n"
+        end_token = end_marker + "\n"
+        if contents.count(begin_token) != 1 or contents.count(end_token) != 1:
+            raise PinError(
+                f"build controller section markers must occur once: {resolved_section}"
+            )
+        begin = contents.index(begin_token)
+        end = contents.index(end_token, begin) + len(end_token)
+        controllers.append(
+            {
+                "path": str(resolved_section),
+                "section": f"{begin_marker}..{end_marker}",
+                "sha256": sha256_bytes(contents[begin:end].encode("utf-8")),
             }
         )
     relevant_environment = {

--- a/Tools/build/test_stack_make.py
+++ b/Tools/build/test_stack_make.py
@@ -19,17 +19,20 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 import tempfile
 import unittest
+from collections import Counter
 from pathlib import Path
 
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 MAKEFILE = REPOSITORY_ROOT / "Makefile"
 PIN_TOOL = REPOSITORY_ROOT / "Tools/build/stack-pin.py"
+DEADLINE_TOOL = REPOSITORY_ROOT / "Tools/ci/run-command-with-deadline.py"
 
 
 class StackMakeRecoveryTests(unittest.TestCase):
@@ -43,6 +46,14 @@ class StackMakeRecoveryTests(unittest.TestCase):
         self.containerization = self.create_repository("containerization")
         self.engine = self.create_repository("container-engine-api")
         self.container = self.create_repository("container")
+        self.builder = self.create_repository("container-builder-shim")
+        self.compose = self.create_repository("container-compose")
+        (self.compose / "Makefile").symlink_to(MAKEFILE)
+        (self.compose / "Package.resolved").write_text(
+            '{"pins":[]}\n', encoding="utf-8"
+        )
+        self.git(self.compose, "add", "Makefile", "Package.resolved")
+        self.git(self.compose, "commit", "-q", "-m", "test: add lockfile")
         self.swift = self.root / "fake-swift"
         self.swift.write_text(
             """#!/bin/bash
@@ -80,6 +91,52 @@ printf 'artifact:%s\n' "${product}" > "${bin_path}/${product}"
             encoding="utf-8",
         )
         self.swift.chmod(0o755)
+        self.go = self.root / "fake-go"
+        self.go.write_text(
+            """#!/bin/bash
+set -euo pipefail
+output=
+while (($#)); do
+  case "$1" in
+    -o) output=$2; shift 2 ;;
+    *) shift ;;
+  esac
+done
+[[ -n "${output}" ]]
+printf 'build:container-builder-shim\n' >> "${STACK_TEST_LOG}"
+mkdir -p "$(dirname "${output}")"
+printf 'artifact:container-builder-shim\n' > "${output}"
+""",
+            encoding="utf-8",
+        )
+        self.go.chmod(0o755)
+        self.stack_wrapper = self.root / "fake-stack-wrapper"
+        self.stack_wrapper.write_text(
+            """#!/usr/bin/env python3
+import os
+import sys
+
+try:
+    separator = sys.argv.index("--")
+except ValueError:
+    print("fake stack wrapper received no command", file=sys.stderr)
+    raise SystemExit(2)
+os.execvp(sys.argv[separator + 1], sys.argv[separator + 1:])
+""",
+            encoding="utf-8",
+        )
+        self.stack_wrapper.chmod(0o755)
+        self.lock = self.root / "fake-lockf"
+        self.lock.write_text(
+            """#!/bin/bash
+set -euo pipefail
+[[ "${1:-}" == -t && "${2:-}" == 0 && -n "${3:-}" ]]
+shift 3
+exec "$@"
+""",
+            encoding="utf-8",
+        )
+        self.lock.chmod(0o755)
 
     def git(self, repository: Path, *arguments: str) -> str:
         result = subprocess.run(
@@ -117,6 +174,7 @@ printf 'artifact:%s\n' "${product}" > "${bin_path}/${product}"
                 "stack-container-build",
                 f"STACK_STATE_ROOT={self.state}",
                 f"STACK_PIN_TOOL={PIN_TOOL}",
+                f"STACK_DEADLINE_TOOL={DEADLINE_TOOL}",
                 f"STACK_SWIFT={self.swift}",
                 f"STACK_SWIFT_CONTRACT={'a' * 64}",
                 "STACK_LOCK_HELD=1",
@@ -126,6 +184,44 @@ printf 'artifact:%s\n' "${product}" > "${bin_path}/${product}"
                 f"CONTAINER_STACK_REPO={self.container}",
             ],
             cwd=self.root,
+            env=environment,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+
+    def run_full_build(self) -> subprocess.CompletedProcess[str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "STACK_TEST_FAIL": str(self.fail),
+                "STACK_TEST_LOG": str(self.log),
+            }
+        )
+        return subprocess.run(
+            [
+                "/usr/bin/make",
+                "-f",
+                str(MAKEFILE),
+                "stack-build",
+                f"STACK_STATE_ROOT={self.state}",
+                f"STACK_PIN_TOOL={PIN_TOOL}",
+                f"STACK_DEADLINE_TOOL={DEADLINE_TOOL}",
+                f"STACK_SWIFT_STACK_TOOL={self.stack_wrapper}",
+                f"STACK_SWIFT={self.swift}",
+                f"STACK_GO={self.go}",
+                f"STACK_LOCK_TOOL={self.lock}",
+                f"STACK_SWIFT_CONTRACT={'a' * 64}",
+                f"STACK_GO_CONTRACT={'b' * 64}",
+                "STACK_BUILD_STAGE_TIMEOUT_SECONDS=30",
+                f"PYTHON={sys.executable}",
+                f"CONTAINERIZATION_STACK_REPO={self.containerization}",
+                f"CONTAINER_ENGINE_API_STACK_REPO={self.engine}",
+                f"CONTAINER_STACK_REPO={self.container}",
+                f"CONTAINER_BUILDER_SHIM_STACK_REPO={self.builder}",
+            ],
+            cwd=self.compose,
             env=environment,
             check=False,
             stdout=subprocess.PIPE,
@@ -198,6 +294,90 @@ printf 'artifact:%s\n' "${product}" > "${bin_path}/${product}"
         rebuilt = self.run_build()
         self.assertEqual(rebuilt.returncode, 0, rebuilt.stderr)
         self.assertEqual(self.logged_builds(), ["build:cctl", "build:container"])
+
+    def test_complete_graph_recovers_and_publishes_verified_bundle(self) -> None:
+        self.fail.write_text("fail once\n", encoding="utf-8")
+
+        failed = self.run_full_build()
+
+        self.assertNotEqual(failed.returncode, 0)
+        pin_root = self.state / "pins/debug"
+        self.assertTrue((pin_root / "containerization.json").is_file())
+        self.assertTrue((pin_root / "container-engine-api.json").is_file())
+        self.assertTrue((pin_root / "container-builder-shim.json").is_file())
+        self.assertFalse((pin_root / "container.json").exists())
+        self.assertFalse((pin_root / "container-compose.json").exists())
+
+        resumed = self.run_full_build()
+
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        self.assertEqual(
+            Counter(self.logged_builds()),
+            Counter(
+                {
+                    "build:cctl": 1,
+                    "build:container-engine": 1,
+                    "build:container-builder-shim": 1,
+                    "build:container": 2,
+                    "build:compose": 1,
+                }
+            ),
+        )
+        bundle = pin_root / "stack.json"
+        self.assertTrue(bundle.is_file())
+        verified = subprocess.run(
+            [
+                sys.executable,
+                str(PIN_TOOL),
+                "verify-bundle",
+                "--quiet",
+                "--bundle",
+                str(bundle),
+                "--repository",
+                "containerization",
+                "--repository",
+                "container-engine-api",
+                "--repository",
+                "container",
+                "--repository",
+                "container-builder-shim",
+                "--repository",
+                "container-compose",
+            ],
+            check=False,
+        )
+        self.assertEqual(verified.returncode, 0)
+        compose_pin = (pin_root / "container-compose.json").read_text(encoding="utf-8")
+        self.assertIn(str(self.state / "scratch"), compose_pin)
+        self.assertNotIn(str(self.compose / ".build/debug/compose"), compose_pin)
+        timing_logs = sorted((self.state / "timings").glob("*.jsonl"))
+        self.assertEqual(len(timing_logs), 2)
+        records = [
+            json.loads(line)
+            for path in timing_logs
+            for line in path.read_text(encoding="utf-8").splitlines()
+        ]
+        labels = {record["label"] for record in records}
+        self.assertIn("stack-total", labels)
+        self.assertIn("container-build", labels)
+        self.assertIn("compose-build", labels)
+        self.assertTrue(all(record["duration_seconds"] >= 0 for record in records))
+
+    def test_compose_build_uses_identity_preserving_manifest_overrides(self) -> None:
+        makefile = MAKEFILE.read_text(encoding="utf-8")
+        package = (REPOSITORY_ROOT / "Package.swift").read_text(encoding="utf-8")
+
+        self.assertIn('CONTAINER_PACKAGE_PATH="$(CONTAINER_STACK_REPO)"', makefile)
+        self.assertIn(
+            'CONTAINERIZATION_PACKAGE_PATH="$(CONTAINERIZATION_STACK_REPO)"',
+            makefile,
+        )
+        self.assertIn(
+            'CONTAINER_ENGINE_API_PACKAGE_PATH="$(CONTAINER_ENGINE_API_STACK_REPO)"',
+            makefile,
+        )
+        self.assertIn('environment["CONTAINER_PACKAGE_PATH"]', package)
+        self.assertIn('"CONTAINERIZATION_PACKAGE_PATH"', package)
 
 
 if __name__ == "__main__":

--- a/Tools/build/test_stack_pin.py
+++ b/Tools/build/test_stack_pin.py
@@ -241,6 +241,56 @@ class StackPinTests(unittest.TestCase):
         self.assertNotEqual(debug, release)
         self.assertNotEqual(release, changed_controller)
 
+    def test_contract_hashes_only_the_declared_controller_section(self) -> None:
+        controller = self.root / "Makefile"
+        controller.write_text(
+            "unrelated = one\nBEGIN STACK\nbuild = one\nEND STACK\n",
+            encoding="utf-8",
+        )
+        options = STACK_PIN.parse_arguments(
+            [
+                "contract",
+                "--tool",
+                "/usr/bin/git",
+                "--configuration",
+                "debug",
+                "--controller-section",
+                f"{controller}::BEGIN STACK::END STACK",
+            ]
+        )
+        baseline = STACK_PIN.build_contract(options)
+        controller.write_text(
+            "unrelated = two\nBEGIN STACK\nbuild = one\nEND STACK\n",
+            encoding="utf-8",
+        )
+        unrelated = STACK_PIN.build_contract(options)
+        controller.write_text(
+            "unrelated = two\nBEGIN STACK\nbuild = two\nEND STACK\n",
+            encoding="utf-8",
+        )
+        changed = STACK_PIN.build_contract(options)
+
+        self.assertEqual(baseline, unrelated)
+        self.assertNotEqual(unrelated, changed)
+
+    def test_contract_rejects_ambiguous_controller_sections(self) -> None:
+        controller = self.root / "Makefile"
+        controller.write_text("BEGIN STACK\nBEGIN STACK\nEND STACK\n", encoding="utf-8")
+        options = STACK_PIN.parse_arguments(
+            [
+                "contract",
+                "--tool",
+                "/usr/bin/git",
+                "--configuration",
+                "debug",
+                "--controller-section",
+                f"{controller}::BEGIN STACK::END STACK",
+            ]
+        )
+
+        with self.assertRaisesRegex(STACK_PIN.PinError, "must occur once"):
+            STACK_PIN.build_contract(options)
+
     def test_contract_changes_with_the_effective_go_target(self) -> None:
         go = shutil.which("go")
         self.assertIsNotNone(go)
@@ -315,6 +365,76 @@ class StackPinTests(unittest.TestCase):
             changed = STACK_PIN.build_contract(options)
 
         self.assertNotEqual(baseline, changed)
+
+    def test_swift_contract_fingerprints_the_selected_macos_sdk(self) -> None:
+        swift = self.root / "swift"
+        swift.write_text(
+            """#!/bin/sh
+if [ "${1:-}" = "-print-target-info" ]; then
+  printf '%s\n' '{"target":{"triple":"arm64-apple-macosx26.0"}}'
+else
+  printf '%s\n' 'Swift version test'
+fi
+""",
+            encoding="utf-8",
+        )
+        swift.chmod(0o755)
+        developer = self.root / "Xcode/Contents/Developer"
+        developer.mkdir(parents=True)
+        sdk = self.root / "MacOSX.sdk"
+        metadata = sdk / "SDKSettings.json"
+        metadata.parent.mkdir()
+        metadata.write_text('{"Version":"26.0"}\n', encoding="utf-8")
+        options = STACK_PIN.parse_arguments(
+            [
+                "contract",
+                "--tool",
+                str(swift),
+                "--configuration",
+                "release",
+            ]
+        )
+
+        with (
+            patch.object(STACK_PIN.platform, "system", return_value="Darwin"),
+            patch.dict(
+                os.environ,
+                {"DEVELOPER_DIR": str(developer), "SDKROOT": str(sdk)},
+                clear=False,
+            ),
+        ):
+            baseline = STACK_PIN.build_contract(options)
+            metadata.write_text('{"Version":"26.1"}\n', encoding="utf-8")
+            changed = STACK_PIN.build_contract(options)
+
+        self.assertNotEqual(baseline, changed)
+
+    def test_swift_environment_rejects_bad_target_and_unidentified_sdk(self) -> None:
+        swift = self.root / "swift"
+        swift.write_text("binary\n", encoding="utf-8")
+        developer = self.root / "Developer"
+        developer.mkdir()
+        sdk = self.root / "MacOSX.sdk"
+        sdk.mkdir()
+        with (
+            patch.object(STACK_PIN.platform, "system", return_value="Darwin"),
+            patch.dict(
+                os.environ,
+                {"DEVELOPER_DIR": str(developer), "SDKROOT": str(sdk)},
+                clear=False,
+            ),
+            patch.object(
+                STACK_PIN, "checked_output", return_value='{"target":{}}'
+            ),
+        ):
+            with self.assertRaisesRegex(STACK_PIN.PinError, "no identity metadata"):
+                STACK_PIN.effective_swift_build_environment(swift)
+        with patch.object(STACK_PIN, "checked_output", return_value="not-json"):
+            with self.assertRaisesRegex(STACK_PIN.PinError, "not valid JSON"):
+                STACK_PIN.effective_swift_build_environment(swift)
+        with patch.object(STACK_PIN, "checked_output", return_value="[]"):
+            with self.assertRaisesRegex(STACK_PIN.PinError, "malformed"):
+                STACK_PIN.effective_swift_build_environment(swift)
 
     def test_dependency_change_invalidates_downstream_pin(self) -> None:
         self.assertEqual(self.create_pin(), 0)

--- a/Tools/ci/run-command-with-deadline.py
+++ b/Tools/ci/run-command-with-deadline.py
@@ -20,13 +20,17 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
+import json
 import os
 import signal
+import stat
 import subprocess
 import sys
 import time
 from collections.abc import Sequence
 from enum import Enum
+from pathlib import Path
 from typing import NamedTuple
 
 TIMEOUT_EXIT_STATUS = 124
@@ -58,6 +62,8 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
         help="supervise the command process group without a wall-clock deadline",
     )
     parser.add_argument("--grace-seconds", type=float, default=10.0)
+    parser.add_argument("--timing-log", type=Path)
+    parser.add_argument("--timing-label")
     parser.add_argument(
         "--ignore-parent-signals",
         action="store_true",
@@ -73,7 +79,35 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
         parser.error("--grace-seconds must be non-negative")
     if not parsed.command:
         parser.error("a command is required after --")
+    if (parsed.timing_log is None) != (parsed.timing_label is None):
+        parser.error("--timing-log and --timing-label must be used together")
     return parsed
+
+
+def append_timing(
+    path: Path, label: str, duration_seconds: float, exit_status: int
+) -> None:
+    """Append one concurrency-safe JSON timing record."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    record = {
+        "duration_seconds": round(duration_seconds, 6),
+        "exit_status": exit_status,
+        "label": label,
+        "recorded_at_epoch_seconds": round(time.time(), 6),
+    }
+    flags = os.O_APPEND | os.O_CREAT | os.O_WRONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags, 0o600)
+    if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+        os.close(descriptor)
+        raise OSError(f"timing log is not a regular file: {path}")
+    with os.fdopen(descriptor, "a", encoding="utf-8") as stream:
+        fcntl.flock(stream.fileno(), fcntl.LOCK_EX)
+        stream.write(json.dumps(record, sort_keys=True) + "\n")
+        stream.flush()
+        os.fsync(stream.fileno())
+        fcntl.flock(stream.fileno(), fcntl.LOCK_UN)
 
 
 def signal_process_group(process_group_id: int, number: int) -> None:
@@ -303,8 +337,7 @@ def reap_direct_child(
         return False
 
 
-def run(arguments: Sequence[str]) -> int:
-    options = parse_arguments(arguments)
+def run_command(options: argparse.Namespace) -> int:
     forwarded_signal: int | None = None
     previous_handlers: dict[int, signal.Handlers] = {}
     forwarded_signals = {
@@ -448,6 +481,20 @@ def run(arguments: Sequence[str]) -> int:
     finally:
         for number, handler in previous_handlers.items():
             signal.signal(number, handler)
+
+
+def run(arguments: Sequence[str]) -> int:
+    options = parse_arguments(arguments)
+    started = time.monotonic()
+    exit_status = run_command(options)
+    if options.timing_log is not None:
+        append_timing(
+            options.timing_log,
+            options.timing_label,
+            time.monotonic() - started,
+            exit_status,
+        )
+    return exit_status
 
 
 if __name__ == "__main__":

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -36,8 +36,17 @@ def make_target(name: str, next_name: str) -> str:
 
 
 class RecoverableStackBuildPolicyTests(unittest.TestCase):
-    def test_default_make_is_only_the_native_compose_build(self) -> None:
-        self.assertIn("\nall: build go-build\n", MAKEFILE)
+    def test_release_supports_automatic_and_explicit_version_selection(self) -> None:
+        release = make_target("release", "release-plan")
+        plan = make_target("release-plan", "release-version")
+        self.assertIn("CONVENTIONAL_VERSION_TOOL", release)
+        self.assertIn("VERSION_SELECTOR", release)
+        self.assertIn("CONVENTIONAL_VERSION_TOOL", plan)
+        self.assertIn("Explicit reviewed release selector", plan)
+
+    def test_default_make_is_the_recoverable_stack_build(self) -> None:
+        self.assertIn("\nlocal-build: build go-build\n", MAKEFILE)
+        self.assertIn("\nall: stack-build\n", MAKEFILE)
         default = make_target("all", "workflow")
         for forbidden in ("codeql", "docs", "package", "release", "codesign"):
             self.assertNotIn(forbidden, default.lower())
@@ -50,7 +59,7 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         )
         self.assertIn("stack-compose-build: stack-container-build", MAKEFILE)
         invocation = make_target("stack-build", "stack-build-locked")
-        self.assertIn("/usr/bin/lockf -t 0", invocation)
+        self.assertIn('"$(STACK_LOCK_TOOL)" -t 0', invocation)
         self.assertIn("stack-build-locked STACK_LOCK_HELD=1", invocation)
 
     def test_global_lock_covers_final_bundle_publication(self) -> None:
@@ -65,7 +74,24 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
             'STACK_GO_CONTRACT = $(shell GOWORK=off "$(PYTHON)"', MAKEFILE
         )
         builder = make_target("stack-builder-build", "stack-compose-build")
-        self.assertIn('GOWORK=off "$(STACK_GO)" build', builder)
+        self.assertIn('GOWORK=off "$(PYTHON)" "$(STACK_DEADLINE_TOOL)"', builder)
+        self.assertIn('"$(STACK_GO)" build -trimpath', builder)
+
+    def test_native_builds_are_bounded_and_compose_uses_durable_scratch(self) -> None:
+        stack = MAKEFILE.split("\nstack-build:", 1)[1].split("\nlocal-build:", 1)[0]
+        self.assertGreaterEqual(stack.count('"$(STACK_DEADLINE_TOOL)" --seconds'), 7)
+        compose = make_target("stack-compose-build", "local-build")
+        self.assertIn("/container-compose", compose)
+        self.assertIn('--scratch-path "$$scratch"', compose)
+        self.assertIn('--artifact "$$bin_path/compose"', compose)
+
+    def test_build_contract_does_not_hash_unrelated_make_targets(self) -> None:
+        contracts = MAKEFILE.split("STACK_SWIFT_CONTRACT =", 1)[1].split(
+            "RELEASE_GATE_CHECKPOINT_DIR", 1
+        )[0]
+        self.assertIn("STACK_BUILD_CONTRACT", contracts)
+        self.assertEqual(contracts.count("--controller-section"), 4)
+        self.assertNotIn("--controller \"$(abspath Makefile)\"", contracts)
 
     def test_individual_stack_stages_reject_unlocked_execution(self) -> None:
         self.assertEqual(MAKEFILE.count("\n\t$(STACK_REQUIRE_LOCK)\n"), 5)
@@ -77,7 +103,7 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
             ("stack-engine-api-build", "stack-container-build", "container-engine-api"),
             ("stack-container-build", "stack-builder-build", "container"),
             ("stack-builder-build", "stack-compose-build", "container-builder-shim"),
-            ("stack-compose-build", "all", "container-compose"),
+            ("stack-compose-build", "local-build", "container-compose"),
         ):
             with self.subTest(repository=repository):
                 target = make_target(current, following)
@@ -88,18 +114,34 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
                 self.assertIn("--expected-tree", target)
                 self.assertLess(target.index(" build"), target.index(" create "))
 
-    def test_downstream_stages_consume_upstream_pin_values(self) -> None:
+    def test_downstream_stages_bind_upstream_receipts_and_source_paths(self) -> None:
         container = make_target("stack-container-build", "stack-builder-build")
         self.assertIn('--dependency "$(STACK_CONTAINERIZATION_PIN)"', container)
         self.assertIn('--dependency "$(STACK_ENGINE_API_PIN)"', container)
-        compose = make_target("stack-compose-build", "all")
-        for pin in (
-            "STACK_CONTAINERIZATION_PIN",
-            "STACK_ENGINE_API_PIN",
-            "STACK_CONTAINER_PIN",
+        self.assertIn(
+            'CONTAINERIZATION_PACKAGE_PATH="$(CONTAINERIZATION_STACK_REPO)"',
+            container,
+        )
+        self.assertIn(
+            'CONTAINER_ENGINE_API_PACKAGE_PATH="$(CONTAINER_ENGINE_API_STACK_REPO)"',
+            container,
+        )
+        compose = make_target("stack-compose-build", "local-build")
+        for variable, source_path, repository in (
+            (
+                "STACK_CONTAINERIZATION_PIN",
+                "CONTAINERIZATION_PACKAGE_PATH",
+                "CONTAINERIZATION_STACK_REPO",
+            ),
+            (
+                "STACK_ENGINE_API_PIN",
+                "CONTAINER_ENGINE_API_PACKAGE_PATH",
+                "CONTAINER_ENGINE_API_STACK_REPO",
+            ),
+            ("STACK_CONTAINER_PIN", "CONTAINER_PACKAGE_PATH", "CONTAINER_STACK_REPO"),
         ):
-            self.assertIn(f'value --receipt "$({pin})"', compose)
-            self.assertIn(f'--dependency "$({pin})"', compose)
+            self.assertIn(f'--dependency "$({variable})"', compose)
+            self.assertIn(f'{source_path}="$({repository})"', compose)
 
     def test_recovery_state_is_durable_and_has_a_safe_local_fallback(self) -> None:
         self.assertIn("/Volumes/SSD/github/.container-compose-build", MAKEFILE)
@@ -115,7 +157,7 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         self.assertNotIn("security find-identity", MAKEFILE)
 
     def test_stack_build_excludes_release_only_work(self) -> None:
-        stack = MAKEFILE.split("\nstack-build:", 1)[1].split("\nall:", 1)[0]
+        stack = MAKEFILE.split("\nstack-build:", 1)[1].split("\nlocal-build:", 1)[0]
         for forbidden in (
             "codeql",
             "docc",

--- a/Tools/ci/test_run_command_with_deadline.py
+++ b/Tools/ci/test_run_command_with_deadline.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import signal
 import subprocess
@@ -172,6 +173,57 @@ class RunCommandWithDeadlineTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 7, result.stderr)
         self.assertEqual(result.stdout, "complete\n")
+
+    def test_optional_timing_log_records_the_label_duration_and_status(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            timing_log = Path(directory) / "timings/run.jsonl"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--seconds",
+                    "5",
+                    "--timing-log",
+                    str(timing_log),
+                    "--timing-label",
+                    "fixture-build",
+                    "--",
+                    "/usr/bin/true",
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            record = json.loads(timing_log.read_text(encoding="utf-8"))
+            self.assertEqual(record["label"], "fixture-build")
+            self.assertEqual(record["exit_status"], 0)
+            self.assertGreaterEqual(record["duration_seconds"], 0)
+
+    def test_timing_log_does_not_follow_a_symbolic_link(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            destination = root / "outside.jsonl"
+            destination.write_text("preserve\n", encoding="utf-8")
+            timing_log = root / "timing.jsonl"
+            timing_log.symlink_to(destination)
+
+            with self.assertRaises(OSError):
+                self.module.run(
+                    [
+                        "--seconds",
+                        "5",
+                        "--timing-log",
+                        str(timing_log),
+                        "--timing-label",
+                        "fixture-build",
+                        "--",
+                        "/usr/bin/true",
+                    ]
+                )
+
+            self.assertEqual(destination.read_text(encoding="utf-8"), "preserve\n")
 
     def test_no_deadline_returns_the_child_status_and_output(self) -> None:
         result = subprocess.run(

--- a/Tools/release/conventional-version.py
+++ b/Tools/release/conventional-version.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Resolve the next stable version from Conventional Commits."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+SEMVER = re.compile(r"(?P<major>0|[1-9][0-9]*)[.](?P<minor>0|[1-9][0-9]*)[.](?P<patch>0|[1-9][0-9]*)")
+CONVENTIONAL_SUBJECT = re.compile(
+    r"(?P<type>[a-z][a-z0-9-]*)(?:[(][^)\r\n]+[)])?(?P<breaking>!)?: (?P<description>\S.*)"
+)
+BREAKING_FOOTER = re.compile(r"^BREAKING(?:[ -]CHANGE)?:\s*\S", re.MULTILINE)
+PATCH_TYPES = frozenset(("fix", "perf", "revert"))
+
+
+class VersionError(RuntimeError):
+    """Raised when release history cannot produce a safe version."""
+
+
+@dataclass(frozen=True, order=True)
+class Version:
+    major: int
+    minor: int
+    patch: int
+
+    @classmethod
+    def parse(cls, value: str) -> Version:
+        match = SEMVER.fullmatch(value)
+        if match is None:
+            raise VersionError(f"version is not bare semantic versioning: {value}")
+        return cls(*(int(match.group(name)) for name in ("major", "minor", "patch")))
+
+    def bump(self, level: str) -> Version:
+        if level == "major":
+            return Version(self.major + 1, 0, 0)
+        if level == "minor":
+            return Version(self.major, self.minor + 1, 0)
+        if level == "patch":
+            return Version(self.major, self.minor, self.patch + 1)
+        raise VersionError("no release-producing Conventional Commit exists")
+
+    def __str__(self) -> str:
+        return f"{self.major}.{self.minor}.{self.patch}"
+
+
+@dataclass(frozen=True)
+class Commit:
+    object_id: str
+    subject: str
+    body: str
+
+
+def checked_git(repository: Path, *arguments: str) -> str:
+    completed = subprocess.run(
+        ["/usr/bin/git", "-C", str(repository), *arguments],
+        check=False,
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        diagnostic = completed.stderr.strip() or "unknown Git failure"
+        raise VersionError(f"could not inspect release history: {diagnostic}")
+    return completed.stdout
+
+
+def latest_tag(repository: Path) -> str | None:
+    tags = checked_git(
+        repository,
+        "tag",
+        "--merged",
+        "HEAD",
+        "--sort=-version:refname",
+        "--format=%(refname:strip=2)",
+    ).splitlines()
+    return next((tag for tag in tags if SEMVER.fullmatch(tag)), None)
+
+
+def commits_since(repository: Path, tag: str | None) -> tuple[Commit, ...]:
+    revision = f"{tag}..HEAD" if tag else "HEAD"
+    field_separator = "%x1f"
+    record_separator = "%x1e"
+    output = checked_git(
+        repository,
+        "log",
+        "--first-parent",
+        f"--format=%H{field_separator}%s{field_separator}%b{record_separator}",
+        revision,
+    )
+    commits: list[Commit] = []
+    for record in output.split("\x1e"):
+        record = record.strip("\n")
+        if not record:
+            continue
+        fields = record.split("\x1f", 2)
+        if len(fields) != 3:
+            raise VersionError("Git returned malformed commit metadata")
+        commits.append(Commit(fields[0], fields[1], fields[2].rstrip("\n")))
+    return tuple(commits)
+
+
+def commit_level(commit: Commit) -> str | None:
+    subject = commit.subject
+    body = commit.body
+    if subject.startswith("Merge pull request "):
+        body_lines = body.splitlines()
+        if not body_lines:
+            return None
+        subject = body_lines[0]
+        body = "\n".join(body_lines[1:])
+    match = CONVENTIONAL_SUBJECT.fullmatch(subject)
+    if match is None:
+        raise VersionError(
+            f"commit {commit.object_id[:12]} is not Conventional Commits compliant: "
+            f"{subject}"
+        )
+    if match.group("breaking") or BREAKING_FOOTER.search(body):
+        return "major"
+    if match.group("type") == "feat":
+        return "minor"
+    if match.group("type") in PATCH_TYPES:
+        return "patch"
+    return None
+
+
+def release_level(commits: Sequence[Commit]) -> str:
+    levels = {level for commit in commits if (level := commit_level(commit)) is not None}
+    for level in ("major", "minor", "patch"):
+        if level in levels:
+            return level
+    raise VersionError("no release-producing Conventional Commit exists since the latest tag")
+
+
+def selector(level: str) -> str:
+    return {"major": "+--", "minor": "-+-", "patch": "--+"}[level]
+
+
+def plan(repository: Path) -> dict[str, object]:
+    resolved_repository = repository.resolve(strict=True)
+    if not (resolved_repository / ".git").exists() and not checked_git(
+        resolved_repository, "rev-parse", "--git-dir"
+    ).strip():
+        raise VersionError(f"repository is not a Git checkout: {resolved_repository}")
+    tag = latest_tag(resolved_repository)
+    commits = commits_since(resolved_repository, tag)
+    level = release_level(commits)
+    current = Version.parse(tag) if tag else Version(0, 0, 0)
+    return {
+        "base": str(current),
+        "commits": len(commits),
+        "level": level,
+        "next": str(current.bump(level)),
+        "schema": 1,
+        "selector": selector(level),
+    }
+
+
+def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repository",
+        type=Path,
+        default=Path.cwd(),
+        help="Git checkout to inspect (default: current directory)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "selector", "version"),
+        default="json",
+    )
+    parser.add_argument(
+        "--allow-no-release",
+        action="store_true",
+        help="return an empty value when valid history contains no release change",
+    )
+    return parser.parse_args(arguments)
+
+
+def main(arguments: Sequence[str] | None = None) -> int:
+    options = parse_arguments(sys.argv[1:] if arguments is None else arguments)
+    try:
+        value = plan(options.repository)
+    except (OSError, VersionError) as error:
+        if options.allow_no_release and str(error).startswith(
+            "no release-producing Conventional Commit exists"
+        ):
+            print("")
+            return 0
+        print(f"conventional version error: {error}", file=sys.stderr)
+        return 2
+    if options.format == "selector":
+        print(value["selector"])
+    elif options.format == "version":
+        print(value["next"])
+    else:
+        print(json.dumps(value, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "24dec751bd12e3cbaca8e954075f534a2be53586",
+      "ref": "d9d0fd80d38db1f332c854d91f9a479f5e149431",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "a4abc86ce7f2c4169c805ff38b018297b166880a",
+      "ref": "6702ebb6e17196d5b7b195b2de4b1d69b0251d01",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -5278,7 +5278,11 @@ github_cli() {{
         workflow = SCHEDULED_STABLE_RELEASE_WORKFLOW.read_text(encoding="utf-8")
 
         self.assertIn('cron: "17 9 * * 1"', workflow)
-        self.assertIn('default: "-+-"', workflow)
+        self.assertIn('default: "auto"', workflow)
+        self.assertIn('--format selector --allow-no-release', workflow)
+        self.assertIn('Conventional Commit history contains no release-producing change', workflow)
+        self.assertIn('  - "--+"', workflow)
+        self.assertIn('  - "-+-"', workflow)
         self.assertIn('  - "+--"', workflow)
         self.assertIn("container-compose-plugin-current-[0-9a-f]{12}-arm64", workflow)
         self.assertIn(".updated_at", workflow)

--- a/Tools/release/test_conventional_version.py
+++ b/Tools/release/test_conventional_version.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("conventional-version.py")
+SPEC = importlib.util.spec_from_file_location("conventional_version", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+CONVENTIONAL_VERSION = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CONVENTIONAL_VERSION
+SPEC.loader.exec_module(CONVENTIONAL_VERSION)
+
+
+class ConventionalVersionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.repository = Path(self.temporary_directory.name)
+        self.git("init", "-q")
+        self.git("config", "user.name", "Test")
+        self.git("config", "user.email", "test@example.invalid")
+        self.commit("chore: create repository")
+        self.git("tag", "1.2.3")
+
+    def tearDown(self) -> None:
+        self.temporary_directory.cleanup()
+
+    def git(self, *arguments: str) -> str:
+        return subprocess.run(
+            ["/usr/bin/git", "-C", str(self.repository), *arguments],
+            check=True,
+            stdout=subprocess.PIPE,
+            text=True,
+        ).stdout.strip()
+
+    def commit(self, subject: str, body: str = "") -> None:
+        marker = self.repository / "history.txt"
+        with marker.open("a", encoding="utf-8") as stream:
+            stream.write(f"{subject}\n")
+        self.git("add", "history.txt")
+        command = ["commit", "-q", "-m", subject]
+        if body:
+            command.extend(("-m", body))
+        self.git(*command)
+
+    def test_fix_selects_patch(self) -> None:
+        self.commit("fix(runtime): preserve socket ownership")
+
+        self.assertEqual(
+            CONVENTIONAL_VERSION.plan(self.repository),
+            {
+                "base": "1.2.3",
+                "commits": 1,
+                "level": "patch",
+                "next": "1.2.4",
+                "schema": 1,
+                "selector": "--+",
+            },
+        )
+
+    def test_feature_selects_minor_over_patch(self) -> None:
+        self.commit("fix: correct retry")
+        self.commit("feat(compose): support profiles")
+
+        result = CONVENTIONAL_VERSION.plan(self.repository)
+
+        self.assertEqual(result["level"], "minor")
+        self.assertEqual(result["next"], "1.3.0")
+        self.assertEqual(result["selector"], "-+-")
+
+    def test_breaking_marker_selects_major(self) -> None:
+        self.commit("feat(api)!: replace request schema")
+
+        result = CONVENTIONAL_VERSION.plan(self.repository)
+
+        self.assertEqual(result["level"], "major")
+        self.assertEqual(result["next"], "2.0.0")
+
+    def test_breaking_footer_selects_major(self) -> None:
+        self.commit(
+            "fix(api): accept stable identifiers",
+            "BREAKING CHANGE: remove the legacy identifier.",
+        )
+
+        self.assertEqual(CONVENTIONAL_VERSION.plan(self.repository)["level"], "major")
+
+    def test_non_release_types_do_not_bump(self) -> None:
+        self.commit("docs: explain build graph")
+        error = StringIO()
+
+        with redirect_stderr(error):
+            status = CONVENTIONAL_VERSION.main(
+                ["--repository", str(self.repository), "--format", "selector"]
+            )
+
+        self.assertEqual(status, 2)
+        self.assertIn("no release-producing", error.getvalue())
+
+        output = StringIO()
+        with redirect_stdout(output):
+            status = CONVENTIONAL_VERSION.main(
+                [
+                    "--repository",
+                    str(self.repository),
+                    "--format",
+                    "selector",
+                    "--allow-no-release",
+                ]
+            )
+        self.assertEqual(status, 0)
+        self.assertEqual(output.getvalue(), "\n")
+
+    def test_nonconventional_commit_fails_closed(self) -> None:
+        self.commit("update the build")
+
+        with self.assertRaisesRegex(
+            CONVENTIONAL_VERSION.VersionError,
+            "not Conventional Commits compliant",
+        ):
+            CONVENTIONAL_VERSION.plan(self.repository)
+
+    def test_merge_commit_uses_its_conventional_pull_request_title(self) -> None:
+        commit = CONVENTIONAL_VERSION.Commit(
+            "a" * 40,
+            "Merge pull request #1 from example/topic",
+            "fix(runtime): retain result",
+        )
+
+        self.assertEqual(CONVENTIONAL_VERSION.commit_level(commit), "patch")
+
+    def test_empty_merge_commit_is_ignored(self) -> None:
+        commit = CONVENTIONAL_VERSION.Commit(
+            "a" * 40,
+            "Merge pull request #1 from example/topic",
+            "",
+        )
+
+        self.assertIsNone(CONVENTIONAL_VERSION.commit_level(commit))
+
+    def test_cli_formats_are_stable(self) -> None:
+        self.commit("perf: reduce startup allocation")
+        output = StringIO()
+
+        with redirect_stdout(output):
+            status = CONVENTIONAL_VERSION.main(
+                ["--repository", str(self.repository), "--format", "version"]
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(output.getvalue(), "1.2.4\n")
+
+        output = StringIO()
+        with redirect_stdout(output):
+            status = CONVENTIONAL_VERSION.main(
+                ["--repository", str(self.repository)]
+            )
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(output.getvalue())["selector"], "--+")
+
+    def test_version_rejects_leading_zero(self) -> None:
+        with self.assertRaisesRegex(CONVENTIONAL_VERSION.VersionError, "not bare"):
+            CONVENTIONAL_VERSION.Version.parse("01.2.3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -136,6 +136,13 @@ Common types include:
 - `ci` for workflow or automation changes.
 - `chore` for maintenance that does not affect runtime behavior.
 
+Stable-release automation reads these subjects from first-parent history.
+`fix`, `perf`, and `revert` select a patch release; `feat` selects a minor
+release. Add `!` after the type or scope, or a `BREAKING CHANGE:` footer, only
+for an intentional major release. Other valid types do not request a release
+on their own. A non-conventional subject fails the automatic version decision
+rather than guessing.
+
 Examples:
 
 ```text

--- a/docs/architecture/recoverable-container-family-builds.md
+++ b/docs/architecture/recoverable-container-family-builds.md
@@ -2,135 +2,177 @@
 
 ## Decision
 
-The Container-family source build uses Make to declare repository order and
-each repository's native build tool to do the work. Swift packages are built
-with SwiftPM and `container-builder-shim` is built with Go. There is no separate
-workflow runtime and no duplicated build graph.
+Make declares the Container-family repository graph. SwiftPM builds the Swift
+packages, and Go builds `container-builder-shim`. There is no second build
+graph or separate workflow runtime.
 
-This keeps the normal path visible from the command line:
+The default command builds the complete local stack:
 
 ```sh
-make stack-preflight
-make stack-build
-make stack-status
+make
 ```
 
-`make` remains the quick, repository-local Compose build. `make stack-build`
-builds the complete local family and records the exact source and dependency
-pins that produced every executable.
+Use `make local-build` for a quick repository-local Compose build. Use
+`make stack-status` to verify retained output without rebuilding it.
 
-## Repository Graph
+## Build Workflow
 
-Make starts the three independent roots concurrently:
+The three independent roots start concurrently. A consumer starts only after
+its dependencies have published and verified exact build pins.
 
-```text
-containerization ─┐
-                  ├─> container ─> container-compose
-container-engine-api ─┘
-
-container-builder-shim ────────────────────────┐
-                                               ├─> final stack pin bundle
-container-compose ─────────────────────────────┘
+```mermaid
+flowchart LR
+  preflight[Fail-fast preflight] --> lock[Single non-blocking lock]
+  lock --> cz[containerization<br/>SwiftPM]
+  lock --> api[container-engine-api<br/>SwiftPM]
+  lock --> shim[container-builder-shim<br/>Go]
+  cz --> container[container<br/>SwiftPM]
+  api --> container
+  container --> compose[container-compose<br/>SwiftPM]
+  cz --> compose
+  api --> compose
+  cz --> bundle[Verified stack pin bundle]
+  api --> bundle
+  shim --> bundle
+  container --> bundle
+  compose --> bundle
 ```
-
-`container` cannot start until the `containerization` and
-`container-engine-api` pins verify. Compose cannot start until the Container
-pin and its transitive pins verify. The builder is independent, so it runs in
-parallel and joins only at final bundle publication.
-
-## Recovery Contract
 
 Generated state defaults to
 `/Volumes/SSD/github/.container-compose-build`. If that development volume is
-not mounted, the local fallback is `.build/stack`. A marker prevents the build
-from treating an arbitrary directory as owned state, and one non-blocking
-`lockf` lock prevents concurrent writers.
+not mounted, the fallback is `.build/stack`. SwiftPM scratch directories, Go
+artifacts, pins, timing logs, and the final bundle all live below that managed
+state root rather than in source checkouts.
 
-Each repository has a durable JSON build pin. A pin records:
+Every compiler command has a wall-clock deadline and complete process-session
+cleanup. Every full invocation records concurrency-safe JSONL timing evidence
+under `timings/`. The log includes the end-to-end `stack-total` duration and
+the duration and exit status of each native build and bin-path query. This
+makes clean, resumed, and warm no-op runs directly comparable.
 
-- the canonical source path, exact commit, Git tree, and origin;
-- the exact upstream pin receipts it consumed;
-- every published artifact path and SHA-256 digest;
-- the successful native build command, duration, and completion time; and
-- a build-contract digest covering configuration, tool binary and version,
-  relevant compiler environment, host type, Python runtime, and controller
-  source.
+The first real cold and recovered runs are recorded in
+[Recoverable build workflow timings](../reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md).
 
-Pins are written to a temporary regular file, flushed, and atomically renamed
-only after the native build succeeds. Failed or interrupted builds therefore
-cannot publish success. SwiftPM scratch directories and Go output storage are
-retained, so the next invocation can continue through the native compiler
-cache.
+## Recovery Contract
 
-Before a pin is reused, `Tools/build/stack-pin.py` recursively verifies its
-own digest, the clean source commit and tree, every dependency receipt, and
-every artifact digest. A changed source checkout, dependency pin, executable,
-or receipt invalidates that repository and all downstream repositories. A
-configuration, toolchain, operating-system, environment, or controller change
-also selects a different native scratch identity. Work that is still exact is
-reused automatically.
+A marker prevents the build from claiming an arbitrary state directory, and
+one `lockf` lock prevents concurrent writers. Each successful repository build
+atomically publishes a durable JSON pin containing:
 
-The final `stack.json` bundle is published while the global build lock is
-still held. `verify-bundle` then recursively validates every component before
-the lock is released. `make stack-status` reports `valid`, `stale`, or
-`missing`; it never repairs or silently carries a receipt forward.
+- canonical source path, exact commit, Git tree, and origin;
+- exact dependency-pin receipts;
+- artifact paths, modes, and SHA-256 digests;
+- successful native command, duration, and completion time; and
+- a build-contract digest covering configuration, toolchain, effective target,
+  SDK identity, relevant environment, host, Python runtime, and the dedicated
+  build-controller contract.
 
-## What Happens After Failure
+The controller identity hashes a narrow manifest and two marked Makefile
+sections containing only stack configuration and recipes. Unrelated Make
+targets therefore do not invalidate native caches, while any stack recipe
+change automatically changes the contract. Tooling that enforces or records
+the contract is itself hashed into the build identity.
 
-Run the same command again:
+Pins are flushed and atomically renamed only after success. Before reuse,
+`Tools/build/stack-pin.py` recursively verifies its own digest, clean source
+identity, dependencies, and artifacts. Source, dependency, artifact, toolchain,
+SDK, environment, or controller drift invalidates only the affected transitive
+path.
 
-```sh
-make stack-build
+```mermaid
+stateDiagram-v2
+  [*] --> VerifyPin
+  VerifyPin --> Reuse: exact source, contract,<br/>dependencies and artifact
+  VerifyPin --> NativeBuild: missing or stale
+  NativeBuild --> Failed: command fails or times out
+  NativeBuild --> PublishPin: command succeeds
+  PublishPin --> VerifyPin: atomic receipt installed
+  Failed --> VerifyPin: rerun same make command
+  Reuse --> Bundle
+  Bundle --> [*]: every component verifies
 ```
 
-The result depends on the failure boundary:
+After a failure, run `make` again. Successful independent roots are reused;
+the failed stage continues from its retained native cache; downstream work is
+rebuilt only when its verified input changed. If final bundle publication was
+interrupted, component pins are reused and only the bundle is republished. A
+live previous invocation makes the lock fail immediately.
 
-- If a native compile failed, its success pin is absent and that command runs
-  again against the retained native scratch directory.
-- If an upstream source or artifact changed, its pin and every transitive
-  consumer are rebuilt.
-- If an independent repository already has an exact valid pin, it is skipped.
-- If final bundle publication was interrupted, all valid component pins are
-  reused and only the bundle is republished.
-- If the previous process is still running, the lock fails immediately rather
-  than creating a second writer.
+## Test Workflow
 
-Manual editing, copying, or renaming of success pins is unsupported. A modified
-receipt fails its digest check.
+Development keeps feedback proportional to the change. Release-only work does
+not run during ordinary builds.
+
+```mermaid
+flowchart TD
+  edit[Source change] --> focused[Focused unit or policy tests]
+  focused --> review[Exact-diff review]
+  review -->|finding| fix[Fix finding]
+  fix --> focused
+  review -->|clean| ci[Repository CI and coverage]
+  ci -->|feature slice complete| integration[Matched-stack integration and parity]
+  integration --> release{Stable release?}
+  release -->|no| done[Merge-ready evidence]
+  release -->|yes| releaseOnly[CodeQL, package, signing,<br/>notarisation and DocC]
+```
+
+`make stack-self-test` executes the complete five-repository graph with fake
+native builders. It proves fail-once recovery, transitive invalidation,
+parallel-root reuse, external Compose scratch storage, final bundle
+publication, and timing evidence. `Tools/build/test_stack_pin.py` separately
+covers receipt and artifact integrity, including real macOS SDK metadata in the
+Swift build contract.
+
+## GitHub Actions And Release
+
+Conventional Commit history selects the next semantic version:
+
+- `fix`, `perf`, or `revert` produces a patch;
+- `feat` produces a minor;
+- `!` or a `BREAKING CHANGE:` footer produces a major; and
+- documentation, test, build, CI, and maintenance commits alone do not release.
+
+Non-conventional first-parent commits fail closed. For GitHub merge commits,
+the wrapper subject is ignored and the Conventional pull-request title on the
+first body line remains the authority. Use `make release-version` to inspect
+the decision. An explicit
+`VERSION_SELECTOR` remains available for a reviewed maintenance release or an
+exact recovery retry.
+
+```mermaid
+flowchart TD
+  main[Reviewed immutable main] --> version[Resolve Conventional Commit semver]
+  version --> preflight[Homebrew and release fail-fast checks]
+  preflight --> local[Recoverable local release gate]
+  local --> hosted[Candidate-keyed hosted gate]
+  hosted --> codeql[Release-only CodeQL]
+  codeql --> package[Package, sign and notarise]
+  package --> publish[GitHub release and Homebrew]
+  publish --> docc[DocC sites last]
+  local -. retry .-> local
+  hosted -. checkpoint retry .-> hosted
+```
+
+The hosted gate stores stage checkpoints below the immutable release-candidate
+commit. Each checkpoint records exact inputs, status, duration, output name,
+and output digest. A corrected retry starts at the first missing or invalid
+stage. The stable-release authority receipt binds component commits to the
+verified checkpoint and log.
 
 ## Unattended Operation
 
 Build recipes disable Git credential prompting, SSH askpass, inherited shell
-hooks, and dynamic-loader injection. Normal Make parsing never queries the
-macOS Keychain for a signing identity. Source builds do not sign applications,
-start VMs, access removable-volume data, publish artifacts, run CodeQL, build
-DocC, or record performance benchmarks.
+hooks, and dynamic-loader injection. Ordinary builds do not sign applications,
+start VMs, read removable volumes, access the Keychain, publish artifacts, run
+CodeQL, build DocC, or record performance benchmarks.
 
 Release signing receives an explicit 40-character Developer ID fingerprint at
-its release-only boundary. Missing credentials or privacy grants fail there
-with a diagnostic rather than being requested by an ordinary build.
-
-## Release Validation
-
-Release validation remains broader than a source build. Its stages use the
-same Make targets plus `Tools/ci/run-release-checkpoint.py` for bounded,
-content-addressed success checkpoints and durable output logs. Each checkpoint
-records the exact-input fingerprint before and after the stage, status,
-duration, output name, and output digest.
-
-The hosted stable gate retains checkpoints below a directory keyed by the
-immutable release candidate commit. A corrected retry starts with the first
-missing or invalid stage. Its stable-release authority receipt binds the
-candidate and component commits to the verified hosted-gate checkpoint and
-output log; it does not rely on an orchestration session.
-
-CodeQL, full parity, packaging, signing, notarisation, documentation, and
-publication stay in release-specific jobs. Their inclusion is explicit and
-does not widen `make`, `make build`, or `make stack-build`.
+its release-only boundary. Missing credentials or privacy grants fail with a
+diagnostic rather than opening an approval dialog during an unattended build.
 
 ## Verification
 
-Run the focused recovery tests with:
+Run the focused build-system proof with:
 
 ```sh
 make stack-self-test
@@ -138,7 +180,6 @@ python3 -m unittest Tools.ci.test_release_stage_git_history
 python3 -m unittest Tools.release.test_stable_release_authority
 ```
 
-The tests cover atomic replacement, source and artifact drift, transitive pin
-invalidation, bundle corruption, unsafe output links, the declared repository
-graph, lock scope, release-only exclusions, noninteractive identity handling,
-and candidate-keyed hosted checkpoints.
+The final release still runs the repository CI, matched-stack integration,
+Docker parity, CodeQL, packaging, Homebrew, and DocC gates required by the
+release workflow.

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -83,10 +83,12 @@ compatibility.
 
 | Target | Output |
 | --- | --- |
+| `make` or `make all` | Recoverable build of the complete Container-family source stack; writes exact pins and JSONL timings. |
+| `make local-build` | Quick repository-local debug builds of `compose` and `compose-normalizer`. |
 | `make build` | Debug Swift `compose` executable. |
 | `make build-release` | Release Swift `compose` executable. |
 | `make go-build` | Static, trimmed release `compose-normalizer`. |
-| `make stack-build` | Recoverable local build of the complete Container-family source stack with exact pins. |
+| `make stack-build` | Explicit form of the default recoverable full-stack build. |
 | `make stack-status` | Verify every retained source, dependency, and artifact pin plus the final bundle. |
 | `make package` | Release plugin archive and relocatable checksum sidecar. |
 
@@ -142,13 +144,27 @@ Useful focused targets are:
 | `make stack-preflight` | Validate native tools, state ownership, and clean sibling source repositories before expensive work. |
 | `make stack-self-test` | Prove atomic pin publication, transitive invalidation, artifact verification, and bundle recovery. |
 
-The source-build recovery contract is documented in [Recoverable Container-family builds](../architecture/recoverable-container-family-builds.md). Make declares the repository graph; SwiftPM and Go retain their native compiler caches. Each successful repository build atomically publishes a source-, dependency-, and artifact-addressed JSON pin. Downstream repositories read those pins automatically, and any source, dependency, artifact, or receipt drift invalidates the affected transitive path before reuse.
+The source-build recovery contract and diagrams are documented in
+[Recoverable Container-family builds](../architecture/recoverable-container-family-builds.md).
+Make declares the repository graph; SwiftPM and Go retain their native compiler
+caches. Each successful repository build atomically publishes a source-,
+dependency-, and artifact-addressed JSON pin. Downstream repositories read
+those pins automatically, and any source, dependency, artifact, or receipt
+drift invalidates the affected transitive path before reuse. Unrelated Makefile
+changes do not invalidate native caches because the stack contract has its own
+versioned manifest.
 
 The final pin bundle is verified while the single build lock is held. After a
-failure or interruption, rerun `make stack-build`: valid independent pins are
+failure or interruption, rerun `make`: valid independent pins are
 reused and the first missing or stale stage continues from its native build
 cache. The hosted release gate uses candidate-keyed stage checkpoints and
 durable logs under the same principle. Never repair a success receipt by hand.
+
+Each full stack invocation writes a unique JSONL file below
+`$(STACK_STATE_ROOT)/timings`. It records the end-to-end duration plus each
+native compiler and bin-path operation, including failures. Compare a clean
+run, the immediate no-op rerun, and a fail-once recovery using these durable
+records rather than terminal timestamps.
 
 Every stage has a wall-clock deadline and terminates its complete process
 session, including descendant process groups, when that deadline expires. A
@@ -414,7 +430,13 @@ prior SHA.
 
 ### Scheduled Stable Releases
 
-**Scheduled Stable Release** runs every Monday at 09:17 UTC and promotes the next minor version with `-+-` when the Current build has soaked for seven days and `main` contains source newer than the latest semantic tag. It ends successfully without allocating the release runner when either condition is not met, so an unready week is not a failed release. A manual dispatch of the same workflow permits either `-+-` (minor) or `+--` (major); patch, exact-version, and documented security releases remain explicit local helper invocations.
+**Scheduled Stable Release** runs every Monday at 09:17 UTC. When the Current
+build has soaked for seven days and `main` contains source newer than the latest
+semantic tag, it derives the next version from first-parent Conventional Commit
+history. It ends successfully without allocating the release runner when there
+is no release-producing commit or the soak is incomplete, so an unready week is
+not a failed release. Manual dispatch can use the same automatic decision or an
+explicit patch, minor, or major override.
 
 The scheduled stable-release workflow and the Current package workflow run only from `main` on the dedicated `container-compose-release` Apple-silicon self-hosted runner. It creates clean, disposable stack checkouts, reconstructs the read-only Apple remotes and Stephen-owned push remotes, and invokes the existing helper unchanged. That preserves the required local runtime and Docker Compose parity gate, signed semantic tag, source-promotion pull request, hosted stable gate, immutable package assets, and paired Homebrew update. The separate Current Demo workflow consumes the already-published exact-SHA signed packages on the same hardware-virtualization-capable runner, uses a stable internal-volume runtime path, and applies a process-group deadline. Its mutable visual asset is recoverable and deliberately outside the package, attestation, release, and Homebrew critical path. GitHub-hosted macOS workers cannot provide the nested virtualization needed to record Container guest startup, so they must never publish that recording.
 
@@ -432,6 +454,8 @@ From clean `~/github/container-compose`, `~/github/container-builder-shim`,
 
 ```sh
 make release-plan
+make release-version
+make release-plan VERSION_SELECTOR=--+ # reviewed maintenance plan
 ```
 
 ### Promote The Current Build
@@ -444,13 +468,13 @@ formulae, and release notes deterministic. The current prerelease is recreated
 by its workflow after the matching Homebrew formulae update, so its GitHub
 published time always identifies the build users are viewing.
 
-After `make release-plan` confirms the intended next version, promote the
-validated `main` source with one selector. The selector is resolved from the
-latest semantic tag—not from the working-tree version. The explicit intent
-makes a stable release a conscious boundary rather than an automatic response to
-every green slice:
+`make release-version` reports the latest reachable semantic tag, selected
+bump, and next version. `make release-plan` includes that decision. After the
+plan confirms the intended version, promote validated `main`; omission of
+`VERSION_SELECTOR` uses the Conventional Commit decision:
 
 ```sh
+CONTAINER_STACK_RELEASE_INTENT=milestone make release
 CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=--+   # patch: X.Y.Z -> X.Y.(Z+1)
 CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=-+-   # minor: X.Y.Z -> X.(Y+1).0
 CONTAINER_STACK_RELEASE_INTENT=milestone make release VERSION_SELECTOR=+--   # major: X.Y.Z -> (X+1).0.0
@@ -460,6 +484,15 @@ CONTAINER_STACK_RELEASE_INTENT=milestone \\
   make release VERSION_SELECTOR=0.7.0
 CONTAINER_STACK_RELEASE_INTENT=security CONTAINER_STACK_SECURITY_REASON='CVE-2026-12345' make release VERSION_SELECTOR=--+
 ```
+
+The automatic resolver treats `fix`, `perf`, and `revert` as patch changes,
+`feat` as minor, and a `!` marker or `BREAKING CHANGE:` footer as major. Other
+valid Conventional Commit types do not create a release by themselves.
+Non-conventional first-parent subjects fail closed. For a GitHub merge commit,
+the Conventional pull-request title recorded as its first body line supplies
+the decision. Explicit selectors remain available for reviewed maintenance
+promotions, security releases, and exact recovery retries; they are not a way
+to bypass release evidence.
 
 Before source promotion, the helper requires the mutable `current` tag to point
 at the validated `main` head. Milestones also require that Current build's

--- a/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
+++ b/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
@@ -1,0 +1,54 @@
+# Recoverable build workflow timings — 9 September 2026
+
+## Scope
+
+These are diagnostic wall-clock timings from the first real run of the native
+Make, SwiftPM, and Go build controller on the development Mac. They measure
+build-system behaviour, not application runtime performance. The retained
+JSONL records are under the controller's protected external state root.
+
+The previous Nextflow evidence included source checks and test suites as well
+as builds, so its 9 minute 23 second repository profile is not a like-for-like
+cold-build baseline. It must not be used to claim a build speed-up.
+
+## Build timings
+
+The corrected cold five-repository build completed in 292.726 seconds:
+
+- `container-builder-shim`: 0.394 seconds.
+- `container-engine-api`: 31.678 seconds.
+- `containerization`: 56.770 seconds.
+- `container`: 154.122 seconds.
+- `container-compose`: 74.460 seconds.
+
+The independent builder, engine API, and Containerization roots ran in
+parallel, so their durations do not sum to the end-to-end result. Bin-path
+queries added 1.196 seconds in total.
+
+An immediate unchanged rerun verified and reused all five exact pins in 5.873
+seconds. That recovery path was 49.8 times faster than the cold build and
+removed 286.853 seconds, or 98.0%, from the end-to-end duration.
+
+The initial pre-fix run stopped after 225.619 seconds when SwiftPM found that
+Compose and Container required different exact Containerization revisions.
+The successful upstream pins were retained. The fix replaced mutable SwiftPM
+edit sessions with identity-preserving local manifest overrides, and a
+targeted regression now enforces that hand-off.
+
+## Test timings
+
+The targeted build-controller regression suite ran five tests in 10.578
+seconds. The wider exact-head controller review ran 57 relevant tests in
+24.437 seconds.
+
+The complete Python tooling gate ran before the timing exercise and took
+1,215.05 seconds wall time:
+
+- Coverage tools: 7 tests.
+- Release tools: 515 tests in 727.433 seconds.
+- CI tools: 304 tests in 470.572 seconds.
+- Nested stack self-tests: 25 tests in 14.969 seconds.
+
+The release gate remains the authority for full product, parity, security, and
+documentation validation. Those release-only timings will be retained by its
+own checkpoint evidence rather than mixed into this build-only measurement.

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -8412,6 +8412,27 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/594"
     },
     {
+      "id": "container-compose-595",
+      "owner": "stephenlclarke/container-compose",
+      "title": "fix(build): complete recoverable stack workflow",
+      "state": "active-draft",
+      "lastVerified": "2026-09-09",
+      "commits": [
+        "73b886a8a1d66feae5361f92e0ccee581f28b6ce"
+      ],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-595.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-596.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/596"
+    },
+    {
       "id": "process-list-compose-top-process-list",
       "owner": "stephenlclarke/container-compose",
       "title": "Pull request: support Docker-shaped `container compose top`",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-09
 
-Entries: 427. Document snapshots: 746. Current supporting documents: 140.
+Entries: 428. Document snapshots: 748. Current supporting documents: 142.
 
-States: `active-draft` 32, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 33, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -257,6 +257,7 @@ States: `active-draft` 32, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [chore(release): refresh corrected builder classification authority](https://github.com/stephenlclarke/container-compose/pull/558) | `active-draft` | `25399784a692`, `8538b2e7931f`, `d8ccda0fd6f3`, `f99e66b89402` | [Issue details](container-compose/ISSUE-557.md); [PR details](container-compose/PR-558.md) |
 | `stephenlclarke/container-compose` | [fix(release): refresh retained sibling mains](https://github.com/stephenlclarke/container-compose/pull/572) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-571.md); [PR details](container-compose/PR-572.md) |
 | `stephenlclarke/container-compose` | [\[Build\] Replace Nextflow with a recoverable native graph](https://github.com/stephenlclarke/container-compose/pull/594) | `active-draft` | `89f9f7944b58`, `44f4895d88a7` | [Issue details](container-compose/ISSUE-593.md); [PR details](container-compose/PR-594.md) |
+| `stephenlclarke/container-compose` | [fix(build): complete recoverable stack workflow](https://github.com/stephenlclarke/container-compose/pull/596) | `active-draft` | `73b886a8a1d6` | [Issue details](container-compose/ISSUE-595.md); [PR details](container-compose/PR-596.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-595.md
+++ b/docs/upstream/container-compose/ISSUE-595.md
@@ -1,0 +1,31 @@
+# Issue 595: Complete recoverable builds and automatic versioning
+
+Issue [#595](https://github.com/stephenlclarke/container-compose/issues/595)
+closes the remaining gaps in the native Container-family build graph introduced
+by pull request #594.
+
+## Contract
+
+- Plain `make` builds the complete five-repository stack; `make local-build`
+  remains the explicit quick Compose-only path.
+- SwiftPM scratch, Go artifacts, pins, bundles, and timing evidence live below
+  marker-protected build state outside source checkouts.
+- Every native operation and the whole graph have deadlines and durable timing
+  records.
+- Build identity covers exact source, dependencies, artifacts, toolchains,
+  effective Swift SDK and target, and only the marked stack controller sections.
+- An executable fail-once test proves root reuse, downstream recovery, Compose
+  publication, and final bundle verification.
+- Conventional Commit history selects automatic semantic versions; explicit
+  reviewed selectors remain available for maintenance, security, and recovery.
+- Maintained build and contribution documentation shows the build, test,
+  recovery, Actions, and release flows.
+
+## Evidence
+
+The focused Python suites cover the complete graph, atomic pin implementation,
+deadline and timing runner, semantic-version resolver, release workflow policy,
+and scheduled workflow. Markdownlint and Actionlint validate the affected
+documentation and GitHub Actions workflow. Final evidence will add a clean
+native build, immediate warm rerun, exact-head review, and the 0.14.3 release
+transaction.

--- a/docs/upstream/container-compose/PR-596.md
+++ b/docs/upstream/container-compose/PR-596.md
@@ -1,0 +1,35 @@
+# Pull request 596: complete the recoverable stack workflow
+
+## Change
+
+This pull request completes the native Make, SwiftPM, and Go build controller
+introduced by pull request 594. Plain `make` builds the five-repository source
+stack, publishes exact transitive pins, retains compiler caches, and resumes
+only from verified inputs and artifacts.
+
+Each native command has a bounded process session and writes concurrency-safe
+JSONL timing evidence. Independent roots run in parallel. Compose consumes the
+upstream paths through identity-preserving package-manifest overrides, avoiding
+mutable SwiftPM edit sessions and mismatched exact-revision graphs.
+
+Conventional Commit history now selects the next semantic version. An explicit
+maintenance selector remains available for the first migration release and
+other audited exceptional releases.
+
+## Scope boundary
+
+The ordinary build does not start virtual machines, request network or volume
+privacy access, open Keychain, run parity workloads, execute CodeQL or DocC, or
+package a release. Those operations remain explicit release-gate stages.
+
+## Validation
+
+- 73 focused controller and policy tests
+- 851 tests in the complete Python tooling gate, including nested stack tests
+- cold five-repository build in 292.726 seconds
+- unchanged verified-pin recovery in 5.873 seconds
+- Compose-only exact-source rebuild in 17.323 seconds
+- Markdown lint, Actionlint, package-manifest inspection, signed-commit
+  verification, and whitespace validation
+
+Closes [#595](https://github.com/stephenlclarke/container-compose/issues/595).


### PR DESCRIPTION
Closes #595.

## What changed

- replaces the superseded Nextflow path with a native recoverable Make/SwiftPM/Go five-repository build graph
- emits and verifies exact source, dependency, toolchain, artifact, and transitive stack pins
- adds bounded process cleanup, durable checkpoints, and per-step JSONL timings
- makes plain `make` build the full stack and keeps `make local-build` as the quick Compose-only path
- derives SemVer from Conventional Commits while preserving an explicit maintenance override
- documents the build, recovery, test, GitHub Actions, and release flows with Mermaid diagrams
- uses identity-preserving local manifest overrides so matched Container and Containerization heads cannot conflict with stale checked-in release pins

## Review and test evidence

- 73 focused policy/controller tests passed in 24.531s before the real run
- complete Python tooling gate passed: 851 tests including nested stack tests, 1,215.05s wall time
- corrected cold five-repository build: 292.726s
- unchanged verified-pin rerun: 5.873s (49.8x faster; 98.0% less wall time)
- Compose-only rebuild after an exact source-tree change: 17.323s; 23.687s end to end
- Markdownlint, actionlint, `git diff --check`, signed-commit verification, and package-manifest override inspection passed

The retained measurement and comparison limits are documented in `docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md`.
