### PR TITLE
chore(deps): pin guest-device compatibility stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5c85d23dfa6273d2fa2239fd4e9de51c45f2951490055aa7f0b140acb5ce5abf",
+  "originHash" : "2a388b42cc466a97ede74ea11026a85643ffb6df23a13555a74ff527fa15b341",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "7da98fd3c8e03d491672ca8c069e8bee02dd9074"
+        "revision" : "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c"
+        "revision" : "5372b36a691cbb392c4027ccf0ea2b6af7284b5b"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "7da98fd3c8e03d491672ca8c069e8bee02dd9074",
+        revision: "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9",
     )
 }()
 
@@ -38,7 +38,7 @@ let containerizationDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/containerization.git",
-        revision: "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c",
+        revision: "5372b36a691cbb392c4027ccf0ea2b6af7284b5b",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 9 September 2026 snapshot, the three support forks are **1188 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 9 September 2026 snapshot, the three support forks are **1192 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 313 ahead** at [`28ad7c77a2a5`](https://github.com/stephenlclarke/containerization/commit/28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 816 ahead** at [`7da98fd3c8e0`](https://github.com/stephenlclarke/container/commit/7da98fd3c8e03d491672ca8c069e8bee02dd9074).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 315 ahead** at [`5372b36a691c`](https://github.com/stephenlclarke/containerization/commit/5372b36a691cbb392c4027ccf0ea2b6af7284b5b).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 818 ahead** at [`a702f22b0e76`](https://github.com/stephenlclarke/container/commit/a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 59 ahead** at [`5373d9b4363c`](https://github.com/stephenlclarke/container-builder-shim/commit/5373d9b4363c6e536dc6401199da269c7045abf9).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "7da98fd3c8e03d491672ca8c069e8bee02dd9074",
+      "ref": "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c",
+      "ref": "5372b36a691cbb392c4027ccf0ea2b6af7284b5b",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -4,7 +4,7 @@
   "repositories": {
     "container": {
       "upstreamHead": "9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d",
-      "forkHead": "7da98fd3c8e03d491672ca8c069e8bee02dd9074",
+      "forkHead": "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -513,7 +513,8 @@
             "76675683ab8cd4f9a3f8e04d4924d744fc5efd40",
             "25325434897c91173b4127d300ce575f7812deca",
             "2af01c6da3faee8c0e5816cf2b2c4aae31fbc119",
-            "cdaca67e5a5e7e6b835359ba9ce75157a43e966e"
+            "cdaca67e5a5e7e6b835359ba9ce75157a43e966e",
+            "8dc1d66f4f5c4e02588f8233b32cbe6cb03dfec7"
           ]
         },
         {
@@ -760,7 +761,7 @@
     },
     "containerization": {
       "upstreamHead": "9eacc197d7c3663eb29cbab6d51244ede6d1cd7d",
-      "forkHead": "28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c",
+      "forkHead": "5372b36a691cbb392c4027ccf0ea2b6af7284b5b",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -942,7 +943,8 @@
             "9e0626e1171cee5c09b0adecb886f1b24784320c",
             "5b07660964d4e713f17356d6e508b6c42a886e4e",
             "920183b992ea02fb8a096420f6bef7fc6098e750",
-            "c54205ecd77ee443af9994f5edc5a1f5d3bd2e92"
+            "c54205ecd77ee443af9994f5edc5a1f5d3bd2e92",
+            "79d5eb1ec231dc571c9c05875940e72b942fb32e"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d` | `7da98fd3c8e03d491672ca8c069e8bee02dd9074` | 0 | 816 | 678 |
-| `containerization` | `9eacc197d7c3663eb29cbab6d51244ede6d1cd7d` | `28ad7c77a2a5ec7c2a1bdbff5e1e6a588958bb3c` | 0 | 313 | 243 |
+| `container` | `9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d` | `a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9` | 0 | 818 | 679 |
+| `containerization` | `9eacc197d7c3663eb29cbab6d51244ede6d1cd7d` | `5372b36a691cbb392c4027ccf0ea2b6af7284b5b` | 0 | 315 | 244 |
 | `container-builder-shim` | `5dc4286e5adbeb7dac189b22b7d5aab336942fe2` | `5373d9b4363c6e536dc6401199da269c7045abf9` | 0 | 59 | 46 |
-| **Total** | | | **0** | **1188** | **967** |
+| **Total** | | | **0** | **1192** | **969** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -339,3 +339,9 @@ deterministic protobuf and image publishing, retained VSOCK and VM-init
 authority, and strict upstream-aware signature verification. All are support
 maintenance; no generic primitive, temporary upstream port, or rejected
 Compose-policy disposition changed.
+
+The subsequent 0.14.3 release-gate correction advances Containerization to
+`5372b36a691c` and Container to `a702f22b0e76`. Signed Containerization commit
+`79d5eb1ec231` restores the fork's guest-device `stat` protocol adapter while
+retaining Apple's confined implementation; signed Container commit
+`8dc1d66f4f5c` advances the exact dependency pin. Both are support maintenance.


### PR DESCRIPTION
Closes #607

## Summary
- advance Containerization to the guest-device `stat` compatibility fix
- advance Container to its matching Containerization pin
- keep Package.swift, Package.resolved, release stack authority, and fork classifications aligned
- refresh the README upstream snapshot from verified repository graphs

## Focused validation
- `python3 Tools/ci/check-stack-consistency.py`
- `make fork-classifications-check`
- `make readme-upstream-metrics-check`
- `python3 -m unittest Tools.ci.test_check_stack_consistency Tools.ci.test_upstream_divergence_report Tools.ci.test_update_readme_upstream_metrics` (28 passed)
- `markdownlint README.md docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md`
- `git diff --check`

The underlying Containerization correction passed 51 focused unit tests and the exact four-case integration regression (2 passed, 2 capability skips, 0 failures). Container also completed a clean targeted `container` product build against the new pin.