### PR TITLE
fix(release): preserve stable retry control authority

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -41,6 +41,7 @@ jobs:
     outputs:
       sha: ${{ steps.candidate.outputs.sha }}
       authority_ref: ${{ steps.candidate.outputs.authority_ref }}
+      control_sha: ${{ steps.candidate.outputs.control_sha }}
       homebrew_tap_ref: ${{ steps.candidate.outputs.homebrew_tap_ref }}
       init_image_sha256: ${{ steps.candidate.outputs.init_image_sha256 }}
       init_image_authority_object: ${{ steps.candidate.outputs.init_image_authority_object }}
@@ -169,9 +170,12 @@ jobs:
             authority_ref="${release_branch}"
             candidate_ci_branch="${RELEASE_TAG}"
           else
-            printf 'stable tag %s is neither current main nor exact %s head\n' \
-              "${RELEASE_TAG}" "${release_branch}" >&2
-            exit 1
+            # An unpublished latest tag can outlive main when release-control
+            # automation is repaired after the tag was signed. Its payload
+            # authority remains the immutable tag and original main CI; the
+            # current main head independently owns the retry's control tools.
+            authority_ref="main"
+            candidate_ci_branch="main"
           fi
 
           semantic_tags="$(
@@ -268,6 +272,7 @@ jobs:
           {
             printf 'sha=%s\n' "${tag_sha}"
             printf 'authority_ref=%s\n' "${authority_ref}"
+            printf 'control_sha=%s\n' "${main_sha}"
             printf 'homebrew_tap_ref=%s\n' "${homebrew_tap_ref}"
             printf 'init_image_sha256=%s\n' "${INIT_IMAGE_SHA256}"
             printf 'init_image_authority_object=%s\n' "${init_image_authority_object}"
@@ -521,6 +526,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.ref }}
           CANDIDATE_SHA: ${{ needs.resolve-candidate.outputs.sha }}
           AUTHORITY_REF: ${{ needs.resolve-candidate.outputs.authority_ref }}
+          CONTROL_SHA: ${{ needs.resolve-candidate.outputs.control_sha }}
           INIT_IMAGE_SHA256: ${{ needs.resolve-candidate.outputs.init_image_sha256 }}
           INIT_IMAGE_AUTHORITY_OBJECT: ${{ needs.resolve-candidate.outputs.init_image_authority_object }}
           AUTHORITY_ARTIFACT_DIGEST: ${{ needs.release-gate.outputs.authority_artifact_digest }}
@@ -535,14 +541,24 @@ jobs:
               awk '{ print $1 }' |
               tail -n 1
           )"
+          if [[ ! "${CONTROL_SHA}" =~ ^[0-9a-f]{40}$ ]] ||
+            [[ "${GITHUB_SHA}" != "${CONTROL_SHA}" ]]; then
+            printf 'stable release control identity changed: expected %s, got %s\n' \
+              "${CONTROL_SHA:-missing}" "${GITHUB_SHA}" >&2
+            exit 75
+          fi
+          expected_authority_sha="${CANDIDATE_SHA}"
+          if [[ "${AUTHORITY_REF}" == "main" ]]; then
+            expected_authority_sha="${CONTROL_SHA}"
+          fi
           tag_sha="$(
             git ls-remote --tags "${remote}" "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" |
               awk '$2 ~ /\^\{\}$/ { print $1 }' |
               tail -n 1
           )"
-          if [[ "${authority_sha}" != "${CANDIDATE_SHA}" ]]; then
+          if [[ "${authority_sha}" != "${expected_authority_sha}" ]]; then
             printf 'release authority %s moved after validation: expected %s, got %s\n' \
-              "${AUTHORITY_REF}" "${CANDIDATE_SHA}" "${authority_sha:-missing}" >&2
+              "${AUTHORITY_REF}" "${expected_authority_sha}" "${authority_sha:-missing}" >&2
             exit 75
           fi
           if [[ "${tag_sha}" != "${CANDIDATE_SHA}" ]]; then

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3600,7 +3600,12 @@ github_cli() {{
         self.assertIn('candidate_ci_branch="main"', stable_gate)
         self.assertIn('candidate_ci_branch="${RELEASE_TAG}"', stable_gate)
         self.assertIn('.headBranch == \\"${candidate_ci_branch}\\"', stable_gate)
-        self.assertIn("is neither current main nor exact %s head", stable_gate)
+        self.assertNotIn("is neither current main nor exact %s head", stable_gate)
+        self.assertIn(
+            "control_sha: ${{ steps.candidate.outputs.control_sha }}", stable_gate
+        )
+        self.assertIn("expected_authority_sha=\"${CONTROL_SHA}\"", stable_gate)
+        self.assertIn("stable release control identity changed", stable_gate)
         self.assertIn("timeout-minutes: 270", stable_gate)
         self.assertIn("deadline=$((SECONDS + 15600))", stable_gate)
         self.assertIn(
@@ -5164,7 +5169,12 @@ github_cli() {{
         )
         self.assertIn('release_branch="release-${release_series}"', workflow)
         self.assertIn('candidate_ci_branch="${RELEASE_TAG}"', workflow)
-        self.assertIn("is neither current main nor exact %s head", workflow)
+        self.assertNotIn("is neither current main nor exact %s head", workflow)
+        self.assertIn('printf \'control_sha=%s\\n\' "${main_sha}"', workflow)
+        self.assertIn(
+            "CONTROL_SHA: ${{ needs.resolve-candidate.outputs.control_sha }}", workflow
+        )
+        self.assertIn('expected_authority_sha="${CONTROL_SHA}"', workflow)
         self.assertIn(
             'select(.name == "Record successful SonarQube analysis")',
             workflow,

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -8471,6 +8471,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/625"
     },
     {
+      "id": "container-compose-626",
+      "owner": "stephenlclarke/container-compose",
+      "title": "fix(release): preserve stable retry control authority",
+      "state": "active-draft",
+      "lastVerified": "2026-09-10",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-626.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-627.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/627"
+    },
+    {
       "id": "process-list-compose-top-process-list",
       "owner": "stephenlclarke/container-compose",
       "title": "Pull request: support Docker-shaped `container compose top`",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-10
 
-Entries: 430. Document snapshots: 752. Current supporting documents: 146.
+Entries: 431. Document snapshots: 754. Current supporting documents: 148.
 
-States: `active-draft` 35, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 36, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -260,6 +260,7 @@ States: `active-draft` 35, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [fix(build): complete recoverable stack workflow](https://github.com/stephenlclarke/container-compose/pull/596) | `active-draft` | `73b886a8a1d6` | [Issue details](container-compose/ISSUE-595.md); [PR details](container-compose/PR-596.md) |
 | `stephenlclarke/container-compose` | [fix(release): recover stale candidate namespaces](https://github.com/stephenlclarke/container-compose/pull/622) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-621.md); [PR details](container-compose/PR-622.md) |
 | `stephenlclarke/container-compose` | [fix(release): keep stable authority lookup runner-compatible](https://github.com/stephenlclarke/container-compose/pull/625) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-624.md); [PR details](container-compose/PR-625.md) |
+| `stephenlclarke/container-compose` | [fix(release): preserve stable retry control authority](https://github.com/stephenlclarke/container-compose/pull/627) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-626.md); [PR details](container-compose/PR-627.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-626.md
+++ b/docs/upstream/container-compose/ISSUE-626.md
@@ -1,0 +1,18 @@
+# Issue 626: Preserve stable retry control authority after main advances
+
+Issue [#626](https://github.com/stephenlclarke/container-compose/issues/626) tracks a Stable Release Gate failure exposed while recovering the unpublished 0.14.3 release.
+
+## Failure
+
+The gate accepts that a GitHub-verified unpublished semantic tag can remain the immutable package source after release automation changes on `main`. It then rejects that same tag unless it is also the head of a `release-X.Y` branch. The project does not use long-lived release branches, so the documented exact-version recovery path cannot reach the hosted release graph after a release-control fix advances `main`.
+
+## Contract
+
+- Keep the signed semantic tag, candidate CI, and stable init-image authority bound to the immutable package source.
+- Use the exact current `main` revision as the independently pinned release-control authority for a latest-tag retry.
+- Recheck both the current control revision and signed source tag before recording candidate-bound Stable Release Authority.
+- Preserve the existing maintenance-branch path and reject stale semantic tags or candidates without successful SonarQube-backed CI.
+
+## Evidence
+
+Stable Release Gate run [34477380301](https://github.com/stephenlclarke/container-compose/actions/runs/34477380301) stopped in `Resolve Stable Candidate` after logging that 0.14.3 was an accepted verified unpublished retry, then rejected it because no `release-0.14` branch exists.

--- a/docs/upstream/container-compose/PR-627.md
+++ b/docs/upstream/container-compose/PR-627.md
@@ -1,0 +1,38 @@
+# Pull request 627: preserve stable retry control authority
+
+## Summary
+
+- Permit the latest unpublished signed stable tag to use its original successful `main` CI after release-control changes advance `main`.
+- Record the current exact `main` SHA separately as the retry's release-control authority.
+- Recheck both current control authority and immutable candidate authority before recording Stable Release Authority.
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [x] Documentation update
+
+## Motivation and Context
+
+The supported 0.14.3 exact-version recovery reached a contradictory Stable Release Gate branch: it explicitly accepted an unpublished verified source tag after `main` advanced, then required that tag to be the head of a long-lived release branch. Separating immutable payload authority from current release-control authority restores the documented retry without moving the signed tag or weakening candidate CI, SonarQube, init-image, recency, or release-existence checks.
+
+## Testing
+
+- [x] Focused release workflow tests
+- [x] Action workflow validation
+- [x] Markdown and whitespace validation
+
+## container-compose Checks
+
+- [x] No support-status update is needed; this changes internal release control only.
+- [x] This pull request is focused on issue 626.
+- [x] Release-control review notes and CI evidence are attached to this pull request.
+- [x] The commit and pull request title use Conventional Commits.
+- [x] The commit records `Release-Note: none` because the change is internal-only.
+- [x] No upstream-driven source change is included.
+- [x] Release-only CodeQL remains confined to the resumed stable package workflow.
+- [x] The commit is signed with a GitHub-supported signature method.
+- [x] No credentials or private data are included.
+
+Closes [#626](https://github.com/stephenlclarke/container-compose/issues/626).


### PR DESCRIPTION
# Pull request 627: preserve stable retry control authority

## Summary

- Permit the latest unpublished signed stable tag to use its original successful `main` CI after release-control changes advance `main`.
- Record the current exact `main` SHA separately as the retry's release-control authority.
- Recheck both current control authority and immutable candidate authority before recording Stable Release Authority.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

## Motivation and Context

The supported 0.14.3 exact-version recovery reached a contradictory Stable Release Gate branch: it explicitly accepted an unpublished verified source tag after `main` advanced, then required that tag to be the head of a long-lived release branch. Separating immutable payload authority from current release-control authority restores the documented retry without moving the signed tag or weakening candidate CI, SonarQube, init-image, recency, or release-existence checks.

## Testing

- [x] Focused release workflow tests
- [x] Action workflow validation
- [x] Markdown and whitespace validation

## container-compose Checks

- [x] No support-status update is needed; this changes internal release control only.
- [x] This pull request is focused on issue 626.
- [x] Release-control review notes and CI evidence are attached to this pull request.
- [x] The commit and pull request title use Conventional Commits.
- [x] The commit records `Release-Note: none` because the change is internal-only.
- [x] No upstream-driven source change is included.
- [x] Release-only CodeQL remains confined to the resumed stable package workflow.
- [x] The commit is signed with a GitHub-supported signature method.
- [x] No credentials or private data are included.

Closes [#626](https://github.com/stephenlclarke/container-compose/issues/626).
