### PR TITLE
fix(build): refresh release stack authority

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "255429417efd5cd4ffc1bf02451349f78a3c67d6b9e5fb3f0d5092f5465a75c1",
+  "originHash" : "6773a68847fc5ad034c4b7a8d01af2e26568ace0301bdc5551ee1397b133619e",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "d9d0fd80d38db1f332c854d91f9a479f5e149431"
+        "revision" : "39c6ec7ae63b3896bdfb396749f98a3aaac898ca"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "d9d0fd80d38db1f332c854d91f9a479f5e149431",
+        revision: "39c6ec7ae63b3896bdfb396749f98a3aaac898ca",
     )
 }()
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,16 +1,16 @@
 {
   "components": {
     "container": {
-      "ref": "d9d0fd80d38db1f332c854d91f9a479f5e149431",
+      "ref": "39c6ec7ae63b3896bdfb396749f98a3aaac898ca",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
       "image": {
-        "digest": "sha256:5598b550fe76ad4992de94a3f80811326e2f7bd85147a5343bc1edd2205402dd",
+        "digest": "sha256:3c5d4e42dfdfe6b85ca8c928f3e53b5dfa31f64a279bb8ff639ea56a74ba580b",
         "repository": "ghcr.io/stephenlclarke/container-builder-shim/builder",
-        "tag": "current-34122911062-f99e66b89402"
+        "tag": "current-34334330512-5373d9b4363c"
       },
-      "ref": "f99e66b8940242d6ea8bed448619ba61f3f6f1a5",
+      "ref": "5373d9b4363c6e536dc6401199da269c7045abf9",
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {


### PR DESCRIPTION
## Summary

Refresh the 0.14.3 release stack to the exact tested Container main revision and the immutable Container Builder Shim Current artifact produced for its exact source revision.

## Changes

- pin Container to `39c6ec7ae63b3896bdfb396749f98a3aaac898ca` in `Package.swift`, `Package.resolved`, and `stack-refs.json`
- refresh the SwiftPM origin hash after resolving the exact revision
- pin Container Builder Shim source `5373d9b4363c6e536dc6401199da269c7045abf9`, tag `current-34334330512-5373d9b4363c`, and digest `sha256:3c5d4e42dfdfe6b85ca8c928f3e53b5dfa31f64a279bb8ff639ea56a74ba580b`

## Validation

- 11 focused stack-consistency unit tests pass
- four focused Containerization pin resolver tests pass
- live stack consistency passes against Container `39c6ec7a`
- SwiftPM resolves the exact Container revision and produces origin hash `6773a68847fc5ad034c4b7a8d01af2e26568ace0301bdc5551ee1397b133619e`
- `git diff --check` passes

Closes #597.

Related: stephenlclarke/container-builder-shim#23, stephenlclarke/container#234, stephenlclarke/container#236, #596.