### PR TITLE
fix(release): keep authority lookup runner-compatible

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1087,7 +1087,7 @@ jobs:
               authority_record="$(
                 gh api --paginate --slurp \
                   "repos/${GITHUB_REPOSITORY}/commits/${PUBLISH_SHA}/check-runs?per_page=100" \
-                  --jq "${authority_filter}"
+                  | jq -r "${authority_filter}"
               )"
               IFS=$'\t' read -r authority_run_id authority_summary <<< "${authority_record}"
               if [[ ! "${authority_run_id}" =~ ^[0-9]+$ ]]; then

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3914,6 +3914,8 @@ github_cli() {{
         self.assertIn("Stable Release Gate", tag_authority)
         self.assertIn("workflow_dispatch", tag_authority)
         self.assertIn(".output.summary", tag_authority)
+        self.assertIn('| jq -r "${authority_filter}"', tag_authority)
+        self.assertNotIn('--jq "${authority_filter}"', tag_authority)
         self.assertIn("Authority receipt SHA-256", tag_authority)
         self.assertIn("Authority artifact ID", tag_authority)
         self.assertIn("Authority artifact digest", tag_authority)
@@ -9850,7 +9852,21 @@ exit 64
         fake_gh = """\
 gh() {
   case "$1:$2" in
-    api:*) printf '%s\\t%s\\n' "${TEST_AUTHORITY_RUN_ID}" "${TEST_AUTHORITY_SUMMARY}" ;;
+    api:*)
+      jq -cn \
+        --arg name "Stable Release Authority (${PUBLISH_REF_NAME})" \
+        --arg run_id "${TEST_AUTHORITY_RUN_ID}" \
+        --arg summary "${TEST_AUTHORITY_SUMMARY}" \
+        '[{check_runs: [{
+          name: $name,
+          status: "completed",
+          conclusion: "success",
+          app: {slug: "github-actions"},
+          completed_at: "2026-09-10T00:00:00Z",
+          external_id: $run_id,
+          output: {summary: $summary}
+        }]}]'
+      ;;
     run:list) printf '%s\\n' "${TEST_GATE_CONCLUSION}" ;;
     run:view) printf '%s\\n' "${TEST_GATE_CONCLUSION}" ;;
     *) exit 64 ;;

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -8452,6 +8452,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/622"
     },
     {
+      "id": "container-compose-624",
+      "owner": "stephenlclarke/container-compose",
+      "title": "fix(release): keep stable authority lookup runner-compatible",
+      "state": "active-draft",
+      "lastVerified": "2026-09-10",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-624.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-625.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/625"
+    },
+    {
       "id": "process-list-compose-top-process-list",
       "owner": "stephenlclarke/container-compose",
       "title": "Pull request: support Docker-shaped `container compose top`",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-10
 
-Entries: 429. Document snapshots: 750. Current supporting documents: 144.
+Entries: 430. Document snapshots: 752. Current supporting documents: 146.
 
-States: `active-draft` 34, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 35, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -259,6 +259,7 @@ States: `active-draft` 34, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [\[Build\] Replace Nextflow with a recoverable native graph](https://github.com/stephenlclarke/container-compose/pull/594) | `active-draft` | `89f9f7944b58`, `44f4895d88a7` | [Issue details](container-compose/ISSUE-593.md); [PR details](container-compose/PR-594.md) |
 | `stephenlclarke/container-compose` | [fix(build): complete recoverable stack workflow](https://github.com/stephenlclarke/container-compose/pull/596) | `active-draft` | `73b886a8a1d6` | [Issue details](container-compose/ISSUE-595.md); [PR details](container-compose/PR-596.md) |
 | `stephenlclarke/container-compose` | [fix(release): recover stale candidate namespaces](https://github.com/stephenlclarke/container-compose/pull/622) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-621.md); [PR details](container-compose/PR-622.md) |
+| `stephenlclarke/container-compose` | [fix(release): keep stable authority lookup runner-compatible](https://github.com/stephenlclarke/container-compose/pull/625) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-624.md); [PR details](container-compose/PR-625.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-624.md
+++ b/docs/upstream/container-compose/ISSUE-624.md
@@ -1,0 +1,18 @@
+# Issue 624: Keep stable authority lookup compatible with the release runner
+
+Issue [#624](https://github.com/stephenlclarke/container-compose/issues/624) tracks a packaging failure exposed after the candidate-bound 0.14.3 Stable Release Gate passed.
+
+## Failure
+
+The stable package workflow requests paginated check runs with `gh api --paginate --slurp` and applies its filter through the same command's `--jq` option. The GitHub CLI installed on the release runner rejects `--slurp` together with `--jq`, so the workflow stops before building binaries despite having a valid successful release authority.
+
+## Contract
+
+- Preserve pagination and slurping so the authority lookup covers every check-run page.
+- Apply the existing candidate-bound authority filter as a separate `jq -r` process under `set -o pipefail`.
+- Continue to fail closed when no successful GitHub Actions authority, valid receipt binding, or successful authority workflow run exists.
+- Prevent the incompatible combined `gh --slurp --jq` form from returning to the stable tag path.
+
+## Evidence
+
+Stable package run [34468851916](https://github.com/stephenlclarke/container-compose/actions/runs/34468851916) failed in `Require the hosted release authority` with `the --slurp option is not supported with --jq or --template` after Stable Release Gate run [34465109888](https://github.com/stephenlclarke/container-compose/actions/runs/34465109888) passed.

--- a/docs/upstream/container-compose/PR-625.md
+++ b/docs/upstream/container-compose/PR-625.md
@@ -1,0 +1,38 @@
+# Pull request 625: keep stable authority lookup compatible with the release runner
+
+## Summary
+
+- Keep the stable package authority query paginated and slurped.
+- Pipe the complete response to `jq -r` instead of combining GitHub CLI `--slurp` and `--jq` options.
+- Add regression coverage for the compatible command shape.
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [x] Documentation update
+
+## Motivation and Context
+
+The 0.14.3 stable package run stopped before building binaries because the release runner's GitHub CLI rejects `--slurp` together with `--jq`. The candidate-bound Stable Release Gate had already passed, so this is a package-control compatibility failure rather than missing authority. The retained release transaction needs a narrow workflow correction that preserves the existing fail-closed authority binding.
+
+## Testing
+
+- [x] Focused release workflow tests
+- [x] YAML parse validation
+- [x] Whitespace validation
+
+## container-compose Checks
+
+- [x] No support-status update is needed; this changes internal release control only.
+- [x] This pull request is focused on issue 624.
+- [x] Release-control review notes and CI evidence are attached to this pull request.
+- [x] The commit and pull request title use Conventional Commits.
+- [x] The commit records `Release-Note: none` because the change is internal-only.
+- [x] No upstream-driven source change is included.
+- [x] Release-only CodeQL remains confined to the resumed stable package workflow.
+- [x] The commit is signed with a GitHub-supported signature method.
+- [x] No credentials or private data are included.
+
+Closes [#624](https://github.com/stephenlclarke/container-compose/issues/624).


### PR DESCRIPTION
# Pull request 625: keep stable authority lookup compatible with the release runner

## Summary

- Keep the stable package authority query paginated and slurped.
- Pipe the complete response to `jq -r` instead of combining GitHub CLI `--slurp` and `--jq` options.
- Add regression coverage for the compatible command shape.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

The 0.14.3 stable package run stopped before building binaries because the release runner's GitHub CLI rejects `--slurp` together with `--jq`. The candidate-bound Stable Release Gate had already passed, so this is a package-control compatibility failure rather than missing authority. The retained release transaction needs a narrow workflow correction that preserves the existing fail-closed authority binding.

## Testing

- [x] Focused release workflow tests
- [x] YAML parse validation
- [x] Whitespace validation

## container-compose Checks

- [x] No support-status update is needed; this changes internal release control only.
- [x] This pull request is focused on issue 624.
- [x] Release-control review notes and CI evidence are attached to this pull request.
- [x] The commit and pull request title use Conventional Commits.
- [x] The commit records `Release-Note: none` because the change is internal-only.
- [x] No upstream-driven source change is included.
- [x] Release-only CodeQL remains confined to the resumed stable package workflow.
- [x] The commit is signed with a GitHub-supported signature method.
- [x] No credentials or private data are included.

Closes [#624](https://github.com/stephenlclarke/container-compose/issues/624).
