### PR TITLE
fix(release): resume retained VM-init authority

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2923,6 +2923,125 @@ github_cli() {{
             self.assertEqual(removed.returncode, 0, removed.stderr)
             self.assertFalse(authority.exists())
 
+    def test_vm_init_authority_retry_reuses_valid_staged_download(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose"
+            manifest = compose / "Tools" / "release" / "stack-refs.json"
+            manifest.parent.mkdir(parents=True)
+            reference = "a" * 40
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "components": {
+                            "containerization": {"ref": reference},
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            shutil.copy2(
+                ROOT / "Tools" / "release" / "write-sha256-sidecar.py",
+                manifest.parent / "write-sha256-sidecar.py",
+            )
+            self.run_command("git", "-C", str(compose), "init")
+            self.run_command("git", "-C", str(compose), "add", ".")
+            self.run_command(
+                "git",
+                "-C",
+                str(compose),
+                "-c",
+                "user.name=Test",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "current stack",
+            )
+            current = self.git(compose, "rev-parse", "HEAD")
+            self.git(compose, "tag", "current")
+            self.git(compose, "remote", "add", "origin", str(compose))
+
+            cache = root / "authority-cache"
+            cache.mkdir()
+            stage = cache / f".{reference}.retained"
+            stage.mkdir()
+            asset_name = f"container-vminit-current-{current[:12]}-arm64.oci.tar"
+            archive = stage / asset_name
+            self.create_release_guest_archive(
+                archive,
+                qualified_reference=(
+                    "ghcr.io/stephenlclarke/containerization/vminit:" + reference
+                ),
+            )
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "Tools" / "release" / "write-sha256-sidecar.py"),
+                    str(archive),
+                ],
+                check=True,
+            )
+
+            sidecar = archive.with_name(archive.name + ".sha256")
+            with sidecar.open("a", encoding="utf-8") as stream:
+                stream.write(f"{'0' * 64}  unexpected\n")
+            rejected = self.run_release_function(
+                root,
+                "prepare_stable_init_image_authority",
+                shell_setup="\n".join(
+                    [
+                        "unset CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE",
+                        f"RELEASE_INIT_AUTHORITY_CACHE_ROOT={shlex.quote(str(cache))}",
+                        "need_command() { :; }",
+                        (
+                            "github_repo() { printf '%s\\n' "
+                            "'stephenlclarke/container-compose'; }"
+                        ),
+                    ]
+                ),
+            )
+            self.assertNotEqual(rejected.returncode, 0)
+            self.assertIn("checksum is malformed", rejected.stderr)
+            self.assertTrue(stage.is_dir())
+            subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "Tools" / "release" / "write-sha256-sidecar.py"),
+                    str(archive),
+                ],
+                check=True,
+            )
+
+            recovered = self.run_release_function(
+                root,
+                "prepare_stable_init_image_authority",
+                shell_setup="\n".join(
+                    [
+                        "unset CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE",
+                        f"RELEASE_INIT_AUTHORITY_CACHE_ROOT={shlex.quote(str(cache))}",
+                        "need_command() { :; }",
+                        (
+                            "github_repo() { printf '%s\\n' "
+                            "'stephenlclarke/container-compose'; }"
+                        ),
+                        (
+                            "github_cli() { "
+                            "if [[ \"$1:$2\" == \"release:download\" ]]; then "
+                            "printf 'unexpected download\\n' >&2; return 91; fi; "
+                            "[[ \"$1:$2\" == \"attestation:verify\" ]]; }"
+                        ),
+                    ]
+                ),
+            )
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            self.assertIn("resuming retained VM-init authority", recovered.stdout)
+            self.assertNotIn("unexpected download", recovered.stderr)
+            finalized = cache / reference
+            finalized_asset = finalized / f"container-vminit-{reference}-arm64.oci.tar"
+            self.assertTrue(finalized_asset.is_file())
+            self.assertFalse(stage.exists())
+
     def test_current_demo_is_recoverable_and_not_release_critical(self) -> None:
         package = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         release_critical = package[

--- a/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
+++ b/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
@@ -103,6 +103,14 @@ The 0.14.3 upstream refresh supplied additional first-run evidence:
   9 minutes 32 seconds, compilation 8 minutes 24 seconds, and unit tests 6
   minutes 49 seconds. The classifier correctly skipped Linux service workloads
   and documentation packaging.
+- Compose's exact merged-main workflow completed in 15 minutes 1 second.
+  Source checks took 1 minute 6 seconds, CI tool tests 7 minutes 56 seconds,
+  release tool tests 11 minutes 13 seconds, and runtime, coverage, CLI smoke,
+  and Sonar validation 14 minutes 53 seconds. Its exact Current publication
+  then passed the fail-fast release configuration in 17 seconds and packaged,
+  signed, attested, published, and closure-verified the matched stack in 10
+  minutes 52 seconds; the complete Current workflow took 11 minutes 22
+  seconds.
 
 Two workflow defects failed before expensive release work. The Containerization
 signature gate rejected unsigned commits already present on Apple `main`; it
@@ -130,6 +138,16 @@ its tests. [`containerization#92`](https://github.com/stephenlclarke/containeriz
 records the required path classes so guest images, Linux logging workloads,
 and protobuf generation can fail closed when their inputs change and be
 skipped otherwise.
+
+The first retained stable-release retry stopped before any product build when
+GitHub's trust metadata API returned HTTP 503 after the 111 MB Current VM-init
+archive had downloaded and passed its SHA-256 check. A direct attestation retry
+against those exact retained bytes succeeded in 14.667 seconds, proving the
+download was valid. The controller nevertheless rejected its own staging
+directory on the next invocation. [`container-compose#617`](https://github.com/stephenlclarke/container-compose/issues/617)
+tracks the correction: one safe staged authority is now checksummed, attested,
+rechecked against the unchanged Current tag, and atomically finalized without
+another download; malformed or ambiguous retained evidence remains fail-closed.
 
 A clean Compose worktree's first `make source-preflight` stopped after 1.340
 seconds because the repository-local Hawkeye binary was absent and the Make

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -638,13 +638,7 @@ PY
       )
       github_cli attestation verify "${cache_root}/${cache_asset}" --repo "${repo}"
     else
-      if find "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}" -mindepth 1 -maxdepth 1 \
-        -type d -name ".${containerization_reference}.*" -print -quit \
-        | grep -q .; then
-        printf 'an incomplete VM-init authority attempt is retained for diagnosis; resolve it before retrying: %s/.%s.*\n' \
-          "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}" "${containerization_reference}" >&2
-        return 1
-      fi
+      local staged_attempts staged_attempt_count staged_digest staged_name staged_extra staged_line_count
       current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
       remote_current_before="$(git -C "${path}" ls-remote --tags origin \
         'refs/tags/current' 'refs/tags/current^{}' | awk '{print $1}' | tail -n 1)"
@@ -654,13 +648,49 @@ PY
         return 1
       fi
       asset="container-vminit-current-${current_commit:0:12}-arm64.oci.tar"
-      stage="$(mktemp -d \
-        "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}/.${containerization_reference}.XXXXXX")"
-      github_cli release download current \
-        --repo "${repo}" \
-        --dir "${stage}" \
-        --pattern "${asset}" \
-        --pattern "${asset}.sha256"
+      staged_attempts="$(find "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}" \
+        -mindepth 1 -maxdepth 1 \
+        \( -type d -o -type l \) \
+        -name ".${containerization_reference}.*" -print)"
+      staged_attempt_count="$(printf '%s\n' "${staged_attempts}" \
+        | awk 'NF { count += 1 } END { print count + 0 }')"
+      if ((staged_attempt_count > 1)); then
+        printf 'multiple incomplete VM-init authority attempts are retained; preserving ambiguous evidence: %s/.%s.*\n' \
+          "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}" "${containerization_reference}" >&2
+        return 1
+      elif ((staged_attempt_count == 1)); then
+        stage="${staged_attempts}"
+        if [[ ! -d "${stage}" || -L "${stage}" \
+          || ! -f "${stage}/${asset}" || -L "${stage}/${asset}" \
+          || ! -f "${stage}/${asset}.sha256" || -L "${stage}/${asset}.sha256" ]]; then
+          printf 'retained VM-init authority attempt is incomplete or unsafe; preserving evidence: %s\n' \
+            "${stage}" >&2
+          return 1
+        fi
+        staged_digest=""
+        staged_name=""
+        staged_extra=""
+        staged_line_count="$(wc -l < "${stage}/${asset}.sha256" \
+          | tr -d '[:space:]')"
+        if ! read -r staged_digest staged_name staged_extra \
+          < "${stage}/${asset}.sha256" \
+          || [[ "${staged_line_count}" != "1" \
+          || ! "${staged_digest}" =~ ^[0-9a-f]{64}$ \
+          || "${staged_name}" != "${asset}" || -n "${staged_extra}" ]]; then
+          printf 'retained VM-init authority checksum is malformed; preserving evidence: %s\n' \
+            "${stage}/${asset}.sha256" >&2
+          return 1
+        fi
+        printf 'resuming retained VM-init authority verification: %s\n' "${stage}"
+      else
+        stage="$(mktemp -d \
+          "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}/.${containerization_reference}.XXXXXX")"
+        github_cli release download current \
+          --repo "${repo}" \
+          --dir "${stage}" \
+          --pattern "${asset}" \
+          --pattern "${asset}.sha256"
+      fi
       (
         cd "${stage}"
         shasum -a 256 -c "${asset}.sha256"


### PR DESCRIPTION
Closes #617.

## What changed

- Resume one structurally valid retained Current VM-init staging attempt after a transient attestation failure.
- Recheck the exact sidecar shape, archive checksum, GitHub attestation, and unchanged Current tag before atomically finalizing the immutable cache.
- Preserve and reject symlinked, malformed, or ambiguous retained evidence.
- Record the exact merged-main, Current publication, and HTTP 503 recovery timings.

## Evidence

- `python3 -m unittest Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_vm_init_authority_retry_reuses_valid_staged_download Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_vm_init_authority_cache_is_retained_until_release_succeeds Tools.release.test_container_stack_release.ContainerStackReleasePolicyTests.test_stable_controller_resolves_current_vm_init_before_release_work` — 3 passed in 0.656s.
- `shellcheck scripts/CONTAINER_STACK_RELEASE.sh`
- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `markdownlint-cli2 docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md` — 0 errors.
- The real retained 0.14.3 archive resumed without a download, passed SHA-256 and GitHub attestation verification, and finalized under the exact Containerization ref in 7.395s.

## Scope

Release recovery and evidence only. Runtime and Compose functionality are unchanged. No broad test, CodeQL, DocC, or package build was run locally.