### PR TITLE
fix(release): recover stale candidate namespaces

### DIFF
--- a/Tools/ci/manage-release-gate-runtime.sh
+++ b/Tools/ci/manage-release-gate-runtime.sh
@@ -134,6 +134,67 @@ runtime_services() {
     'index($3, prefix) == 1 { print $3 }'
 }
 
+launchd_domain() {
+  local manager
+
+  manager="$("${launchctl_bin}" managername 2>/dev/null || true)"
+  case "${manager}" in
+    Aqua) printf 'gui/%s\n' "${runtime_user_id}" ;;
+    Background) printf 'user/%s\n' "${runtime_user_id}" ;;
+    System) printf 'system\n' ;;
+    *)
+      printf 'could not resolve launchd domain for release runtime cleanup: %s\n' \
+        "${manager:-unset}" >&2
+      return 1
+      ;;
+  esac
+}
+
+# The release wrapper holds the global runtime lock while this script runs, so
+# another release cannot legitimately own an older isolated namespace backed
+# by this candidate. Recover only live launchd jobs whose PID, UID, and exact
+# executable root all prove that ownership; everything else remains untouched.
+recover_stale_candidate_services() {
+  local domain executable label launchctl_snapshot process_id process_snapshot
+  local process_uid service_pid
+  local -a stale_services=()
+
+  if ! launchctl_snapshot="$("${launchctl_bin}" list)"; then
+    printf 'failed to inspect launchd services for stale release runtimes\n' >&2
+    return 1
+  fi
+  if ! process_snapshot="$("${ps_bin}" -axo pid=,uid=,command=)"; then
+    printf 'failed to inspect release runtime processes\n' >&2
+    return 1
+  fi
+  while read -r service_pid _ label; do
+    [[ "${service_pid}" =~ ^[1-9][0-9]*$ ]] || continue
+    [[ "${label}" =~ ^io\.github\.stephenlclarke\.container-compose\.runtime\.[A-Za-z0-9_-]+\.[A-Za-z0-9._-]+$ ]] || continue
+    [[ "${label}" != "${service_namespace}."* ]] || continue
+    while read -r process_id process_uid executable _; do
+      if [[ "${process_id}" == "${service_pid}" && \
+        "${process_uid}" == "${runtime_user_id}" && \
+        "${executable}" == "${candidate_root}/"* ]]; then
+        stale_services+=("${label}")
+        break
+      fi
+    done <<<"${process_snapshot}"
+  done <<<"${launchctl_snapshot}"
+
+  ((${#stale_services[@]} > 0)) || return 0
+  domain="$(launchd_domain)" || return 1
+  for label in "${stale_services[@]}"; do
+    if ! "${deadline_runner}" --seconds 30 --grace-seconds 0 -- \
+      "${launchctl_bin}" bootout "${domain}/${label}"; then
+      printf 'failed to boot out stale release runtime service: %s/%s\n' \
+        "${domain}" "${label}" >&2
+      return 1
+    fi
+    printf 'recovered stale release runtime service: %s/%s\n' \
+      "${domain}" "${label}"
+  done
+}
+
 runtime_processes() {
   local process_id process_uid executable process_snapshot
   if ! process_snapshot="$("${ps_bin}" -axo pid=,uid=,command=)"; then
@@ -156,6 +217,8 @@ if [[ "${action}" == quiesce ]]; then
     CONTAINER_SERVICE_NAMESPACE="${service_namespace}" \
     "${deadline_runner}" --seconds 60 --grace-seconds 0 -- \
       "${container_cli}" system stop
+
+  recover_stale_candidate_services
 
   remaining_services=""
   remaining_processes=""

--- a/Tools/ci/test_manage_release_gate_runtime.py
+++ b/Tools/ci/test_manage_release_gate_runtime.py
@@ -90,10 +90,25 @@ class ManageReleaseGateRuntimeTests(unittest.TestCase):
         self._write_executable(
             self.launchctl,
             """
+            if [[ "${1:-}" == managername ]]; then
+              printf 'Aqua\n'
+              exit 0
+            fi
             if [[ "${1:-}" == list ]]; then
-              while IFS= read -r label; do
-                [[ -n "$label" ]] && printf -- '-\t0\t%s\n' "$label"
+              while read -r first second; do
+                [[ -n "$first" ]] || continue
+                if [[ -n "$second" ]]; then
+                  printf '%s\t0\t%s\n' "$first" "$second"
+                else
+                  printf '991\t0\t%s\n' "$first"
+                fi
               done <"${LIFECYCLE_SERVICE_STATE:?}"
+              exit 0
+            fi
+            if [[ "${1:-}" == bootout ]]; then
+              printf 'launchctl:bootout:%s\n' "${2:-}" >>"${LIFECYCLE_COMMAND_LOG:?}"
+              : >"${LIFECYCLE_SERVICE_STATE:?}"
+              : >"${LIFECYCLE_PROCESS_STATE:?}"
               exit 0
             fi
             exit 64
@@ -214,6 +229,45 @@ class ManageReleaseGateRuntimeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("runtime services survived quiescence", result.stderr)
         self.assertIn("runtime processes survived quiescence", result.stderr)
+
+    def test_recovers_a_stale_namespace_backed_by_the_candidate(self) -> None:
+        stale_namespace = (
+            "io.github.stephenlclarke.container-compose.runtime.retained"
+        )
+        self.service_state.write_text(
+            f"991 {stale_namespace}.apiserver\n", encoding="utf-8"
+        )
+        self.process_state.write_text(
+            f"{self.candidate_root}/libexec/container-apiserver\n",
+            encoding="utf-8",
+        )
+
+        result = self._run("quiesce", LEAVE_RUNTIME_STATE="1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("recovered stale release runtime service", result.stdout)
+        commands = self.command_log.read_text(encoding="utf-8")
+        self.assertIn(
+            f"launchctl:bootout:gui/{os.getuid()}/{stale_namespace}.apiserver",
+            commands,
+        )
+
+    def test_does_not_boot_out_a_stale_namespace_without_candidate_ownership(
+        self,
+    ) -> None:
+        stale_namespace = (
+            "io.github.stephenlclarke.container-compose.runtime.unrelated"
+        )
+        self.service_state.write_text(
+            f"991 {stale_namespace}.apiserver\n", encoding="utf-8"
+        )
+        self.process_state.write_text("/usr/bin/true\n", encoding="utf-8")
+
+        result = self._run("quiesce", LEAVE_RUNTIME_STATE="1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        commands = self.command_log.read_text(encoding="utf-8")
+        self.assertNotIn("launchctl:bootout", commands)
 
     def test_rejects_a_failed_process_snapshot(self) -> None:
         result = self._run("quiesce", FAIL_PROCESS_SNAPSHOT="1")

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "archiveCommit": "3d77ec228c7f55a04f689d5e1453752fc0c27f72",
-  "generatedAt": "2026-09-09",
+  "generatedAt": "2026-09-10",
   "entries": [
     {
       "id": "apple-container-1459",
@@ -8431,6 +8431,25 @@
         }
       ],
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/596"
+    },
+    {
+      "id": "container-compose-621",
+      "owner": "stephenlclarke/container-compose",
+      "title": "fix(release): recover stale candidate namespaces",
+      "state": "active-draft",
+      "lastVerified": "2026-09-10",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-621.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-622.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/622"
     },
     {
       "id": "process-list-compose-top-process-list",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -6,11 +6,11 @@ This registry replaces the retired issue and pull-request handoff pairs.
 Current supporting records remain as ordinary Markdown files; every retired document
 links to an immutable Git snapshot.
 
-Last verified: 2026-09-09
+Last verified: 2026-09-10
 
-Entries: 428. Document snapshots: 748. Current supporting documents: 142.
+Entries: 429. Document snapshots: 750. Current supporting documents: 144.
 
-States: `active-draft` 33, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 34, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -258,6 +258,7 @@ States: `active-draft` 33, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [fix(release): refresh retained sibling mains](https://github.com/stephenlclarke/container-compose/pull/572) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-571.md); [PR details](container-compose/PR-572.md) |
 | `stephenlclarke/container-compose` | [\[Build\] Replace Nextflow with a recoverable native graph](https://github.com/stephenlclarke/container-compose/pull/594) | `active-draft` | `89f9f7944b58`, `44f4895d88a7` | [Issue details](container-compose/ISSUE-593.md); [PR details](container-compose/PR-594.md) |
 | `stephenlclarke/container-compose` | [fix(build): complete recoverable stack workflow](https://github.com/stephenlclarke/container-compose/pull/596) | `active-draft` | `73b886a8a1d6` | [Issue details](container-compose/ISSUE-595.md); [PR details](container-compose/PR-596.md) |
+| `stephenlclarke/container-compose` | [fix(release): recover stale candidate namespaces](https://github.com/stephenlclarke/container-compose/pull/622) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-621.md); [PR details](container-compose/PR-622.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-621.md
+++ b/docs/upstream/container-compose/ISSUE-621.md
@@ -1,0 +1,30 @@
+# Issue 621: Recover stale retained release runtime namespaces
+
+Issue [#621](https://github.com/stephenlclarke/container-compose/issues/621)
+tracks a release-gate cleanup gap exposed while resuming the retained 0.14.3
+transaction.
+
+## Failure
+
+The release gate correctly detected seven processes from an older isolated
+release-runtime namespace under the exact protected Container candidate. Its
+graceful stop addressed only the current namespace, so the gate failed closed
+without a bounded recovery path for the retained namespace.
+
+## Contract
+
+- Keep the current namespace's graceful `container system stop` as the first
+  cleanup action.
+- While the global runtime lock is held, identify older release namespaces from
+  one launchd and process snapshot.
+- Boot out a stale service only when its live PID, user ID, and executable path
+  prove that it belongs to the same validated candidate root.
+- Continue to reject current-namespace survivors, ambiguous services, orphaned
+  candidate processes, launchd inspection failures, and process inspection
+  failures.
+
+## Evidence
+
+The focused lifecycle suite covers successful retained-namespace recovery,
+current-namespace fail-closed behavior, and refusal to touch a similarly named
+service without candidate ownership.

--- a/docs/upstream/container-compose/PR-622.md
+++ b/docs/upstream/container-compose/PR-622.md
@@ -1,0 +1,20 @@
+# Pull request 622: recover stale candidate namespaces
+
+## Change
+
+The release runtime lifecycle gate now recovers launchd services retained by
+older isolated release namespaces before checking candidate quiescence. The
+recovery is bounded to the current launchd manager domain and requires a live
+service PID owned by the current user whose executable is beneath the exact
+marker-protected Container candidate root.
+
+Current-namespace survivors remain errors, as do candidate processes that the
+gate cannot associate with a safely recoverable stale service.
+
+## Validation
+
+- 7 focused release-runtime lifecycle tests
+- Bash syntax and ShellCheck validation
+- whitespace validation
+
+Closes [#621](https://github.com/stephenlclarke/container-compose/issues/621).


### PR DESCRIPTION
## Summary

- recover stale isolated release-runtime launchd services after the current namespace stops
- require exact candidate-root, PID, and UID ownership before bootout
- retain fail-closed behavior for current-namespace survivors and ambiguous candidate processes
- record the issue and pull-request handoff

## Validation

- `python3 -m unittest Tools.ci.test_manage_release_gate_runtime Tools.ci.test_upstream_handoff_registry`
- `bash -n Tools/ci/manage-release-gate-runtime.sh`
- `shellcheck Tools/ci/manage-release-gate-runtime.sh`
- `python3 Tools/ci/upstream-handoff-registry.py check`
- `git diff --check`

Closes #621