### PR TITLE
fix(docs): preserve prerelease publication authority

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -170,7 +170,7 @@ jobs:
             gh api \
               "repos/stephenlclarke/container-k8s/releases/tags/${K8S_RELEASE_TAG}"
           )"
-          if [[ "$(jq -r '.draft or .prerelease' <<<"${k8s_release}")" != "false" ]] || \
+          if [[ "$(jq -r '.draft' <<<"${k8s_release}")" != "false" ]] || \
             [[ "$(jq -r '.tag_name' <<<"${k8s_release}")" != "${K8S_RELEASE_TAG}" ]] || \
             [[ ! "$(jq -r '.id' <<<"${k8s_release}")" =~ ^[0-9]+$ ]] || \
             [[ "${k8s_tag_ref}" != "${K8S_REF}" ]]; then

--- a/Tools/release/documentation-authority.py
+++ b/Tools/release/documentation-authority.py
@@ -79,17 +79,24 @@ def resolve_tag(repository: str, tag: str) -> str:
 
 
 def verify_release(
-    repository: str, tag: str, expected_id: int, expected_sha: str
+    repository: str,
+    tag: str,
+    expected_id: int,
+    expected_sha: str,
+    *,
+    allow_prerelease: bool = False,
 ) -> dict[str, object]:
     release = json.loads(
         run_command(("gh", "api", f"repos/{repository}/releases/tags/{tag}"))
     )
     actual_id = release.get("id")
+    prerelease = release.get("prerelease")
     if (
         actual_id != expected_id
         or release.get("tag_name") != tag
         or release.get("draft") is not False
-        or release.get("prerelease") is not False
+        or not isinstance(prerelease, bool)
+        or (prerelease and not allow_prerelease)
     ):
         raise ValueError(f"published release authority changed: {repository}@{tag}")
     actual_sha = resolve_tag(repository, tag)
@@ -100,6 +107,7 @@ def verify_release(
         )
     return {
         "id": actual_id,
+        "prerelease": prerelease,
         "repository": repository,
         "sha": actual_sha,
         "tag": tag,
@@ -175,6 +183,7 @@ def authority_digest(options: argparse.Namespace) -> str:
             options.k8s_tag,
             options.k8s_release_id,
             options.k8s_ref,
+            allow_prerelease=True,
         ),
         "schema": 1,
     }

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -3289,6 +3289,14 @@ github_cli() {{
         self.assertIn(
             "container-k8s ref is not attached to a published release", workflow
         )
+        self.assertIn(
+            "if [[ \"$(jq -r '.draft' <<<\"${k8s_release}\")\" != \"false\" ]]",
+            workflow,
+        )
+        self.assertNotIn(
+            "'.draft or .prerelease' <<<\"${k8s_release}\"",
+            workflow,
+        )
         self.assertIn("Tools/release/stack-refs.json", workflow)
         self.assertIn("Tools/release/documentation-refs.json", workflow)
         self.assertIn("ref: ${{ matrix.ref }}", workflow)

--- a/Tools/release/test_documentation_authority.py
+++ b/Tools/release/test_documentation_authority.py
@@ -67,7 +67,7 @@ class DocumentationAuthorityTests(unittest.TestCase):
         if "releases/tags/4.5.6" in joined:
             return (
                 '{"id":34,"tag_name":"4.5.6",'
-                '"draft":false,"prerelease":false}'
+                '"draft":false,"prerelease":true}'
             )
         if "commits/" in joined:
             return "b" * 40
@@ -108,6 +108,53 @@ class DocumentationAuthorityTests(unittest.TestCase):
 
         with mock.patch.object(AUTHORITY, "run_command", side_effect=moved):
             with self.assertRaisesRegex(ValueError, "published tag moved"):
+                AUTHORITY.authority_digest(self.options())
+
+    def test_compose_prerelease_is_rejected(self) -> None:
+        def prerelease(arguments):
+            if "releases/tags/1.2.3" in " ".join(arguments):
+                return (
+                    '{"id":12,"tag_name":"1.2.3",'
+                    '"draft":false,"prerelease":true}'
+                )
+            return self.command_result(arguments)
+
+        with mock.patch.object(
+            AUTHORITY, "run_command", side_effect=prerelease
+        ):
+            with self.assertRaisesRegex(ValueError, "release authority changed"):
+                AUTHORITY.authority_digest(self.options())
+
+    def test_k8s_prerelease_state_is_bound_into_authority(self) -> None:
+        with mock.patch.object(
+            AUTHORITY, "run_command", side_effect=self.command_result
+        ):
+            prerelease = AUTHORITY.authority_digest(self.options())
+
+        def stable(arguments):
+            if "releases/tags/4.5.6" in " ".join(arguments):
+                return (
+                    '{"id":34,"tag_name":"4.5.6",'
+                    '"draft":false,"prerelease":false}'
+                )
+            return self.command_result(arguments)
+
+        with mock.patch.object(AUTHORITY, "run_command", side_effect=stable):
+            release = AUTHORITY.authority_digest(self.options())
+
+        self.assertNotEqual(prerelease, release)
+
+    def test_k8s_draft_is_rejected(self) -> None:
+        def draft(arguments):
+            if "releases/tags/4.5.6" in " ".join(arguments):
+                return (
+                    '{"id":34,"tag_name":"4.5.6",'
+                    '"draft":true,"prerelease":true}'
+                )
+            return self.command_result(arguments)
+
+        with mock.patch.object(AUTHORITY, "run_command", side_effect=draft):
+            with self.assertRaisesRegex(ValueError, "release authority changed"):
                 AUTHORITY.authority_digest(self.options())
 
 

--- a/docs/upstream/HANDOFF-REGISTRY.json
+++ b/docs/upstream/HANDOFF-REGISTRY.json
@@ -8490,6 +8490,25 @@
       "upstream": "https://github.com/stephenlclarke/container-compose/pull/627"
     },
     {
+      "id": "container-compose-629",
+      "owner": "stephenlclarke/container-compose",
+      "title": "fix(docs): preserve prerelease publication authority",
+      "state": "active-draft",
+      "lastVerified": "2026-09-10",
+      "commits": [],
+      "documents": [
+        {
+          "kind": "issue",
+          "path": "docs/upstream/container-compose/ISSUE-629.md"
+        },
+        {
+          "kind": "pull-request",
+          "path": "docs/upstream/container-compose/PR-630.md"
+        }
+      ],
+      "upstream": "https://github.com/stephenlclarke/container-compose/pull/630"
+    },
+    {
       "id": "process-list-compose-top-process-list",
       "owner": "stephenlclarke/container-compose",
       "title": "Pull request: support Docker-shaped `container compose top`",

--- a/docs/upstream/HANDOFF-REGISTRY.md
+++ b/docs/upstream/HANDOFF-REGISTRY.md
@@ -8,9 +8,9 @@ links to an immutable Git snapshot.
 
 Last verified: 2026-09-10
 
-Entries: 431. Document snapshots: 754. Current supporting documents: 148.
+Entries: 432. Document snapshots: 756. Current supporting documents: 150.
 
-States: `active-draft` 36, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
+States: `active-draft` 37, `archived` 304, `closed` 22, `merged` 11, `submitted` 16, `tracked-upstream` 15, `unsubmitted` 27.
 
 | Owner | Capability or pull request | State | Referenced commits | Documents |
 | --- | --- | --- | --- | --- |
@@ -261,6 +261,7 @@ States: `active-draft` 36, `archived` 304, `closed` 22, `merged` 11, `submitted`
 | `stephenlclarke/container-compose` | [fix(release): recover stale candidate namespaces](https://github.com/stephenlclarke/container-compose/pull/622) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-621.md); [PR details](container-compose/PR-622.md) |
 | `stephenlclarke/container-compose` | [fix(release): keep stable authority lookup runner-compatible](https://github.com/stephenlclarke/container-compose/pull/625) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-624.md); [PR details](container-compose/PR-625.md) |
 | `stephenlclarke/container-compose` | [fix(release): preserve stable retry control authority](https://github.com/stephenlclarke/container-compose/pull/627) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-626.md); [PR details](container-compose/PR-627.md) |
+| `stephenlclarke/container-compose` | [fix(docs): preserve prerelease publication authority](https://github.com/stephenlclarke/container-compose/pull/630) | `active-draft` | None recorded | [Issue details](container-compose/ISSUE-629.md); [PR details](container-compose/PR-630.md) |
 | `stephenlclarke/container-compose` | Isolate deterministic anonymous volume identities | `archived` | None recorded | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-anonymous-volume-identity.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-anonymous-volume-identity.md) |
 | `stephenlclarke/container-compose` | Support bind create_host_path policy | `archived` | `12c6ed0b8a1e` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-create-host-path.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-create-host-path.md) |
 | `stephenlclarke/container-compose` | Support bind propagation mount options | `archived` | `5fbe9f0937d8` | [Issue archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/ISSUE-bind-propagation.md); [PR archive](https://github.com/stephenlclarke/container-compose/blob/3d77ec228c7f55a04f689d5e1453752fc0c27f72/docs/upstream/container-compose/PR-bind-propagation.md) |

--- a/docs/upstream/container-compose/ISSUE-629.md
+++ b/docs/upstream/container-compose/ISSUE-629.md
@@ -1,0 +1,18 @@
+# Issue 629: Preserve immutable prerelease documentation authority
+
+Issue [#629](https://github.com/stephenlclarke/container-compose/issues/629) tracks the failed documentation tail of the published 0.14.3 release.
+
+## Failure
+
+The released documentation manifest pins container-k8s tag `homebrew-main-17-21b4325d2d16` at immutable commit `21b4325d2d169aab4c4ff9090720f2f141e99860`. That snapshot is intentionally a published prerelease, but the documentation authority verifier incorrectly generalized the Compose stable-release rule and rejected every container-k8s prerelease.
+
+## Contract
+
+- Keep the Compose semantic release restricted to a published non-prerelease.
+- Permit the separately pinned container-k8s documentation snapshot to be a published release or prerelease, but never a draft.
+- Bind the exact container-k8s release ID, tag, commit, and prerelease state into the authority digest checked before and after Pages deployment.
+- Preserve immutable documentation source checkouts and fail closed if any authority changes during deployment.
+
+## Evidence
+
+Documentation run [34491354958](https://github.com/stephenlclarke/container-compose/actions/runs/34491354958) rejected the exact pinned snapshot after stable package run [34489932954](https://github.com/stephenlclarke/container-compose/actions/runs/34489932954) published and verified the complete 0.14.3 artifact closure.

--- a/docs/upstream/container-compose/PR-630.md
+++ b/docs/upstream/container-compose/PR-630.md
@@ -1,0 +1,41 @@
+# Pull request 630: preserve prerelease publication authority
+
+## Summary
+
+- Accept the manifest-pinned container-k8s documentation snapshot when it is an immutable published prerelease.
+- Keep the Compose semantic release restricted to a published non-prerelease.
+- Bind the container-k8s prerelease state into the authority digest checked before and after Pages deployment.
+
+## Type of Change
+
+- [x] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [x] Documentation update
+
+## Motivation and Context
+
+The required documentation tail for 0.14.3 rejected its exact released container-k8s source because the snapshot's immutable GitHub release is intentionally marked as a prerelease. Allowing either published state for that separately pinned documentation dependency restores deployment without weakening the stable Compose release rule or the exact release-ID, tag, commit, draft-state, and prerelease-state authority checks.
+
+## Testing
+
+- [x] Documentation authority unit tests
+- [x] Focused documentation workflow policy test
+- [x] Action workflow validation
+- [x] Markdown and whitespace validation
+- [x] Live authority digest against the published 0.14.3 inputs
+
+## container-compose Checks
+
+- [x] No support-status update is needed; this changes publication control only.
+- [x] This pull request is focused on issue 629.
+- [x] Release-control review notes and CI evidence are attached to this pull request.
+- [x] The commit and pull request title use Conventional Commits.
+- [x] The commit records `Release-Note: none` because the change is internal-only.
+- [x] No upstream-driven source change is included.
+- [x] The Compose stable-release requirement remains non-prerelease.
+- [x] The pinned container-k8s release identity and state remain fail-closed.
+- [x] The commit is signed with a GitHub-supported signature method.
+- [x] No credentials or private data are included.
+
+Closes [#629](https://github.com/stephenlclarke/container-compose/issues/629).


### PR DESCRIPTION
## Summary

- accept the manifest-pinned container-k8s documentation snapshot when it is an immutable published prerelease
- keep the Compose semantic release restricted to a stable non-prerelease
- bind the container-k8s prerelease state into the before/after Pages authority digest
- cover the published-prerelease, stable-state-change, draft, and Compose-prerelease cases

## Testing

- `python3 -m unittest Tools.release.test_documentation_authority`
- focused documentation workflow policy test
- `actionlint .github/workflows/docs.yml`
- markdownlint and `git diff --check`
- live authority digest against the published 0.14.3 inputs

Closes #629