### PR TITLE
fix(release): preserve current across candidate refreshes

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -8024,6 +8024,11 @@ esac
             self.commit_file(updater, "FIRST.md", "first\n", "fix: first main repair")
             self.run_command("git", "-C", str(updater), "push", "origin", "main")
             first_remote_head = self.git(updater, "rev-parse", "main")
+            published_head = first_remote_head
+            self.run_command("git", "-C", str(local), "fetch", "origin", "main")
+            self.run_command(
+                "git", "-C", str(local), "tag", "--no-sign", "current", published_head
+            )
             first = self.run_release_function(
                 root / "github", "recover_unpublished_release_candidate 0.6.71"
             )
@@ -8063,6 +8068,29 @@ esac
             )
             self.assertEqual(self.git(local, "show", "main:SECOND.md"), "second")
             self.assertEqual(self.git(local, "status", "--short"), "")
+
+            restarted = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "ensure_current_release_source_identity",
+            )
+            self.assertEqual(restarted.returncode, 0, restarted.stderr)
+            self.assertIn(
+                f"current tag targets published parent {published_head}",
+                restarted.stdout,
+            )
+
+            earlier_main = self.git(local, "rev-parse", f"{candidate_head}^")
+            self.run_command(
+                "git", "-C", str(local), "tag", "--force", "current", earlier_main
+            )
+            stale = self.run_release_function(
+                root / "github",
+                "recover_unpublished_release_candidate 0.6.71; "
+                "ensure_current_release_source_identity",
+            )
+            self.assertNotEqual(stale.returncode, 0)
+            self.assertIn(f"current tag targets {earlier_main}", stale.stderr)
 
     def test_release_helper_refreshes_superseded_classification_authority(
         self,

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -1031,6 +1031,41 @@ validate_unpublished_release_commit() {
   return 1
 }
 
+# Recover the published Current base from a validated retained candidate. A
+# candidate may have been refreshed from canonical main more than once, so the
+# published base can be the main parent of an earlier refresh rather than the
+# latest remote head.
+published_base_for_retained_candidate() {
+  local path="$1" version="$2" remote_head="$3" commits="$4"
+  local current_head commit subject main_parent
+
+  current_head="$(git -C "${path}" rev-parse --verify -q 'refs/tags/current^{}' || true)"
+  if [[ ! "${current_head}" =~ ^[0-9a-f]{40}$ ]] ||
+    ! git -C "${path}" merge-base --is-ancestor "${current_head}" "${remote_head}"; then
+    printf '%s\n' "${remote_head}"
+    return 0
+  fi
+  if [[ "${current_head}" == "${remote_head}" ]]; then
+    printf '%s\n' "${current_head}"
+    return 0
+  fi
+
+  while IFS= read -r commit; do
+    [[ -n "${commit}" ]] || continue
+    subject="$(git -C "${path}" show -s --format=%s "${commit}")"
+    if [[ "${subject}" != "chore(release): refresh ${version} candidate from main" ]]; then
+      continue
+    fi
+    main_parent="$(git -C "${path}" rev-parse --verify -q "${commit}^2" || true)"
+    if [[ "${main_parent}" == "${current_head}" ]]; then
+      printf '%s\n' "${current_head}"
+      return 0
+    fi
+  done <<<"${commits}"
+
+  printf '%s\n' "${remote_head}"
+}
+
 recover_unpublished_release_candidate() {
   local version="$1" path remote local_head remote_head local_tree remote_tree current_head promotion_parent commit commits
   RECOVERED_UNPUBLISHED_RELEASE_BASE=""
@@ -1121,7 +1156,10 @@ recover_unpublished_release_candidate() {
       "${path}" "${commit}" "${version}" "${remote_head}" || exit 1
   done <<<"${commits}"
 
-  RECOVERED_UNPUBLISHED_RELEASE_BASE="${remote_head}"
+  RECOVERED_UNPUBLISHED_RELEASE_BASE="$(
+    published_base_for_retained_candidate \
+      "${path}" "${version}" "${remote_head}" "${commits}"
+  )"
   printf 'retaining unpublished release candidate %s after an earlier local gate failure\n' "${local_head}"
 }
 


### PR DESCRIPTION
## Summary

- recover the published `current` authority after multiple signed candidate refreshes
- require it to remain an ancestor of canonical main and an exact main parent of a validated refresh commit
- retain rejection of merely stale ancestor tags

## Validation

- 7 focused release recovery and adversarial tests passed
- the retained 0.14.3 candidate recovered its exact published base (`4b8e9e7e`) successfully
- `bash -n`, ShellCheck, Python compilation, and `git diff --check` passed

Closes #611