### PR TITLE
test(release): isolate managed runtime fixture

### DIFF
--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -4611,14 +4611,36 @@ github_cli() {{
             environment["CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE"] = "/tmp/runtime-init.oci.tar"
             environment["CONTAINER_RUNTIME_BUILDER_IMAGE_TAR"] = "/tmp/runtime-builder.oci.tar"
             environment["CONTAINER_RUNTIME_CLI"] = str(candidate_tools_resolved / "container")
+            environment.update(
+                {
+                    "CONTAINER_RUNTIME_CLI_SHA256": "1" * 64,
+                    "CONTAINER_RUNTIME_CANDIDATE_SHA256": "2" * 64,
+                    "CONTAINER_STACK_VALIDATION_SCRATCH_ROOT": str(
+                        root / "live-scratch"
+                    ),
+                    "CONTAINER_RUNTIME_MANAGED": "1",
+                    "CONTAINER_RUNTIME_APP_ROOT": str(root / "live-app"),
+                    "CONTAINER_RUNTIME_SERVICE_NAMESPACE": "example.live-runtime",
+                    "CONTAINER_APP_ROOT": str(root / "live-app"),
+                    "CONTAINER_SERVICE_NAMESPACE": "example.live-runtime",
+                }
+            )
             # This fixture substitutes its own candidate CLI. A full release
-            # gate exports candidate identity and scratch locations for the
-            # real validation run before running the policy tests. Inheriting
+            # gate exports candidate identity, managed-runtime ownership, and
+            # scratch locations before running the policy tests. Inheriting
             # any of them would make the fixture validate its fake binary or
             # expected default paths against unrelated live state.
-            environment.pop("CONTAINER_RUNTIME_CLI_SHA256", None)
-            environment.pop("CONTAINER_RUNTIME_CANDIDATE_SHA256", None)
-            environment.pop("CONTAINER_STACK_VALIDATION_SCRATCH_ROOT", None)
+            for variable in (
+                "CONTAINER_RUNTIME_CLI_SHA256",
+                "CONTAINER_RUNTIME_CANDIDATE_SHA256",
+                "CONTAINER_STACK_VALIDATION_SCRATCH_ROOT",
+                "CONTAINER_RUNTIME_MANAGED",
+                "CONTAINER_RUNTIME_APP_ROOT",
+                "CONTAINER_RUNTIME_SERVICE_NAMESPACE",
+                "CONTAINER_APP_ROOT",
+                "CONTAINER_SERVICE_NAMESPACE",
+            ):
+                environment.pop(variable, None)
             environment["CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR"] = str(
                 root / "checkpoints"
             )

--- a/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
+++ b/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md
@@ -155,3 +155,20 @@ target had not authorized its checksum-pinned non-interactive bootstrap. The
 corrected target installed verified Hawkeye 6.5.1 and completed the whole
 source preflight in 3.130 seconds. Subsequent runs reuse that local binary and
 do not need network access or an approval prompt.
+
+The retained 0.14.3 stable-release transaction then completed its full sibling
+stack gate in 4,726.982 seconds (78 minutes 46.982 seconds). The checkpoint is
+content-addressed, records digest `fd27b268cdd6`, and remains valid evidence for
+the exact candidate inputs. The following Compose CI stage stopped after
+673.138 seconds (11 minutes 13.138 seconds): 515 of its 516 release-policy tests
+passed, while one synthetic hosted-stack fixture inherited the outer managed
+runtime's ownership variables and tried to validate its fake CLI as the live
+release candidate.
+
+[`container-compose#619`](https://github.com/stephenlclarke/container-compose/issues/619)
+tracks that test-isolation defect. The focused reproduction failed in 0.611
+seconds with the managed environment and passed in 42.928 seconds after the
+fixture discarded candidate identity, managed-runtime ownership, and scratch
+state before invoking its fake stack. The same focused test passed from a clean
+environment in 41.905 seconds. Production candidate-path and ownership checks
+were not relaxed.


### PR DESCRIPTION
## Summary

- isolate the synthetic hosted-stack policy fixture from the outer release runtime ownership environment
- seed the fixture with managed-runtime values so this regression remains deterministic on hosted and local workers
- retain the failed and corrected stage timings in the build-workflow evidence

## Contract and risk

This changes release-test isolation only. Production candidate-path, ownership, signing, runtime, migration, and rollback behaviour are unchanged. The defect appeared when the stable release controller correctly ran the test suite inside its managed candidate runtime.

## Evidence

- Before: the focused test failed in 0.611 seconds with `release runtime application root is not the exact protected path`
- After, managed environment: passed in 42.928 seconds
- After, clean environment: passed in 41.905 seconds
- `python3 -m py_compile Tools/release/test_container_stack_release.py`
- `markdownlint-cli2 docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md`
- `git diff --check`

Closes #619