### PR TITLE
fix(release): reject missing VM-init authority early

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -529,6 +529,69 @@ jobs:
             exit 1
           fi
 
+      - name: Require exact Current VM-init authority
+        if: needs.resolve-publish-context.outputs.ref_type == 'branch'
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        working-directory: container-compose
+        shell: bash
+        run: |
+          set -euo pipefail
+          containerization_ref="$(
+            jq -er '.components.containerization.ref' \
+              Tools/release/stack-refs.json
+          )"
+          if [[ ! "${containerization_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+            printf 'Current VM-init authority requires an exact Containerization ref: %s\n' \
+              "${containerization_ref:-<unset>}" >&2
+            exit 1
+          fi
+
+          authority_root="${RUNNER_TEMP}/current-vminit-preflight"
+          mkdir -p "${authority_root}"
+          gh api --paginate --slurp \
+            "repos/stephenlclarke/containerization/actions/workflows/containerization-build.yml/runs?head_sha=${containerization_ref}&per_page=100" \
+            > "${authority_root}/run-pages.json"
+          jq '[.[].workflow_runs[] | {
+            databaseId: .id,
+            workflowName: .name,
+            headSha: .head_sha,
+            status,
+            conclusion,
+            event,
+            createdAt: .created_at,
+            url: .html_url
+          }]' "${authority_root}/run-pages.json" > "${authority_root}/runs.json"
+          python3 Tools/parity/historical_reconstruction_benchmark.py \
+            run-candidates \
+            --runs "${authority_root}/runs.json" \
+            --revision "${containerization_ref}" \
+            > "${authority_root}/run-candidates.json"
+
+          authority_found=false
+          while IFS= read -r run_id; do
+            candidate_run="${authority_root}/run-${run_id}.json"
+            candidate_artifacts="${authority_root}/artifacts-${run_id}.json"
+            jq --argjson id "${run_id}" \
+              '.[] | select(.runId == $id)' \
+              "${authority_root}/run-candidates.json" > "${candidate_run}"
+            gh api \
+              "repos/stephenlclarke/containerization/actions/runs/${run_id}/artifacts" \
+              > "${candidate_artifacts}"
+            if python3 Tools/parity/historical_reconstruction_benchmark.py \
+              validate-initfs \
+              --run "${candidate_run}" \
+              --artifacts "${candidate_artifacts}" >/dev/null; then
+              authority_found=true
+              break
+            fi
+          done < <(jq -r '.[].runId' "${authority_root}/run-candidates.json")
+          if [[ "${authority_found}" != "true" ]]; then
+            printf 'no exact, retained initfs artifact exists for Containerization %s\n' \
+              "${containerization_ref}" >&2
+            exit 1
+          fi
+
       - name: Resolve the pinned Container formula source
         id: container-source
         working-directory: container-compose

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2308,6 +2308,13 @@ github_cli() {{
         self.assertIn("name: Checkout immutable release control tools", fail_fast)
         self.assertIn("ref: ${{ github.sha }}", fail_fast)
         self.assertIn("name: Require Current stack pins to match fork mains", fail_fast)
+        self.assertIn("name: Require exact Current VM-init authority", fail_fast)
+        self.assertIn("run-candidates", fail_fast)
+        self.assertIn("validate-initfs", fail_fast)
+        self.assertIn(
+            "no exact, retained initfs artifact exists for Containerization",
+            fail_fast,
+        )
         self.assertIn(
             "for component in container-builder-shim containerization container",
             fail_fast,


### PR DESCRIPTION
## Summary
- validate the pinned exact Containerization `initfs` authority in the existing release preflight
- stop before signing and product packaging when no valid retained artifact exists
- retain full archive download and cryptographic verification in the package job

## Focused validation
- `actionlint .github/workflows/prebuilt-binaries.yml`
- `python3 -m unittest Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_homebrew_configuration_fails_before_codeql_and_product_builds`
- `git diff --check`

The failed Current run spent 4m34s building its matched runtime before reaching this invariant. This change moves the rejection into the 11-second fail-fast job.

Closes #601.