### PR TITLE
chore(release): refresh 0.14.3 upstream authority

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2497,11 +2497,11 @@ format: update-licenses swift-style-format
 	cd Tools/compose-normalizer && $(GO) fmt ./...
 
 check-licenses:
-	@HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh
+	@HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh --auto-install
 	@$(HAWKEYE) check --fail-if-unknown
 
 update-licenses:
-	@HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh
+	@HAWKEYE="$(HAWKEYE)" ./scripts/ensure-hawkeye-exists.sh --auto-install
 	@$(HAWKEYE) format --fail-if-unknown --fail-if-updated false
 
 pre-commit:

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c6d1a6c9033d71036c5ad79049e07a27f55cab3c99c2e8b0ffd91e63af457ef5",
+  "originHash" : "5c85d23dfa6273d2fa2239fd4e9de51c45f2951490055aa7f0b140acb5ce5abf",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "e6ead30574d58373c5ce29410bcc9326e2b43252"
+        "revision" : "7da98fd3c8e03d491672ca8c069e8bee02dd9074"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "84e48ea1cca0deb527279704f12685ffc010aeea"
+        "revision" : "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "e6ead30574d58373c5ce29410bcc9326e2b43252",
+        revision: "7da98fd3c8e03d491672ca8c069e8bee02dd9074",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "84e48ea1cca0deb527279704f12685ffc010aeea",
+        revision: "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -128,11 +128,11 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 8 September 2026 snapshot, the three support forks are **1159 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 9 September 2026 snapshot, the three support forks are **1188 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 304 ahead** at [`9e0626e1171c`](https://github.com/stephenlclarke/containerization/commit/9e0626e1171cee5c09b0adecb886f1b24784320c).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 800 ahead** at [`7ed777a17155`](https://github.com/stephenlclarke/container/commit/7ed777a171554cd6309ca96d3d2a4e7135c910c5).
-> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 55 ahead** at [`f99e66b89402`](https://github.com/stephenlclarke/container-builder-shim/commit/f99e66b8940242d6ea8bed448619ba61f3f6f1a5).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 313 ahead** at [`28ad7c77a2a5`](https://github.com/stephenlclarke/containerization/commit/28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 816 ahead** at [`7da98fd3c8e0`](https://github.com/stephenlclarke/container/commit/7da98fd3c8e03d491672ca8c069e8bee02dd9074).
+> - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 59 ahead** at [`5373d9b4363c`](https://github.com/stephenlclarke/container-builder-shim/commit/5373d9b4363c6e536dc6401199da269c7045abf9).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >
 > What looks like a local Compose change can therefore require coordinated conflict resolution, pin updates, builds, tests, packaging, and release validation across the entire stack. The pinned revisions must move together.

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "e6ead30574d58373c5ce29410bcc9326e2b43252",
+      "ref": "7da98fd3c8e03d491672ca8c069e8bee02dd9074",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "84e48ea1cca0deb527279704f12685ffc010aeea",
+      "ref": "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
+++ b/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
@@ -71,3 +71,49 @@ time.
 The release gate remains the authority for full product, parity, security, and
 documentation validation. Those release-only timings will be retained by its
 own checkpoint evidence rather than mixed into this build-only measurement.
+
+## Upstream-refresh validation timings
+
+The 0.14.3 upstream refresh supplied additional first-run evidence:
+
+- Containerization's matching Swift 6.3.0 Linux-musl `vminitd` rebuild took
+  13.300 seconds. Its focused macOS OCI and socket tests took 17.250 seconds;
+  14 applicable tests passed.
+- Containerization's exact-head Linux workflow took 20 minutes 40 seconds.
+  Its parallel macOS/initfs workflow took 22 minutes 54 seconds. Both passed
+  without a retry.
+- Container's SwiftPM resolve took 73.530 seconds. Its two focused provenance
+  and application-health suites took 144.620 seconds including the cold
+  compile; 22 tests passed.
+- Container's exact-head hosted workflow took 26 minutes 35 seconds. The
+  build/test job accounted for 26 minutes 14 seconds. Release-only Linux
+  workloads and documentation packaging were correctly skipped.
+- Compose's classification refresh took 4.399 seconds. Stack consistency plus
+  the strict current-upstream gate took 3.060 seconds after the canonical
+  source checkouts were fast-forwarded. The focused consistency/divergence
+  regression set ran 22 tests in 2.614 seconds.
+
+Two workflow defects failed before expensive release work. The Containerization
+signature gate rejected unsigned commits already present on Apple `main`; it
+now accepts them only after GitHub proves upstream ancestry and still rejects
+unsigned fork-only commits. Compose's strict divergence gate correctly found
+that the clean canonical source checkouts under `~/github` were behind their
+fork remotes, but the preceding stack-consistency target had initially used
+that stale checkout without reporting the authority mismatch. The checkouts
+were restored with fast-forward-only updates; a later workflow refinement
+should make the shared canonical-source precondition explicit before any stage
+that reads lower-stack manifests.
+
+The Container hosted run also spent over ten minutes in `Check protobuf`
+because that step cold-builds both Swift protobuf generators. The integrity
+check is valid, but build-input classification should skip it when neither the
+protobuf inputs nor generator pins changed. That optimization belongs after
+the stable release so this release candidate is not changed while under
+exact-head review.
+
+A clean Compose worktree's first `make source-preflight` stopped after 1.340
+seconds because the repository-local Hawkeye binary was absent and the Make
+target had not authorized its checksum-pinned non-interactive bootstrap. The
+corrected target installed verified Hawkeye 6.5.1 and completed the whole
+source preflight in 3.130 seconds. Subsequent runs reuse that local binary and
+do not need network access or an approval prompt.

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-09-08",
+  "reviewedAt": "2026-09-09",
   "repositories": {
     "container": {
-      "upstreamHead": "eee7ad097079cc3b02d5309ec10160143f2d0c6a",
-      "forkHead": "7ed777a171554cd6309ca96d3d2a4e7135c910c5",
+      "upstreamHead": "9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d",
+      "forkHead": "7da98fd3c8e03d491672ca8c069e8bee02dd9074",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -507,7 +507,13 @@
             "7601ceca01d4a221a6724e78a6d6738576f22b60",
             "0eb4a7e9df9bda860e48b809d777a8ba4e28b7df",
             "fed883357d578cc3701c2dcc76a7b8a65a8f3fcf",
-            "6cac63afeadd0378baaf5eed3175c0533e025a8a"
+            "6cac63afeadd0378baaf5eed3175c0533e025a8a",
+            "f21a86510bc2995592e070d4f2821896a34d4b14",
+            "24d6c7ae5fabce800b12d933eab8737515ed4493",
+            "76675683ab8cd4f9a3f8e04d4924d744fc5efd40",
+            "25325434897c91173b4127d300ce575f7812deca",
+            "2af01c6da3faee8c0e5816cf2b2c4aae31fbc119",
+            "cdaca67e5a5e7e6b835359ba9ce75157a43e966e"
           ]
         },
         {
@@ -753,8 +759,8 @@
       ]
     },
     "containerization": {
-      "upstreamHead": "847655d373a27b8b8d0c3a9747f04f16b5de1206",
-      "forkHead": "9e0626e1171cee5c09b0adecb886f1b24784320c",
+      "upstreamHead": "9eacc197d7c3663eb29cbab6d51244ede6d1cd7d",
+      "forkHead": "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -933,7 +939,10 @@
             "c40599fadb6a14e934c4cc1b997fd133bf416df2",
             "6ad1113465f105a5e3bb18c00582fdfdc275f946",
             "1044451748d8f2614dbb7289d99329577c13c7e6",
-            "9e0626e1171cee5c09b0adecb886f1b24784320c"
+            "9e0626e1171cee5c09b0adecb886f1b24784320c",
+            "5b07660964d4e713f17356d6e508b6c42a886e4e",
+            "920183b992ea02fb8a096420f6bef7fc6098e750",
+            "c54205ecd77ee443af9994f5edc5a1f5d3bd2e92"
           ]
         },
         {
@@ -1107,8 +1116,8 @@
       ]
     },
     "container-builder-shim": {
-      "upstreamHead": "e18d2182fd060dbf1c68113a74e7564d563dde27",
-      "forkHead": "f99e66b8940242d6ea8bed448619ba61f3f6f1a5",
+      "upstreamHead": "5dc4286e5adbeb7dac189b22b7d5aab336942fe2",
+      "forkHead": "5373d9b4363c6e536dc6401199da269c7045abf9",
       "slices": [
         {
           "id": "container-builder-shim-support-maintenance",
@@ -1151,7 +1160,8 @@
             "b6990e48e4a345081d86ed04d72a355296a2d672",
             "711d64048d01c181b8c29cf9acb782da9491290b",
             "3b0e23c02f035a4b7825a124c4d95c36c3c9019f",
-            "8538b2e7931f41a831af66dc65381f7acc46cc64"
+            "8538b2e7931f41a831af66dc65381f7acc46cc64",
+            "fa0fd18588cec322e35d4bda1bc1c0375d66380d"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 8 September 2026
+Updated: 9 September 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `eee7ad097079cc3b02d5309ec10160143f2d0c6a` | `7ed777a171554cd6309ca96d3d2a4e7135c910c5` | 0 | 800 | 672 |
-| `containerization` | `847655d373a27b8b8d0c3a9747f04f16b5de1206` | `9e0626e1171cee5c09b0adecb886f1b24784320c` | 0 | 304 | 240 |
-| `container-builder-shim` | `e18d2182fd060dbf1c68113a74e7564d563dde27` | `f99e66b8940242d6ea8bed448619ba61f3f6f1a5` | 0 | 55 | 45 |
-| **Total** | | | **0** | **1159** | **957** |
+| `container` | `9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d` | `7da98fd3c8e03d491672ca8c069e8bee02dd9074` | 0 | 816 | 678 |
+| `containerization` | `9eacc197d7c3663eb29cbab6d51244ede6d1cd7d` | `28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c` | 0 | 313 | 243 |
+| `container-builder-shim` | `5dc4286e5adbeb7dac189b22b7d5aab336942fe2` | `5373d9b4363c6e536dc6401199da269c7045abf9` | 0 | 59 | 46 |
+| **Total** | | | **0** | **1188** | **967** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -327,3 +327,15 @@ error propagation. The companion Kubernetes test proves that a retained
 cluster restarts on its configured address without preserving the obsolete
 address-rotation expectation. Neither commit adds a fork-only capability or
 temporary upstream port.
+
+The 9 September 2026 release refresh advances Apple Container through
+`9a8917ca2da5`, Container through `7da98fd3c8e0`, Apple Containerization
+through `9eacc197d7c3`, Containerization through `28ad7c77a2a5`, Apple builder
+shim through `5dc4286e5adb`, and the builder shim through `5373d9b4363c`.
+Apple's Kubernetes guide, CZ 0.45.0 update, OCI-layout hardening, confined
+rootfs copy/stat handling, and Unix-socket length fix are upstream history.
+The ten new patch-unique commits cover dependency security and exact pins,
+deterministic protobuf and image publishing, retained VSOCK and VM-init
+authority, and strict upstream-aware signature verification. All are support
+maintenance; no generic primitive, temporary upstream port, or rejected
+Compose-policy disposition changed.

--- a/scripts/ensure-hawkeye-exists.sh
+++ b/scripts/ensure-hawkeye-exists.sh
@@ -79,11 +79,11 @@ the repository-pinned Hawkeye is missing or incompatible in this checkout.
 
 scripts/install-hawkeye.sh will install a repository-local fallback by running:
 
-    curl -LsSf https://github.com/korandoru/hawkeye/releases/download/<version>/hawkeye-installer.sh | sh
+    scripts/install-hawkeye.sh
 
-and performs the installation by passing the downloaded content to \`sh\`.
-
-See scripts/install-hawkeye.sh for the pinned version.
+The installer downloads the pinned platform archive over TLS, verifies its
+checked-in SHA-256 digest, and installs only the verified Hawkeye binary under
+.local/bin. See scripts/install-hawkeye.sh for the pinned version and digest.
 EOF
 
 if [[ "${auto_install}" -eq 1 ]]; then


### PR DESCRIPTION
## Summary

- consume merged Container `7da98fd3c8e0` and Containerization `28ad7c77a2a5`
- refresh exact SwiftPM and release-stack pins
- classify all 967 current patch-unique commits and refresh the 9 September support-fork snapshot
- make checksum-pinned Hawkeye 6.5.1 bootstrap unattended in clean worktrees
- extend the build/test timing and defect evidence

Closes #605

## Focused validation

- `make fork-classifications-check`
- `make stack-consistency upstream-divergence-release-check`
- `make source-preflight` (3.13s clean bootstrap)
- 22 focused stack consistency/divergence tests (2.614s)
- Markdown, JSON, shell syntax, Make dry-run, and `git diff --check`

No local VM integration, CodeQL, or DocC was run; those remain release-only authorities.
