### PR TITLE
chore(deps): pin Apple 1.0 compatibility sync

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2a388b42cc466a97ede74ea11026a85643ffb6df23a13555a74ff527fa15b341",
+  "originHash" : "481f5ef97d3d6483b52d711b8e7233d0041165fe1d3657944c5c612d99248333",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9"
+        "revision" : "cc424d2be1cdcefcec57e1d138c3a4cead278d5a"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let containerDependency: Package.Dependency = {
     }
     return .package(
         url: "https://github.com/stephenlclarke/container.git",
-        revision: "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9",
+        revision: "cc424d2be1cdcefcec57e1d138c3a4cead278d5a",
     )
 }()
 

--- a/README.md
+++ b/README.md
@@ -128,10 +128,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 9 September 2026 snapshot, the three support forks are **1192 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 9 September 2026 snapshot, the three support forks are **1194 commits ahead of Apple upstream**:
 >
 > - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 315 ahead** at [`5372b36a691c`](https://github.com/stephenlclarke/containerization/commit/5372b36a691cbb392c4027ccf0ea2b6af7284b5b).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 818 ahead** at [`a702f22b0e76`](https://github.com/stephenlclarke/container/commit/a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 820 ahead** at [`cc424d2be1cd`](https://github.com/stephenlclarke/container/commit/cc424d2be1cdcefcec57e1d138c3a4cead278d5a).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 59 ahead** at [`5373d9b4363c`](https://github.com/stephenlclarke/container-builder-shim/commit/5373d9b4363c6e536dc6401199da269c7045abf9).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9",
+      "ref": "cc424d2be1cdcefcec57e1d138c3a4cead278d5a",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -3,8 +3,8 @@
   "reviewedAt": "2026-09-09",
   "repositories": {
     "container": {
-      "upstreamHead": "9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d",
-      "forkHead": "a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9",
+      "upstreamHead": "8ca5c80c380cdd925d87b497fb23eddb6b58843f",
+      "forkHead": "cc424d2be1cdcefcec57e1d138c3a4cead278d5a",
       "slices": [
         {
           "id": "container-support-maintenance",

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d` | `a702f22b0e76daf74c0c2ec3009ccf4a2150c0e9` | 0 | 818 | 679 |
+| `container` | `8ca5c80c380cdd925d87b497fb23eddb6b58843f` | `cc424d2be1cdcefcec57e1d138c3a4cead278d5a` | 0 | 820 | 679 |
 | `containerization` | `9eacc197d7c3663eb29cbab6d51244ede6d1cd7d` | `5372b36a691cbb392c4027ccf0ea2b6af7284b5b` | 0 | 315 | 244 |
 | `container-builder-shim` | `5dc4286e5adbeb7dac189b22b7d5aab336942fe2` | `5373d9b4363c6e536dc6401199da269c7045abf9` | 0 | 59 | 46 |
-| **Total** | | | **0** | **1192** | **969** |
+| **Total** | | | **0** | **1194** | **969** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -345,3 +345,8 @@ The subsequent 0.14.3 release-gate correction advances Containerization to
 `79d5eb1ec231` restores the fork's guest-device `stat` protocol adapter while
 retaining Apple's confined implementation; signed Container commit
 `8dc1d66f4f5c` advances the exact dependency pin. Both are support maintenance.
+
+Apple's subsequent v1.0 compatibility-policy update is preserved through the
+signed Container merge at `36db202b7a42` and reviewed fork merge
+`cc424d2be1cd`. It adds no new fork-only semantic commit, so the classification
+count is unchanged.


### PR DESCRIPTION
## Summary

- advance Container to reviewed Apple-sync merge `cc424d2b`
- keep Package.swift, Package.resolved, and stable stack authority on the same immutable revision
- refresh the fork-classification and README divergence snapshots
- retain the existing Containerization and builder-shim pins

## Focused validation

- `python3 Tools/ci/check-stack-consistency.py`
- `make fork-classifications-check`
- `make readme-upstream-metrics-check`
- 28 focused consistency, divergence, and snapshot tests
- Markdown lint, JSON parsing, and `git diff --check`

Container PR #246 retained Apple/container#2233 as an exact signed merge and passed its docs-only exact-head checks.

Closes #613

Depends on stephenlclarke/container#245 and stephenlclarke/container#246.