### PR TITLE
fix(release): make build recovery durable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       - changes
       - resolve-canonical-main
     if: >
-      (needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main') &&
+      needs.changes.outputs.runtime == 'true' &&
       needs.resolve-canonical-main.result == 'success'
     # This lane compiles and exercises unit/CLI coverage only. Keep VM-backed
     # integration in the recoverable release graph and use a managed runner
@@ -765,7 +765,7 @@ jobs:
   resolve-canonical-main:
     name: Resolve Canonical Main
     needs: changes
-    if: needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main'
+    if: needs.changes.outputs.runtime == 'true'
     runs-on: ubuntu-24.04
     outputs:
       artifact_run_id: ${{ steps.main.outputs.artifact_run_id }}
@@ -901,7 +901,7 @@ jobs:
       - name: Check parallel validation jobs
         env:
           RESOLVE_CANONICAL_MAIN_RESULT: ${{ needs.resolve-canonical-main.result }}
-          RUNTIME_SELECTED: ${{ needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main' }}
+          RUNTIME_SELECTED: ${{ needs.changes.outputs.runtime == 'true' }}
           SOURCE_CHECKS_RESULT: ${{ needs.source_checks.result }}
           TOOLS_SELECTED: ${{ needs.changes.outputs.tools }}
           TOOL_TESTS_RESULT: ${{ needs.tool_tests.result }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
       - changes
       - resolve-canonical-main
     if: >
-      needs.changes.outputs.runtime == 'true' &&
+      (needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main') &&
       needs.resolve-canonical-main.result == 'success'
     # This lane compiles and exercises unit/CLI coverage only. Keep VM-backed
     # integration in the recoverable release graph and use a managed runner
@@ -765,7 +765,7 @@ jobs:
   resolve-canonical-main:
     name: Resolve Canonical Main
     needs: changes
-    if: needs.changes.outputs.runtime == 'true'
+    if: needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
     outputs:
       artifact_run_id: ${{ steps.main.outputs.artifact_run_id }}
@@ -901,7 +901,7 @@ jobs:
       - name: Check parallel validation jobs
         env:
           RESOLVE_CANONICAL_MAIN_RESULT: ${{ needs.resolve-canonical-main.result }}
-          RUNTIME_SELECTED: ${{ needs.changes.outputs.runtime == 'true' }}
+          RUNTIME_SELECTED: ${{ needs.changes.outputs.runtime == 'true' || github.ref == 'refs/heads/main' }}
           SOURCE_CHECKS_RESULT: ${{ needs.source_checks.result }}
           TOOLS_SELECTED: ${{ needs.changes.outputs.tools }}
           TOOL_TESTS_RESULT: ${{ needs.tool_tests.result }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,14 +24,17 @@ on:
         description: "Published stable semantic tag"
         required: true
         type: string
+      expected_control_sha:
+        description: "Controller-observed main SHA for race-safe dispatch"
+        required: false
+        type: string
+      request_id:
+        description: "Durable controller request identifier"
+        required: false
+        type: string
 
 permissions:
   contents: read
-
-concurrency:
-  group: documentation-${{ inputs.ref }}
-  cancel-in-progress: false
-  queue: max
 
 jobs:
   resolve-release:
@@ -46,7 +49,26 @@ jobs:
       k8s_ref: ${{ steps.stack.outputs.k8s_ref }}
       k8s_release_id: ${{ steps.k8s-authority.outputs.release_id }}
       k8s_release_tag: ${{ steps.stack.outputs.k8s_release_tag }}
+      deploy: ${{ steps.release.outputs.deploy }}
     steps:
+      - name: Verify dispatch identity
+        env:
+          EXPECTED_CONTROL_SHA: ${{ inputs.expected_control_sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${EXPECTED_CONTROL_SHA}" && \
+            ( ! "${EXPECTED_CONTROL_SHA}" =~ ^[0-9a-f]{40}$ || \
+              "${GITHUB_SHA}" != "${EXPECTED_CONTROL_SHA}" ) ]]; then
+            printf 'documentation controls changed before execution: expected %s, got %s\n' \
+              "${EXPECTED_CONTROL_SHA:-missing}" "${GITHUB_SHA}" >&2
+            exit 1
+          fi
+          if [[ -n "${REQUEST_ID}" && ! "${REQUEST_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+            printf 'documentation request ID is invalid: %s\n' "${REQUEST_ID}" >&2
+            exit 1
+          fi
+
       - name: Require exact published release inputs
         id: release
         env:
@@ -88,6 +110,14 @@ jobs:
           printf 'compose_ref=%s\n' "${compose_ref}" >> "${GITHUB_OUTPUT}"
           printf 'release_id=%s\n' "$(jq -er '.id' <<<"${release}")" \
             >> "${GITHUB_OUTPUT}"
+          latest_tag="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name')"
+          if [[ "${latest_tag}" == "${RELEASE_TAG}" ]]; then
+            printf 'deploy=true\n' >> "${GITHUB_OUTPUT}"
+          else
+            printf 'deploy=false\n' >> "${GITHUB_OUTPUT}"
+            printf 'Retaining documentation artifacts without replacing Pages because latest stable is %s.\n' \
+              "${latest_tag}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
           printf 'Released documentation input: %s at %s.\n' \
             "${RELEASE_TAG}" "${compose_ref}" >> "${GITHUB_STEP_SUMMARY}"
 
@@ -206,6 +236,13 @@ jobs:
             repository: stephenlclarke/container-k8s
             ref: ${{ needs.resolve-release.outputs.k8s_ref }}
     steps:
+      - name: Checkout immutable documentation controls
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 1
+          path: release-tools
+          ref: ${{ github.sha }}
+
       - name: Checkout ${{ matrix.site }} source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -221,6 +258,22 @@ jobs:
           set -euo pipefail
           [[ "$(git -C source rev-parse HEAD)" == "${EXPECTED_REF}" ]]
 
+      - name: Resolve documentation toolchain identity
+        id: toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          identity="$(
+            {
+              xcodebuild -version
+              /usr/bin/swift --version
+              xcrun --sdk macosx --show-sdk-path
+              xcrun --sdk macosx --show-sdk-version
+            } | shasum -a 256 | awk '{print $1}'
+          )"
+          [[ "${identity}" =~ ^[0-9a-f]{64}$ ]]
+          printf 'digest=%s\n' "${identity}" >> "${GITHUB_OUTPUT}"
+
       - name: Restore SwiftPM documentation cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
@@ -228,19 +281,34 @@ jobs:
             source/.build
             source/.swiftpm
             ~/Library/Caches/org.swift.swiftpm
-          key: docs-swiftpm-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.site }}-${{ matrix.ref }}
+          key: docs-swiftpm-v3-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.digest }}-${{ matrix.site }}-${{ matrix.ref }}-${{ hashFiles('source/Package.resolved') }}
           restore-keys: |
-            docs-swiftpm-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.site }}-
+            docs-swiftpm-v3-${{ runner.os }}-${{ runner.arch }}-${{ steps.toolchain.outputs.digest }}-${{ matrix.site }}-
 
       - name: Restore exact DocC site
         id: site-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: _site
-          key: docs-site-v2-${{ github.sha }}-${{ inputs.ref }}-${{ matrix.site }}-${{ matrix.ref }}
+          key: docs-site-v3-${{ matrix.site }}-${{ matrix.ref }}-${{ steps.toolchain.outputs.digest }}-${{ hashFiles('release-tools/.github/workflows/docs.yml', 'release-tools/Tools/ci/doc-site-manifest.py', 'source/Package.resolved', 'source/scripts/make-docs.sh') }}
+
+      - name: Inspect restored DocC site
+        id: site
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ steps.site-cache.outputs.cache-hit }}" == true ]] && \
+            python3 release-tools/Tools/ci/doc-site-manifest.py verify _site; then
+            printf 'reusable=true\n' >> "${GITHUB_OUTPUT}"
+          else
+            if [[ -d _site ]]; then
+              find _site -depth -delete
+            fi
+            printf 'reusable=false\n' >> "${GITHUB_OUTPUT}"
+          fi
 
       - name: Build static API documentation
-        if: steps.site-cache.outputs.cache-hit != 'true'
+        if: steps.site.outputs.reusable != 'true'
         env:
           DOCS_SOURCE_REFERENCE: ${{ matrix.ref }}
           SITE: ${{ matrix.site }}
@@ -301,16 +369,19 @@ jobs:
               ;;
           esac
 
+      - name: Record DocC site manifest
+        if: steps.site.outputs.reusable != 'true'
+        run: python3 release-tools/Tools/ci/doc-site-manifest.py create _site
+
       - name: Verify reusable DocC site
         env:
           SITE: ${{ matrix.site }}
         shell: bash
         run: |
           set -euo pipefail
-          [[ -s _site/index.html ]]
-          [[ -s _site/theme-settings.json ]]
-          printf 'DocC site ready for %s (cache hit: %s).\n' \
-            "${SITE}" "${{ steps.site-cache.outputs.cache-hit }}"
+          python3 release-tools/Tools/ci/doc-site-manifest.py verify _site
+          printf 'DocC site ready for %s (verified reuse: %s).\n' \
+            "${SITE}" "${{ steps.site.outputs.reusable }}"
 
       - name: Verify documentation source remained exact
         env:
@@ -335,7 +406,10 @@ jobs:
 
   upload-pages-artifact:
     name: Assemble and Upload GitHub Pages Artifact
-    needs: build-sites
+    needs:
+      - resolve-release
+      - build-sites
+    if: needs.resolve-release.outputs.deploy == 'true'
     runs-on: ubuntu-24.04
     permissions:
       pages: write
@@ -370,7 +444,12 @@ jobs:
     needs:
       - resolve-release
       - upload-pages-artifact
+    if: needs.resolve-release.outputs.deploy == 'true'
     runs-on: ubuntu-24.04
+    concurrency:
+      group: documentation-pages
+      cancel-in-progress: false
+      queue: max
     permissions:
       contents: read
       id-token: write
@@ -395,8 +474,28 @@ jobs:
           [[ "$(git -C release-tools rev-parse HEAD)" == "${RELEASE_CONTROL_SHA}" ]]
           [[ -z "$(git -C release-tools status --porcelain --untracked-files=no)" ]]
 
+      - name: Confirm release still owns Pages
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ inputs.ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          latest_tag="$(
+            gh api "repos/${GITHUB_REPOSITORY}/releases/latest" --jq '.tag_name'
+          )"
+          if [[ "${latest_tag}" == "${RELEASE_TAG}" ]]; then
+            printf 'deploy=true\n' >> "${GITHUB_OUTPUT}"
+          else
+            printf 'deploy=false\n' >> "${GITHUB_OUTPUT}"
+            printf 'Skipping superseded Pages deployment for %s; latest stable is now %s.\n' \
+              "${RELEASE_TAG}" "${latest_tag}" >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
       - name: Re-resolve documentation authority before deployment
         id: authority
+        if: steps.latest.outputs.deploy == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         shell: bash
@@ -419,9 +518,11 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
+        if: steps.latest.outputs.deploy == 'true'
         uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5
 
       - name: Verify documentation authority after deployment
+        if: steps.latest.outputs.deploy == 'true'
         env:
           EXPECTED_AUTHORITY: ${{ steps.authority.outputs.digest }}
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,7 @@
 #===----------------------------------------------------------------------===#
 
 name: Documentation
-run-name: Documentation · ${{ inputs.ref }}
+run-name: Documentation · ${{ inputs.ref }} · ${{ inputs.request_id || 'manual' }}
 
 on:
   workflow_dispatch:
@@ -294,11 +294,20 @@ jobs:
 
       - name: Inspect restored DocC site
         id: site
+        env:
+          SITE: ${{ matrix.site }}
+          SOURCE_REF: ${{ matrix.ref }}
+          TOOLCHAIN_DIGEST: ${{ steps.toolchain.outputs.digest }}
         shell: bash
         run: |
           set -euo pipefail
+          hosting_base_path="container-compose/${SITE}"
+          [[ "${SITE}" == compose ]] && hosting_base_path=container-compose
           if [[ "${{ steps.site-cache.outputs.cache-hit }}" == true ]] && \
-            python3 release-tools/Tools/ci/doc-site-manifest.py verify _site; then
+            python3 release-tools/Tools/ci/doc-site-manifest.py verify _site \
+              --site "${SITE}" --source-ref "${SOURCE_REF}" \
+              --toolchain-digest "${TOOLCHAIN_DIGEST}" \
+              --hosting-base-path "${hosting_base_path}"; then
             printf 'reusable=true\n' >> "${GITHUB_OUTPUT}"
           else
             if [[ -d _site ]]; then
@@ -371,15 +380,34 @@ jobs:
 
       - name: Record DocC site manifest
         if: steps.site.outputs.reusable != 'true'
-        run: python3 release-tools/Tools/ci/doc-site-manifest.py create _site
+        env:
+          SITE: ${{ matrix.site }}
+          SOURCE_REF: ${{ matrix.ref }}
+          TOOLCHAIN_DIGEST: ${{ steps.toolchain.outputs.digest }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          hosting_base_path="container-compose/${SITE}"
+          [[ "${SITE}" == compose ]] && hosting_base_path=container-compose
+          python3 release-tools/Tools/ci/doc-site-manifest.py create _site \
+            --site "${SITE}" --source-ref "${SOURCE_REF}" \
+            --toolchain-digest "${TOOLCHAIN_DIGEST}" \
+            --hosting-base-path "${hosting_base_path}"
 
       - name: Verify reusable DocC site
         env:
           SITE: ${{ matrix.site }}
+          SOURCE_REF: ${{ matrix.ref }}
+          TOOLCHAIN_DIGEST: ${{ steps.toolchain.outputs.digest }}
         shell: bash
         run: |
           set -euo pipefail
-          python3 release-tools/Tools/ci/doc-site-manifest.py verify _site
+          hosting_base_path="container-compose/${SITE}"
+          [[ "${SITE}" == compose ]] && hosting_base_path=container-compose
+          python3 release-tools/Tools/ci/doc-site-manifest.py verify _site \
+            --site "${SITE}" --source-ref "${SOURCE_REF}" \
+            --toolchain-digest "${TOOLCHAIN_DIGEST}" \
+            --hosting-base-path "${hosting_base_path}"
           printf 'DocC site ready for %s (verified reuse: %s).\n' \
             "${SITE}" "${{ steps.site.outputs.reusable }}"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,6 +31,7 @@ permissions:
 concurrency:
   group: documentation-${{ inputs.ref }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   resolve-release:
@@ -187,7 +188,9 @@ jobs:
     runs-on: macos-26
     timeout-minutes: 60
     strategy:
-      fail-fast: true
+      # Preserve every independently successful immutable site when a sibling
+      # fails so a retry can restore it instead of rebuilding all four.
+      fail-fast: false
       matrix:
         include:
           - site: compose
@@ -218,7 +221,26 @@ jobs:
           set -euo pipefail
           [[ "$(git -C source rev-parse HEAD)" == "${EXPECTED_REF}" ]]
 
+      - name: Restore SwiftPM documentation cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: |
+            source/.build
+            source/.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+          key: docs-swiftpm-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.site }}-${{ matrix.ref }}
+          restore-keys: |
+            docs-swiftpm-v2-${{ runner.os }}-${{ runner.arch }}-${{ matrix.site }}-
+
+      - name: Restore exact DocC site
+        id: site-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: _site
+          key: docs-site-v2-${{ github.sha }}-${{ inputs.ref }}-${{ matrix.site }}-${{ matrix.ref }}
+
       - name: Build static API documentation
+        if: steps.site-cache.outputs.cache-hit != 'true'
         env:
           DOCS_SOURCE_REFERENCE: ${{ matrix.ref }}
           SITE: ${{ matrix.site }}
@@ -278,6 +300,17 @@ jobs:
               exit 1
               ;;
           esac
+
+      - name: Verify reusable DocC site
+        env:
+          SITE: ${{ matrix.site }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ -s _site/index.html ]]
+          [[ -s _site/theme-settings.json ]]
+          printf 'DocC site ready for %s (cache hit: %s).\n' \
+            "${SITE}" "${{ steps.site-cache.outputs.cache-hit }}"
 
       - name: Verify documentation source remained exact
         env:

--- a/.github/workflows/historical-benchmark.yml
+++ b/.github/workflows/historical-benchmark.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, container-compose-release]
     timeout-minutes: 240
     env:
-      BUILD_STATE_ROOT: /Volumes/SSD/github/.container-compose-build/historical-benchmark
+      BUILD_TRANSIENT_ROOT: /Volumes/SSD/cf/build
       REPETITIONS: ${{ inputs.repetitions }}
       FIXTURE_GROUPS: ${{ inputs.fixture_groups }}
       FIXTURE_IMAGE: alpine:3.20
@@ -70,13 +70,20 @@ jobs:
       FIXTURE_IMAGE_MANIFEST_MEDIA_TYPE: application/vnd.oci.image.manifest.v1+json
       RUNTIME_ROOT_PREFIX: /private/tmp/cchr-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - name: Select local benchmark root
+      - name: Select separated benchmark storage
         shell: bash
         run: |
           set -euo pipefail
-          printf 'BENCHMARK_ROOT=%s/container-compose-historical-benchmark-%s-%s\n' \
-            "${RUNNER_TEMP}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}" \
-            >> "${GITHUB_ENV}"
+          retained_base="${HOME}/Library/Application Support/ContainerFamily/retained"
+          {
+            printf 'BUILD_RETAINED_ROOT=%s/build\n' "${retained_base}"
+            printf 'BENCHMARK_ROOT=%s/benchmarks/historical/run-%s-%s\n' \
+              "${BUILD_TRANSIENT_ROOT}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}"
+            printf 'BENCHMARK_RETAINED_ROOT=%s/historical-benchmark/run-%s-%s\n' \
+              "${retained_base}/build" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}"
+            printf 'BENCHMARK_CACHE_ROOT=%s/historical-benchmark/cache\n' \
+              "${retained_base}/build"
+          } >> "${GITHUB_ENV}"
 
       - name: Checkout benchmark controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -168,19 +175,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          resolution_root="$(mktemp -d \
+            /Volumes/SSD/github/container-compose-release-resolution.XXXXXX)"
+          trap 'find "${resolution_root}" -depth -delete' EXIT
           gh api --paginate --slurp \
             "repos/${GITHUB_REPOSITORY}/releases?per_page=100" \
-            > "${RUNNER_TEMP}/published-release-pages.json"
+            > "${resolution_root}/published-release-pages.json"
           jq '[.[][] | {
               tagName: .tag_name,
               isDraft: .draft,
               isPrerelease: .prerelease,
               publishedAt: .published_at
-            }]' "${RUNNER_TEMP}/published-release-pages.json" \
-            > "${RUNNER_TEMP}/published-releases.json"
+            }]' "${resolution_root}/published-release-pages.json" \
+            > "${resolution_root}/published-releases.json"
           arguments=(
             resolve
-            --releases "${RUNNER_TEMP}/published-releases.json"
+            --releases "${resolution_root}/published-releases.json"
             --target "${TARGET_INPUT}"
           )
           if [[ -n "${BASELINE_INPUT}" ]]; then
@@ -188,9 +198,9 @@ jobs:
           fi
           /usr/bin/python3 Tools/parity/published_release_benchmark.py \
             "${arguments[@]}" \
-            > "${RUNNER_TEMP}/comparison.json"
-          target="$(jq -r '.target' "${RUNNER_TEMP}/comparison.json")"
-          baseline="$(jq -r '.baseline' "${RUNNER_TEMP}/comparison.json")"
+            > "${resolution_root}/comparison.json"
+          target="$(jq -r '.target' "${resolution_root}/comparison.json")"
+          baseline="$(jq -r '.baseline' "${resolution_root}/comparison.json")"
 
           # Resolve one published release to its immutable object and tag identities.
           resolve_release() {
@@ -232,10 +242,15 @@ jobs:
         run: |
           set -euo pipefail
           [[ -d /Volumes/SSD/github ]]
-          make stack-state-init STACK_STATE_ROOT="${BUILD_STATE_ROOT}"
-          [[ -f "${BUILD_STATE_ROOT}/.container-compose-build-root" ]]
-          [[ "$(<"${BUILD_STATE_ROOT}/.container-compose-build-root")" == \
-            'container-compose recoverable build v1' ]]
+          make stack-state-init \
+            STACK_RETAINED_ROOT="${BUILD_RETAINED_ROOT}" \
+            STACK_TRANSIENT_ROOT="${BUILD_TRANSIENT_ROOT}"
+          [[ -f "${BUILD_RETAINED_ROOT}/.container-family-retained-root" ]]
+          [[ "$(<"${BUILD_RETAINED_ROOT}/.container-family-retained-root")" == \
+            'container-compose retained build v2' ]]
+          [[ -f "${BUILD_TRANSIENT_ROOT}/.container-family-transient-root" ]]
+          [[ "$(<"${BUILD_TRANSIENT_ROOT}/.container-family-transient-root")" == \
+            'container-compose transient build v2' ]]
           if [[ -e "${BENCHMARK_ROOT}" ]]; then
             printf 'benchmark root already exists: %s\n' "${BENCHMARK_ROOT}" >&2
             exit 1
@@ -246,43 +261,41 @@ jobs:
           install -d -m 0700 \
             "${BENCHMARK_ROOT}/downloads" \
             "${BENCHMARK_ROOT}/prepared" \
-            "${BENCHMARK_ROOT}/evidence" \
             "${BENCHMARK_ROOT}/fixtures" \
             "${BENCHMARK_ROOT}/work"
+          if [[ -e "${BENCHMARK_RETAINED_ROOT}" ]]; then
+            printf 'retained benchmark root already exists: %s\n' \
+              "${BENCHMARK_RETAINED_ROOT}" >&2
+            exit 1
+          fi
+          install -d -m 0700 \
+            "${BENCHMARK_CACHE_ROOT}/fixtures" \
+            "${BENCHMARK_RETAINED_ROOT}/downloads" \
+            "${BENCHMARK_RETAINED_ROOT}/evidence" \
+            "${BENCHMARK_RETAINED_ROOT}/prepared"
+          printf 'container-compose retained historical benchmark v1\n' \
+            > "${BENCHMARK_RETAINED_ROOT}/.historical-benchmark-retained-root"
 
-      - name: Prepare pinned offline fixture image
+      - name: Prepare pinned fixture for candidate and Docker oracle
         shell: bash
         run: |
           set -euo pipefail
           command -v /opt/homebrew/bin/skopeo >/dev/null
-          docker_metadata="${BENCHMARK_ROOT}/evidence/fixture-docker-image.json"
+          fixture_metadata="${BENCHMARK_RETAINED_ROOT}/evidence/fixture-image.json"
           expected_reference="alpine@${FIXTURE_IMAGE_INDEX_DIGEST}"
-          recovery_command="docker pull ${expected_reference} && docker image tag ${expected_reference} ${FIXTURE_IMAGE}"
-          if ! docker image inspect "${FIXTURE_IMAGE}" > "${docker_metadata}"; then
-            printf 'the pinned local fixture is unavailable: expected %s, found []\n' \
-              "${expected_reference}" >&2
-            printf 'recover before retrying with: %s\n' \
-              "${recovery_command}" >&2
-            exit 1
-          fi
-          jq -e --arg expected "${expected_reference}" \
-            '.[0].RepoDigests | index($expected) != null' \
-            "${docker_metadata}" >/dev/null || {
-            printf 'the pinned local fixture is unavailable: expected %s, found %s\n' \
-              "${expected_reference}" \
-              "$(jq -c '.[0].RepoDigests // []' "${docker_metadata}")" >&2
-            printf 'recover before retrying with: %s\n' \
-              "${recovery_command}" >&2
-            exit 1
-          }
           archive="${BENCHMARK_ROOT}/fixtures/alpine-3.20-arm64.oci.tar"
-          docker_host="$(docker context inspect --format \
-            '{{(index .Endpoints "docker").Host}}')"
-          [[ "${docker_host}" == unix:///* ]]
-          [[ -S "${docker_host#unix://}" ]]
-          /opt/homebrew/bin/skopeo copy --format oci \
-            --src-daemon-host "${docker_host}" \
-            "docker-daemon:${FIXTURE_IMAGE}" "oci-archive:${archive}:3.20"
+          cached_archive="${BENCHMARK_CACHE_ROOT}/fixtures/alpine-${FIXTURE_IMAGE_MANIFEST_DIGEST#sha256:}.oci.tar"
+          if [[ -f "${cached_archive}" && ! -L "${cached_archive}" ]]; then
+            /bin/cp "${cached_archive}" "${archive}"
+          else
+            [[ ! -e "${cached_archive}" ]] || {
+              printf 'cached fixture is not a regular file: %s\n' \
+                "${cached_archive}" >&2
+              exit 1
+            }
+            /opt/homebrew/bin/skopeo copy --format oci \
+              "docker://${expected_reference}" "oci-archive:${archive}:3.20"
+          fi
           archive_digest="$(/opt/homebrew/bin/skopeo inspect \
             "oci-archive:${archive}:3.20" | jq -r '.Digest')"
           [[ "${archive_digest}" == "${FIXTURE_IMAGE_MANIFEST_DIGEST}" ]]
@@ -291,8 +304,19 @@ jobs:
           [[ "${archive_media_type}" == "${FIXTURE_IMAGE_MANIFEST_MEDIA_TYPE}" ]]
           /usr/bin/python3 Tools/release/validate-oci-image-layout.py \
             "${archive}" 3.20
+          if [[ ! -e "${cached_archive}" ]]; then
+            cache_partial="${cached_archive}.partial.${GITHUB_RUN_ID}.${GITHUB_RUN_ATTEMPT}"
+            /usr/bin/install -m 0444 "${archive}" "${cache_partial}"
+            /bin/mv "${cache_partial}" "${cached_archive}"
+          fi
+          /opt/homebrew/bin/skopeo inspect \
+            "oci-archive:${archive}:3.20" > "${fixture_metadata}"
+          # Docker is retained only as this benchmark's isolated reference
+          # oracle. Both lanes consume bytes fetched by immutable digest.
+          /opt/homebrew/bin/skopeo copy \
+            "oci-archive:${archive}:3.20" "docker-daemon:${FIXTURE_IMAGE}"
           shasum -a 256 "${archive}" \
-            > "${BENCHMARK_ROOT}/evidence/fixture-image.sha256"
+            > "${BENCHMARK_RETAINED_ROOT}/evidence/fixture-image.sha256"
           printf 'PARITY_FIXTURE_IMAGE_ARCHIVE=%s\n' "${archive}" \
             >> "${GITHUB_ENV}"
           printf 'PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE=3.20\n' \
@@ -503,7 +527,6 @@ jobs:
               --digest "${initfs_artifact_digest}" --output "${initfs_root}"
 
             source_worktree="${BENCHMARK_ROOT}/work/containerization-${version}"
-            cctl_pin="${version_root}/containerization-cctl.pin.json"
             git -C containerization-source worktree add --detach \
               "${source_worktree}" "${containerization_ref}"
             source_commit="$(git -C "${source_worktree}" rev-parse 'HEAD^{commit}')"
@@ -512,27 +535,37 @@ jobs:
               --tool /usr/bin/swift --configuration release \
               --controller "$(pwd -P)/.github/workflows/historical-benchmark.yml" \
               --controller "$(pwd -P)/Tools/build/stack-pin.py")"
-            scratch="${BUILD_STATE_ROOT}/scratch/${cctl_contract}/containerization-${containerization_ref}"
-            started=${SECONDS}
-            /usr/bin/swift build --package-path "${source_worktree}" \
-              --disable-automatic-resolution --scratch-path "${scratch}" \
-              -c release --product cctl
-            cctl_bin_path="$(/usr/bin/swift build --package-path "${source_worktree}" \
-              --scratch-path "${scratch}" -c release --show-bin-path)"
-            /usr/bin/install -m 0755 "${cctl_bin_path}/cctl" \
-              "${version_root}/cctl"
-            /usr/bin/python3 Tools/build/stack-pin.py create \
-              --repository containerization \
-              --repository-path "${source_worktree}" --output "${cctl_pin}" \
-              --artifact "${version_root}/cctl" \
-              --expected-commit "${source_commit}" --expected-tree "${source_tree}" \
-              --build-contract "${cctl_contract}" \
-              --duration-seconds "$((SECONDS - started))" \
-              --command-label 'swift build -c release --product cctl' >/dev/null
+            scratch="${BUILD_TRANSIENT_ROOT}/scratch/${cctl_contract}/containerization-${containerization_ref}"
+            cctl_cache="${BENCHMARK_CACHE_ROOT}/cctl/${cctl_contract}/${containerization_ref}"
+            cctl_pin="${cctl_cache}/pin.json"
+            if [[ ! -f "${cctl_pin}" ]]; then
+              [[ ! -e "${cctl_pin}" ]]
+              install -d -m 0700 "${cctl_cache}"
+              started=${SECONDS}
+              /usr/bin/swift build --package-path "${source_worktree}" \
+                --disable-automatic-resolution --scratch-path "${scratch}" \
+                -c release --product cctl
+              cctl_bin_path="$(/usr/bin/swift build --package-path "${source_worktree}" \
+                --scratch-path "${scratch}" -c release --show-bin-path)"
+              retained_cctl="$(/usr/bin/python3 Tools/build/stack-artifact.py \
+                --source "${cctl_bin_path}/cctl" \
+                --root "${BUILD_RETAINED_ROOT}/artifacts" --name cctl)"
+              /usr/bin/python3 Tools/build/stack-pin.py create \
+                --repository containerization \
+                --repository-path "${source_worktree}" --output "${cctl_pin}" \
+                --artifact "${retained_cctl}" \
+                --expected-commit "${source_commit}" --expected-tree "${source_tree}" \
+                --build-contract "${cctl_contract}" \
+                --duration-seconds "$((SECONDS - started))" \
+                --command-label 'swift build -c release --product cctl' >/dev/null
+            fi
             /usr/bin/python3 Tools/build/stack-pin.py verify --quiet \
               --receipt "${cctl_pin}" --repository containerization \
               --repository-path "${source_worktree}" \
               --build-contract "${cctl_contract}"
+            retained_cctl="$(jq -er '.artifacts | if length == 1 then .[0].path else error("expected one cctl artifact") end' \
+              "${cctl_pin}")"
+            /usr/bin/install -m 0755 "${retained_cctl}" "${version_root}/cctl"
             cctl_result="${version_root}/cctl-result.json"
             jq -e '
               if .schema == 1 and
@@ -579,6 +612,11 @@ jobs:
             jq -s '.[0] + .[1]' \
               "${version_root}/guest-provenance.json" "${cctl_result}" \
               > "${version_root}/guest-provenance.complete.json"
+            install -d -m 0700 \
+              "${BENCHMARK_RETAINED_ROOT}/downloads/${version}"
+            /usr/bin/install -m 0600 \
+              "${version_root}/guest-provenance.complete.json" \
+              "${BENCHMARK_RETAINED_ROOT}/downloads/${version}/guest-provenance.complete.json"
 
             /usr/bin/python3 Tools/parity/historical_reconstruction_benchmark.py prepare \
               --version "${version}" --distribution "${distribution}" \
@@ -590,6 +628,9 @@ jobs:
             /usr/bin/python3 Tools/release/validate-oci-image-layout.py \
               "${BENCHMARK_ROOT}/prepared/${version}/init/container-vminit-arm64.oci.tar" \
               vminit:container-compose "${exact_reference}"
+            /usr/bin/install -m 0600 \
+              "${BENCHMARK_ROOT}/prepared/${version}/published-distribution.json" \
+              "${BENCHMARK_RETAINED_ROOT}/prepared/${version}.published-distribution.json"
           done
 
       - name: Require a quiet benchmark host
@@ -605,12 +646,12 @@ jobs:
               competing=1
             fi
           done
-          pmset -g therm > "${BENCHMARK_ROOT}/evidence/thermal-before.txt"
-          sysctl -n vm.loadavg > "${BENCHMARK_ROOT}/evidence/load-before.txt"
+          pmset -g therm > "${BENCHMARK_RETAINED_ROOT}/evidence/thermal-before.txt"
+          sysctl -n vm.loadavg > "${BENCHMARK_RETAINED_ROOT}/evidence/load-before.txt"
           ps -Ao pid,ppid,%cpu,comm -r \
-            > "${BENCHMARK_ROOT}/evidence/processes-before.txt"
+            > "${BENCHMARK_RETAINED_ROOT}/evidence/processes-before.txt"
           load_one="$(awk '{ print $2 }' \
-            "${BENCHMARK_ROOT}/evidence/load-before.txt")"
+            "${BENCHMARK_RETAINED_ROOT}/evidence/load-before.txt")"
           cpu_count="$(sysctl -n hw.ncpu)"
           awk -v load="${load_one}" -v cpus="${cpu_count}" \
             'BEGIN { exit !(load <= cpus / 2) }'
@@ -665,7 +706,7 @@ jobs:
                 PARITY_FIXTURE_IMAGE_ARCHIVE="${PARITY_FIXTURE_IMAGE_ARCHIVE}" \
                 PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE="${PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE}" \
                 PARITY_WORK_ROOT="${run_root}/fixtures" \
-                PARITY_EVIDENCE_DIR="${BENCHMARK_ROOT}/evidence/${version}" \
+                PARITY_EVIDENCE_DIR="${BENCHMARK_RETAINED_ROOT}/evidence/${version}" \
                 PARITY_EVIDENCE_MODE="${evidence_mode}" \
                 PARITY_FINALIZE_EVIDENCE=0 \
                 PARITY_FIXTURE_GROUPS="${phase}" \
@@ -676,7 +717,7 @@ jobs:
                   Tools/parity/check-compose-performance-matrix.sh --strict
               evidence_mode=append
             done
-            PARITY_EVIDENCE_DIR="${BENCHMARK_ROOT}/evidence/${version}" \
+            PARITY_EVIDENCE_DIR="${BENCHMARK_RETAINED_ROOT}/evidence/${version}" \
               PARITY_FIXTURE_GROUPS="${FIXTURE_GROUPS}" \
               PARITY_REPETITIONS="${REPETITIONS}" \
               PARITY_INCLUDE_REMOTE_LOGGING=0 \
@@ -685,8 +726,8 @@ jobs:
           }
           run_version "${BASELINE_VERSION}"
           run_version "${TARGET_VERSION}"
-          pmset -g therm > "${BENCHMARK_ROOT}/evidence/thermal-after.txt"
-          sysctl -n vm.loadavg > "${BENCHMARK_ROOT}/evidence/load-after.txt"
+          pmset -g therm > "${BENCHMARK_RETAINED_ROOT}/evidence/thermal-after.txt"
+          sysctl -n vm.loadavg > "${BENCHMARK_RETAINED_ROOT}/evidence/load-after.txt"
 
       - name: Render reconstruction evidence report
         if: inputs.fixture_groups == 'all'
@@ -697,10 +738,10 @@ jobs:
           set -euo pipefail
           report="docs/benchmarks/${TARGET_VERSION}-vs-${BASELINE_VERSION}.md"
           /usr/bin/python3 Tools/parity/published_release_benchmark.py render \
-            --target-evidence "${BENCHMARK_ROOT}/evidence/${TARGET_VERSION}" \
-            --baseline-evidence "${BENCHMARK_ROOT}/evidence/${BASELINE_VERSION}" \
-            --target-distribution "${BENCHMARK_ROOT}/prepared/${TARGET_VERSION}/published-distribution.json" \
-            --baseline-distribution "${BENCHMARK_ROOT}/prepared/${BASELINE_VERSION}/published-distribution.json" \
+            --target-evidence "${BENCHMARK_RETAINED_ROOT}/evidence/${TARGET_VERSION}" \
+            --baseline-evidence "${BENCHMARK_RETAINED_ROOT}/evidence/${BASELINE_VERSION}" \
+            --target-distribution "${BENCHMARK_RETAINED_ROOT}/prepared/${TARGET_VERSION}.published-distribution.json" \
+            --baseline-distribution "${BENCHMARK_RETAINED_ROOT}/prepared/${BASELINE_VERSION}.published-distribution.json" \
             --output "${report}" --workflow-url "${WORKFLOW_URL}"
           printf 'REPORT_PATH=%s\n' "${report}" >> "${GITHUB_ENV}"
 
@@ -710,9 +751,9 @@ jobs:
         with:
           name: historical-benchmark-${{ github.run_id }}-${{ github.run_attempt }}
           path: |
-            ${{ env.BENCHMARK_ROOT }}/evidence
-            ${{ env.BENCHMARK_ROOT }}/prepared/*/published-distribution.json
-            ${{ env.BENCHMARK_ROOT }}/downloads/*/guest-provenance.complete.json
+            ${{ env.BENCHMARK_RETAINED_ROOT }}/evidence
+            ${{ env.BENCHMARK_RETAINED_ROOT }}/prepared/*.published-distribution.json
+            ${{ env.BENCHMARK_RETAINED_ROOT }}/downloads/*/guest-provenance.complete.json
           if-no-files-found: warn
           retention-days: 90
 

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1887,7 +1887,7 @@ jobs:
               --asset "${{ steps.authority-bundle.outputs.local_asset }}" \
               --asset "${{ steps.authority-bundle.outputs.local_asset }}.sha256" \
               --asset "${highlights}" --asset "${quality_snapshot_svg}"
-            retained_complete_manifest="${retained_root}/release/manifests/${COMPOSE_VERSION}.json"
+            retained_complete_manifest="${retained_root}/release/releases/${COMPOSE_VERSION}/assets.json"
           fi
 
           release_mutable="false"

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -15,7 +15,7 @@
 #===----------------------------------------------------------------------===#
 
 name: Prebuilt Binaries
-run-name: Prebuilt Binaries · ${{ inputs.ref || github.event.workflow_run.head_branch || github.ref_name }}
+run-name: Prebuilt Binaries · ${{ inputs.ref || github.event.workflow_run.head_branch || github.ref_name }} · ${{ inputs.repair_tap && 'tap-repair' || 'package' }}
 
 on:
   workflow_run:
@@ -50,6 +50,7 @@ concurrency:
   # stable promotion and a current promotion from racing the shared tap branch.
   group: container-stack-package-and-tap
   cancel-in-progress: false
+  queue: max
 
 jobs:
   resolve-publish-context:
@@ -1193,10 +1194,12 @@ jobs:
             jq -r '.message' <<< "${init_authority}" |
               sed -nE 's/^Guest init image SHA-256: ([0-9a-f]{64})[.]$/\1/p'
           )"
-          homebrew_tap_ref="$(
-            git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git \
-              refs/heads/main | awk '{print $1}' | tail -n 1
-          )"
+          # Build authority is immutable. A later Current publication may move
+          # the tap before this package consumes the receipt, so verify the
+          # snapshot recorded by the gate and handle tap movement only in the
+          # conflict-checked formula publication transaction.
+          homebrew_tap_ref="$(jq -er '.components["homebrew-tap"]' "${receipt}")"
+          [[ "${homebrew_tap_ref}" =~ ^[0-9a-f]{40}$ ]]
           [[ "$(git -C release-tools rev-parse HEAD)" == "${GITHUB_SHA}" ]]
           python3 release-tools/Tools/release/stable-release-authority.py verify \
             --evidence-dir "${authority_root}/bundle" \

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -36,6 +36,14 @@ on:
         required: false
         default: false
         type: boolean
+      expected_control_sha:
+        description: "Controller-observed main SHA for race-safe dispatch"
+        required: false
+        type: string
+      request_id:
+        description: "Durable controller request identifier"
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -73,6 +81,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           DISPATCH_REF: ${{ inputs.ref }}
           REPAIR_TAP: ${{ inputs.repair_tap }}
+          EXPECTED_CONTROL_SHA: ${{ inputs.expected_control_sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
           WORKFLOW_RUN_EVENT: ${{ github.event.workflow_run.event }}
           WORKFLOW_RUN_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -80,6 +90,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
+          if [[ "${GITHUB_EVENT_NAME}" == workflow_dispatch ]]; then
+            if [[ -n "${EXPECTED_CONTROL_SHA}" && \
+              ( ! "${EXPECTED_CONTROL_SHA}" =~ ^[0-9a-f]{40}$ || \
+                "${GITHUB_SHA}" != "${EXPECTED_CONTROL_SHA}" ) ]]; then
+              printf 'package controls changed before dispatch execution: expected %s, got %s\n' \
+                "${EXPECTED_CONTROL_SHA:-missing}" "${GITHUB_SHA}" >&2
+              exit 1
+            fi
+          if [[ -n "${REQUEST_ID}" && ! "${REQUEST_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+              printf 'package request ID is invalid: %s\n' "${REQUEST_ID}" >&2
+              exit 1
+            fi
+          fi
 
           publish=false
           ref_type=""
@@ -1902,9 +1926,9 @@ jobs:
             fi
           done
 
-          # Finalizing Current recreates the mutable release. Carry the last
-          # successful, non-authoritative demo through that replacement so a
-          # failed asynchronous recording never leaves the README asset absent.
+          # Finalizing Current edits the mutable release in place. Carry the
+          # last successful, non-authoritative demo through the idempotent asset
+          # upload so a failed asynchronous recording never removes it.
           retained_demo="${RUNNER_TEMP}/container-compose-demo-current.gif"
           demo_asset_present="$(
             gh release view "${RELEASE_TAG}" \

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -15,7 +15,7 @@
 #===----------------------------------------------------------------------===#
 
 name: Prebuilt Binaries
-run-name: Prebuilt Binaries · ${{ inputs.ref || github.event.workflow_run.head_branch || github.ref_name }} · ${{ inputs.repair_tap && 'tap-repair' || 'package' }}
+run-name: Prebuilt Binaries · ${{ inputs.ref || github.event.workflow_run.head_branch || github.ref_name }} · ${{ inputs.repair_tap && 'tap-repair' || 'package' }} · ${{ inputs.request_id || 'automatic' }}
 
 on:
   workflow_run:
@@ -806,6 +806,27 @@ jobs:
     runs-on: [self-hosted, macOS, ARM64, container-compose-release, container-compose-current]
     timeout-minutes: 120
     steps:
+      - name: Enforce local storage lifetime boundaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          for transient in "${GITHUB_WORKSPACE}" "${RUNNER_TEMP}"; do
+            resolved="$(cd "${transient}" && pwd -P)"
+            [[ "${resolved}" == /Volumes/SSD/* ]] || {
+              printf 'self-hosted transient path is not on /Volumes/SSD: %s\n' \
+                "${resolved}" >&2
+              exit 1
+            }
+          done
+          retained="${CONTAINER_FAMILY_RETAINED_ROOT:-${HOME}/Library/Application Support/ContainerFamily/retained}"
+          case "${retained}" in
+            /Volumes/SSD|/Volumes/SSD/*)
+              printf 'retained release state must be on the internal disk: %s\n' \
+                "${retained}" >&2
+              exit 1
+              ;;
+          esac
+
       - name: Checkout container-compose
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
@@ -1178,6 +1199,50 @@ jobs:
         shell: /bin/bash --noprofile --norc -e -o pipefail {0}
         run: |
           set -euo pipefail
+          retained_root="${CONTAINER_FAMILY_RETAINED_ROOT:-${HOME}/Library/Application Support/ContainerFamily/retained}"
+          retained_archive="$(
+            python3 release-tools/Tools/release/retain-local-release-assets.py path \
+              --root "${retained_root}" --version "${PUBLISH_REF_NAME}" \
+              --name stable-release-authority.tar.gz 2>/dev/null || true
+          )"
+          retained_sidecar="$(
+            python3 release-tools/Tools/release/retain-local-release-assets.py path \
+              --root "${retained_root}" --version "${PUBLISH_REF_NAME}" \
+              --name stable-release-authority.tar.gz.sha256 2>/dev/null || true
+          )"
+          if [[ -n "${retained_archive}" && -n "${retained_sidecar}" ]]; then
+            init_authority_object="$(
+              gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/stable-init-image-authority/${PUBLISH_REF_NAME}" \
+                --jq '.object.sha'
+            )"
+            init_authority="$(
+              gh api "repos/${GITHUB_REPOSITORY}/git/tags/${init_authority_object}"
+            )"
+            if [[ "$(jq -r '.verification.verified' <<< "${init_authority}")" != "true" ]] ||
+              [[ "$(jq -r '.object.sha' <<< "${init_authority}")" != "${PUBLISH_SHA}" ]]; then
+              printf 'stable init-image authority no longer verifies the package source\n' >&2
+              exit 1
+            fi
+            init_image_sha256="$(
+              jq -r '.message' <<< "${init_authority}" |
+                sed -nE 's/^Guest init image SHA-256: ([0-9a-f]{64})[.]$/\1/p'
+            )"
+            python3 release-tools/Tools/release/verify-stable-authority-bundle.py \
+              --archive "${retained_archive}" --release-tag "${PUBLISH_REF_NAME}" \
+              --candidate-sha "${PUBLISH_SHA}" --builder-ref "${BUILDER_REF}" \
+              --containerization-ref "${CONTAINERIZATION_REF}" \
+              --container-ref "${CONTAINER_REF}" \
+              --init-image-sha256 "${init_image_sha256}" \
+              --receipt-sha256 "${AUTHORITY_RECEIPT_SHA256}" >/dev/null
+            local_archive="${RUNNER_TEMP}/stable-release-authority.tar.gz"
+            cp "${retained_archive}" "${local_archive}"
+            cp "${retained_sidecar}" "${local_archive}.sha256"
+            {
+              printf 'asset=stable-release-authority.tar.gz\n'
+              printf 'local_asset=%s\n' "${local_archive}"
+            } >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
           authority_root="${RUNNER_TEMP}/stable-release-authority-${PUBLISH_REF_NAME}"
           mkdir "${authority_root}"
           artifact_json="${authority_root}/artifact.json"
@@ -1812,6 +1877,17 @@ jobs:
               printf 'stable release tag is missing: %s\n' "${RELEASE_TAG}" >&2
               exit 1
             fi
+            retained_root="${CONTAINER_FAMILY_RETAINED_ROOT:-${HOME}/Library/Application Support/ContainerFamily/retained}"
+            python3 ../release-tools/Tools/release/retain-local-release-assets.py retain \
+              --root "${retained_root}" --version "${COMPOSE_VERSION}" \
+              --asset "${RUNNER_TEMP}/${ASSET}" \
+              --asset "${RUNNER_TEMP}/${ASSET}.sha256" \
+              --asset "${{ steps.runtime-package.outputs.local_asset }}" \
+              --asset "${{ steps.runtime-package.outputs.local_asset }}.sha256" \
+              --asset "${{ steps.authority-bundle.outputs.local_asset }}" \
+              --asset "${{ steps.authority-bundle.outputs.local_asset }}.sha256" \
+              --asset "${highlights}" --asset "${quality_snapshot_svg}"
+            retained_complete_manifest="${retained_root}/release/manifests/${COMPOSE_VERSION}.json"
           fi
 
           release_mutable="false"
@@ -1835,6 +1911,7 @@ jobs:
             PUBLISH_SHA="${PUBLISH_SHA}" \
             RELEASE_ASSET_PATH="${RUNNER_TEMP}/${ASSET}" \
             RELEASE_CHECKSUM_PATH="${RUNNER_TEMP}/${ASSET}.sha256" \
+            RELEASE_RETAINED_COMPLETE_MANIFEST="${retained_complete_manifest:-}" \
             ../release-tools/Tools/release/publish-github-release.sh
 
       - name: Checkout Homebrew tap

--- a/.github/workflows/published-benchmark.yml
+++ b/.github/workflows/published-benchmark.yml
@@ -178,21 +178,21 @@ jobs:
       REPETITIONS: ${{ inputs.repetitions }}
       RUNTIME_ROOT_PREFIX: /private/tmp/ccpb-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
-      - name: Select Docker-shared local benchmark root
+      - name: Select separated Docker-oracle benchmark storage
         shell: bash
         run: |
           set -euo pipefail
-          case "${RUNNER_TEMP}" in
-            "${HOME}"/*) ;;
-            *)
-              printf 'RUNNER_TEMP must be on local storage under HOME so Docker can bind-mount benchmark fixtures: %s\n' \
-                "${RUNNER_TEMP}" >&2
-              exit 1
-              ;;
-          esac
-          printf 'BENCHMARK_ROOT=%s/container-compose-published-benchmark-%s-%s\n' \
-            "${RUNNER_TEMP}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}" \
-            >> "${GITHUB_ENV}"
+          [[ -d /Volumes/SSD/github ]]
+          retained_base="${HOME}/Library/Application Support/ContainerFamily/retained/build"
+          transient_base=/Volumes/SSD/cf/build
+          {
+            printf 'BUILD_RETAINED_ROOT=%s\n' "${retained_base}"
+            printf 'BUILD_TRANSIENT_ROOT=%s\n' "${transient_base}"
+            printf 'BENCHMARK_ROOT=%s/benchmarks/published/run-%s-%s\n' \
+              "${transient_base}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}"
+            printf 'BENCHMARK_RETAINED_ROOT=%s/published-benchmark/run-%s-%s\n' \
+              "${retained_base}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}"
+          } >> "${GITHUB_ENV}"
 
       - name: Checkout documentation and benchmark controls
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -230,10 +230,13 @@ jobs:
           git config commit.gpgsign true
           git config user.signingkey "${signing_key}"
 
-      - name: Create marker-protected local benchmark root
+      - name: Create marker-protected benchmark roots
         shell: bash
         run: |
           set -euo pipefail
+          make stack-state-init \
+            STACK_RETAINED_ROOT="${BUILD_RETAINED_ROOT}" \
+            STACK_TRANSIENT_ROOT="${BUILD_TRANSIENT_ROOT}"
           if [[ -e "${BENCHMARK_ROOT}" ]]; then
             printf 'benchmark root already exists: %s\n' "${BENCHMARK_ROOT}" >&2
             exit 1
@@ -247,8 +250,18 @@ jobs:
             "${BENCHMARK_ROOT}/downloads/${BASELINE_VERSION}/release" \
             "${BENCHMARK_ROOT}/downloads/${BASELINE_VERSION}/actions" \
             "${BENCHMARK_ROOT}/prepared" \
-            "${BENCHMARK_ROOT}/evidence" \
             "${BENCHMARK_ROOT}/work"
+          if [[ -e "${BENCHMARK_RETAINED_ROOT}" ]]; then
+            printf 'retained benchmark root already exists: %s\n' \
+              "${BENCHMARK_RETAINED_ROOT}" >&2
+            exit 1
+          fi
+          install -d -m 0700 \
+            "${BENCHMARK_RETAINED_ROOT}/downloads" \
+            "${BENCHMARK_RETAINED_ROOT}/evidence" \
+            "${BENCHMARK_RETAINED_ROOT}/prepared"
+          printf 'container-compose retained published benchmark v1\n' \
+            > "${BENCHMARK_RETAINED_ROOT}/.published-benchmark-retained-root"
 
       - name: Download immutable release and Homebrew inputs
         env:
@@ -379,7 +392,41 @@ jobs:
             )
             python3 Tools/release/validate-oci-image-layout.py \
               "${init_archive}" "${init_references[@]}"
+            /usr/bin/install -m 0600 \
+              "${BENCHMARK_ROOT}/prepared/${version}/published-distribution.json" \
+              "${BENCHMARK_RETAINED_ROOT}/prepared/${version}.published-distribution.json"
+            install -d -m 0700 \
+              "${BENCHMARK_RETAINED_ROOT}/downloads/${version}"
+            for checksum in "${release_dir}"/*.sha256 "${actions_dir}"/*.sha256; do
+              [[ -f "${checksum}" && ! -L "${checksum}" ]] || continue
+              /usr/bin/install -m 0600 "${checksum}" \
+                "${BENCHMARK_RETAINED_ROOT}/downloads/${version}/$(basename "${checksum}")"
+            done
           done
+
+      - name: Require a quiet benchmark host
+        shell: bash
+        run: |
+          set -euo pipefail
+          competing=0
+          for process_name in swift-frontend swiftc clang xcodebuild; do
+            if pgrep -x "${process_name}" > \
+              "${BENCHMARK_ROOT}/work/competing-${process_name}.txt" 2>/dev/null; then
+              printf 'competing build process is still active: %s\n' \
+                "${process_name}" >&2
+              competing=1
+            fi
+          done
+          pmset -g therm > "${BENCHMARK_RETAINED_ROOT}/evidence/thermal-before.txt"
+          sysctl -n vm.loadavg > "${BENCHMARK_RETAINED_ROOT}/evidence/load-before.txt"
+          ps -Ao pid,ppid,%cpu,comm -r \
+            > "${BENCHMARK_RETAINED_ROOT}/evidence/processes-before.txt"
+          load_one="$(awk '{ print $2 }' \
+            "${BENCHMARK_RETAINED_ROOT}/evidence/load-before.txt")"
+          cpu_count="$(sysctl -n hw.ncpu)"
+          awk -v load="${load_one}" -v cpus="${cpu_count}" \
+            'BEGIN { exit !(load <= cpus / 2) }'
+          ((competing == 0))
 
       - name: Run same-host published comparisons
         shell: bash
@@ -411,7 +458,7 @@ jobs:
               PARITY_INIT_IMAGE_ARCHIVE="${init_archive}" \
               PARITY_INIT_IMAGE_REFERENCES="${init_references}" \
               PARITY_WORK_ROOT="${run_root}/fixtures" \
-              PARITY_EVIDENCE_DIR="${BENCHMARK_ROOT}/evidence/${version}" \
+              PARITY_EVIDENCE_DIR="${BENCHMARK_RETAINED_ROOT}/evidence/${version}" \
               PARITY_REPETITIONS="${REPETITIONS}" \
               PARITY_INCLUDE_REMOTE_LOGGING=0 \
               PARITY_TIMING_POLICY=record \
@@ -420,6 +467,8 @@ jobs:
           }
           run_version "${BASELINE_VERSION}"
           run_version "${TARGET_VERSION}"
+          pmset -g therm > "${BENCHMARK_RETAINED_ROOT}/evidence/thermal-after.txt"
+          sysctl -n vm.loadavg > "${BENCHMARK_RETAINED_ROOT}/evidence/load-after.txt"
 
       - name: Render repository evidence report
         env:
@@ -429,10 +478,10 @@ jobs:
           set -euo pipefail
           report="docs/benchmarks/${TARGET_VERSION}-vs-${BASELINE_VERSION}.md"
           python3 Tools/parity/published_release_benchmark.py render \
-            --target-evidence "${BENCHMARK_ROOT}/evidence/${TARGET_VERSION}" \
-            --baseline-evidence "${BENCHMARK_ROOT}/evidence/${BASELINE_VERSION}" \
-            --target-distribution "${BENCHMARK_ROOT}/prepared/${TARGET_VERSION}/published-distribution.json" \
-            --baseline-distribution "${BENCHMARK_ROOT}/prepared/${BASELINE_VERSION}/published-distribution.json" \
+            --target-evidence "${BENCHMARK_RETAINED_ROOT}/evidence/${TARGET_VERSION}" \
+            --baseline-evidence "${BENCHMARK_RETAINED_ROOT}/evidence/${BASELINE_VERSION}" \
+            --target-distribution "${BENCHMARK_RETAINED_ROOT}/prepared/${TARGET_VERSION}.published-distribution.json" \
+            --baseline-distribution "${BENCHMARK_RETAINED_ROOT}/prepared/${BASELINE_VERSION}.published-distribution.json" \
             --output "${report}" \
             --workflow-url "${WORKFLOW_URL}"
           printf 'REPORT_PATH=%s\n' "${report}" >> "${GITHUB_ENV}"
@@ -443,9 +492,9 @@ jobs:
         with:
           name: published-benchmark-${{ needs.resolve.outputs.target }}-vs-${{ needs.resolve.outputs.baseline }}
           path: |
-            ${{ runner.temp }}/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}/evidence
-            ${{ runner.temp }}/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}/prepared/*/published-distribution.json
-            ${{ runner.temp }}/container-compose-published-benchmark-${{ github.run_id }}-${{ github.run_attempt }}/downloads/*/*/*.sha256
+            ${{ env.BENCHMARK_RETAINED_ROOT }}/evidence
+            ${{ env.BENCHMARK_RETAINED_ROOT }}/prepared/*.published-distribution.json
+            ${{ env.BENCHMARK_RETAINED_ROOT }}/downloads/*/*.sha256
           if-no-files-found: warn
           retention-days: 90
 

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -15,7 +15,7 @@
 #===----------------------------------------------------------------------===#
 
 name: Stable Release Gate
-run-name: Stable Release Gate · ${{ inputs.ref }}
+run-name: Stable Release Gate · ${{ inputs.ref }} · ${{ inputs.request_id || 'manual' }}
 
 on:
   workflow_dispatch:

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -15,6 +15,7 @@
 #===----------------------------------------------------------------------===#
 
 name: Stable Release Gate
+run-name: Stable Release Gate · ${{ inputs.ref }}
 
 on:
   workflow_dispatch:
@@ -31,6 +32,7 @@ permissions:
 concurrency:
   group: stable-release-gate-${{ inputs.ref }}
   cancel-in-progress: false
+  queue: max
 
 jobs:
   resolve-candidate:

--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -24,6 +24,14 @@ on:
         description: "Bare semantic tag to validate and promote"
         required: true
         type: string
+      expected_control_sha:
+        description: "Controller-observed main SHA for race-safe dispatch"
+        required: false
+        type: string
+      request_id:
+        description: "Durable controller request identifier"
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -48,6 +56,24 @@ jobs:
       init_image_sha256: ${{ steps.candidate.outputs.init_image_sha256 }}
       init_image_authority_object: ${{ steps.candidate.outputs.init_image_authority_object }}
     steps:
+      - name: Verify dispatch identity
+        env:
+          EXPECTED_CONTROL_SHA: ${{ inputs.expected_control_sha }}
+          REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${EXPECTED_CONTROL_SHA}" && \
+            ( ! "${EXPECTED_CONTROL_SHA}" =~ ^[0-9a-f]{40}$ || \
+              "${GITHUB_SHA}" != "${EXPECTED_CONTROL_SHA}" ) ]]; then
+            printf 'stable gate controls changed before execution: expected %s, got %s\n' \
+              "${EXPECTED_CONTROL_SHA:-missing}" "${GITHUB_SHA}" >&2
+            exit 1
+          fi
+          if [[ -n "${REQUEST_ID}" && ! "${REQUEST_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$ ]]; then
+            printf 'stable gate request ID is invalid: %s\n' "${REQUEST_ID}" >&2
+            exit 1
+          fi
+
       - name: Require an immutable main tag and green main CI
         id: candidate
         env:
@@ -381,9 +407,35 @@ jobs:
         run: |
           set -euo pipefail
           [[ "${CANDIDATE_SHA}" =~ ^[[:xdigit:]]{40}$ ]]
-          runner_work_root="$(cd "${RUNNER_TEMP}/.." && pwd -P)"
           workspace_root="$(cd "${GITHUB_WORKSPACE}" && pwd -P)"
-          state_parent="${runner_work_root}/.container-compose-release-build"
+          retained_root="${HOME}/Library/Application Support/ContainerFamily/retained"
+          retained_marker="${retained_root}/.container-family-retained-root"
+          [[ ! -L "${retained_root}" ]] || {
+            printf 'Retained release root is a symbolic link: %s\n' \
+              "${retained_root}" >&2
+            exit 2
+          }
+          if [[ -d "${retained_root}" && ! -f "${retained_marker}" ]] && \
+            [[ -n "$(find "${retained_root}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+            printf 'Refusing to claim non-empty unmarked retained root: %s\n' \
+              "${retained_root}" >&2
+            exit 2
+          fi
+          mkdir -p "${retained_root}"
+          if [[ -L "${retained_marker}" ]] || \
+            [[ -e "${retained_marker}" && ! -f "${retained_marker}" ]]; then
+            printf 'Retained release marker is unsafe: %s\n' \
+              "${retained_marker}" >&2
+            exit 2
+          fi
+          if [[ -f "${retained_marker}" ]]; then
+            [[ "$(<"${retained_marker}")" == \
+              'container-compose retained build v2' ]]
+          else
+            printf 'container-compose retained build v2\n' > "${retained_marker}"
+            chmod 0600 "${retained_marker}"
+          fi
+          state_parent="${retained_root}/release/checkpoints"
           if [[ -L "${state_parent}" ]]; then
             printf 'Release state parent must not be a symbolic link: %s\n' \
               "${state_parent}" >&2
@@ -467,7 +519,7 @@ jobs:
         run: |
           set -euo pipefail
           evidence="${RELEASE_BUILD_STATE_ROOT}/checkpoints/compose-release-gate"
-          bundle="${RUNNER_TEMP}/stable-release-authority"
+          bundle="${RELEASE_BUILD_STATE_ROOT}/authority/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           if [[ -e "${bundle}" || -L "${bundle}" ]]; then
             printf 'stable release authority bundle already exists: %s\n' "${bundle}" >&2
             exit 2
@@ -501,13 +553,14 @@ jobs:
           )"
           [[ "${receipt_sha256}" =~ ^[0-9a-f]{64}$ ]]
           printf 'sha256=%s\n' "${receipt_sha256}" >> "${GITHUB_OUTPUT}"
+          printf 'RELEASE_AUTHORITY_ROOT=%s\n' "${bundle}" >> "${GITHUB_ENV}"
 
       - name: Upload candidate-bound authority receipt
         id: upload-authority
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: stable-release-authority-${{ inputs.ref }}-${{ needs.resolve-candidate.outputs.sha }}
-          path: ${{ runner.temp }}/stable-release-authority
+          path: ${{ env.RELEASE_AUTHORITY_ROOT }}
           if-no-files-found: error
           retention-days: 90
 

--- a/Makefile
+++ b/Makefile
@@ -201,13 +201,20 @@ RELEASE_GATE_STACK_TIMEOUT_SECONDS ?= 14400
 RELEASE_GATE_PARITY_TIMEOUT_SECONDS ?= 14400
 PARITY_STAGE_TIMEOUT_SECONDS ?= 900
 CONTAINER_RUNTIME_START_DEADLINE_SECONDS ?= 300
-# Durable stack state lives beside the disposable worktrees when the external
-# development volume is available. A local fallback keeps ordinary source
-# builds usable when that volume is intentionally disconnected.
-STACK_STATE_ROOT ?= $(if $(wildcard /Volumes/SSD/github/.),/Volumes/SSD/github/.container-compose-build,$(abspath .build/stack))
+# Completed artifacts and evidence survive disposal of external workspaces and
+# build scratch. New transient work fails closed when the external volume is
+# unavailable; verification of retained outputs remains local.
+STACK_RETAINED_ROOT ?= $(HOME)/Library/Application Support/ContainerFamily/retained/build
+STACK_TRANSIENT_ROOT ?= /Volumes/SSD/cf/build
+STACK_REQUIRE_SEPARATE_FILESYSTEMS ?= 1
 # BEGIN RECOVERABLE STACK CONFIGURATION
-STACK_MARKER_VALUE := container-compose recoverable build v1
+STACK_RETAINED_MARKER_VALUE := container-compose retained build v2
+STACK_TRANSIENT_MARKER_VALUE := container-compose transient build v2
 STACK_PIN_TOOL := $(abspath Tools/build/stack-pin.py)
+STACK_ARTIFACT_TOOL := $(abspath Tools/build/stack-artifact.py)
+STACK_TRANSIENT_CLEAN_TOOL := $(abspath Tools/build/stack-transient-clean.py)
+RELEASE_STATE_TOOL := $(abspath Tools/release/release-state.py)
+RELEASE_RETAINED_ROOT ?= $(HOME)/Library/Application Support/ContainerFamily/retained
 STACK_BUILD_CONTRACT := $(abspath Tools/build/stack-build-contract.json)
 STACK_DEADLINE_TOOL := $(abspath Tools/ci/run-command-with-deadline.py)
 STACK_SWIFT_STACK_TOOL := $(abspath Tools/ci/run-with-local-swift-stack.py)
@@ -215,11 +222,11 @@ STACK_CONFIGURATION ?= debug
 STACK_BUILD_STAGE_TIMEOUT_SECONDS ?= 3600
 STACK_BUILD_TIMEOUT_SECONDS ?= 14400
 STACK_LOCK_TOOL ?= /usr/bin/lockf
-STACK_TIMING_ROOT := $(STACK_STATE_ROOT)/timings
+STACK_TIMING_ROOT := $(STACK_RETAINED_ROOT)/timings
 STACK_TIMING_LOG ?= $(STACK_TIMING_ROOT)/direct-stage.jsonl
-STACK_PIN_DIR := $(STACK_STATE_ROOT)/pins/$(STACK_CONFIGURATION)
-STACK_SCRATCH_ROOT := $(STACK_STATE_ROOT)/scratch
-STACK_ARTIFACT_ROOT := $(STACK_STATE_ROOT)/artifacts/$(STACK_CONFIGURATION)
+STACK_PIN_DIR := $(STACK_RETAINED_ROOT)/pins/$(STACK_CONFIGURATION)
+STACK_SCRATCH_ROOT := $(STACK_TRANSIENT_ROOT)/scratch
+STACK_ARTIFACT_ROOT := $(STACK_RETAINED_ROOT)/artifacts
 STACK_CONTAINERIZATION_PIN := $(STACK_PIN_DIR)/containerization.json
 STACK_ENGINE_API_PIN := $(STACK_PIN_DIR)/container-engine-api.json
 STACK_CONTAINER_PIN := $(STACK_PIN_DIR)/container.json
@@ -232,6 +239,7 @@ STACK_SWIFT_CONTRACT = $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--tool $(call SHELL_QUOTE,$(STACK_SWIFT)) \
 	--configuration $(call SHELL_QUOTE,$(STACK_CONFIGURATION)) \
 	--controller "$(STACK_BUILD_CONTRACT)" --controller "$(STACK_PIN_TOOL)" \
+	--controller "$(STACK_ARTIFACT_TOOL)" \
 	--controller "$(STACK_DEADLINE_TOOL)" --controller "$(STACK_SWIFT_STACK_TOOL)" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK CONFIGURATION::END RECOVERABLE STACK CONFIGURATION" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK TARGETS::END RECOVERABLE STACK TARGETS")
@@ -372,7 +380,7 @@ SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -
 
 .PHONY: all local-build workflow ci ci-fast release-gate-environment-fingerprint-check release-gate release-gate-hosted ci-release clean run build build-release test resolve swift-test-build swift-test swift-test-direct swift-runtime-test-build swift-runtime-test swift-coverage swift-coverage-check go-test go-coverage-check go-build go-release-check cli-smoke cli-smoke-built container-stack-build container-stack-build-if-needed docker-log-fixtures docker-log-fixtures-update docker-compose-reference docker-compose-e2e-fixtures docker-compose-parity docker-compose-parity-stages docker-compose-cli-surface-parity docker-compose-bridge-parity docker-compose-compatibility-names-parity docker-compose-config-all-resources-parity docker-compose-env-file-parity docker-compose-git-remote-parity docker-compose-commit-parity docker-compose-cp-stdio-archive-streams-parity docker-compose-build-builder-parity docker-compose-build-check-parity docker-compose-build-external-dockerfile-parity docker-compose-build-external-secret-parity docker-compose-build-isolation-parity docker-compose-build-no-cache-filter-parity docker-compose-build-secret-metadata-parity docker-compose-bind-create-host-path-parity docker-compose-bind-propagation-parity docker-compose-image-volumes-parity docker-compose-deploy-endpoint-mode-parity docker-compose-deploy-resource-reservations-parity docker-compose-cpu-limit-parity docker-compose-privileged-parity docker-compose-security-opt-parity docker-compose-deploy-scheduler-metadata-parity docker-compose-memory-byte-precision-parity docker-compose-memory-swap-limit-parity docker-compose-pids-limit-parity docker-compose-device-cgroup-rules-parity docker-compose-devices-parity docker-compose-gpus-parity docker-compose-network-driver-opts-parity docker-compose-network-service-discovery-parity docker-compose-links-parity docker-compose-up-menu-parity docker-compose-host-namespaces-parity docker-compose-health-wait-parity docker-compose-create-options-parity docker-compose-events-parity docker-compose-state-status-parity docker-compose-rm-parity docker-compose-lifecycle-hooks-parity docker-compose-signal-log-reliability-parity docker-compose-restart-policy-parity docker-compose-userns-mode-parity coverage coverage-check sonar sonar-scan release release-plan release-version package package-release package-debug package-built stack-consistency coverage-tools-syntax coverage-python-tools-test release-tools-test ci-tools-test coverage-tools-test source-checks lint format fmt check check-licenses update-licenses pre-commit swift-style-tools swift-style-paths swift-style-check swift-style-format local-swift-stack-clean
 
-.PHONY: print-release-gate-static-fingerprint print-release-gate-fingerprint
+.PHONY: print-release-gate-static-fingerprint print-release-gate-fingerprint actions-lint
 .PHONY: worktree-audit worktree-audit-strict
 .PHONY: core-runtime-neutrality
 .PHONY: codeql-local codeql-sarif-upload codeql-sarif-upload-dry-run
@@ -382,7 +390,7 @@ SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -
 .PHONY: docker-compose-stop-defaults-parity docker-compose-cpu-cfs-parity docker-compose-cpu-shares-parity docker-compose-cpuset-parity docker-compose-pid-namespace-parity docker-compose-cgroup-namespace-parity docker-compose-cgroup-parent-parity docker-compose-ipc-uts-namespace-parity docker-compose-userns-mode-parity docker-compose-privileged-parity docker-compose-network-attachable-parity docker-compose-network-ipv6-parity docker-compose-deploy-job-modes-parity
 .PHONY: docker-compose-up-exit-code-from-parity docker-compose-api-socket-client-fixture docker-compose-api-socket-client-parity docker-compose-performance-matrix performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test compose-events-harness-test
 .PHONY: docker-terminal-session-oracle docker-terminal-session-oracle-update docker-terminal-session-candidate-oracle docker-rest-logging-oracle docker-rest-logging-candidate docker-rest-logging-parity docker-rest-discovery-oracle docker-rest-discovery-candidate docker-rest-discovery-parity docker-rest-image-discovery-oracle docker-rest-image-discovery-candidate docker-rest-image-discovery-parity docker-rest-image-mutation-oracle docker-rest-image-mutation-candidate docker-rest-image-mutation-parity
-.PHONY: stack-help stack-state-init stack-preflight stack-status stack-self-test stack-build stack-build-locked stack-containerization-build stack-engine-api-build stack-container-build stack-builder-build stack-compose-build
+.PHONY: stack-help stack-state-init stack-preflight stack-status stack-self-test stack-transient-clean-plan stack-transient-clean stack-build stack-build-locked stack-containerization-build stack-engine-api-build stack-container-build stack-builder-build stack-compose-build
 
 # BEGIN RECOVERABLE STACK TARGETS
 STACK_REQUIRE_LOCK = @[[ "$(STACK_LOCK_HELD)" == 1 ]] || { printf 'stack stage requires the stack-build lock\n' >&2; exit 2; }
@@ -395,6 +403,8 @@ stack-help:
 		'  make stack-preflight Verify tools and clean sibling source repositories.' \
 		'  make stack-build     Build the complete source stack and publish exact pins.' \
 		'  make stack-status    Verify each retained build pin and artifact.' \
+		'  make stack-transient-clean-plan  List disposable external build data.' \
+		'  make stack-transient-clean       Remove only disposable external build data.' \
 		'  make stack-self-test Run the focused receipt/recovery regression tests.' \
 		'  Each full run writes durable JSONL stage timings under the state root.' \
 		'' \
@@ -403,54 +413,41 @@ stack-help:
 		'  container (consumes the first two pins)' \
 		'  container-compose (consumes all Swift pins)' \
 		'' \
-		'All generated state defaults to: $(STACK_STATE_ROOT)'
+		'Retained artifacts and evidence: $(STACK_RETAINED_ROOT)' \
+		'Transient build scratch: $(STACK_TRANSIENT_ROOT)'
 
 stack-state-init:
 	@case "$(STACK_CONFIGURATION)" in debug|release) ;; *) printf 'STACK_CONFIGURATION must be debug or release: %s\n' "$(STACK_CONFIGURATION)" >&2; exit 2 ;; esac; \
-	state_root="$(STACK_STATE_ROOT)"; \
-	case "$$state_root" in /*) ;; *) printf 'STACK_STATE_ROOT must be absolute: %s\n' "$$state_root" >&2; exit 2 ;; esac; \
-	[[ "$$state_root" != / ]] || { printf 'STACK_STATE_ROOT must not be /.\n' >&2; exit 2; }; \
-	if [[ -L "$$state_root" ]]; then \
-		printf 'STACK_STATE_ROOT must not be a symbolic link: %s\n' "$$state_root" >&2; \
-		exit 2; \
+	retained_root="$(STACK_RETAINED_ROOT)"; transient_root="$(STACK_TRANSIENT_ROOT)"; \
+	for specification in "$$retained_root|.container-family-retained-root|$(STACK_RETAINED_MARKER_VALUE)" "$$transient_root|.container-family-transient-root|$(STACK_TRANSIENT_MARKER_VALUE)"; do \
+		IFS='|' read -r root marker_name marker_value <<<"$$specification"; \
+		case "$$root" in /*) ;; *) printf 'stack storage root must be absolute: %s\n' "$$root" >&2; exit 2 ;; esac; \
+		[[ "$$root" != / ]] || { printf 'stack storage root must not be /.\n' >&2; exit 2; }; \
+		[[ ! -L "$$root" ]] || { printf 'stack storage root must not be a symbolic link: %s\n' "$$root" >&2; exit 2; }; \
+		[[ ! -e "$$root" || -d "$$root" ]] || { printf 'stack storage root is not a directory: %s\n' "$$root" >&2; exit 2; }; \
+		marker="$$root/$$marker_name"; \
+		if [[ -d "$$root" && ! -f "$$marker" ]] && [[ -n "$$(/usr/bin/find "$$root" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then \
+			printf 'refusing to claim non-empty unmarked stack storage root: %s\n' "$$root" >&2; exit 2; \
+		fi; \
+		/usr/bin/install -d -m 0700 "$$root"; root="$$(cd "$$root" && pwd -P)"; marker="$$root/$$marker_name"; \
+		[[ ! -L "$$marker" && ( ! -e "$$marker" || -f "$$marker" ) ]] || { printf 'stack storage marker must be a regular file: %s\n' "$$marker" >&2; exit 2; }; \
+		[[ ! -f "$$marker" || "$$(<"$$marker")" == "$$marker_value" ]] || { printf 'stack storage root has an unexpected ownership marker: %s\n' "$$marker" >&2; exit 2; }; \
+		if [[ ! -f "$$marker" ]]; then temporary="$$marker.$$$$.tmp"; printf '%s\n' "$$marker_value" >"$$temporary"; /bin/chmod 0600 "$$temporary"; /bin/mv "$$temporary" "$$marker"; fi; \
+	done; \
+	retained_root="$$(cd "$$retained_root" && pwd -P)"; transient_root="$$(cd "$$transient_root" && pwd -P)"; \
+	case "$$retained_root/" in "$$transient_root/"*) printf 'retained root is inside transient root: %s\n' "$$retained_root" >&2; exit 2 ;; esac; \
+	case "$$transient_root/" in "$$retained_root/"*) printf 'transient root is inside retained root: %s\n' "$$transient_root" >&2; exit 2 ;; esac; \
+	if [[ "$(STACK_REQUIRE_SEPARATE_FILESYSTEMS)" == 1 ]] && [[ "$$(/usr/bin/stat -f %d "$$retained_root")" == "$$(/usr/bin/stat -f %d "$$transient_root")" ]]; then \
+		printf 'retained and transient roots must be on separate filesystems: %s and %s\n' "$$retained_root" "$$transient_root" >&2; exit 2; \
 	fi; \
-	if [[ -e "$$state_root" && ! -d "$$state_root" ]]; then \
-		printf 'STACK_STATE_ROOT is not a directory: %s\n' "$$state_root" >&2; \
-		exit 2; \
-	fi; \
-	marker="$$state_root/.container-compose-build-root"; \
-	if [[ -d "$$state_root" && ! -f "$$marker" ]] \
-		&& [[ -n "$$(/usr/bin/find "$$state_root" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then \
-		printf 'refusing to claim non-empty unmarked STACK_STATE_ROOT: %s\n' "$$state_root" >&2; \
-		exit 2; \
-	fi; \
-	/usr/bin/install -d -m 0700 "$$state_root"; \
-	state_root="$$(cd "$$state_root" && pwd -P)"; \
-	marker="$$state_root/.container-compose-build-root"; \
-	if [[ -L "$$marker" ]] || [[ -e "$$marker" && ! -f "$$marker" ]]; then \
-		printf 'build state marker must be a regular file: %s\n' "$$marker" >&2; \
-		exit 2; \
-	fi; \
-	if [[ -f "$$marker" ]] && [[ "$$(<"$$marker")" != "$(STACK_MARKER_VALUE)" ]]; then \
-		printf 'STACK_STATE_ROOT has an unexpected ownership marker: %s\n' "$$marker" >&2; \
-		exit 2; \
-	fi; \
-	if [[ ! -f "$$marker" ]]; then \
-		temporary="$$marker.$$$$.tmp"; \
-		trap '/bin/rm -f "$$temporary"' EXIT; \
-		printf '%s\n' "$(STACK_MARKER_VALUE)" >"$$temporary"; \
-		/bin/chmod 0600 "$$temporary"; \
-		/bin/mv "$$temporary" "$$marker"; \
-		trap - EXIT; \
-	fi; \
-	for managed in "$(STACK_PIN_DIR)" "$(STACK_SCRATCH_ROOT)" "$(STACK_ARTIFACT_ROOT)" "$(STACK_TIMING_ROOT)"; do \
+	for managed in "$(STACK_PIN_DIR)" "$(STACK_ARTIFACT_ROOT)" "$(STACK_TIMING_ROOT)" "$(STACK_SCRATCH_ROOT)"; do \
 		if [[ -L "$$managed" ]] || [[ -e "$$managed" && ! -d "$$managed" ]]; then \
 			printf 'build state path must be a direct directory: %s\n' "$$managed" >&2; \
 			exit 2; \
 		fi; \
 		/usr/bin/install -d -m 0700 "$$managed"; \
 		managed="$$(cd "$$managed" && pwd -P)"; \
-		case "$$managed" in "$$state_root"/*) ;; *) printf 'build state path escaped its root: %s\n' "$$managed" >&2; exit 2 ;; esac; \
+		case "$$managed" in "$$retained_root"/*|"$$transient_root"/*) ;; *) printf 'build state path escaped its roots: %s\n' "$$managed" >&2; exit 2 ;; esac; \
 	done
 
 stack-preflight: stack-state-init
@@ -515,13 +512,29 @@ stack-status:
 stack-self-test:
 	"$(PYTHON)" -m unittest discover Tools/build
 
+stack-transient-clean-plan:
+	@if [[ -d "$(STACK_TRANSIENT_ROOT)" ]]; then \
+		"$(PYTHON)" "$(STACK_TRANSIENT_CLEAN_TOOL)" --root "$(STACK_TRANSIENT_ROOT)"; \
+	else \
+		printf 'No transient stack root exists: %s\n' "$(STACK_TRANSIENT_ROOT)"; \
+	fi
+
+stack-transient-clean:
+	@if [[ -d "$(STACK_TRANSIENT_ROOT)" ]]; then \
+		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_TRANSIENT_ROOT)/stack-build.lock" \
+			"$(PYTHON)" "$(STACK_TRANSIENT_CLEAN_TOOL)" \
+			--root "$(STACK_TRANSIENT_ROOT)" --execute; \
+	else \
+		printf 'No transient stack root exists: %s\n' "$(STACK_TRANSIENT_ROOT)"; \
+	fi
+
 stack-build: stack-preflight
 	@timing_log="$(STACK_TIMING_ROOT)/$$(date -u +%Y%m%dT%H%M%SZ)-$$$$.jsonl"; \
 	"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_TIMEOUT_SECONDS)" \
 		--timing-log "$$timing_log" --timing-label stack-total -- \
-		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_STATE_ROOT)/stack-build.lock" \
+		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_TRANSIENT_ROOT)/stack-build.lock" \
 		$(MAKE) --no-print-directory stack-build-locked STACK_LOCK_HELD=1 \
-			STACK_STATE_ROOT="$(STACK_STATE_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)" \
+			STACK_RETAINED_ROOT="$(STACK_RETAINED_ROOT)" STACK_TRANSIENT_ROOT="$(STACK_TRANSIENT_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)" \
 			STACK_TIMING_LOG="$$timing_log"; \
 	exit_status=$$?; \
 	printf 'Stack timing evidence: %s\n' "$$timing_log"; \
@@ -530,7 +543,7 @@ stack-build: stack-preflight
 stack-build-locked:
 	@[[ "$(STACK_LOCK_HELD)" == 1 ]] || { printf 'stack-build-locked requires the stack-build lock\n' >&2; exit 2; }
 	@$(MAKE) --no-print-directory -j3 stack-builder-build stack-compose-build \
-		STACK_STATE_ROOT="$(STACK_STATE_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)"
+		STACK_RETAINED_ROOT="$(STACK_RETAINED_ROOT)" STACK_TRANSIENT_ROOT="$(STACK_TRANSIENT_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)"
 	@"$(PYTHON)" "$(STACK_PIN_TOOL)" bundle --output "$(STACK_BUNDLE)" \
 		--pin "$(STACK_CONTAINERIZATION_PIN)" --pin "$(STACK_ENGINE_API_PIN)" \
 		--pin "$(STACK_CONTAINER_PIN)" --pin "$(STACK_BUILDER_PIN)" \
@@ -562,9 +575,11 @@ stack-containerization-build:
 			--timing-log "$(STACK_TIMING_LOG)" --timing-label containerization-bin-path -- \
 			"$(STACK_SWIFT)" build --scratch-path "$$scratch" \
 			-c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
+		artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$bin_path/cctl" \
+			--root "$(STACK_ARTIFACT_ROOT)" --name cctl)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository containerization \
 			--repository-path "$(CONTAINERIZATION_STACK_REPO)" \
-			--output "$(STACK_CONTAINERIZATION_PIN)" --artifact "$$bin_path/cctl" \
+			--output "$(STACK_CONTAINERIZATION_PIN)" --artifact "$$artifact" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_SWIFT_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
@@ -592,9 +607,11 @@ stack-engine-api-build:
 			--timing-log "$(STACK_TIMING_LOG)" --timing-label engine-api-bin-path -- \
 			"$(STACK_SWIFT)" build --scratch-path "$$scratch" \
 			-c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
+		artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$bin_path/container-engine" \
+			--root "$(STACK_ARTIFACT_ROOT)" --name container-engine)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-engine-api \
 			--repository-path "$(CONTAINER_ENGINE_API_STACK_REPO)" \
-			--output "$(STACK_ENGINE_API_PIN)" --artifact "$$bin_path/container-engine" \
+			--output "$(STACK_ENGINE_API_PIN)" --artifact "$$artifact" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_SWIFT_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
@@ -628,10 +645,12 @@ stack-container-build: stack-containerization-build stack-engine-api-build
 			--timing-log "$(STACK_TIMING_LOG)" --timing-label container-bin-path -- \
 			"$(STACK_SWIFT)" build --scratch-path "$$scratch" \
 			-c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
+		artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$bin_path/container" \
+			--root "$(STACK_ARTIFACT_ROOT)" --name container)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container \
 			--repository-path "$(CONTAINER_STACK_REPO)" --output "$(STACK_CONTAINER_PIN)" \
 			--dependency "$(STACK_CONTAINERIZATION_PIN)" \
-			--dependency "$(STACK_ENGINE_API_PIN)" --artifact "$$bin_path/container" \
+			--dependency "$(STACK_ENGINE_API_PIN)" --artifact "$$artifact" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_SWIFT_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
@@ -648,13 +667,16 @@ stack-builder-build:
 	else \
 		source_commit="$$(/usr/bin/git -C "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" rev-parse 'HEAD^{commit}')"; \
 		source_tree="$$(/usr/bin/git -C "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" rev-parse 'HEAD^{tree}')"; \
-		artifact="$(STACK_ARTIFACT_ROOT)/container-builder-shim/container-builder-shim"; \
-		/usr/bin/install -d -m 0700 "$$(dirname "$$artifact")"; \
+		scratch="$(STACK_SCRATCH_ROOT)/$(STACK_GO_CONTRACT)/container-builder-shim"; \
+		candidate="$$scratch/container-builder-shim"; \
+		/usr/bin/install -d -m 0700 "$$scratch"; \
 		cd "$(CONTAINER_BUILDER_SHIM_STACK_REPO)"; \
 		started=$$SECONDS; \
 		GOWORK=off "$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
 			--timing-log "$(STACK_TIMING_LOG)" --timing-label builder-build -- \
-			"$(STACK_GO)" build -trimpath -o "$$artifact" .; \
+			"$(STACK_GO)" build -trimpath -o "$$candidate" .; \
+		artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$candidate" \
+			--root "$(STACK_ARTIFACT_ROOT)" --name container-builder-shim)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-builder-shim \
 			--repository-path "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" \
 			--output "$(STACK_BUILDER_PIN)" --artifact "$$artifact" \
@@ -688,10 +710,12 @@ stack-compose-build: stack-container-build
 			"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
 			--timing-log "$(STACK_TIMING_LOG)" --timing-label compose-bin-path -- \
 			"$(STACK_SWIFT)" build --scratch-path "$$scratch" -c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
+		artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$bin_path/compose" \
+			--root "$(STACK_ARTIFACT_ROOT)" --name compose)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-compose \
 			--repository-path "$(CURDIR)" --output "$(STACK_COMPOSE_PIN)" \
 			--dependency "$(STACK_CONTAINERIZATION_PIN)" --dependency "$(STACK_ENGINE_API_PIN)" \
-			--dependency "$(STACK_CONTAINER_PIN)" --artifact "$$bin_path/compose" \
+			--dependency "$(STACK_CONTAINER_PIN)" --artifact "$$artifact" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_SWIFT_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
@@ -786,7 +810,15 @@ build-release:
 			$(SWIFT) build $(SWIFT_RESOLVED_FLAGS) -c release --product compose $(SWIFT_RELEASE_FLAGS); \
 	fi
 
-.PHONY: release-parity-build-info
+.PHONY: release-status release-recovery-plan release-parity-build-info
+release-status:
+	@[[ "$(VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$$ ]] || { printf 'VERSION must be a stable semantic version\n' >&2; exit 2; }
+	$(PYTHON) "$(RELEASE_STATE_TOOL)" inspect --root "$(RELEASE_RETAINED_ROOT)" --version "$(VERSION)"
+
+release-recovery-plan:
+	@[[ "$(VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$$ ]] || { printf 'VERSION must be a stable semantic version\n' >&2; exit 2; }
+	$(PYTHON) "$(RELEASE_STATE_TOOL)" plan --root "$(RELEASE_RETAINED_ROOT)" --version "$(VERSION)"
+
 release-parity-build-info:
 	$(PYTHON) Tools/release/write-build-info.py \
 		--output "$(RELEASE_PARITY_BUILD_INFO)" \
@@ -2378,6 +2410,10 @@ package-built:
 
 coverage-tools-syntax:
 	$(PYTHON) -m py_compile Tools/build/*.py Tools/coverage/*.py Tools/release/*.py Tools/ci/*.py
+
+actions-lint:
+	$(PYTHON) Tools/ci/validate-actions-workflows.py \
+		.github/workflows/*.yml
 
 coverage-python-tools-test: coverage-tools-syntax
 	$(PYTHON) -m unittest discover Tools/coverage

--- a/Makefile
+++ b/Makefile
@@ -213,6 +213,8 @@ STACK_TRANSIENT_MARKER_VALUE := container-compose transient build v2
 STACK_PIN_TOOL := $(abspath Tools/build/stack-pin.py)
 STACK_ARTIFACT_TOOL := $(abspath Tools/build/stack-artifact.py)
 STACK_TRANSIENT_CLEAN_TOOL := $(abspath Tools/build/stack-transient-clean.py)
+STACK_STORAGE_TOOL := $(abspath Tools/build/stack-storage.py)
+STACK_REQUIRED_TRANSIENT_VOLUME ?= /Volumes/SSD
 RELEASE_STATE_TOOL := $(abspath Tools/release/release-state.py)
 RELEASE_RETAINED_ROOT ?= $(HOME)/Library/Application Support/ContainerFamily/retained
 STACK_BUILD_CONTRACT := $(abspath Tools/build/stack-build-contract.json)
@@ -225,7 +227,10 @@ STACK_LOCK_TOOL ?= /usr/bin/lockf
 STACK_TIMING_ROOT := $(STACK_RETAINED_ROOT)/timings
 STACK_TIMING_LOG ?= $(STACK_TIMING_ROOT)/direct-stage.jsonl
 STACK_PIN_DIR := $(STACK_RETAINED_ROOT)/pins/$(STACK_CONFIGURATION)
+STACK_PIN_INDEX := $(STACK_RETAINED_ROOT)/pin-index/$(STACK_CONFIGURATION)
+STACK_LOCK_ROOT := $(STACK_RETAINED_ROOT)/control/locks
 STACK_SCRATCH_ROOT := $(STACK_TRANSIENT_ROOT)/scratch
+STACK_PROCESS_TEMP_ROOT := $(STACK_TRANSIENT_ROOT)/process-tmp
 STACK_ARTIFACT_ROOT := $(STACK_RETAINED_ROOT)/artifacts
 STACK_CONTAINERIZATION_PIN := $(STACK_PIN_DIR)/containerization.json
 STACK_ENGINE_API_PIN := $(STACK_PIN_DIR)/container-engine-api.json
@@ -235,7 +240,8 @@ STACK_COMPOSE_PIN := $(STACK_PIN_DIR)/container-compose.json
 STACK_BUNDLE := $(STACK_PIN_DIR)/stack.json
 STACK_SWIFT ?= /usr/bin/swift
 STACK_GO ?= $(GO)
-STACK_SWIFT_CONTRACT = $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
+ifeq ($(origin STACK_SWIFT_CONTRACT),undefined)
+STACK_SWIFT_CONTRACT := $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--tool $(call SHELL_QUOTE,$(STACK_SWIFT)) \
 	--configuration $(call SHELL_QUOTE,$(STACK_CONFIGURATION)) \
 	--controller "$(STACK_BUILD_CONTRACT)" --controller "$(STACK_PIN_TOOL)" \
@@ -243,19 +249,29 @@ STACK_SWIFT_CONTRACT = $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--controller "$(STACK_DEADLINE_TOOL)" --controller "$(STACK_SWIFT_STACK_TOOL)" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK CONFIGURATION::END RECOVERABLE STACK CONFIGURATION" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK TARGETS::END RECOVERABLE STACK TARGETS")
-STACK_GO_CONTRACT = $(shell GOWORK=off "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
+endif
+ifeq ($(origin STACK_GO_CONTRACT),undefined)
+STACK_GO_CONTRACT := $(shell GOWORK=off "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--tool $(call SHELL_QUOTE,$(STACK_GO)) \
 	--configuration $(call SHELL_QUOTE,$(STACK_CONFIGURATION)) \
 	--controller "$(STACK_BUILD_CONTRACT)" --controller "$(STACK_PIN_TOOL)" \
 	--controller "$(STACK_DEADLINE_TOOL)" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK CONFIGURATION::END RECOVERABLE STACK CONFIGURATION" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK TARGETS::END RECOVERABLE STACK TARGETS")
+endif
+ifeq ($(origin STACK_COMPOSE_CONTRACT),undefined)
+STACK_COMPOSE_CONTRACT := $(shell { printf 'swift=%s\ngo=%s\n' \
+	$(call SHELL_QUOTE,$(STACK_SWIFT_CONTRACT)) $(call SHELL_QUOTE,$(STACK_GO_CONTRACT)); \
+	shasum -a 256 config.toml "$(PLUGIN_ICON)" Tools/release/runtime-capabilities.json; \
+	} | shasum -a 256 | awk '{print $$1}')
+endif
 # END RECOVERABLE STACK CONFIGURATION
 RELEASE_GATE_CHECKPOINT_DIR = $(if $(CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR),$(CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR)/compose-release-gate,)
 PARITY_GATE_CHECKPOINT_DIR = $(if $(RELEASE_GATE_CHECKPOINT_DIR),$(RELEASE_GATE_CHECKPOINT_DIR)/parity,)
 RELEASE_GATE_INIT_ARCHIVE_FINGERPRINT = $(shell if [[ -z "$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" ]]; then printf unset; elif [[ -f "$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" ]]; then shasum -a 256 "$(CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE)" | awk '{print $$1}'; else printf missing; fi)
 RELEASE_GATE_COMPOSE_TEST_BINARY_FINGERPRINT = $(shell { printf 'selector=%s\n' "$(COMPOSE_TEST_BINARY)"; if [[ "$(COMPOSE_TEST_BINARY)" == "$(DEFAULT_COMPOSE_TEST_BINARY)" ]]; then printf 'source-built\n'; elif [[ -f "$(COMPOSE_TEST_BINARY)" ]]; then shasum -a 256 "$(COMPOSE_TEST_BINARY)"; else printf 'missing\n'; fi; } | shasum -a 256 | awk '{print $$1}')
-RELEASE_GATE_TOOL_FINGERPRINT = $(shell { record_tool() { local label="$$1" selector="$$2" executable="$$3" path; if [[ "$$executable" == */* && -e "$$executable" ]]; then path="$$executable"; else path="$$(command -v "$$executable" 2>/dev/null || true)"; fi; printf '%s=%s\n%s-path=%s\n' "$$label" "$$selector" "$$label" "$${path:-missing}"; if [[ -f "$$path" ]]; then shasum -a 256 "$$path"; fi; }; for tool in git make swift clang go gofmt ruby python3 docker hawkeye shellcheck markdownlint markdownlint-cli2 xcodebuild xcrun codesign shasum tar gtar curl jq; do record_tool "$$tool" "$$tool" "$$tool"; done; record_tool selected-swift "$(SWIFT)" "$(firstword $(SWIFT))"; record_tool selected-go "$(GO)" "$(firstword $(GO))"; record_tool selected-python "$(PYTHON)" "$(firstword $(PYTHON))"; record_tool selected-markdownlint "$(MARKDOWNLINT)" "$(firstword $(MARKDOWNLINT))"; record_tool selected-hawkeye "$(HAWKEYE)" "$(firstword $(HAWKEYE))"; record_tool selected-llvm-cov "$(SWIFT_LLVM_COV)" "$(SWIFT_LLVM_COV)"; record_tool selected-llvm-profdata "$(SWIFT_LLVM_PROFDATA)" "$(SWIFT_LLVM_PROFDATA)"; record_tool selected-docker-compose "$(DOCKER_COMPOSE_REFERENCE)" "$(firstword $(DOCKER_COMPOSE_REFERENCE))"; } | shasum -a 256 | awk '{print $$1}')
+RELEASE_GATE_TOOL_FINGERPRINT = $(shell { record_tool() { local label="$$1" selector="$$2" executable="$$3" path; if [[ "$$executable" == */* && -e "$$executable" ]]; then path="$$executable"; else path="$$(command -v "$$executable" 2>/dev/null || true)"; fi; printf '%s=%s\n%s-path=%s\n' "$$label" "$$selector" "$$label" "$${path:-missing}"; if [[ -f "$$path" ]]; then shasum -a 256 "$$path"; fi; }; for tool in git make swift clang go gofmt ruby python3 hawkeye shellcheck markdownlint markdownlint-cli2 xcodebuild xcrun codesign shasum tar gtar curl jq; do record_tool "$$tool" "$$tool" "$$tool"; done; record_tool selected-swift "$(SWIFT)" "$(firstword $(SWIFT))"; record_tool selected-go "$(GO)" "$(firstword $(GO))"; record_tool selected-python "$(PYTHON)" "$(firstword $(PYTHON))"; record_tool selected-markdownlint "$(MARKDOWNLINT)" "$(firstword $(MARKDOWNLINT))"; record_tool selected-hawkeye "$(HAWKEYE)" "$(firstword $(HAWKEYE))"; record_tool selected-llvm-cov "$(SWIFT_LLVM_COV)" "$(SWIFT_LLVM_COV)"; record_tool selected-llvm-profdata "$(SWIFT_LLVM_PROFDATA)" "$(SWIFT_LLVM_PROFDATA)"; } | shasum -a 256 | awk '{print $$1}')
+RELEASE_GATE_DOCKER_ORACLE_FINGERPRINT = $(shell { selector=$(call SHELL_QUOTE,$(DOCKER_COMPOSE_REFERENCE)); executable=$(call SHELL_QUOTE,$(firstword $(DOCKER_COMPOSE_REFERENCE))); if [[ "$$executable" == */* && -e "$$executable" ]]; then path="$$executable"; else path="$$(command -v "$$executable" 2>/dev/null || true)"; fi; printf 'selector=%s\npath=%s\nversion=%s\n' "$$selector" "$${path:-missing}" "$(DOCKER_COMPOSE_REFERENCE_VERSION)"; if [[ -f "$$path" ]]; then shasum -a 256 "$$path"; fi; } | shasum -a 256 | awk '{print $$1}')
 RELEASE_GATE_PARITY_INPUT_FINGERPRINT = $(shell { printf '%s\n' \
 	'targets=$(DOCKER_COMPOSE_PARITY_TARGETS)' \
 	'repetitions=$(PARITY_REPETITIONS)' \
@@ -279,7 +295,7 @@ RELEASE_GATE_PARITY_INPUT_FINGERPRINT = $(shell { printf '%s\n' \
 	'fixture-image-reference='$(call SHELL_QUOTE,$(PARITY_FIXTURE_IMAGE_ARCHIVE_REFERENCE)) \
 	'work-root='$(call SHELL_QUOTE,$(PARITY_WORK_ROOT)); \
 	} | shasum -a 256 | awk '{print $$1}')
-override RELEASE_GATE_STATIC_FINGERPRINT = compose=$(shell /usr/bin/git rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):builder=$(shell /usr/bin/git -C "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):containerization=$(shell /usr/bin/git -C "$(CONTAINERIZATION_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):container=$(shell /usr/bin/git -C "$(CONTAINER_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):homebrew=$(shell if [[ -f "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" ]]; then shasum -a 256 "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" | awk '{print $$1}'; else printf missing; fi):candidate=$(CONTAINER_RUNTIME_CANDIDATE_SHA256):init=$(RELEASE_GATE_INIT_ARCHIVE_FINGERPRINT):compose-test=$(RELEASE_GATE_COMPOSE_TEST_BINARY_FINGERPRINT):tools=$(RELEASE_GATE_TOOL_FINGERPRINT):engine=$(PARITY_CONTAINER_ENGINE_API_REF):container-source=$(CONTAINER_SOURCE):container-ref=$(PARITY_CONTAINER_REF):containerization-source=$(CONTAINERIZATION_SOURCE):containerization-ref=$(PARITY_CONTAINERIZATION_REF):swift=$(shell $(SWIFT) --version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):swift-resolved-flags=$(SWIFT_RESOLVED_FLAGS):swift-test-flags=$(SWIFT_TEST_FLAGS):swift-test-run-flags=$(SWIFT_TEST_RUN_FLAGS):swift-test-attempts=$(SWIFT_TEST_ATTEMPTS):swift-coverage-attempts=$(SWIFT_COVERAGE_TEST_ATTEMPTS):swift-runtime-filter=$(SWIFT_RUNTIME_TEST_FILTER):go=$(shell $(GO) version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):go-release-env=$(GO_RELEASE_ENV):go-release-build-flags=$(GO_RELEASE_BUILD_FLAGS):go-release-ldflags=$(GO_RELEASE_LDFLAGS):docker=$(shell $(DOCKER_COMPOSE_REFERENCE) version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):reference=$(DOCKER_COMPOSE_REFERENCE_VERSION):fixtures=$(DOCKER_COMPOSE_E2E_REF):parity-inputs=$(RELEASE_GATE_PARITY_INPUT_FINGERPRINT):release-stack-timeout=$(RELEASE_GATE_STACK_TIMEOUT_SECONDS):release-parity-timeout=$(RELEASE_GATE_PARITY_TIMEOUT_SECONDS):parity-stage-timeout=$(PARITY_STAGE_TIMEOUT_SECONDS):runtime-start-deadline=$(CONTAINER_RUNTIME_START_DEADLINE_SECONDS):parity-live=1:build-check-live=1:swift-core-min=$(SWIFT_CORE_COVERAGE_MIN):swift-runtime-spi-min=$(SWIFT_RUNTIME_SPI_COVERAGE_MIN):swift-provider-min=$(SWIFT_PROVIDER_COVERAGE_MIN):swift-plugin-min=$(SWIFT_PLUGIN_COVERAGE_MIN):swift-aggregate-min=$(SWIFT_AGGREGATE_COVERAGE_MIN):go-min=$(GO_COVERAGE_MIN)
+override RELEASE_GATE_STATIC_FINGERPRINT = compose=$(shell /usr/bin/git rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):builder=$(shell /usr/bin/git -C "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):containerization=$(shell /usr/bin/git -C "$(CONTAINERIZATION_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):container=$(shell /usr/bin/git -C "$(CONTAINER_STACK_REPO)" rev-parse 'HEAD^{tree}' 2>/dev/null || printf fixture):homebrew=$(shell if [[ -f "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" ]]; then shasum -a 256 "$(HOMEBREW_TAP_REPO)/Formula/container-compose.rb" | awk '{print $$1}'; else printf missing; fi):candidate=$(CONTAINER_RUNTIME_CANDIDATE_SHA256):init=$(RELEASE_GATE_INIT_ARCHIVE_FINGERPRINT):compose-test=$(RELEASE_GATE_COMPOSE_TEST_BINARY_FINGERPRINT):tools=$(RELEASE_GATE_TOOL_FINGERPRINT):engine=$(PARITY_CONTAINER_ENGINE_API_REF):container-source=$(CONTAINER_SOURCE):container-ref=$(PARITY_CONTAINER_REF):containerization-source=$(CONTAINERIZATION_SOURCE):containerization-ref=$(PARITY_CONTAINERIZATION_REF):swift=$(shell $(SWIFT) --version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):swift-resolved-flags=$(SWIFT_RESOLVED_FLAGS):swift-test-flags=$(SWIFT_TEST_FLAGS):swift-test-run-flags=$(SWIFT_TEST_RUN_FLAGS):swift-test-attempts=$(SWIFT_TEST_ATTEMPTS):swift-coverage-attempts=$(SWIFT_COVERAGE_TEST_ATTEMPTS):swift-runtime-filter=$(SWIFT_RUNTIME_TEST_FILTER):go=$(shell $(GO) version 2>/dev/null | shasum -a 256 | awk '{print $$1}'):go-release-env=$(GO_RELEASE_ENV):go-release-build-flags=$(GO_RELEASE_BUILD_FLAGS):go-release-ldflags=$(GO_RELEASE_LDFLAGS):docker-oracle=$(RELEASE_GATE_DOCKER_ORACLE_FINGERPRINT):fixtures=$(DOCKER_COMPOSE_E2E_REF):parity-inputs=$(RELEASE_GATE_PARITY_INPUT_FINGERPRINT):release-stack-timeout=$(RELEASE_GATE_STACK_TIMEOUT_SECONDS):release-parity-timeout=$(RELEASE_GATE_PARITY_TIMEOUT_SECONDS):parity-stage-timeout=$(PARITY_STAGE_TIMEOUT_SECONDS):runtime-start-deadline=$(CONTAINER_RUNTIME_START_DEADLINE_SECONDS):parity-live=1:build-check-live=1:swift-core-min=$(SWIFT_CORE_COVERAGE_MIN):swift-runtime-spi-min=$(SWIFT_RUNTIME_SPI_COVERAGE_MIN):swift-provider-min=$(SWIFT_PROVIDER_COVERAGE_MIN):swift-plugin-min=$(SWIFT_PLUGIN_COVERAGE_MIN):swift-aggregate-min=$(SWIFT_AGGREGATE_COVERAGE_MIN):go-min=$(GO_COVERAGE_MIN)
 PARITY_ENV = \
 	CONTAINER_COMPOSE_CONTAINER="$(CONTAINER_COMPOSE_CONTAINER)" \
 	CONTAINER_COMPOSE_LIVE="$(CONTAINER_COMPOSE_LIVE)" \
@@ -390,7 +406,7 @@ SWIFT_TEST_FLAGS += $(if $(strip $(SWIFT_TEST_FRAMEWORK_SEARCH_PATH)),-Xswiftc -
 .PHONY: docker-compose-stop-defaults-parity docker-compose-cpu-cfs-parity docker-compose-cpu-shares-parity docker-compose-cpuset-parity docker-compose-pid-namespace-parity docker-compose-cgroup-namespace-parity docker-compose-cgroup-parent-parity docker-compose-ipc-uts-namespace-parity docker-compose-userns-mode-parity docker-compose-privileged-parity docker-compose-network-attachable-parity docker-compose-network-ipv6-parity docker-compose-deploy-job-modes-parity
 .PHONY: docker-compose-up-exit-code-from-parity docker-compose-api-socket-client-fixture docker-compose-api-socket-client-parity docker-compose-performance-matrix performance-matrix-harness-test isolation-performance-harness-test signal-log-reliability-harness-test compose-events-harness-test
 .PHONY: docker-terminal-session-oracle docker-terminal-session-oracle-update docker-terminal-session-candidate-oracle docker-rest-logging-oracle docker-rest-logging-candidate docker-rest-logging-parity docker-rest-discovery-oracle docker-rest-discovery-candidate docker-rest-discovery-parity docker-rest-image-discovery-oracle docker-rest-image-discovery-candidate docker-rest-image-discovery-parity docker-rest-image-mutation-oracle docker-rest-image-mutation-candidate docker-rest-image-mutation-parity
-.PHONY: stack-help stack-state-init stack-preflight stack-status stack-self-test stack-transient-clean-plan stack-transient-clean stack-build stack-build-locked stack-containerization-build stack-engine-api-build stack-container-build stack-builder-build stack-compose-build
+.PHONY: stack-help stack-state-init stack-preflight stack-status stack-self-test stack-transient-clean-plan stack-transient-clean stack-build stack-build-locked stack-containerization-build stack-engine-api-build stack-container-build stack-builder-build stack-compose-build stack-restore-containerization-pin stack-restore-engine-api-pin stack-restore-container-pin stack-restore-builder-pin stack-restore-compose-pin package-retained
 
 # BEGIN RECOVERABLE STACK TARGETS
 STACK_REQUIRE_LOCK = @[[ "$(STACK_LOCK_HELD)" == 1 ]] || { printf 'stack stage requires the stack-build lock\n' >&2; exit 2; }
@@ -417,38 +433,20 @@ stack-help:
 		'Transient build scratch: $(STACK_TRANSIENT_ROOT)'
 
 stack-state-init:
-	@case "$(STACK_CONFIGURATION)" in debug|release) ;; *) printf 'STACK_CONFIGURATION must be debug or release: %s\n' "$(STACK_CONFIGURATION)" >&2; exit 2 ;; esac; \
-	retained_root="$(STACK_RETAINED_ROOT)"; transient_root="$(STACK_TRANSIENT_ROOT)"; \
-	for specification in "$$retained_root|.container-family-retained-root|$(STACK_RETAINED_MARKER_VALUE)" "$$transient_root|.container-family-transient-root|$(STACK_TRANSIENT_MARKER_VALUE)"; do \
-		IFS='|' read -r root marker_name marker_value <<<"$$specification"; \
-		case "$$root" in /*) ;; *) printf 'stack storage root must be absolute: %s\n' "$$root" >&2; exit 2 ;; esac; \
-		[[ "$$root" != / ]] || { printf 'stack storage root must not be /.\n' >&2; exit 2; }; \
-		[[ ! -L "$$root" ]] || { printf 'stack storage root must not be a symbolic link: %s\n' "$$root" >&2; exit 2; }; \
-		[[ ! -e "$$root" || -d "$$root" ]] || { printf 'stack storage root is not a directory: %s\n' "$$root" >&2; exit 2; }; \
-		marker="$$root/$$marker_name"; \
-		if [[ -d "$$root" && ! -f "$$marker" ]] && [[ -n "$$(/usr/bin/find "$$root" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then \
-			printf 'refusing to claim non-empty unmarked stack storage root: %s\n' "$$root" >&2; exit 2; \
-		fi; \
-		/usr/bin/install -d -m 0700 "$$root"; root="$$(cd "$$root" && pwd -P)"; marker="$$root/$$marker_name"; \
-		[[ ! -L "$$marker" && ( ! -e "$$marker" || -f "$$marker" ) ]] || { printf 'stack storage marker must be a regular file: %s\n' "$$marker" >&2; exit 2; }; \
-		[[ ! -f "$$marker" || "$$(<"$$marker")" == "$$marker_value" ]] || { printf 'stack storage root has an unexpected ownership marker: %s\n' "$$marker" >&2; exit 2; }; \
-		if [[ ! -f "$$marker" ]]; then temporary="$$marker.$$$$.tmp"; printf '%s\n' "$$marker_value" >"$$temporary"; /bin/chmod 0600 "$$temporary"; /bin/mv "$$temporary" "$$marker"; fi; \
-	done; \
-	retained_root="$$(cd "$$retained_root" && pwd -P)"; transient_root="$$(cd "$$transient_root" && pwd -P)"; \
-	case "$$retained_root/" in "$$transient_root/"*) printf 'retained root is inside transient root: %s\n' "$$retained_root" >&2; exit 2 ;; esac; \
-	case "$$transient_root/" in "$$retained_root/"*) printf 'transient root is inside retained root: %s\n' "$$transient_root" >&2; exit 2 ;; esac; \
-	if [[ "$(STACK_REQUIRE_SEPARATE_FILESYSTEMS)" == 1 ]] && [[ "$$(/usr/bin/stat -f %d "$$retained_root")" == "$$(/usr/bin/stat -f %d "$$transient_root")" ]]; then \
-		printf 'retained and transient roots must be on separate filesystems: %s and %s\n' "$$retained_root" "$$transient_root" >&2; exit 2; \
-	fi; \
-	for managed in "$(STACK_PIN_DIR)" "$(STACK_ARTIFACT_ROOT)" "$(STACK_TIMING_ROOT)" "$(STACK_SCRATCH_ROOT)"; do \
-		if [[ -L "$$managed" ]] || [[ -e "$$managed" && ! -d "$$managed" ]]; then \
-			printf 'build state path must be a direct directory: %s\n' "$$managed" >&2; \
-			exit 2; \
-		fi; \
-		/usr/bin/install -d -m 0700 "$$managed"; \
-		managed="$$(cd "$$managed" && pwd -P)"; \
-		case "$$managed" in "$$retained_root"/*|"$$transient_root"/*) ;; *) printf 'build state path escaped its roots: %s\n' "$$managed" >&2; exit 2 ;; esac; \
-	done
+	@case "$(STACK_CONFIGURATION)" in debug|release) ;; *) printf 'STACK_CONFIGURATION must be debug or release: %s\n' "$(STACK_CONFIGURATION)" >&2; exit 2 ;; esac
+	@"$(PYTHON)" "$(STACK_STORAGE_TOOL)" \
+		--retained-root "$(STACK_RETAINED_ROOT)" --transient-root "$(STACK_TRANSIENT_ROOT)" \
+		--transient-volume "$(STACK_REQUIRED_TRANSIENT_VOLUME)" \
+		--retained-marker .container-family-retained-root \
+		--retained-marker-value "$(STACK_RETAINED_MARKER_VALUE)" \
+		--transient-marker .container-family-transient-root \
+		--transient-marker-value "$(STACK_TRANSIENT_MARKER_VALUE)" \
+		--retained-path "$(STACK_PIN_DIR)" --retained-path "$(STACK_PIN_INDEX)" \
+		--retained-path "$(STACK_ARTIFACT_ROOT)" --retained-path "$(STACK_TIMING_ROOT)" \
+		--retained-path "$(STACK_LOCK_ROOT)" \
+		--transient-path "$(STACK_SCRATCH_ROOT)" \
+		--transient-path "$(STACK_PROCESS_TEMP_ROOT)" \
+		$(if $(filter 1,$(STACK_REQUIRE_SEPARATE_FILESYSTEMS)),--require-separate-filesystems,)
 
 stack-preflight: stack-state-init
 	@for tool in /usr/bin/git "$(STACK_LOCK_TOOL)" "$(STACK_SWIFT)" "$(STACK_GO)" "$(PYTHON)"; do \
@@ -521,7 +519,7 @@ stack-transient-clean-plan:
 
 stack-transient-clean:
 	@if [[ -d "$(STACK_TRANSIENT_ROOT)" ]]; then \
-		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_TRANSIENT_ROOT)/stack-build.lock" \
+		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_LOCK_ROOT)/stack-build.lock" \
 			"$(PYTHON)" "$(STACK_TRANSIENT_CLEAN_TOOL)" \
 			--root "$(STACK_TRANSIENT_ROOT)" --execute; \
 	else \
@@ -530,9 +528,11 @@ stack-transient-clean:
 
 stack-build: stack-preflight
 	@timing_log="$(STACK_TIMING_ROOT)/$$(date -u +%Y%m%dT%H%M%SZ)-$$$$.jsonl"; \
+	TMPDIR="$(STACK_PROCESS_TEMP_ROOT)" TMP="$(STACK_PROCESS_TEMP_ROOT)" \
+	TEMP="$(STACK_PROCESS_TEMP_ROOT)" GOTMPDIR="$(STACK_PROCESS_TEMP_ROOT)" \
 	"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_TIMEOUT_SECONDS)" \
 		--timing-log "$$timing_log" --timing-label stack-total -- \
-		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_TRANSIENT_ROOT)/stack-build.lock" \
+		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_LOCK_ROOT)/stack-build.lock" \
 		$(MAKE) --no-print-directory stack-build-locked STACK_LOCK_HELD=1 \
 			STACK_RETAINED_ROOT="$(STACK_RETAINED_ROOT)" STACK_TRANSIENT_ROOT="$(STACK_TRANSIENT_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)" \
 			STACK_TIMING_LOG="$$timing_log"; \
@@ -554,7 +554,35 @@ stack-build-locked:
 		--repository container-compose
 	@printf 'Recoverable stack build complete. Pin bundle: %s\n' "$(STACK_BUNDLE)"
 
-stack-containerization-build:
+stack-restore-containerization-pin:
+	@"$(PYTHON)" "$(STACK_PIN_TOOL)" lookup --repository containerization \
+		--repository-path "$(CONTAINERIZATION_STACK_REPO)" --build-contract "$(STACK_SWIFT_CONTRACT)" \
+		--index-root "$(STACK_PIN_INDEX)" --output "$(STACK_CONTAINERIZATION_PIN)" >/dev/null 2>&1 || true
+
+stack-restore-engine-api-pin:
+	@"$(PYTHON)" "$(STACK_PIN_TOOL)" lookup --repository container-engine-api \
+		--repository-path "$(CONTAINER_ENGINE_API_STACK_REPO)" --build-contract "$(STACK_SWIFT_CONTRACT)" \
+		--index-root "$(STACK_PIN_INDEX)" --output "$(STACK_ENGINE_API_PIN)" >/dev/null 2>&1 || true
+
+stack-restore-builder-pin:
+	@"$(PYTHON)" "$(STACK_PIN_TOOL)" lookup --repository container-builder-shim \
+		--repository-path "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" --build-contract "$(STACK_GO_CONTRACT)" \
+		--index-root "$(STACK_PIN_INDEX)" --output "$(STACK_BUILDER_PIN)" >/dev/null 2>&1 || true
+
+stack-restore-container-pin: stack-restore-containerization-pin stack-restore-engine-api-pin
+	@"$(PYTHON)" "$(STACK_PIN_TOOL)" lookup --repository container \
+		--repository-path "$(CONTAINER_STACK_REPO)" --build-contract "$(STACK_SWIFT_CONTRACT)" \
+		--dependency "$(STACK_CONTAINERIZATION_PIN)" --dependency "$(STACK_ENGINE_API_PIN)" \
+		--index-root "$(STACK_PIN_INDEX)" --output "$(STACK_CONTAINER_PIN)" >/dev/null 2>&1 || true
+
+stack-restore-compose-pin: stack-restore-container-pin
+	@"$(PYTHON)" "$(STACK_PIN_TOOL)" lookup --repository container-compose \
+		--repository-path "$(CURDIR)" --build-contract "$(STACK_COMPOSE_CONTRACT)" \
+		--dependency "$(STACK_CONTAINERIZATION_PIN)" --dependency "$(STACK_ENGINE_API_PIN)" \
+		--dependency "$(STACK_CONTAINER_PIN)" --index-root "$(STACK_PIN_INDEX)" \
+		--output "$(STACK_COMPOSE_PIN)" >/dev/null 2>&1 || true
+
+stack-containerization-build: stack-restore-containerization-pin
 	$(STACK_REQUIRE_LOCK)
 	@if "$(PYTHON)" "$(STACK_PIN_TOOL)" verify --quiet \
 		--receipt "$(STACK_CONTAINERIZATION_PIN)" --repository containerization \
@@ -580,13 +608,14 @@ stack-containerization-build:
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository containerization \
 			--repository-path "$(CONTAINERIZATION_STACK_REPO)" \
 			--output "$(STACK_CONTAINERIZATION_PIN)" --artifact "$$artifact" \
+			--index-root "$(STACK_PIN_INDEX)" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_SWIFT_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
 			--command-label 'swift build --product cctl' >/dev/null; \
 	fi
 
-stack-engine-api-build:
+stack-engine-api-build: stack-restore-engine-api-pin
 	$(STACK_REQUIRE_LOCK)
 	@if "$(PYTHON)" "$(STACK_PIN_TOOL)" verify --quiet \
 		--receipt "$(STACK_ENGINE_API_PIN)" --repository container-engine-api \
@@ -612,13 +641,14 @@ stack-engine-api-build:
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-engine-api \
 			--repository-path "$(CONTAINER_ENGINE_API_STACK_REPO)" \
 			--output "$(STACK_ENGINE_API_PIN)" --artifact "$$artifact" \
+			--index-root "$(STACK_PIN_INDEX)" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_SWIFT_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
 			--command-label 'swift build --product container-engine' >/dev/null; \
 	fi
 
-stack-container-build: stack-containerization-build stack-engine-api-build
+stack-container-build: stack-containerization-build stack-engine-api-build stack-restore-container-pin
 	$(STACK_REQUIRE_LOCK)
 	@if "$(PYTHON)" "$(STACK_PIN_TOOL)" verify --quiet \
 		--receipt "$(STACK_CONTAINER_PIN)" --repository container \
@@ -649,6 +679,7 @@ stack-container-build: stack-containerization-build stack-engine-api-build
 			--root "$(STACK_ARTIFACT_ROOT)" --name container)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container \
 			--repository-path "$(CONTAINER_STACK_REPO)" --output "$(STACK_CONTAINER_PIN)" \
+			--index-root "$(STACK_PIN_INDEX)" \
 			--dependency "$(STACK_CONTAINERIZATION_PIN)" \
 			--dependency "$(STACK_ENGINE_API_PIN)" --artifact "$$artifact" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
@@ -657,7 +688,7 @@ stack-container-build: stack-containerization-build stack-engine-api-build
 			--command-label 'swift build --product container' >/dev/null; \
 	fi
 
-stack-builder-build:
+stack-builder-build: stack-restore-builder-pin
 	$(STACK_REQUIRE_LOCK)
 	@if "$(PYTHON)" "$(STACK_PIN_TOOL)" verify --quiet \
 		--receipt "$(STACK_BUILDER_PIN)" --repository container-builder-shim \
@@ -680,23 +711,26 @@ stack-builder-build:
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-builder-shim \
 			--repository-path "$(CONTAINER_BUILDER_SHIM_STACK_REPO)" \
 			--output "$(STACK_BUILDER_PIN)" --artifact "$$artifact" \
+			--index-root "$(STACK_PIN_INDEX)" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
 			--build-contract "$(STACK_GO_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
 			--command-label 'go build -trimpath' >/dev/null; \
 	fi
 
-stack-compose-build: stack-container-build
+stack-compose-build: stack-container-build stack-restore-compose-pin
 	$(STACK_REQUIRE_LOCK)
 	@if "$(PYTHON)" "$(STACK_PIN_TOOL)" verify --quiet \
 		--receipt "$(STACK_COMPOSE_PIN)" --repository container-compose \
 		--repository-path "$(CURDIR)" \
-		--build-contract "$(STACK_SWIFT_CONTRACT)"; then \
+		--build-contract "$(STACK_COMPOSE_CONTRACT)"; then \
 		printf 'Reusing container-compose build pin.\n'; \
 	else \
 		source_commit="$$(/usr/bin/git -C "$(CURDIR)" rev-parse 'HEAD^{commit}')"; \
 		source_tree="$$(/usr/bin/git -C "$(CURDIR)" rev-parse 'HEAD^{tree}')"; \
 		scratch="$(STACK_SCRATCH_ROOT)/$(STACK_SWIFT_CONTRACT)/container-compose"; \
+		product="$$scratch/retained-product"; \
+		mkdir -p "$$product"; \
 		started=$$SECONDS; \
 		CONTAINER_PACKAGE_PATH="$(CONTAINER_STACK_REPO)" \
 		CONTAINERIZATION_PACKAGE_PATH="$(CONTAINERIZATION_STACK_REPO)" \
@@ -710,16 +744,39 @@ stack-compose-build: stack-container-build
 			"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
 			--timing-log "$(STACK_TIMING_LOG)" --timing-label compose-bin-path -- \
 			"$(STACK_SWIFT)" build --scratch-path "$$scratch" -c "$(STACK_CONFIGURATION)" --show-bin-path)"; \
-		artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$bin_path/compose" \
-			--root "$(STACK_ARTIFACT_ROOT)" --name compose)"; \
+		cd Tools/compose-normalizer; \
+		GOWORK=off $(GO_RELEASE_ENV) "$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" \
+			--timing-log "$(STACK_TIMING_LOG)" --timing-label compose-normalizer-build -- \
+			"$(STACK_GO)" build $(GO_RELEASE_BUILD_FLAGS) -ldflags "$(GO_RELEASE_LDFLAGS)" -o "$$product/compose-normalizer" .; \
+		cd "$(CURDIR)"; \
+		"$(PYTHON)" Tools/release/write-build-info.py \
+			--output "$$product/build-info.json" --version "$(COMPOSE_VERSION)" \
+			--source "$(CONTAINER_COMPOSE_SOURCE)" --branch "$(CONTAINER_COMPOSE_BRANCH)" \
+			--lane "$(CONTAINER_COMPOSE_LANE)" --commit "$$source_commit" \
+			--build-type "$(STACK_CONFIGURATION)" --container-source "$(CONTAINER_SOURCE)" \
+			--container-ref "$$(/usr/bin/git -C "$(CONTAINER_STACK_REPO)" rev-parse HEAD)" \
+			--containerization-source "$(CONTAINERIZATION_SOURCE)" \
+			--containerization-ref "$$(/usr/bin/git -C "$(CONTAINERIZATION_STACK_REPO)" rev-parse HEAD)" \
+			--compose-go-version "$(COMPOSE_GO_VERSION)"; \
+		compose_artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$bin_path/compose" --root "$(STACK_ARTIFACT_ROOT)" --name compose)"; \
+		normalizer_artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$product/compose-normalizer" --root "$(STACK_ARTIFACT_ROOT)" --name compose-normalizer)"; \
+		config_artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$(abspath config.toml)" --root "$(STACK_ARTIFACT_ROOT)" --name config.toml)"; \
+		icon_artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$(abspath $(PLUGIN_ICON))" --root "$(STACK_ARTIFACT_ROOT)" --name container-compose-icon.png)"; \
+		metadata_artifact="$$($(PYTHON) "$(STACK_ARTIFACT_TOOL)" --source "$$product/build-info.json" --root "$(STACK_ARTIFACT_ROOT)" --name build-info.json)"; \
 		"$(PYTHON)" "$(STACK_PIN_TOOL)" create --repository container-compose \
 			--repository-path "$(CURDIR)" --output "$(STACK_COMPOSE_PIN)" \
+			--index-root "$(STACK_PIN_INDEX)" \
 			--dependency "$(STACK_CONTAINERIZATION_PIN)" --dependency "$(STACK_ENGINE_API_PIN)" \
-			--dependency "$(STACK_CONTAINER_PIN)" --artifact "$$artifact" \
+			--dependency "$(STACK_CONTAINER_PIN)" \
+			--artifact-map "compose/bin/compose=$$compose_artifact" \
+			--artifact-map "compose/config.toml=$$config_artifact" \
+			--artifact-map "compose/resources/build-info.json=$$metadata_artifact" \
+			--artifact-map "compose/resources/compose-normalizer=$$normalizer_artifact" \
+			--artifact-map "compose/resources/container-compose-icon.png=$$icon_artifact" \
 			--expected-commit "$$source_commit" --expected-tree "$$source_tree" \
-			--build-contract "$(STACK_SWIFT_CONTRACT)" \
+			--build-contract "$(STACK_COMPOSE_CONTRACT)" \
 			--duration-seconds "$$((SECONDS - started))" \
-			--command-label 'swift build --product compose' >/dev/null; \
+			--command-label 'swift build --product compose + go build compose-normalizer' >/dev/null; \
 	fi
 # END RECOVERABLE STACK TARGETS
 
@@ -749,7 +806,7 @@ print-release-gate-fingerprint: release-gate-environment-fingerprint-check
 
 release-gate:
 	RELEASE_GATE_MAKE="$(MAKE)" /usr/bin/python3 ./Tools/ci/run-release-checkpoint.py --checkpoint-dir "$(RELEASE_GATE_CHECKPOINT_DIR)" --stage sibling-stack --fingerprint-command ./Tools/ci/print-release-gate-fingerprint.py --seconds "$(RELEASE_GATE_STACK_TIMEOUT_SECONDS)" -- $(MAKE) --no-print-directory container-stack-release-validation
-	RELEASE_GATE_MAKE="$(MAKE)" /usr/bin/python3 ./Tools/ci/run-release-checkpoint.py --checkpoint-dir "$(RELEASE_GATE_CHECKPOINT_DIR)" --stage compose-ci --fingerprint-command ./Tools/ci/print-release-gate-fingerprint.py --seconds "$(RELEASE_GATE_STAGE_TIMEOUT_SECONDS)" -- $(MAKE) --no-print-directory ci
+	RELEASE_GATE_MAKE="$(MAKE)" /usr/bin/python3 ./Tools/ci/run-release-checkpoint.py --checkpoint-dir "$(RELEASE_GATE_CHECKPOINT_DIR)" --stage compose-ci --fingerprint-command ./Tools/ci/print-release-gate-fingerprint.py --seconds "$(RELEASE_GATE_STAGE_TIMEOUT_SECONDS)" --required-output "$(abspath .build/debug/compose)" --required-output "$(abspath Tools/compose-normalizer/compose-normalizer)" -- $(MAKE) --no-print-directory ci
 	RELEASE_GATE_MAKE="$(MAKE)" /usr/bin/python3 ./Tools/ci/run-release-checkpoint.py --checkpoint-dir "$(RELEASE_GATE_CHECKPOINT_DIR)" --stage swift-runtime --fingerprint-command ./Tools/ci/print-release-gate-fingerprint.py --seconds "$(RELEASE_GATE_STAGE_TIMEOUT_SECONDS)" -- $(MAKE) --no-print-directory swift-runtime-test
 	RELEASE_GATE_MAKE="$(MAKE)" /usr/bin/python3 ./Tools/ci/run-release-checkpoint.py --checkpoint-dir "$(RELEASE_GATE_CHECKPOINT_DIR)" --stage compose-parity --fingerprint-command ./Tools/ci/print-release-gate-fingerprint.py --seconds "$(RELEASE_GATE_PARITY_TIMEOUT_SECONDS)" -- $(MAKE) --no-print-directory docker-compose-parity
 
@@ -817,7 +874,7 @@ release-status:
 
 release-recovery-plan:
 	@[[ "$(VERSION)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$$ ]] || { printf 'VERSION must be a stable semantic version\n' >&2; exit 2; }
-	$(PYTHON) "$(RELEASE_STATE_TOOL)" plan --root "$(RELEASE_RETAINED_ROOT)" --version "$(VERSION)"
+	$(PYTHON) "$(RELEASE_STATE_TOOL)" plan --deep --root "$(RELEASE_RETAINED_ROOT)" --version "$(VERSION)"
 
 release-parity-build-info:
 	$(PYTHON) Tools/release/write-build-info.py \
@@ -952,9 +1009,11 @@ go-build:
 	cd Tools/compose-normalizer && $(GO_RELEASE_ENV) $(GO) build $(GO_RELEASE_BUILD_FLAGS) -ldflags "$(GO_RELEASE_LDFLAGS)" -o compose-normalizer .
 	$(MAKE) go-release-check
 
+GO_RELEASE_BINARY ?= Tools/compose-normalizer/compose-normalizer
+
 go-release-check:
-	@test -x Tools/compose-normalizer/compose-normalizer || { \
-		printf 'Tools/compose-normalizer/compose-normalizer is missing; run make go-build first\n' >&2; \
+	@test -x "$(GO_RELEASE_BINARY)" || { \
+		printf '%s is missing; run make go-build first\n' "$(GO_RELEASE_BINARY)" >&2; \
 		exit 1; \
 	}
 	@case " $(GO_RELEASE_BUILD_FLAGS) " in \
@@ -978,17 +1037,17 @@ go-release-check:
 			exit 1; \
 			;; \
 	esac
-	@$(GO) version -m Tools/compose-normalizer/compose-normalizer | grep -E '^[[:space:]]*build[[:space:]]+-trimpath=true$$' >/dev/null || { \
+	@$(GO) version -m "$(GO_RELEASE_BINARY)" | grep -E '^[[:space:]]*build[[:space:]]+-trimpath=true$$' >/dev/null || { \
 		printf 'compose-normalizer was not built with -trimpath; Homebrew packages require the release Go build path\n' >&2; \
-		$(GO) version -m Tools/compose-normalizer/compose-normalizer >&2; \
+		$(GO) version -m "$(GO_RELEASE_BINARY)" >&2; \
 		exit 1; \
 	}
-	@$(GO) version -m Tools/compose-normalizer/compose-normalizer | grep -E '^[[:space:]]*build[[:space:]]+CGO_ENABLED=0$$' >/dev/null || { \
+	@$(GO) version -m "$(GO_RELEASE_BINARY)" | grep -E '^[[:space:]]*build[[:space:]]+CGO_ENABLED=0$$' >/dev/null || { \
 		printf 'compose-normalizer was not built with CGO_ENABLED=0; Homebrew packages require the release Go build path\n' >&2; \
-		$(GO) version -m Tools/compose-normalizer/compose-normalizer >&2; \
+		$(GO) version -m "$(GO_RELEASE_BINARY)" >&2; \
 		exit 1; \
 	}
-	@if otool -l Tools/compose-normalizer/compose-normalizer | grep -E '__DWARF|__debug' >/dev/null; then \
+	@if otool -l "$(GO_RELEASE_BINARY)" | grep -E '__DWARF|__debug' >/dev/null; then \
 		printf 'compose-normalizer contains DWARF debug sections; Homebrew packages require stripped release Go binaries\n' >&2; \
 		exit 1; \
 	fi
@@ -2366,6 +2425,11 @@ sonar-scan:
 
 package: package-release
 
+package-retained:
+	$(MAKE) stack-build STACK_CONFIGURATION=release
+	$(MAKE) package-built PACKAGE_BUILD_CONFIGURATION=release \
+		PACKAGE_RETAINED_RECEIPT="$(STACK_RETAINED_ROOT)/pins/release/container-compose.json"
+
 package-release: PACKAGE_BUILD_CONFIGURATION = release
 package-release: build-release go-build
 	$(MAKE) package-built PACKAGE_BUILD_CONFIGURATION="$(PACKAGE_BUILD_CONFIGURATION)"
@@ -2375,22 +2439,20 @@ package-debug: build go-build
 	$(MAKE) package-built PACKAGE_BUILD_CONFIGURATION="$(PACKAGE_BUILD_CONFIGURATION)"
 
 package-built:
-	$(MAKE) go-release-check
 	rm -rf "$(DIST_DIR)"
+
+ifneq ($(strip $(PACKAGE_RETAINED_RECEIPT)),)
+	$(PYTHON) "$(STACK_PIN_TOOL)" materialize \
+		--receipt "$(PACKAGE_RETAINED_RECEIPT)" --output "$(abspath $(DIST_DIR))"
+	$(MAKE) go-release-check \
+		GO_RELEASE_BINARY="$(abspath $(DIST_DIR))/compose/resources/compose-normalizer"
+else
+	$(MAKE) go-release-check
 	mkdir -p "$(DIST_DIR)/compose/bin" "$(DIST_DIR)/compose/resources"
 	cp ".build/$(PACKAGE_BUILD_CONFIGURATION)/compose" "$(DIST_DIR)/compose/bin/compose"
 	cp config.toml "$(DIST_DIR)/compose/config.toml"
 	cp Tools/compose-normalizer/compose-normalizer "$(DIST_DIR)/compose/resources/compose-normalizer"
 	cp "$(PLUGIN_ICON)" "$(DIST_DIR)/compose/resources/container-compose-icon.png"
-	$(CODESIGN) $(CODESIGN_OPTS) \
-		--identifier io.github.stephenlclarke.container-compose \
-		"$(DIST_DIR)/compose/bin/compose"
-	$(CODESIGN) $(CODESIGN_OPTS) \
-		--identifier io.github.stephenlclarke.container-compose.normalizer \
-		"$(DIST_DIR)/compose/resources/compose-normalizer"
-	$(CODESIGN) --verify --strict --verbose=2 "$(DIST_DIR)/compose/bin/compose"
-	$(CODESIGN) --verify --strict --verbose=2 \
-		"$(DIST_DIR)/compose/resources/compose-normalizer"
 	$(PYTHON) Tools/release/write-build-info.py \
 		--output "$(DIST_DIR)/compose/resources/build-info.json" \
 		--version "$(COMPOSE_VERSION)" \
@@ -2404,6 +2466,16 @@ package-built:
 		--containerization-source "$(CONTAINERIZATION_SOURCE)" \
 		--containerization-ref "$(CONTAINERIZATION_REF)" \
 		--compose-go-version "$(COMPOSE_GO_VERSION)"
+endif
+	$(CODESIGN) $(CODESIGN_OPTS) \
+		--identifier io.github.stephenlclarke.container-compose \
+		"$(DIST_DIR)/compose/bin/compose"
+	$(CODESIGN) $(CODESIGN_OPTS) \
+		--identifier io.github.stephenlclarke.container-compose.normalizer \
+		"$(DIST_DIR)/compose/resources/compose-normalizer"
+	$(CODESIGN) --verify --strict --verbose=2 "$(DIST_DIR)/compose/bin/compose"
+	$(CODESIGN) --verify --strict --verbose=2 \
+		"$(DIST_DIR)/compose/resources/compose-normalizer"
 	tar -czf "$(PLUGIN_ARCHIVE)" -C "$(DIST_DIR)" compose
 	tar -tzf "$(PLUGIN_ARCHIVE)" | grep -Fx 'compose/resources/container-compose-icon.png' >/dev/null
 	$(PYTHON) Tools/release/write-sha256-sidecar.py "$(PLUGIN_ARCHIVE)"

--- a/Makefile
+++ b/Makefile
@@ -241,8 +241,7 @@ STACK_COMPOSE_PIN := $(STACK_PIN_DIR)/container-compose.json
 STACK_BUNDLE := $(STACK_PIN_DIR)/stack.json
 STACK_SWIFT ?= /usr/bin/swift
 STACK_GO ?= $(GO)
-ifeq ($(origin STACK_SWIFT_CONTRACT),undefined)
-STACK_SWIFT_CONTRACT := $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
+STACK_SWIFT_CONTRACT = $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--tool $(call SHELL_QUOTE,$(STACK_SWIFT)) \
 	--configuration $(call SHELL_QUOTE,$(STACK_CONFIGURATION)) \
 	--controller "$(STACK_BUILD_CONTRACT)" --controller "$(STACK_PIN_TOOL)" \
@@ -250,23 +249,18 @@ STACK_SWIFT_CONTRACT := $(shell "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--controller "$(STACK_DEADLINE_TOOL)" --controller "$(STACK_SWIFT_STACK_TOOL)" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK CONFIGURATION::END RECOVERABLE STACK CONFIGURATION" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK TARGETS::END RECOVERABLE STACK TARGETS")
-endif
-ifeq ($(origin STACK_GO_CONTRACT),undefined)
-STACK_GO_CONTRACT := $(shell GOWORK=off "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
+STACK_GO_CONTRACT = $(shell GOWORK=off "$(PYTHON)" "$(STACK_PIN_TOOL)" contract \
 	--tool $(call SHELL_QUOTE,$(STACK_GO)) \
 	--configuration $(call SHELL_QUOTE,$(STACK_CONFIGURATION)) \
 	--controller "$(STACK_BUILD_CONTRACT)" --controller "$(STACK_PIN_TOOL)" \
 	--controller "$(STACK_DEADLINE_TOOL)" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK CONFIGURATION::END RECOVERABLE STACK CONFIGURATION" \
 	--controller-section "$(abspath Makefile)::BEGIN RECOVERABLE STACK TARGETS::END RECOVERABLE STACK TARGETS")
-endif
-ifeq ($(origin STACK_COMPOSE_CONTRACT),undefined)
-STACK_COMPOSE_CONTRACT := $(shell { printf 'swift=%s\ngo=%s\nprofile=%s\n' \
+STACK_COMPOSE_CONTRACT = $(shell { printf 'swift=%s\ngo=%s\nprofile=%s\n' \
 	$(call SHELL_QUOTE,$(STACK_SWIFT_CONTRACT)) $(call SHELL_QUOTE,$(STACK_GO_CONTRACT)) \
 	$(call SHELL_QUOTE,$(CONTAINER_COMPOSE_BUILD_PROFILE)); \
 	shasum -a 256 config.toml "$(PLUGIN_ICON)" Tools/release/runtime-capabilities.json; \
 	} | shasum -a 256 | awk '{print $$1}')
-endif
 # END RECOVERABLE STACK CONFIGURATION
 RELEASE_GATE_CHECKPOINT_DIR = $(if $(CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR),$(CONTAINER_STACK_VALIDATION_CHECKPOINT_DIR)/compose-release-gate,)
 PARITY_GATE_CHECKPOINT_DIR = $(if $(RELEASE_GATE_CHECKPOINT_DIR),$(RELEASE_GATE_CHECKPOINT_DIR)/parity,)
@@ -465,9 +459,6 @@ stack-preflight: stack-state-init
 			exit 2; \
 		fi; \
 	done; \
-	for contract in "$(STACK_SWIFT_CONTRACT)" "$(STACK_GO_CONTRACT)"; do \
-		[[ "$$contract" =~ ^[0-9a-f]{64}$$ ]] || { printf 'could not establish an exact build contract\n' >&2; exit 2; }; \
-	done; \
 	for timeout in "$(STACK_BUILD_STAGE_TIMEOUT_SECONDS)" "$(STACK_BUILD_TIMEOUT_SECONDS)"; do \
 		awk 'BEGIN { exit !(ARGV[1] + 0 > 0) }' "$$timeout" || { \
 			printf 'stack build timeouts must be greater than zero: %s\n' "$$timeout" >&2; \
@@ -529,7 +520,16 @@ stack-transient-clean:
 	fi
 
 stack-build: stack-preflight
-	@timing_log="$(STACK_TIMING_ROOT)/$$(date -u +%Y%m%dT%H%M%SZ)-$$$$.jsonl"; \
+	@swift_contract="$(STACK_SWIFT_CONTRACT)"; \
+	go_contract="$(STACK_GO_CONTRACT)"; \
+	for contract in "$$swift_contract" "$$go_contract"; do \
+		[[ "$$contract" =~ ^[0-9a-f]{64}$$ ]] || { printf 'could not establish an exact build contract\n' >&2; exit 2; }; \
+	done; \
+	compose_contract="$$( { printf 'swift=%s\ngo=%s\nprofile=%s\n' \
+		"$$swift_contract" "$$go_contract" "$(CONTAINER_COMPOSE_BUILD_PROFILE)"; \
+		shasum -a 256 config.toml "$(PLUGIN_ICON)" Tools/release/runtime-capabilities.json; \
+	} | shasum -a 256 | awk '{print $$1}')"; \
+	timing_log="$(STACK_TIMING_ROOT)/$$(date -u +%Y%m%dT%H%M%SZ)-$$$$.jsonl"; \
 	TMPDIR="$(STACK_PROCESS_TEMP_ROOT)" TMP="$(STACK_PROCESS_TEMP_ROOT)" \
 	TEMP="$(STACK_PROCESS_TEMP_ROOT)" GOTMPDIR="$(STACK_PROCESS_TEMP_ROOT)" \
 	"$(PYTHON)" "$(STACK_DEADLINE_TOOL)" --seconds "$(STACK_BUILD_TIMEOUT_SECONDS)" \
@@ -537,6 +537,8 @@ stack-build: stack-preflight
 		"$(STACK_LOCK_TOOL)" -t 0 "$(STACK_LOCK_ROOT)/stack-build.lock" \
 		$(MAKE) --no-print-directory stack-build-locked STACK_LOCK_HELD=1 \
 			STACK_RETAINED_ROOT="$(STACK_RETAINED_ROOT)" STACK_TRANSIENT_ROOT="$(STACK_TRANSIENT_ROOT)" STACK_SOURCE_ROOT="$(STACK_SOURCE_ROOT)" \
+			STACK_SWIFT_CONTRACT="$$swift_contract" STACK_GO_CONTRACT="$$go_contract" \
+			STACK_COMPOSE_CONTRACT="$$compose_contract" \
 			STACK_TIMING_LOG="$$timing_log"; \
 	exit_status=$$?; \
 	printf 'Stack timing evidence: %s\n' "$$timing_log"; \

--- a/Makefile
+++ b/Makefile
@@ -475,7 +475,7 @@ stack-status:
 		"container-engine-api|$(CONTAINER_ENGINE_API_STACK_REPO)|$(STACK_ENGINE_API_PIN)|$(STACK_SWIFT_CONTRACT)" \
 		"container|$(CONTAINER_STACK_REPO)|$(STACK_CONTAINER_PIN)|$(STACK_SWIFT_CONTRACT)" \
 		"container-builder-shim|$(CONTAINER_BUILDER_SHIM_STACK_REPO)|$(STACK_BUILDER_PIN)|$(STACK_GO_CONTRACT)" \
-		"container-compose|$(CURDIR)|$(STACK_COMPOSE_PIN)|$(STACK_SWIFT_CONTRACT)"; do \
+		"container-compose|$(CURDIR)|$(STACK_COMPOSE_PIN)|$(STACK_COMPOSE_CONTRACT)"; do \
 		IFS='|' read -r repository source receipt contract <<<"$$specification"; \
 		if "$(PYTHON)" "$(STACK_PIN_TOOL)" verify --quiet --receipt "$$receipt" \
 			--repository "$$repository" --repository-path "$$source" \

--- a/README.md
+++ b/README.md
@@ -220,7 +220,13 @@ stack, automatically consumes exact upstream pins, and retains recoverable
 native caches and timing evidence. Use `make local-build` for a quick
 Compose-only build, `make stack-status` to verify retained pins, and
 `make release-version` to preview the Conventional Commit semantic-version
-decision. The complete build, test, Actions, recovery, and release diagrams are
+decision. Transient workspaces and build scratch live on `/Volumes/SSD`; verified
+artifacts, receipts, and reusable evidence live under
+`~/Library/Application Support/ContainerFamily/retained` and survive transient
+cleanup. Use `make release-status VERSION=X.Y.Z` or
+`make release-recovery-plan VERSION=X.Y.Z` to inspect recovery state without
+building, dispatching, or changing a published release. The complete build,
+test, Actions, recovery, and release diagrams are
 in [Recoverable Container-family builds](docs/architecture/recoverable-container-family-builds.md).
 
 ## Plugin Recognition

--- a/Tools/build/stack-artifact.py
+++ b/Tools/build/stack-artifact.py
@@ -80,39 +80,65 @@ def validate_name(name: str) -> None:
         raise ArtifactError(f"artifact name must be one safe path component: {name!r}")
 
 
+def reject_symlink_components(path: Path) -> None:
+    """Reject every existing symbolic-link component in an absolute path."""
+    current = Path(path.anchor)
+    for component in path.parts[1:]:
+        current /= component
+        try:
+            status = current.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(status.st_mode):
+            raise ArtifactError(f"artifact path contains a symbolic link: {current}")
+
+
 def resolve_root(root: Path) -> Path:
     if not root.is_absolute():
         raise ArtifactError(f"retained artifact root must be absolute: {root}")
-    if root.is_symlink():
-        raise ArtifactError(f"retained artifact root must not be a symbolic link: {root}")
+    normalized = Path(os.path.abspath(root))
+    reject_symlink_components(normalized)
     root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    reject_symlink_components(normalized)
     resolved = root.resolve(strict=True)
-    if resolved == Path("/"):
+    if resolved == Path("/") or resolved != normalized:
         raise ArtifactError("retained artifact root must not be /")
     return resolved
 
 
 def promote(source: Path, root: Path, name: str) -> Path:
     validate_name(name)
-    if not source.is_absolute() or source.is_symlink():
+    if not source.is_absolute():
         raise ArtifactError(f"source artifact must be an absolute regular file: {source}")
-    resolved_source = source.resolve(strict=True)
-    source_status = resolved_source.stat(follow_symlinks=False)
+    source_flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    try:
+        source_descriptor = os.open(source, source_flags)
+    except OSError as error:
+        raise ArtifactError(
+            f"source artifact must be an absolute regular file: {source}"
+        ) from error
+    source_status = os.fstat(source_descriptor)
     if not stat.S_ISREG(source_status.st_mode):
+        os.close(source_descriptor)
         raise ArtifactError(f"source artifact is not a regular file: {source}")
 
     resolved_root = resolve_root(root)
     incoming = resolved_root / "incoming"
     objects = resolved_root / "objects" / "sha256"
+    reject_symlink_components(incoming)
+    reject_symlink_components(objects)
     incoming.mkdir(mode=0o700, exist_ok=True)
     objects.mkdir(mode=0o700, parents=True, exist_ok=True)
+    reject_symlink_components(incoming)
+    reject_symlink_components(objects)
     descriptor, temporary_name = tempfile.mkstemp(prefix=".promote-", dir=incoming)
     temporary = Path(temporary_name)
     try:
         with (
-            resolved_source.open("rb") as source_stream,
+            os.fdopen(source_descriptor, "rb") as source_stream,
             os.fdopen(descriptor, "wb") as destination_stream,
         ):
+            source_descriptor = -1
             descriptor = -1
             digest = copy_and_digest(source_stream, destination_stream)
             destination_stream.flush()
@@ -121,6 +147,7 @@ def promote(source: Path, root: Path, name: str) -> Path:
         temporary.chmod(retained_mode)
         destination_directory = objects / digest[:2] / digest
         destination_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        reject_symlink_components(destination_directory)
         destination = destination_directory / name
         if destination.exists():
             if destination.is_symlink() or digest_file(destination) != digest:
@@ -152,6 +179,8 @@ def promote(source: Path, root: Path, name: str) -> Path:
                     os.close(directory)
         return destination
     finally:
+        if source_descriptor >= 0:
+            os.close(source_descriptor)
         if descriptor >= 0:
             os.close(descriptor)
         temporary.unlink(missing_ok=True)

--- a/Tools/build/stack-artifact.py
+++ b/Tools/build/stack-artifact.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Atomically promote completed build products into retained local storage."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import shutil
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from typing import BinaryIO
+
+
+class ArtifactError(RuntimeError):
+    """A candidate artifact or retained-store operation is unsafe."""
+
+
+def parse_arguments(arguments: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--name", required=True)
+    return parser.parse_args(arguments)
+
+
+def copy_and_digest(source: BinaryIO, destination: BinaryIO) -> str:
+    digest = hashlib.sha256()
+    for chunk in iter(lambda: source.read(1024 * 1024), b""):
+        digest.update(chunk)
+        destination.write(chunk)
+    return digest.hexdigest()
+
+
+def digest_file(path: Path) -> str:
+    flags = os.O_RDONLY
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    descriptor = os.open(path, flags)
+    digest = hashlib.sha256()
+    try:
+        if not stat.S_ISREG(os.fstat(descriptor).st_mode):
+            raise ArtifactError(f"artifact is not a regular file: {path}")
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return digest.hexdigest()
+
+
+def validate_name(name: str) -> None:
+    if (
+        not name
+        or name in {".", ".."}
+        or "/" in name
+        or "\0" in name
+        or Path(name).name != name
+    ):
+        raise ArtifactError(f"artifact name must be one safe path component: {name!r}")
+
+
+def resolve_root(root: Path) -> Path:
+    if not root.is_absolute():
+        raise ArtifactError(f"retained artifact root must be absolute: {root}")
+    if root.is_symlink():
+        raise ArtifactError(f"retained artifact root must not be a symbolic link: {root}")
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    resolved = root.resolve(strict=True)
+    if resolved == Path("/"):
+        raise ArtifactError("retained artifact root must not be /")
+    return resolved
+
+
+def promote(source: Path, root: Path, name: str) -> Path:
+    validate_name(name)
+    if not source.is_absolute() or source.is_symlink():
+        raise ArtifactError(f"source artifact must be an absolute regular file: {source}")
+    resolved_source = source.resolve(strict=True)
+    source_status = resolved_source.stat(follow_symlinks=False)
+    if not stat.S_ISREG(source_status.st_mode):
+        raise ArtifactError(f"source artifact is not a regular file: {source}")
+
+    resolved_root = resolve_root(root)
+    incoming = resolved_root / "incoming"
+    objects = resolved_root / "objects" / "sha256"
+    incoming.mkdir(mode=0o700, exist_ok=True)
+    objects.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(prefix=".promote-", dir=incoming)
+    temporary = Path(temporary_name)
+    try:
+        with (
+            resolved_source.open("rb") as source_stream,
+            os.fdopen(descriptor, "wb") as destination_stream,
+        ):
+            descriptor = -1
+            digest = copy_and_digest(source_stream, destination_stream)
+            destination_stream.flush()
+            os.fsync(destination_stream.fileno())
+        retained_mode = stat.S_IMODE(source_status.st_mode) & ~0o222
+        temporary.chmod(retained_mode)
+        destination_directory = objects / digest[:2] / digest
+        destination_directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        destination = destination_directory / name
+        if destination.exists():
+            if destination.is_symlink() or digest_file(destination) != digest:
+                raise ArtifactError(f"retained artifact conflicts with {destination}")
+            if stat.S_IMODE(destination.stat(follow_symlinks=False).st_mode) != retained_mode:
+                raise ArtifactError(f"retained artifact mode conflicts with {destination}")
+        else:
+            try:
+                # A hard-link install is an atomic no-clobber operation. Two
+                # publishers may race, but neither can replace retained bytes.
+                os.link(temporary, destination, follow_symlinks=False)
+            except FileExistsError:
+                if destination.is_symlink() or digest_file(destination) != digest:
+                    raise ArtifactError(
+                        f"retained artifact conflicts with {destination}"
+                    )
+                if (
+                    stat.S_IMODE(destination.stat(follow_symlinks=False).st_mode)
+                    != retained_mode
+                ):
+                    raise ArtifactError(
+                        f"retained artifact mode conflicts with {destination}"
+                    )
+            else:
+                directory = os.open(destination_directory, os.O_RDONLY)
+                try:
+                    os.fsync(directory)
+                finally:
+                    os.close(directory)
+        return destination
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        temporary.unlink(missing_ok=True)
+
+
+def main(arguments: list[str] | None = None) -> int:
+    options = parse_arguments(arguments if arguments is not None else sys.argv[1:])
+    try:
+        destination = promote(options.source, options.root, options.name)
+    except (ArtifactError, OSError, shutil.Error) as error:
+        print(f"stack-artifact: {error}", file=sys.stderr)
+        return 2
+    print(destination)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/build/stack-pin.py
+++ b/Tools/build/stack-pin.py
@@ -88,18 +88,31 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
     create.add_argument("--repository-path", type=Path, required=True)
     create.add_argument("--output", type=Path, required=True)
     create.add_argument("--artifact", type=Path, action="append", default=[])
+    create.add_argument(
+        "--artifact-map",
+        action="append",
+        default=[],
+        metavar="LOGICAL_PATH=FILE",
+        help="retain a file under a package-relative logical path",
+    )
     create.add_argument("--dependency", type=Path, action="append", default=[])
     create.add_argument("--command-label", required=True)
     create.add_argument("--build-contract", required=True)
     create.add_argument("--duration-seconds", type=float, required=True)
     create.add_argument("--expected-commit", required=True)
     create.add_argument("--expected-tree", required=True)
+    create.add_argument("--index-root", type=Path)
 
     verify = subparsers.add_parser("verify")
     verify.add_argument("--receipt", type=Path, required=True)
     verify.add_argument("--repository")
     verify.add_argument("--repository-path", type=Path)
     verify.add_argument("--build-contract")
+    verify.add_argument(
+        "--retained-only",
+        action="store_true",
+        help="verify retained receipts and artifacts without requiring source checkouts",
+    )
     verify.add_argument("--quiet", action="store_true")
 
     value = subparsers.add_parser("value")
@@ -114,6 +127,18 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
     verify_bundle_parser.add_argument("--bundle", type=Path, required=True)
     verify_bundle_parser.add_argument("--repository", action="append", default=[])
     verify_bundle_parser.add_argument("--quiet", action="store_true")
+
+    materialize = subparsers.add_parser("materialize")
+    materialize.add_argument("--receipt", type=Path, required=True)
+    materialize.add_argument("--output", type=Path, required=True)
+
+    lookup = subparsers.add_parser("lookup")
+    lookup.add_argument("--repository", required=True)
+    lookup.add_argument("--repository-path", type=Path, required=True)
+    lookup.add_argument("--build-contract", required=True)
+    lookup.add_argument("--dependency", type=Path, action="append", default=[])
+    lookup.add_argument("--index-root", type=Path, required=True)
+    lookup.add_argument("--output", type=Path, required=True)
 
     contract = subparsers.add_parser("contract")
     contract.add_argument("--tool", required=True)
@@ -175,6 +200,20 @@ def payload_digest(payload: dict[str, Any]) -> str:
     unsigned = dict(payload)
     unsigned.pop("receipt_sha256", None)
     return sha256_bytes(canonical_json(unsigned))
+
+
+def output_manifest_digest(artifacts: list[dict[str, Any]]) -> str:
+    """Return location-independent identity for a retained product closure."""
+    members = [
+        {
+            "mode": artifact["mode"],
+            "name": artifact["name"],
+            "sha256": artifact["sha256"],
+            "size": artifact["size"],
+        }
+        for artifact in artifacts
+    ]
+    return sha256_bytes(canonical_json({"members": members, "schema": 1}))
 
 
 def git_output(repository_path: Path, *arguments: str) -> str:
@@ -498,17 +537,20 @@ def verify_artifacts(receipt: dict[str, Any]) -> None:
     artifacts = receipt.get("artifacts")
     if not isinstance(artifacts, list) or not artifacts:
         raise PinError("build receipt has no artifacts")
-    recorded_paths: list[str] = []
+    recorded_names: list[str] = []
     for artifact in artifacts:
         if not isinstance(artifact, dict):
             raise PinError("build receipt has a malformed artifact")
         path_value = artifact.get("path")
         if not isinstance(path_value, str):
             raise PinError("build receipt artifact has no path")
-        recorded_paths.append(path_value)
+        recorded_names.append(
+            validate_logical_path(str(artifact.get("name", Path(path_value).name)))
+        )
         path = Path(path_value)
         expected = validate_digest(artifact.get("sha256"), f"artifact {path} digest")
         expected_mode = artifact.get("mode")
+        expected_size = artifact.get("size")
         if (
             isinstance(expected_mode, bool)
             or not isinstance(expected_mode, int)
@@ -516,6 +558,12 @@ def verify_artifacts(receipt: dict[str, Any]) -> None:
             or expected_mode > 0o7777
         ):
             raise PinError(f"artifact {path} has an invalid file mode")
+        if expected_size is not None and (
+            isinstance(expected_size, bool)
+            or not isinstance(expected_size, int)
+            or expected_size < 0
+        ):
+            raise PinError(f"artifact {path} has an invalid size")
         try:
             actual = sha256_file(path)
             actual_mode = stat.S_IMODE(path.stat(follow_symlinks=False).st_mode)
@@ -530,8 +578,10 @@ def verify_artifacts(receipt: dict[str, Any]) -> None:
                 f"build artifact mode changed: {path} "
                 f"(expected {expected_mode:#o}, got {actual_mode:#o})"
             )
-    if recorded_paths != sorted(set(recorded_paths)):
-        raise PinError("build receipt artifact paths are duplicated or not canonical")
+        if expected_size is not None and path.stat(follow_symlinks=False).st_size != expected_size:
+            raise PinError(f"build artifact size changed: {path}")
+    if recorded_names != sorted(set(recorded_names)):
+        raise PinError("build receipt artifact names are duplicated or not canonical")
 
 
 def verify_receipt(
@@ -539,6 +589,7 @@ def verify_receipt(
     expected_repository: str | None = None,
     expected_path: Path | None = None,
     expected_build_contract: str | None = None,
+    verify_source: bool = True,
     seen: set[Path] | None = None,
 ) -> dict[str, Any]:
     if path.is_symlink():
@@ -614,27 +665,29 @@ def verify_receipt(
         # A clean checkout may be recreated elsewhere after external workspace
         # cleanup. When a caller supplies its current path, validate that exact
         # repository against the recorded commit/tree/origin.
-        source_path = expected_path if expected_path is not None else Path(source["path"])
-        current_source = repository_record(source_path)
         for field in ("commit", "tree"):
             recorded = source.get(field)
             if not isinstance(recorded, str) or not OBJECT_ID_PATTERN.fullmatch(recorded):
                 raise PinError(
                     f"build pin has an invalid source {field}: {resolved_receipt}"
                 )
-            if current_source[field] != recorded:
-                raise PinError(
-                    f"{repository} {field} changed: expected {recorded}, "
-                    f"got {current_source[field]}"
-                )
         recorded_remote = source.get("remote")
         if not isinstance(recorded_remote, str):
             raise PinError(f"build pin has no source remote: {resolved_receipt}")
-        if current_source["remote"] != recorded_remote:
-            raise PinError(
-                f"{repository} remote changed: expected {recorded_remote!r}, "
-                f"got {current_source['remote']!r}"
-            )
+        if verify_source:
+            source_path = expected_path if expected_path is not None else Path(source["path"])
+            current_source = repository_record(source_path)
+            for field in ("commit", "tree"):
+                if current_source[field] != source[field]:
+                    raise PinError(
+                        f"{repository} {field} changed: expected {source[field]}, "
+                        f"got {current_source[field]}"
+                    )
+            if current_source["remote"] != recorded_remote:
+                raise PinError(
+                    f"{repository} remote changed: expected {recorded_remote!r}, "
+                    f"got {current_source['remote']!r}"
+                )
         dependencies = receipt.get("dependencies")
         if not isinstance(dependencies, list):
             raise PinError(f"build pin has malformed dependencies: {resolved_receipt}")
@@ -647,6 +700,11 @@ def verify_receipt(
             dependency_digest = validate_digest(
                 dependency.get("receipt_sha256"), "dependency receipt digest"
             )
+            dependency_output_digest = dependency.get("output_manifest_digest")
+            if dependency_output_digest is not None:
+                dependency_output_digest = validate_digest(
+                    dependency_output_digest, "dependency output manifest digest"
+                )
             if not isinstance(dependency_path, str) or not isinstance(
                 dependency_name, str
             ):
@@ -656,11 +714,23 @@ def verify_receipt(
             verified = verify_receipt(
                 Path(dependency_path),
                 expected_repository=dependency_name,
+                verify_source=False,
                 seen=seen,
             )
-            if verified["receipt_sha256"] != dependency_digest:
+            if (
+                dependency_output_digest is None
+                and verified["receipt_sha256"] != dependency_digest
+            ):
                 raise PinError(
                     f"dependency pin changed for {dependency_name}: "
+                    f"{dependency_path}"
+                )
+            if (
+                dependency_output_digest is not None
+                and verified.get("output_manifest_digest") != dependency_output_digest
+            ):
+                raise PinError(
+                    f"dependency output changed for {dependency_name}: "
                     f"{dependency_path}"
                 )
         if dependency_names != sorted(set(dependency_names)):
@@ -668,6 +738,13 @@ def verify_receipt(
                 f"build pin dependencies are duplicated or not canonical: {resolved_receipt}"
             )
         verify_artifacts(receipt)
+        recorded_output_digest = receipt.get("output_manifest_digest")
+        if recorded_output_digest is not None:
+            recorded_output_digest = validate_digest(
+                recorded_output_digest, f"receipt {resolved_receipt} output manifest"
+            )
+            if recorded_output_digest != output_manifest_digest(receipt["artifacts"]):
+                raise PinError(f"build pin output manifest changed: {resolved_receipt}")
         return receipt
     finally:
         seen.remove(resolved_receipt)
@@ -676,20 +753,48 @@ def verify_receipt(
 def dependency_record(path: Path) -> dict[str, str]:
     receipt = verify_receipt(path)
     return {
+        "output_manifest_digest": receipt.get(
+            "output_manifest_digest", output_manifest_digest(receipt["artifacts"])
+        ),
         "receipt": str(path.resolve(strict=True)),
         "receipt_sha256": receipt["receipt_sha256"],
         "repository": receipt["repository"],
     }
 
 
-def artifact_record(path: Path) -> dict[str, str | int]:
+def validate_logical_path(value: str) -> str:
+    path = Path(value)
+    if (
+        not value
+        or path.is_absolute()
+        or ".." in path.parts
+        or any(component in {"", "."} for component in path.parts)
+    ):
+        raise PinError(f"invalid artifact logical path: {value!r}")
+    return path.as_posix()
+
+
+def artifact_record(path: Path, logical_path: str | None = None) -> dict[str, str | int]:
     if not path.is_absolute():
         raise PinError(f"artifact path must be absolute: {path}")
     if path.is_symlink():
         raise PinError(f"artifact path must not be a symbolic link: {path}")
     resolved = path.resolve(strict=True)
     mode = stat.S_IMODE(resolved.stat(follow_symlinks=False).st_mode)
-    return {"mode": mode, "path": str(resolved), "sha256": sha256_file(resolved)}
+    return {
+        "mode": mode,
+        "name": validate_logical_path(logical_path or resolved.name),
+        "path": str(resolved),
+        "sha256": sha256_file(resolved),
+        "size": resolved.stat(follow_symlinks=False).st_size,
+    }
+
+
+def mapped_artifact(value: str) -> tuple[str, Path]:
+    logical, separator, source = value.partition("=")
+    if not separator or not source:
+        raise PinError(f"artifact map must be LOGICAL_PATH=FILE: {value!r}")
+    return validate_logical_path(logical), Path(source)
 
 
 def write_json_atomically(path: Path, value: dict[str, Any]) -> None:
@@ -718,6 +823,35 @@ def write_json_atomically(path: Path, value: dict[str, Any]) -> None:
         temporary_path.unlink(missing_ok=True)
 
 
+def receipt_input_key(
+    repository: str,
+    source: dict[str, str],
+    build_contract: str,
+    dependencies: list[dict[str, str]],
+) -> str:
+    semantic_dependencies = [
+        {
+            "repository": dependency["repository"],
+            "output_manifest_digest": dependency["output_manifest_digest"],
+        }
+        for dependency in dependencies
+    ]
+    return sha256_bytes(
+        canonical_json(
+            {
+                "build_contract": validate_digest(build_contract, "build contract"),
+                "dependencies": semantic_dependencies,
+                "repository": validate_repository_name(repository),
+                "source": {
+                    "commit": source["commit"],
+                    "remote": source["remote"],
+                    "tree": source["tree"],
+                },
+            }
+        )
+    )
+
+
 def create_receipt(options: argparse.Namespace) -> dict[str, Any]:
     repository = validate_repository_name(options.repository)
     source = repository_record(options.repository_path)
@@ -732,18 +866,20 @@ def create_receipt(options: argparse.Namespace) -> dict[str, Any]:
                 f"{repository} {field} changed while the build ran: "
                 f"expected {expected}, got {source[field]}"
             )
-    if not options.artifact:
+    if not options.artifact and not options.artifact_map:
         raise PinError("at least one --artifact is required")
     if not math.isfinite(options.duration_seconds) or options.duration_seconds < 0:
         raise PinError("build duration must be finite and non-negative")
     if not options.command_label.strip():
         raise PinError("build command label must not be empty")
-    artifacts = sorted(
-        (artifact_record(path) for path in options.artifact),
-        key=lambda record: record["path"],
+    artifacts = [artifact_record(path) for path in options.artifact]
+    artifacts.extend(
+        artifact_record(source, logical)
+        for logical, source in (mapped_artifact(value) for value in options.artifact_map)
     )
-    if len({artifact["path"] for artifact in artifacts}) != len(artifacts):
-        raise PinError("build receipt contains duplicate artifact paths")
+    artifacts.sort(key=lambda record: str(record["name"]))
+    if len({artifact["name"] for artifact in artifacts}) != len(artifacts):
+        raise PinError("build receipt contains duplicate artifact logical paths")
     dependencies = sorted(
         (dependency_record(path) for path in options.dependency),
         key=lambda record: record["repository"],
@@ -765,7 +901,44 @@ def create_receipt(options: argparse.Namespace) -> dict[str, Any]:
         "schema": SCHEMA_VERSION,
         "source": source,
     }
+    receipt["output_manifest_digest"] = output_manifest_digest(artifacts)
     receipt["receipt_sha256"] = payload_digest(receipt)
+    write_json_atomically(options.output, receipt)
+    if options.index_root is not None:
+        if not options.index_root.is_absolute() or options.index_root == Path("/"):
+            raise PinError(f"unsafe build pin index: {options.index_root}")
+        input_key = receipt_input_key(
+            repository, source, receipt["build"]["contract"], dependencies
+        )
+        indexed = options.index_root / repository / f"{input_key}.json"
+        if indexed.exists():
+            existing = verify_receipt(indexed, verify_source=False)
+            if existing["receipt_sha256"] != receipt["receipt_sha256"]:
+                # Attempt metadata may differ while the same semantic input is
+                # rebuilt. Preserve the first valid result as the reusable one.
+                return receipt
+        else:
+            write_json_atomically(indexed, receipt)
+    return receipt
+
+
+def lookup_receipt(options: argparse.Namespace) -> dict[str, Any]:
+    repository = validate_repository_name(options.repository)
+    source = repository_record(options.repository_path)
+    dependencies = sorted(
+        (dependency_record(path) for path in options.dependency),
+        key=lambda record: record["repository"],
+    )
+    input_key = receipt_input_key(
+        repository, source, options.build_contract, dependencies
+    )
+    indexed = options.index_root / repository / f"{input_key}.json"
+    receipt = verify_receipt(
+        indexed,
+        expected_repository=repository,
+        expected_path=options.repository_path,
+        expected_build_contract=options.build_contract,
+    )
     write_json_atomically(options.output, receipt)
     return receipt
 
@@ -822,7 +995,7 @@ def verify_bundle(
             raise PinError(f"stack pin bundle contains duplicate pin: {repository}")
         repositories.add(repository)
         receipt = verify_receipt(
-            Path(receipt_path), expected_repository=repository
+            Path(receipt_path), expected_repository=repository, verify_source=False
         )
         if receipt["receipt_sha256"] != recorded_digest:
             raise PinError(f"bundled receipt changed for {repository}: {receipt_path}")
@@ -848,6 +1021,31 @@ def receipt_value(receipt: dict[str, Any], field: str) -> object:
     return value
 
 
+def materialize_receipt(receipt_path: Path, output: Path) -> None:
+    receipt = verify_receipt(receipt_path, verify_source=False)
+    if not output.is_absolute() or output == Path("/") or output.is_symlink():
+        raise PinError(f"unsafe materialization output: {output}")
+    if output.exists() and any(output.iterdir()):
+        raise PinError(f"materialization output is not empty: {output}")
+    output.mkdir(parents=True, exist_ok=True, mode=0o700)
+    resolved_output = output.resolve(strict=True)
+    if resolved_output != Path(os.path.abspath(output)):
+        raise PinError(f"materialization output contains a symbolic link: {output}")
+    for artifact in receipt["artifacts"]:
+        logical = validate_logical_path(str(artifact.get("name", Path(artifact["path"]).name)))
+        destination = resolved_output / logical
+        destination.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if destination.parent.resolve(strict=True) != destination.parent:
+            raise PinError(f"materialization path contains a symbolic link: {destination}")
+        shutil.copyfile(Path(artifact["path"]), destination, follow_symlinks=False)
+        if sha256_file(destination) != artifact["sha256"]:
+            raise PinError(f"materialized artifact changed: {logical}")
+        # The retained object is immutable. A materialization is a transient
+        # staging copy which must remain writable for operations such as code
+        # signing without ever mutating the shared retained object.
+        os.chmod(destination, int(artifact["mode"]) | stat.S_IWUSR)
+
+
 def main(arguments: Sequence[str] | None = None) -> int:
     options = parse_arguments(sys.argv[1:] if arguments is None else arguments)
     try:
@@ -860,11 +1058,12 @@ def main(arguments: Sequence[str] | None = None) -> int:
                 expected_repository=options.repository,
                 expected_path=options.repository_path,
                 expected_build_contract=options.build_contract,
+                verify_source=not options.retained_only,
             )
             if not options.quiet:
                 print(receipt["receipt_sha256"])
         elif options.action == "value":
-            receipt = verify_receipt(options.receipt)
+            receipt = verify_receipt(options.receipt, verify_source=False)
             print(receipt_value(receipt, options.field))
         elif options.action == "bundle":
             bundle = create_bundle(options)
@@ -875,6 +1074,11 @@ def main(arguments: Sequence[str] | None = None) -> int:
                 print(bundle["receipt_sha256"])
         elif options.action == "contract":
             print(build_contract(options))
+        elif options.action == "materialize":
+            materialize_receipt(options.receipt, options.output)
+        elif options.action == "lookup":
+            receipt = lookup_receipt(options)
+            print(receipt["receipt_sha256"])
         else:  # pragma: no cover - argparse enforces the action.
             raise AssertionError(options.action)
     except (OSError, PinError) as error:

--- a/Tools/build/stack-pin.py
+++ b/Tools/build/stack-pin.py
@@ -610,15 +610,12 @@ def verify_receipt(
         source = receipt.get("source")
         if not isinstance(source, dict) or not isinstance(source.get("path"), str):
             raise PinError(f"build pin has no source path: {resolved_receipt}")
-        source_path = Path(source["path"])
+        # The recorded path is build-time audit evidence, not artifact identity.
+        # A clean checkout may be recreated elsewhere after external workspace
+        # cleanup. When a caller supplies its current path, validate that exact
+        # repository against the recorded commit/tree/origin.
+        source_path = expected_path if expected_path is not None else Path(source["path"])
         current_source = repository_record(source_path)
-        if expected_path is not None and current_source["path"] != str(
-            expected_path.resolve(strict=True)
-        ):
-            raise PinError(
-                f"build pin source is {current_source['path']}, expected "
-                f"{expected_path.resolve(strict=True)}"
-            )
         for field in ("commit", "tree"):
             recorded = source.get(field)
             if not isinstance(recorded, str) or not OBJECT_ID_PATTERN.fullmatch(recorded):

--- a/Tools/build/stack-storage.py
+++ b/Tools/build/stack-storage.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Initialize and validate retained/internal and transient/external roots."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+import tempfile
+from pathlib import Path
+
+
+class StorageError(RuntimeError):
+    """A storage role or path cannot be proved safe."""
+
+
+def normalized(path: Path) -> Path:
+    if not path.is_absolute():
+        raise StorageError(f"stack storage path must be absolute: {path}")
+    value = Path(os.path.abspath(path))
+    if value == Path("/"):
+        raise StorageError("stack storage path must not be /")
+    current = Path(value.anchor)
+    for component in value.parts[1:]:
+        current /= component
+        try:
+            status = current.lstat()
+        except FileNotFoundError:
+            continue
+        if stat.S_ISLNK(status.st_mode):
+            raise StorageError(f"stack storage path contains a symbolic link: {current}")
+    return value
+
+
+def inside(path: Path, root: Path) -> bool:
+    return path == root or root in path.parents
+
+
+def existing_device(path: Path) -> int:
+    current = path
+    while not current.exists():
+        current = current.parent
+    return current.stat().st_dev
+
+
+def preflight_root(path: Path, marker_name: str, marker_value: str) -> None:
+    normalized(path)
+    if path.exists() and not path.is_dir():
+        raise StorageError(f"stack storage root is not a directory: {path}")
+    if path.exists():
+        marker = path / marker_name
+        entries = list(path.iterdir())
+        if entries and not marker.is_file():
+            raise StorageError(f"refusing to claim non-empty unmarked stack storage root: {path}")
+        if marker.exists() and marker.read_text(encoding="utf-8") != marker_value + "\n":
+            raise StorageError(f"stack storage root has an unexpected ownership marker: {path}")
+
+
+def initialize_root(path: Path, marker_name: str, marker_value: str) -> Path:
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if path.resolve(strict=True) != normalized(path):
+        raise StorageError(f"stack storage root changed while initializing: {path}")
+    marker = path / marker_name
+    if not marker.exists():
+        descriptor, name = tempfile.mkstemp(dir=path, prefix=f".{marker_name}.")
+        temporary = Path(name)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                stream.write(marker_value + "\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.chmod(temporary, 0o600)
+            os.replace(temporary, marker)
+        finally:
+            temporary.unlink(missing_ok=True)
+    return path.resolve(strict=True)
+
+
+def initialize(options: argparse.Namespace) -> None:
+    retained = normalized(options.retained_root)
+    transient = normalized(options.transient_root)
+    required_volume = (
+        Path(os.path.abspath(options.transient_volume))
+        if options.transient_volume
+        else None
+    )
+    if required_volume is not None:
+        if not required_volume.is_dir() or not os.path.ismount(required_volume):
+            raise StorageError(f"required transient volume is not mounted: {required_volume}")
+        if not inside(transient, required_volume):
+            raise StorageError(
+                f"transient root is outside required volume {required_volume}: {transient}"
+            )
+        if inside(retained, required_volume):
+            raise StorageError(f"retained root is on the transient volume: {retained}")
+    if inside(retained, transient) or inside(transient, retained):
+        raise StorageError("retained and transient roots overlap")
+    if options.require_separate_filesystems and existing_device(retained) == existing_device(transient):
+        raise StorageError("retained and transient roots must be on separate filesystems")
+
+    managed: list[tuple[str, Path, Path]] = []
+    for role, values, root in (
+        ("retained", options.retained_path, retained),
+        ("transient", options.transient_path, transient),
+    ):
+        for raw in values:
+            path = normalized(raw)
+            if not inside(path, root):
+                raise StorageError(f"{role} state path escaped its root: {path}")
+            managed.append((role, path, root))
+
+    preflight_root(retained, options.retained_marker, options.retained_marker_value)
+    preflight_root(transient, options.transient_marker, options.transient_marker_value)
+    retained = initialize_root(
+        retained, options.retained_marker, options.retained_marker_value
+    )
+    transient = initialize_root(
+        transient, options.transient_marker, options.transient_marker_value
+    )
+    for role, path, _ in managed:
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if path.resolve(strict=True) != path:
+            raise StorageError(f"{role} state path contains a symbolic link: {path}")
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--retained-root", type=Path, required=True)
+    parser.add_argument("--transient-root", type=Path, required=True)
+    parser.add_argument("--transient-volume", default="")
+    parser.add_argument("--retained-marker", required=True)
+    parser.add_argument("--retained-marker-value", required=True)
+    parser.add_argument("--transient-marker", required=True)
+    parser.add_argument("--transient-marker-value", required=True)
+    parser.add_argument("--retained-path", type=Path, action="append", default=[])
+    parser.add_argument("--transient-path", type=Path, action="append", default=[])
+    parser.add_argument("--require-separate-filesystems", action="store_true")
+    options = parser.parse_args(arguments)
+    try:
+        initialize(options)
+    except (StorageError, OSError, UnicodeError) as error:
+        print(f"stack-storage: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/build/stack-transient-clean.py
+++ b/Tools/build/stack-transient-clean.py
@@ -38,7 +38,10 @@ class CleanupError(RuntimeError):
 def validate_root(root: Path) -> Path:
     if not root.is_absolute() or root == Path("/") or root.is_symlink():
         raise CleanupError(f"unsafe transient root: {root}")
+    normalized = Path(os.path.abspath(root))
     resolved = root.resolve(strict=True)
+    if resolved != normalized:
+        raise CleanupError(f"transient root contains a symbolic link: {root}")
     marker = resolved / MARKER
     if marker.is_symlink() or not marker.is_file():
         raise CleanupError(f"transient root has no regular ownership marker: {resolved}")
@@ -47,19 +50,33 @@ def validate_root(root: Path) -> Path:
     return resolved
 
 
-def remove_tree(path: Path) -> None:
-    status = path.lstat()
-    if stat.S_ISLNK(status.st_mode) or not stat.S_ISDIR(status.st_mode):
-        path.unlink()
+def remove_entry(parent_descriptor: int, name: str) -> None:
+    """Remove one entry relative to an opened parent without following links."""
+    status = os.stat(name, dir_fd=parent_descriptor, follow_symlinks=False)
+    if not stat.S_ISDIR(status.st_mode):
+        os.unlink(name, dir_fd=parent_descriptor)
         return
-    with os.scandir(path) as entries:
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(name, flags, dir_fd=parent_descriptor)
+    try:
+        entries = list(os.scandir(descriptor))
         for entry in entries:
-            child = path / entry.name
-            if entry.is_dir(follow_symlinks=False):
-                remove_tree(child)
-            else:
-                child.unlink()
-    path.rmdir()
+            remove_entry(descriptor, entry.name)
+    finally:
+        os.close(descriptor)
+    os.rmdir(name, dir_fd=parent_descriptor)
+
+
+def remove_tree(path: Path) -> None:
+    """Remove a direct child through an opened, no-follow parent descriptor."""
+    parent = path.parent
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    descriptor = os.open(parent, flags)
+    try:
+        remove_entry(descriptor, path.name)
+    finally:
+        os.close(descriptor)
 
 
 def targets(root: Path) -> list[Path]:

--- a/Tools/build/stack-transient-clean.py
+++ b/Tools/build/stack-transient-clean.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Plan or remove only marker-owned transient Container-family build data."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+from pathlib import Path
+
+
+MARKER = ".container-family-transient-root"
+MARKER_VALUE = "container-compose transient build v2\n"
+REMOVABLE = ("attempts", "builds", "downloads", "scratch", "tmp")
+
+
+class CleanupError(RuntimeError):
+    """Transient cleanup could not prove a target is safe."""
+
+
+def validate_root(root: Path) -> Path:
+    if not root.is_absolute() or root == Path("/") or root.is_symlink():
+        raise CleanupError(f"unsafe transient root: {root}")
+    resolved = root.resolve(strict=True)
+    marker = resolved / MARKER
+    if marker.is_symlink() or not marker.is_file():
+        raise CleanupError(f"transient root has no regular ownership marker: {resolved}")
+    if marker.read_text(encoding="utf-8") != MARKER_VALUE:
+        raise CleanupError(f"transient root has an unexpected ownership marker: {resolved}")
+    return resolved
+
+
+def remove_tree(path: Path) -> None:
+    status = path.lstat()
+    if stat.S_ISLNK(status.st_mode) or not stat.S_ISDIR(status.st_mode):
+        path.unlink()
+        return
+    with os.scandir(path) as entries:
+        for entry in entries:
+            child = path / entry.name
+            if entry.is_dir(follow_symlinks=False):
+                remove_tree(child)
+            else:
+                child.unlink()
+    path.rmdir()
+
+
+def targets(root: Path) -> list[Path]:
+    resolved = validate_root(root)
+    return [resolved / name for name in REMOVABLE if (resolved / name).exists()]
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--execute", action="store_true")
+    options = parser.parse_args(arguments)
+    try:
+        selected = targets(options.root)
+        for target in selected:
+            print(target)
+            if options.execute:
+                remove_tree(target)
+    except (CleanupError, OSError, UnicodeError) as error:
+        print(f"stack-transient-clean: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/build/test_stack_artifact.py
+++ b/Tools/build/test_stack_artifact.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("stack-artifact.py")
+SPEC = importlib.util.spec_from_file_location("stack_artifact", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+STACK_ARTIFACT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(STACK_ARTIFACT)
+
+
+class StackArtifactTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.source = self.root / "external/build/compose"
+        self.source.parent.mkdir(parents=True)
+        self.source.write_bytes(b"binary\n")
+        self.source.chmod(0o755)
+        self.retained = self.root / "local/retained"
+
+    def test_promotes_content_addressed_read_only_artifact(self) -> None:
+        result = STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+
+        self.assertTrue(result.is_file())
+        self.assertEqual(result.read_bytes(), b"binary\n")
+        self.assertEqual(stat.S_IMODE(result.stat().st_mode), 0o555)
+        self.assertEqual(result.parts[-4], "sha256")
+        self.assertFalse(str(result).startswith(str(self.source.parent)))
+
+    def test_reuses_identical_promoted_artifact(self) -> None:
+        first = STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+        second = STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+
+        self.assertEqual(first, second)
+
+    def test_rejects_symlink_source_and_unsafe_name(self) -> None:
+        link = self.root / "link"
+        link.symlink_to(self.source)
+        with self.assertRaisesRegex(STACK_ARTIFACT.ArtifactError, "regular file"):
+            STACK_ARTIFACT.promote(link, self.retained, "compose")
+        with self.assertRaisesRegex(STACK_ARTIFACT.ArtifactError, "path component"):
+            STACK_ARTIFACT.promote(self.source, self.retained, "../compose")
+
+    def test_existing_conflicting_object_is_rejected(self) -> None:
+        destination = STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+        os.chmod(destination, 0o755)
+        with self.assertRaisesRegex(STACK_ARTIFACT.ArtifactError, "mode conflicts"):
+            STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+
+    def test_concurrent_identical_promotion_cannot_replace_retained_bytes(self) -> None:
+        original_link = STACK_ARTIFACT.os.link
+
+        def race(source: Path, destination: Path, **options: object) -> None:
+            destination.write_bytes(b"binary\n")
+            destination.chmod(0o555)
+            original_link(source, destination, **options)
+
+        with mock.patch.object(STACK_ARTIFACT.os, "link", side_effect=race):
+            result = STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+
+        self.assertEqual(result.read_bytes(), b"binary\n")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/build/test_stack_artifact.py
+++ b/Tools/build/test_stack_artifact.py
@@ -37,7 +37,7 @@ class StackArtifactTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
-        self.root = Path(self.temporary.name)
+        self.root = Path(self.temporary.name).resolve()
         self.source = self.root / "external/build/compose"
         self.source.parent.mkdir(parents=True)
         self.source.write_bytes(b"binary\n")
@@ -72,6 +72,16 @@ class StackArtifactTests(unittest.TestCase):
         os.chmod(destination, 0o755)
         with self.assertRaisesRegex(STACK_ARTIFACT.ArtifactError, "mode conflicts"):
             STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+
+    def test_rejects_symlinked_object_store_ancestor(self) -> None:
+        outside = self.root / "outside"
+        outside.mkdir()
+        self.retained.mkdir(parents=True)
+        (self.retained / "objects").symlink_to(outside, target_is_directory=True)
+
+        with self.assertRaisesRegex(STACK_ARTIFACT.ArtifactError, "symbolic link"):
+            STACK_ARTIFACT.promote(self.source, self.retained, "compose")
+        self.assertEqual(list(outside.iterdir()), [])
 
     def test_concurrent_identical_promotion_cannot_replace_retained_bytes(self) -> None:
         original_link = STACK_ARTIFACT.os.link

--- a/Tools/build/test_stack_make.py
+++ b/Tools/build/test_stack_make.py
@@ -32,6 +32,7 @@ from pathlib import Path
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 MAKEFILE = REPOSITORY_ROOT / "Makefile"
 PIN_TOOL = REPOSITORY_ROOT / "Tools/build/stack-pin.py"
+ARTIFACT_TOOL = REPOSITORY_ROOT / "Tools/build/stack-artifact.py"
 DEADLINE_TOOL = REPOSITORY_ROOT / "Tools/ci/run-command-with-deadline.py"
 
 
@@ -40,7 +41,8 @@ class StackMakeRecoveryTests(unittest.TestCase):
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
         self.root = Path(self.temporary.name)
-        self.state = self.root / "state"
+        self.retained = self.root / "local-retained"
+        self.transient = self.root / "external-transient"
         self.log = self.root / "build.log"
         self.fail = self.root / "fail-container"
         self.containerization = self.create_repository("containerization")
@@ -172,8 +174,11 @@ exec "$@"
                 "-f",
                 str(MAKEFILE),
                 "stack-container-build",
-                f"STACK_STATE_ROOT={self.state}",
+                f"STACK_RETAINED_ROOT={self.retained}",
+                f"STACK_TRANSIENT_ROOT={self.transient}",
+                "STACK_REQUIRE_SEPARATE_FILESYSTEMS=0",
                 f"STACK_PIN_TOOL={PIN_TOOL}",
+                f"STACK_ARTIFACT_TOOL={ARTIFACT_TOOL}",
                 f"STACK_DEADLINE_TOOL={DEADLINE_TOOL}",
                 f"STACK_SWIFT={self.swift}",
                 f"STACK_SWIFT_CONTRACT={'a' * 64}",
@@ -205,8 +210,11 @@ exec "$@"
                 "-f",
                 str(MAKEFILE),
                 "stack-build",
-                f"STACK_STATE_ROOT={self.state}",
+                f"STACK_RETAINED_ROOT={self.retained}",
+                f"STACK_TRANSIENT_ROOT={self.transient}",
+                "STACK_REQUIRE_SEPARATE_FILESYSTEMS=0",
                 f"STACK_PIN_TOOL={PIN_TOOL}",
+                f"STACK_ARTIFACT_TOOL={ARTIFACT_TOOL}",
                 f"STACK_DEADLINE_TOOL={DEADLINE_TOOL}",
                 f"STACK_SWIFT_STACK_TOOL={self.stack_wrapper}",
                 f"STACK_SWIFT={self.swift}",
@@ -235,15 +243,17 @@ exec "$@"
         return self.log.read_text(encoding="utf-8").splitlines()
 
     def test_state_initialization_refuses_to_claim_unmarked_data(self) -> None:
-        self.state.mkdir()
-        (self.state / "unrelated.txt").write_text("preserve\n", encoding="utf-8")
+        self.retained.mkdir()
+        (self.retained / "unrelated.txt").write_text("preserve\n", encoding="utf-8")
         result = subprocess.run(
             [
                 "/usr/bin/make",
                 "-f",
                 str(MAKEFILE),
                 "stack-state-init",
-                f"STACK_STATE_ROOT={self.state}",
+                f"STACK_RETAINED_ROOT={self.retained}",
+                f"STACK_TRANSIENT_ROOT={self.transient}",
+                "STACK_REQUIRE_SEPARATE_FILESYSTEMS=0",
             ],
             cwd=self.root,
             check=False,
@@ -254,18 +264,18 @@ exec "$@"
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("non-empty unmarked", result.stderr)
         self.assertEqual(
-            (self.state / "unrelated.txt").read_text(encoding="utf-8"),
+            (self.retained / "unrelated.txt").read_text(encoding="utf-8"),
             "preserve\n",
         )
-        self.assertFalse((self.state / ".container-compose-build-root").exists())
+        self.assertFalse((self.retained / ".container-family-retained-root").exists())
 
     def test_retry_reuses_successful_upstream_pins_after_failure(self) -> None:
         self.fail.write_text("fail once\n", encoding="utf-8")
         failed = self.run_build()
         self.assertEqual(failed.returncode, 2, failed.stderr)
-        self.assertTrue((self.state / "pins/debug/containerization.json").is_file())
-        self.assertTrue((self.state / "pins/debug/container-engine-api.json").is_file())
-        self.assertFalse((self.state / "pins/debug/container.json").exists())
+        self.assertTrue((self.retained / "pins/debug/containerization.json").is_file())
+        self.assertTrue((self.retained / "pins/debug/container-engine-api.json").is_file())
+        self.assertFalse((self.retained / "pins/debug/container.json").exists())
 
         resumed = self.run_build()
         self.assertEqual(resumed.returncode, 0, resumed.stderr)
@@ -273,7 +283,7 @@ exec "$@"
             self.logged_builds(),
             ["build:cctl", "build:container-engine", "build:container", "build:container"],
         )
-        self.assertTrue((self.state / "pins/debug/container.json").is_file())
+        self.assertTrue((self.retained / "pins/debug/container.json").is_file())
 
     def test_changed_upstream_rebuilds_only_its_transitive_path(self) -> None:
         first = self.run_build()
@@ -301,7 +311,7 @@ exec "$@"
         failed = self.run_full_build()
 
         self.assertNotEqual(failed.returncode, 0)
-        pin_root = self.state / "pins/debug"
+        pin_root = self.retained / "pins/debug"
         self.assertTrue((pin_root / "containerization.json").is_file())
         self.assertTrue((pin_root / "container-engine-api.json").is_file())
         self.assertTrue((pin_root / "container-builder-shim.json").is_file())
@@ -348,9 +358,10 @@ exec "$@"
         )
         self.assertEqual(verified.returncode, 0)
         compose_pin = (pin_root / "container-compose.json").read_text(encoding="utf-8")
-        self.assertIn(str(self.state / "scratch"), compose_pin)
+        self.assertIn(str(self.retained / "artifacts/objects/sha256"), compose_pin)
+        self.assertNotIn(str(self.transient / "scratch"), compose_pin)
         self.assertNotIn(str(self.compose / ".build/debug/compose"), compose_pin)
-        timing_logs = sorted((self.state / "timings").glob("*.jsonl"))
+        timing_logs = sorted((self.retained / "timings").glob("*.jsonl"))
         self.assertEqual(len(timing_logs), 2)
         records = [
             json.loads(line)
@@ -362,6 +373,22 @@ exec "$@"
         self.assertIn("container-build", labels)
         self.assertIn("compose-build", labels)
         self.assertTrue(all(record["duration_seconds"] >= 0 for record in records))
+
+        for transient_product in self.transient.glob("scratch/**/*"):
+            if transient_product.is_file():
+                transient_product.unlink()
+        verified_after_scratch_cleanup = subprocess.run(
+            [
+                sys.executable,
+                str(PIN_TOOL),
+                "verify-bundle",
+                "--quiet",
+                "--bundle",
+                str(bundle),
+            ],
+            check=False,
+        )
+        self.assertEqual(verified_after_scratch_cleanup.returncode, 0)
 
     def test_compose_build_uses_identity_preserving_manifest_overrides(self) -> None:
         makefile = MAKEFILE.read_text(encoding="utf-8")

--- a/Tools/build/test_stack_make.py
+++ b/Tools/build/test_stack_make.py
@@ -34,17 +34,18 @@ MAKEFILE = REPOSITORY_ROOT / "Makefile"
 PIN_TOOL = REPOSITORY_ROOT / "Tools/build/stack-pin.py"
 ARTIFACT_TOOL = REPOSITORY_ROOT / "Tools/build/stack-artifact.py"
 DEADLINE_TOOL = REPOSITORY_ROOT / "Tools/ci/run-command-with-deadline.py"
+STORAGE_TOOL = REPOSITORY_ROOT / "Tools/build/stack-storage.py"
 
 
 class StackMakeRecoveryTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
         self.addCleanup(self.temporary.cleanup)
-        self.root = Path(self.temporary.name)
+        self.root = Path(self.temporary.name).resolve()
         self.retained = self.root / "local-retained"
         self.transient = self.root / "external-transient"
         self.log = self.root / "build.log"
-        self.fail = self.root / "fail-container"
+        self.fail_marker = self.root / "fail-container"
         self.containerization = self.create_repository("containerization")
         self.engine = self.create_repository("container-engine-api")
         self.container = self.create_repository("container")
@@ -54,7 +55,23 @@ class StackMakeRecoveryTests(unittest.TestCase):
         (self.compose / "Package.resolved").write_text(
             '{"pins":[]}\n', encoding="utf-8"
         )
-        self.git(self.compose, "add", "Makefile", "Package.resolved")
+        (self.compose / "config.toml").write_text("[compose]\n", encoding="utf-8")
+        (self.compose / "docs/images").mkdir(parents=True)
+        (self.compose / "docs/images/container-compose-icon-octopus.png").write_bytes(
+            b"fixture icon"
+        )
+        (self.compose / "Tools/release").mkdir(parents=True)
+        (self.compose / "Tools/release/write-build-info.py").symlink_to(
+            REPOSITORY_ROOT / "Tools/release/write-build-info.py"
+        )
+        (self.compose / "Tools/release/runtime-capabilities.json").symlink_to(
+            REPOSITORY_ROOT / "Tools/release/runtime-capabilities.json"
+        )
+        (self.compose / "Tools/compose-normalizer").mkdir(parents=True)
+        (self.compose / "Tools/compose-normalizer/go.mod").write_text(
+            "module example.invalid/fixture\n", encoding="utf-8"
+        )
+        self.git(self.compose, "add", "Makefile", "Package.resolved", "config.toml", "docs", "Tools")
         self.git(self.compose, "commit", "-q", "-m", "test: add lockfile")
         self.swift = self.root / "fake-swift"
         self.swift.write_text(
@@ -105,7 +122,7 @@ while (($#)); do
   esac
 done
 [[ -n "${output}" ]]
-printf 'build:container-builder-shim\n' >> "${STACK_TEST_LOG}"
+printf 'build:%s\n' "$(basename "${output}")" >> "${STACK_TEST_LOG}"
 mkdir -p "$(dirname "${output}")"
 printf 'artifact:container-builder-shim\n' > "${output}"
 """,
@@ -164,7 +181,7 @@ exec "$@"
         environment = os.environ.copy()
         environment.update(
             {
-                "STACK_TEST_FAIL": str(self.fail),
+                "STACK_TEST_FAIL": str(self.fail_marker),
                 "STACK_TEST_LOG": str(self.log),
             }
         )
@@ -180,6 +197,8 @@ exec "$@"
                 f"STACK_PIN_TOOL={PIN_TOOL}",
                 f"STACK_ARTIFACT_TOOL={ARTIFACT_TOOL}",
                 f"STACK_DEADLINE_TOOL={DEADLINE_TOOL}",
+                f"STACK_STORAGE_TOOL={STORAGE_TOOL}",
+                "STACK_REQUIRED_TRANSIENT_VOLUME=",
                 f"STACK_SWIFT={self.swift}",
                 f"STACK_SWIFT_CONTRACT={'a' * 64}",
                 "STACK_LOCK_HELD=1",
@@ -200,7 +219,7 @@ exec "$@"
         environment = os.environ.copy()
         environment.update(
             {
-                "STACK_TEST_FAIL": str(self.fail),
+                "STACK_TEST_FAIL": str(self.fail_marker),
                 "STACK_TEST_LOG": str(self.log),
             }
         )
@@ -216,12 +235,21 @@ exec "$@"
                 f"STACK_PIN_TOOL={PIN_TOOL}",
                 f"STACK_ARTIFACT_TOOL={ARTIFACT_TOOL}",
                 f"STACK_DEADLINE_TOOL={DEADLINE_TOOL}",
+                f"STACK_STORAGE_TOOL={STORAGE_TOOL}",
+                "STACK_REQUIRED_TRANSIENT_VOLUME=",
                 f"STACK_SWIFT_STACK_TOOL={self.stack_wrapper}",
                 f"STACK_SWIFT={self.swift}",
                 f"STACK_GO={self.go}",
                 f"STACK_LOCK_TOOL={self.lock}",
                 f"STACK_SWIFT_CONTRACT={'a' * 64}",
                 f"STACK_GO_CONTRACT={'b' * 64}",
+                f"STACK_COMPOSE_CONTRACT={'c' * 64}",
+                "COMPOSE_GO_VERSION=fixture",
+                "CONTAINER_COMPOSE_SOURCE=fixture/container-compose",
+                "CONTAINER_COMPOSE_BRANCH=fixture",
+                "CONTAINER_COMPOSE_LANE=fixture",
+                "CONTAINER_SOURCE=fixture/container",
+                "CONTAINERIZATION_SOURCE=fixture/containerization",
                 "STACK_BUILD_STAGE_TIMEOUT_SECONDS=30",
                 f"PYTHON={sys.executable}",
                 f"CONTAINERIZATION_STACK_REPO={self.containerization}",
@@ -254,6 +282,8 @@ exec "$@"
                 f"STACK_RETAINED_ROOT={self.retained}",
                 f"STACK_TRANSIENT_ROOT={self.transient}",
                 "STACK_REQUIRE_SEPARATE_FILESYSTEMS=0",
+                f"STACK_STORAGE_TOOL={STORAGE_TOOL}",
+                "STACK_REQUIRED_TRANSIENT_VOLUME=",
             ],
             cwd=self.root,
             check=False,
@@ -270,7 +300,7 @@ exec "$@"
         self.assertFalse((self.retained / ".container-family-retained-root").exists())
 
     def test_retry_reuses_successful_upstream_pins_after_failure(self) -> None:
-        self.fail.write_text("fail once\n", encoding="utf-8")
+        self.fail_marker.write_text("fail once\n", encoding="utf-8")
         failed = self.run_build()
         self.assertEqual(failed.returncode, 2, failed.stderr)
         self.assertTrue((self.retained / "pins/debug/containerization.json").is_file())
@@ -285,7 +315,7 @@ exec "$@"
         )
         self.assertTrue((self.retained / "pins/debug/container.json").is_file())
 
-    def test_changed_upstream_rebuilds_only_its_transitive_path(self) -> None:
+    def test_changed_upstream_with_identical_output_reuses_downstream(self) -> None:
         first = self.run_build()
         self.assertEqual(first.returncode, 0, first.stderr)
         self.log.unlink()
@@ -303,10 +333,10 @@ exec "$@"
         )
         rebuilt = self.run_build()
         self.assertEqual(rebuilt.returncode, 0, rebuilt.stderr)
-        self.assertEqual(self.logged_builds(), ["build:cctl", "build:container"])
+        self.assertEqual(self.logged_builds(), ["build:cctl"])
 
     def test_complete_graph_recovers_and_publishes_verified_bundle(self) -> None:
-        self.fail.write_text("fail once\n", encoding="utf-8")
+        self.fail_marker.write_text("fail once\n", encoding="utf-8")
 
         failed = self.run_full_build()
 
@@ -328,6 +358,7 @@ exec "$@"
                     "build:cctl": 1,
                     "build:container-engine": 1,
                     "build:container-builder-shim": 1,
+                    "build:compose-normalizer": 1,
                     "build:container": 2,
                     "build:compose": 1,
                 }
@@ -361,6 +392,35 @@ exec "$@"
         self.assertIn(str(self.retained / "artifacts/objects/sha256"), compose_pin)
         self.assertNotIn(str(self.transient / "scratch"), compose_pin)
         self.assertNotIn(str(self.compose / ".build/debug/compose"), compose_pin)
+        compose_receipt = json.loads(compose_pin)
+        self.assertEqual(
+            [artifact["name"] for artifact in compose_receipt["artifacts"]],
+            [
+                "compose/bin/compose",
+                "compose/config.toml",
+                "compose/resources/build-info.json",
+                "compose/resources/compose-normalizer",
+                "compose/resources/container-compose-icon.png",
+            ],
+        )
+        materialized = self.root / "restored-compose"
+        materialize = subprocess.run(
+            [
+                sys.executable,
+                str(PIN_TOOL),
+                "materialize",
+                "--receipt",
+                str(pin_root / "container-compose.json"),
+                "--output",
+                str(materialized),
+            ],
+            check=False,
+        )
+        self.assertEqual(materialize.returncode, 0)
+        self.assertTrue((materialized / "compose/bin/compose").is_file())
+        self.assertTrue(
+            (materialized / "compose/resources/compose-normalizer").is_file()
+        )
         timing_logs = sorted((self.retained / "timings").glob("*.jsonl"))
         self.assertEqual(len(timing_logs), 2)
         records = [

--- a/Tools/build/test_stack_make.py
+++ b/Tools/build/test_stack_make.py
@@ -216,7 +216,9 @@ exec "$@"
             text=True,
         )
 
-    def run_full_build(self) -> subprocess.CompletedProcess[str]:
+    def run_full_build(
+        self, target: str = "stack-build"
+    ) -> subprocess.CompletedProcess[str]:
         environment = os.environ.copy()
         environment.update(
             {
@@ -229,7 +231,7 @@ exec "$@"
                 "/usr/bin/make",
                 "-f",
                 str(MAKEFILE),
-                "stack-build",
+                target,
                 f"STACK_RETAINED_ROOT={self.retained}",
                 f"STACK_TRANSIENT_ROOT={self.transient}",
                 "STACK_REQUIRE_SEPARATE_FILESYSTEMS=0",
@@ -244,7 +246,6 @@ exec "$@"
                 f"STACK_LOCK_TOOL={self.lock}",
                 f"STACK_SWIFT_CONTRACT={'a' * 64}",
                 f"STACK_GO_CONTRACT={'b' * 64}",
-                f"STACK_COMPOSE_CONTRACT={'c' * 64}",
                 "COMPOSE_GO_VERSION=fixture",
                 "CONTAINER_COMPOSE_SOURCE=fixture/container-compose",
                 "CONTAINER_COMPOSE_BRANCH=fixture",
@@ -352,6 +353,9 @@ exec "$@"
         resumed = self.run_full_build()
 
         self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        status = self.run_full_build("stack-status")
+        self.assertEqual(status.returncode, 0, status.stderr)
+        self.assertIn("container-compose            valid", status.stdout)
         self.assertEqual(
             Counter(self.logged_builds()),
             Counter(

--- a/Tools/build/test_stack_pin.py
+++ b/Tools/build/test_stack_pin.py
@@ -40,7 +40,7 @@ SPEC.loader.exec_module(STACK_PIN)
 class StackPinTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary_directory = tempfile.TemporaryDirectory()
-        self.root = Path(self.temporary_directory.name)
+        self.root = Path(self.temporary_directory.name).resolve()
         self.repository = self.create_repository("containerization")
         self.artifact = self.root / "artifacts/cctl"
         self.artifact.parent.mkdir()
@@ -196,6 +196,138 @@ class StackPinTests(unittest.TestCase):
             ),
             0,
         )
+
+    def test_dependent_pin_accepts_relocated_parent_and_retained_dependency(self) -> None:
+        self.assertEqual(self.create_pin(), 0)
+        downstream = self.create_repository("container")
+        downstream_artifact = self.root / "artifacts/container"
+        downstream_artifact.write_text("container\n", encoding="utf-8")
+        downstream_receipt = self.root / "pins/container.json"
+        self.assertEqual(
+            self.create_pin(
+                repository=downstream,
+                receipt=downstream_receipt,
+                artifact=downstream_artifact,
+                dependencies=[self.receipt],
+            ),
+            0,
+        )
+        moved = self.root / "relocated/container"
+        moved.parent.mkdir()
+        downstream.rename(moved)
+        shutil.rmtree(self.repository)
+
+        self.assertEqual(
+            self.invoke(
+                [
+                    "verify",
+                    "--receipt",
+                    str(downstream_receipt),
+                    "--repository-path",
+                    str(moved),
+                    "--quiet",
+                ]
+            ),
+            0,
+        )
+
+    def test_retained_only_verification_does_not_require_source_checkout(self) -> None:
+        self.assertEqual(self.create_pin(), 0)
+        shutil.rmtree(self.repository)
+        self.assertEqual(
+            self.invoke(
+                [
+                    "verify",
+                    "--receipt",
+                    str(self.receipt),
+                    "--retained-only",
+                    "--quiet",
+                ]
+            ),
+            0,
+        )
+
+    def test_materialize_restores_logical_product_layout_without_source(self) -> None:
+        self.assertEqual(self.create_pin(), 0)
+        shutil.rmtree(self.repository)
+        output = self.root / "materialized"
+
+        self.assertEqual(
+            self.invoke(
+                [
+                    "materialize",
+                    "--receipt",
+                    str(self.receipt),
+                    "--output",
+                    str(output),
+                ]
+            ),
+            0,
+        )
+        self.assertEqual((output / "cctl").read_bytes(), self.artifact.read_bytes())
+
+    def test_index_recovers_an_earlier_exact_input_after_latest_pin_changes(self) -> None:
+        index = self.root / "pin-index"
+        first_commit = self.git(self.repository, "rev-parse", "HEAD")
+        first_tree = self.git(self.repository, "rev-parse", "HEAD^{tree}")
+        first_arguments = [
+            "create",
+            "--repository",
+            self.repository.name,
+            "--repository-path",
+            str(self.repository),
+            "--output",
+            str(self.receipt),
+            "--artifact",
+            str(self.artifact),
+            "--command-label",
+            "fixture",
+            "--build-contract",
+            "a" * 64,
+            "--duration-seconds",
+            "0",
+            "--expected-commit",
+            first_commit,
+            "--expected-tree",
+            first_tree,
+            "--index-root",
+            str(index),
+        ]
+        self.assertEqual(self.invoke(first_arguments), 0)
+        first_receipt = self.receipt.read_bytes()
+        (self.repository / "source.txt").write_text("second\n", encoding="utf-8")
+        self.git(self.repository, "add", "source.txt")
+        self.git(self.repository, "commit", "-qm", "test: second input")
+        second_arguments = first_arguments.copy()
+        second_arguments[second_arguments.index(first_commit)] = self.git(
+            self.repository, "rev-parse", "HEAD"
+        )
+        second_arguments[second_arguments.index(first_tree)] = self.git(
+            self.repository, "rev-parse", "HEAD^{tree}"
+        )
+        self.assertEqual(self.invoke(second_arguments), 0)
+        self.assertNotEqual(self.receipt.read_bytes(), first_receipt)
+        self.git(self.repository, "checkout", "-q", first_commit)
+
+        self.assertEqual(
+            self.invoke(
+                [
+                    "lookup",
+                    "--repository",
+                    self.repository.name,
+                    "--repository-path",
+                    str(self.repository),
+                    "--build-contract",
+                    "a" * 64,
+                    "--index-root",
+                    str(index),
+                    "--output",
+                    str(self.receipt),
+                ]
+            ),
+            0,
+        )
+        self.assertEqual(self.receipt.read_bytes(), first_receipt)
 
     def test_source_change_during_build_refuses_to_publish_pin(self) -> None:
         arguments = [

--- a/Tools/build/test_stack_pin.py
+++ b/Tools/build/test_stack_pin.py
@@ -176,6 +176,27 @@ class StackPinTests(unittest.TestCase):
             2,
         )
 
+    def test_exact_source_recreated_at_new_path_reuses_retained_artifact(self) -> None:
+        self.assertEqual(self.create_pin(), 0)
+        moved = self.root / "recreated/containerization"
+        moved.parent.mkdir()
+        shutil.copytree(self.repository, moved)
+        shutil.rmtree(self.repository)
+
+        self.assertEqual(
+            self.invoke(
+                [
+                    "verify",
+                    "--receipt",
+                    str(self.receipt),
+                    "--repository-path",
+                    str(moved),
+                    "--quiet",
+                ]
+            ),
+            0,
+        )
+
     def test_source_change_during_build_refuses_to_publish_pin(self) -> None:
         arguments = [
             "create",

--- a/Tools/build/test_stack_storage.py
+++ b/Tools/build/test_stack_storage.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("stack-storage.py")
+SPEC = importlib.util.spec_from_file_location("stack_storage", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class StackStorageTests(unittest.TestCase):
+    def arguments(self, retained: Path, transient: Path) -> list[str]:
+        return [
+            "--retained-root", str(retained),
+            "--transient-root", str(transient),
+            "--retained-marker", ".retained",
+            "--retained-marker-value", "retained-v1",
+            "--transient-marker", ".transient",
+            "--transient-marker-value", "transient-v1",
+            "--retained-path", str(retained / "pins"),
+            "--transient-path", str(transient / "scratch"),
+        ]
+
+    def test_initializes_role_specific_paths_and_markers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            retained, transient = root / "retained", root / "transient"
+            self.assertEqual(MODULE.main(self.arguments(retained, transient)), 0)
+            self.assertTrue((retained / "pins").is_dir())
+            self.assertTrue((transient / "scratch").is_dir())
+
+    def test_refuses_to_claim_nonempty_root_before_writing_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            retained, transient = root / "retained", root / "transient"
+            retained.mkdir()
+            (retained / "keep").write_text("keep", encoding="utf-8")
+            self.assertEqual(MODULE.main(self.arguments(retained, transient)), 2)
+            self.assertFalse((retained / ".retained").exists())
+            self.assertFalse(transient.exists())
+
+    def test_rejects_role_escape(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            retained, transient = root / "retained", root / "transient"
+            arguments = self.arguments(retained, transient)
+            arguments.extend(("--retained-path", str(transient / "wrong")))
+            self.assertEqual(MODULE.main(arguments), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/build/test_stack_transient_clean.py
+++ b/Tools/build/test_stack_transient_clean.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("stack-transient-clean.py")
+SPEC = importlib.util.spec_from_file_location("stack_transient_clean", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class StackTransientCleanTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name) / "transient"
+        self.root.mkdir()
+        (self.root / MODULE.MARKER).write_text(MODULE.MARKER_VALUE, encoding="utf-8")
+        self.retained = Path(temporary.name) / "retained"
+        self.retained.mkdir()
+        (self.retained / "compose").write_text("keep", encoding="utf-8")
+        (self.root / "scratch/nested").mkdir(parents=True)
+        (self.root / "scratch/nested/output").write_text("discard", encoding="utf-8")
+
+    def invoke(self, *arguments: str) -> int:
+        with redirect_stdout(StringIO()):
+            return MODULE.main(["--root", str(self.root), *arguments])
+
+    def test_plan_does_not_delete_transient_or_retained_data(self) -> None:
+        self.assertEqual(self.invoke(), 0)
+        self.assertTrue((self.root / "scratch/nested/output").exists())
+        self.assertTrue((self.retained / "compose").exists())
+
+    def test_execute_removes_only_allowlisted_transient_directories(self) -> None:
+        (self.root / "unrelated").write_text("preserve", encoding="utf-8")
+        self.assertEqual(self.invoke("--execute"), 0)
+        self.assertFalse((self.root / "scratch").exists())
+        self.assertTrue((self.root / "unrelated").exists())
+        self.assertTrue((self.root / MODULE.MARKER).exists())
+        self.assertTrue((self.retained / "compose").exists())
+
+    def test_symlink_target_is_unlinked_without_following_it(self) -> None:
+        outside = self.retained / "outside"
+        outside.mkdir()
+        (outside / "keep").write_text("keep", encoding="utf-8")
+        (self.root / "tmp").symlink_to(outside, target_is_directory=True)
+        self.assertEqual(self.invoke("--execute"), 0)
+        self.assertFalse((self.root / "tmp").exists())
+        self.assertTrue((outside / "keep").exists())
+
+    def test_wrong_marker_refuses_cleanup(self) -> None:
+        (self.root / MODULE.MARKER).write_text("wrong\n", encoding="utf-8")
+        self.assertEqual(self.invoke("--execute"), 2)
+        self.assertTrue((self.root / "scratch/nested/output").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/build/test_stack_transient_clean.py
+++ b/Tools/build/test_stack_transient_clean.py
@@ -18,11 +18,13 @@
 from __future__ import annotations
 
 import importlib.util
+import os
 import tempfile
 import unittest
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("stack-transient-clean.py")
@@ -36,10 +38,11 @@ class StackTransientCleanTests(unittest.TestCase):
     def setUp(self) -> None:
         temporary = tempfile.TemporaryDirectory()
         self.addCleanup(temporary.cleanup)
-        self.root = Path(temporary.name) / "transient"
+        temporary_root = Path(temporary.name).resolve()
+        self.root = temporary_root / "transient"
         self.root.mkdir()
         (self.root / MODULE.MARKER).write_text(MODULE.MARKER_VALUE, encoding="utf-8")
-        self.retained = Path(temporary.name) / "retained"
+        self.retained = temporary_root / "retained"
         self.retained.mkdir()
         (self.retained / "compose").write_text("keep", encoding="utf-8")
         (self.root / "scratch/nested").mkdir(parents=True)
@@ -75,6 +78,28 @@ class StackTransientCleanTests(unittest.TestCase):
         (self.root / MODULE.MARKER).write_text("wrong\n", encoding="utf-8")
         self.assertEqual(self.invoke("--execute"), 2)
         self.assertTrue((self.root / "scratch/nested/output").exists())
+
+    def test_directory_replaced_by_symlink_during_cleanup_cannot_escape(self) -> None:
+        outside = self.retained / "outside"
+        outside.mkdir()
+        sentinel = outside / "keep"
+        sentinel.write_text("keep", encoding="utf-8")
+        original_open = MODULE.os.open
+        replaced = False
+
+        def replace_before_open(path: object, flags: int, *args: object, **kwargs: object) -> int:
+            nonlocal replaced
+            if path == "scratch" and kwargs.get("dir_fd") is not None and not replaced:
+                replaced = True
+                (self.root / "scratch").rename(self.root / "scratch-original")
+                (self.root / "scratch").symlink_to(outside, target_is_directory=True)
+            return original_open(path, flags, *args, **kwargs)
+
+        with mock.patch.object(MODULE.os, "open", side_effect=replace_before_open):
+            with self.assertRaises(OSError):
+                MODULE.remove_tree(self.root / "scratch")
+
+        self.assertTrue(sentinel.is_file())
 
 
 if __name__ == "__main__":

--- a/Tools/ci/classify-ci-changes.py
+++ b/Tools/ci/classify-ci-changes.py
@@ -74,6 +74,14 @@ def classify(paths: list[str], *, full: bool = False) -> ValidationScope:
             runtime = True
             continue
 
+        if _under(path, "Tools") and (
+            value.startswith("Tools/build/")
+            or value == "Tools/release/stack-refs.json"
+        ):
+            tools = True
+            runtime = True
+            continue
+
         if (
             _under(path, "Sources")
             or _under(path, "Tests")

--- a/Tools/ci/doc-site-manifest.py
+++ b/Tools/ci/doc-site-manifest.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Create or verify a complete content manifest for a generated DocC site."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import stat
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+
+SCHEMA = 1
+MANIFEST_NAME = ".docc-site-manifest.json"
+MAX_ARCHIVE_FILE_SIZE = 512 * 1024 * 1024
+MAX_ARCHIVE_SIZE = 4 * 1024 * 1024 * 1024
+
+
+class ManifestError(RuntimeError):
+    """The generated site or its retained manifest is unsafe or incomplete."""
+
+
+def digest(path: Path) -> str:
+    descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+    value = hashlib.sha256()
+    try:
+        status = os.fstat(descriptor)
+        if not stat.S_ISREG(status.st_mode):
+            raise ManifestError(f"site entry is not a regular file: {path}")
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                value.update(chunk)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    return value.hexdigest()
+
+
+def files(root: Path) -> list[dict[str, object]]:
+    entries: list[dict[str, object]] = []
+    for path in sorted(root.rglob("*")):
+        if path.name == MANIFEST_NAME:
+            continue
+        if path.is_symlink():
+            raise ManifestError(f"DocC site contains a symbolic link: {path}")
+        if path.is_dir():
+            continue
+        relative = path.relative_to(root).as_posix()
+        status = path.stat(follow_symlinks=False)
+        if not stat.S_ISREG(status.st_mode):
+            raise ManifestError(f"DocC site contains a special file: {path}")
+        entries.append(
+            {
+                "path": relative,
+                "sha256": digest(path),
+                "size": status.st_size,
+            }
+        )
+    return entries
+
+
+def validate_required(entries: list[dict[str, object]]) -> None:
+    paths = {entry["path"] for entry in entries}
+    for required in ("index.html", "theme-settings.json"):
+        if required not in paths:
+            raise ManifestError(f"DocC site is missing required entry: {required}")
+    if not any(str(path).startswith("documentation/") for path in paths):
+        raise ManifestError("DocC site has no documentation payload")
+
+
+def create(root: Path) -> None:
+    resolved = root.resolve(strict=True)
+    entries = files(resolved)
+    validate_required(entries)
+    value = {"files": entries, "schema": SCHEMA}
+    descriptor, name = tempfile.mkstemp(dir=resolved, prefix=".manifest-", suffix=".tmp")
+    temporary = Path(name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, resolved / MANIFEST_NAME)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def verify(root: Path) -> None:
+    resolved = root.resolve(strict=True)
+    manifest_path = resolved / MANIFEST_NAME
+    if manifest_path.is_symlink():
+        raise ManifestError("DocC manifest must not be a symbolic link")
+    try:
+        value = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ManifestError(f"could not read DocC manifest: {error}") from error
+    if not isinstance(value, dict) or value.get("schema") != SCHEMA:
+        raise ManifestError("DocC manifest has an unsupported schema")
+    recorded = value.get("files")
+    if not isinstance(recorded, list) or recorded != files(resolved):
+        raise ManifestError("DocC site does not match its content manifest")
+    validate_required(recorded)
+
+
+def verify_archive(path: Path) -> None:
+    if not path.is_absolute() or path.is_symlink() or not path.is_file():
+        raise ManifestError(f"DocC archive is indirect or missing: {path}")
+    entries: list[dict[str, object]] = []
+    manifest: dict[str, object] | None = None
+    names: set[str] = set()
+    total_size = 0
+    with tarfile.open(path, "r:gz") as archive:
+        for member in archive.getmembers():
+            name = member.name
+            while name.startswith("./"):
+                name = name[2:]
+            if member.isdir():
+                continue
+            if (
+                not member.isfile()
+                or not name
+                or PurePosixPath(name).is_absolute()
+                or ".." in PurePosixPath(name).parts
+                or name in names
+                or member.size < 0
+                or member.size > MAX_ARCHIVE_FILE_SIZE
+            ):
+                raise ManifestError(f"DocC archive contains an unsafe entry: {member.name}")
+            names.add(name)
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise ManifestError(f"DocC archive entry is unreadable: {name}")
+            payload = stream.read(MAX_ARCHIVE_FILE_SIZE + 1)
+            total_size += len(payload)
+            if len(payload) != member.size:
+                raise ManifestError(f"DocC archive entry is truncated: {name}")
+            if total_size > MAX_ARCHIVE_SIZE:
+                raise ManifestError("DocC archive exceeds its safe size")
+            if name == MANIFEST_NAME:
+                try:
+                    value = json.loads(payload)
+                except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                    raise ManifestError("DocC archive manifest is malformed") from error
+                if not isinstance(value, dict):
+                    raise ManifestError("DocC archive manifest is not an object")
+                manifest = value
+                continue
+            entries.append(
+                {
+                    "path": name,
+                    "sha256": hashlib.sha256(payload).hexdigest(),
+                    "size": len(payload),
+                }
+            )
+    entries.sort(key=lambda entry: str(entry["path"]))
+    if manifest is None or manifest.get("schema") != SCHEMA:
+        raise ManifestError("DocC archive has no supported content manifest")
+    if manifest.get("files") != entries:
+        raise ManifestError("DocC archive does not match its content manifest")
+    validate_required(entries)
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("create", "verify", "verify-archive"))
+    parser.add_argument("root", type=Path)
+    options = parser.parse_args(arguments)
+    try:
+        if options.action == "verify-archive":
+            verify_archive(options.root)
+        else:
+            globals()[options.action](options.root)
+    except (ManifestError, OSError, tarfile.TarError) as error:
+        print(f"doc-site-manifest: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/ci/doc-site-manifest.py
+++ b/Tools/ci/doc-site-manifest.py
@@ -30,7 +30,7 @@ import tempfile
 from pathlib import Path, PurePosixPath
 
 
-SCHEMA = 1
+SCHEMA = 2
 MANIFEST_NAME = ".docc-site-manifest.json"
 MAX_ARCHIVE_FILE_SIZE = 512 * 1024 * 1024
 MAX_ARCHIVE_SIZE = 4 * 1024 * 1024 * 1024
@@ -89,11 +89,22 @@ def validate_required(entries: list[dict[str, object]]) -> None:
         raise ManifestError("DocC site has no documentation payload")
 
 
-def create(root: Path) -> None:
+def validate_context(value: object, expected: dict[str, str] | None = None) -> None:
+    if not isinstance(value, dict) or any(
+        not isinstance(key, str) or not isinstance(item, str) or not item
+        for key, item in value.items()
+    ):
+        raise ManifestError("DocC site has an invalid semantic context")
+    for key, item in (expected or {}).items():
+        if value.get(key) != item:
+            raise ManifestError(f"DocC site context changed: {key}")
+
+
+def create(root: Path, context: dict[str, str] | None = None) -> None:
     resolved = root.resolve(strict=True)
     entries = files(resolved)
     validate_required(entries)
-    value = {"files": entries, "schema": SCHEMA}
+    value = {"context": context or {}, "files": entries, "schema": SCHEMA}
     descriptor, name = tempfile.mkstemp(dir=resolved, prefix=".manifest-", suffix=".tmp")
     temporary = Path(name)
     try:
@@ -107,7 +118,7 @@ def create(root: Path) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def verify(root: Path) -> None:
+def verify(root: Path, expected_context: dict[str, str] | None = None) -> None:
     resolved = root.resolve(strict=True)
     manifest_path = resolved / MANIFEST_NAME
     if manifest_path.is_symlink():
@@ -118,13 +129,14 @@ def verify(root: Path) -> None:
         raise ManifestError(f"could not read DocC manifest: {error}") from error
     if not isinstance(value, dict) or value.get("schema") != SCHEMA:
         raise ManifestError("DocC manifest has an unsupported schema")
+    validate_context(value.get("context"), expected_context)
     recorded = value.get("files")
     if not isinstance(recorded, list) or recorded != files(resolved):
         raise ManifestError("DocC site does not match its content manifest")
     validate_required(recorded)
 
 
-def verify_archive(path: Path) -> None:
+def verify_archive(path: Path, expected_context: dict[str, str] | None = None) -> None:
     if not path.is_absolute() or path.is_symlink() or not path.is_file():
         raise ManifestError(f"DocC archive is indirect or missing: {path}")
     entries: list[dict[str, object]] = []
@@ -177,6 +189,7 @@ def verify_archive(path: Path) -> None:
     entries.sort(key=lambda entry: str(entry["path"]))
     if manifest is None or manifest.get("schema") != SCHEMA:
         raise ManifestError("DocC archive has no supported content manifest")
+    validate_context(manifest.get("context"), expected_context)
     if manifest.get("files") != entries:
         raise ManifestError("DocC archive does not match its content manifest")
     validate_required(entries)
@@ -186,12 +199,28 @@ def main(arguments: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("action", choices=("create", "verify", "verify-archive"))
     parser.add_argument("root", type=Path)
+    parser.add_argument("--site")
+    parser.add_argument("--source-ref")
+    parser.add_argument("--toolchain-digest")
+    parser.add_argument("--hosting-base-path")
     options = parser.parse_args(arguments)
+    context = {
+        key: value
+        for key, value in {
+            "hosting_base_path": options.hosting_base_path,
+            "site": options.site,
+            "source_ref": options.source_ref,
+            "toolchain_digest": options.toolchain_digest,
+        }.items()
+        if value
+    }
     try:
-        if options.action == "verify-archive":
-            verify_archive(options.root)
+        if options.action == "create":
+            create(options.root, context)
+        elif options.action == "verify-archive":
+            verify_archive(options.root, context)
         else:
-            globals()[options.action](options.root)
+            verify(options.root, context)
     except (ManifestError, OSError, tarfile.TarError) as error:
         print(f"doc-site-manifest: {error}", file=sys.stderr)
         return 2

--- a/Tools/ci/run-release-checkpoint.py
+++ b/Tools/ci/run-release-checkpoint.py
@@ -50,6 +50,12 @@ def parse_arguments(arguments: Sequence[str]) -> argparse.Namespace:
     fingerprint.add_argument("--fingerprint-command")
     parser.add_argument("--seconds", type=int, required=True)
     parser.add_argument(
+        "--required-output",
+        action="append",
+        default=[],
+        help="regular output file whose content must remain valid for reuse",
+    )
+    parser.add_argument(
         "--supervised-worker", action="store_true", help=argparse.SUPPRESS
     )
     parser.add_argument("--active-output", default="", help=argparse.SUPPRESS)
@@ -99,7 +105,11 @@ def sha256_file(path: Path) -> str:
 
 
 def stage_digest(
-    stage: str, fingerprint: str, seconds: int, command: Sequence[str]
+    stage: str,
+    fingerprint: str,
+    seconds: int,
+    command: Sequence[str],
+    required_outputs: Sequence[str] = (),
 ) -> str:
     encoded = json.dumps(
         {
@@ -108,6 +118,7 @@ def stage_digest(
             "seconds": seconds,
             "schema": SCHEMA_VERSION,
             "stage": stage,
+            "required_outputs": list(required_outputs),
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -139,6 +150,36 @@ def checkpoint_output_is_valid(
         return False
     try:
         return sha256_file(output_path) == recorded_digest
+    except OSError:
+        return False
+
+
+def required_output_path(value: str) -> Path:
+    return Path(os.path.abspath(os.path.expanduser(value)))
+
+
+def required_output_record(path: Path) -> dict[str, object]:
+    if path.is_symlink():
+        raise OSError(f"release checkpoint required output is indirect: {path}")
+    status = path.stat(follow_symlinks=False)
+    if not stat.S_ISREG(status.st_mode):
+        raise OSError(f"release checkpoint required output is not regular: {path}")
+    return {
+        "mode": stat.S_IMODE(status.st_mode),
+        "path": str(path),
+        "sha256": sha256_file(path),
+        "size": status.st_size,
+    }
+
+
+def required_outputs_are_valid(
+    checkpoint: dict[str, object], required_outputs: Sequence[Path]
+) -> bool:
+    recorded = checkpoint.get("required_outputs", [])
+    if not isinstance(recorded, list) or len(recorded) != len(required_outputs):
+        return False
+    try:
+        return recorded == [required_output_record(path) for path in required_outputs]
     except OSError:
         return False
 
@@ -307,8 +348,13 @@ def run_supervised(options: argparse.Namespace) -> int:
     fingerprint_after = fingerprint_before
 
     digest = stage_digest(
-        options.stage, fingerprint, options.seconds, options.command
+        options.stage,
+        fingerprint,
+        options.seconds,
+        options.command,
+        options.required_output,
     )
+    required_outputs = [required_output_path(value) for value in options.required_output]
     checkpoint_directory = (
         Path(options.checkpoint_dir).expanduser().resolve()
         if options.checkpoint_dir
@@ -351,7 +397,9 @@ def run_supervised(options: argparse.Namespace) -> int:
         checkpoint = read_checkpoint(success_path)
         if checkpoint is not None and checkpoint.get("digest") == digest:
             assert output_path is not None
-            if checkpoint_output_is_valid(checkpoint, output_path):
+            if checkpoint_output_is_valid(
+                checkpoint, output_path
+            ) and required_outputs_are_valid(checkpoint, required_outputs):
                 print(f"reusing exact-input release checkpoint: {options.stage}")
                 return 0
             print(
@@ -424,6 +472,15 @@ def run_supervised(options: argparse.Namespace) -> int:
                     file=sys.stderr,
                 )
                 status = 75
+    required_output_records: list[dict[str, object]] = []
+    if status == 0:
+        try:
+            required_output_records = [
+                required_output_record(path) for path in required_outputs
+            ]
+        except OSError as error:
+            print(f"could not verify release checkpoint products: {error}", file=sys.stderr)
+            status = 74
     result: dict[str, object] = {
         "command_sha256": hashlib.sha256(
             json.dumps(options.command, separators=(",", ":")).encode("utf-8")
@@ -444,6 +501,8 @@ def run_supervised(options: argparse.Namespace) -> int:
     if output_digest is not None and output_file is not None:
         result["output_sha256"] = output_digest
         result["output_file"] = output_file
+    if required_output_records:
+        result["required_outputs"] = required_output_records
     if result_path is not None:
         write_json_atomically(result_path, result)
     if status == 0 and success_path is not None:

--- a/Tools/ci/run-stack-release-validation.sh
+++ b/Tools/ci/run-stack-release-validation.sh
@@ -60,6 +60,11 @@ for path in "${compose_repo}" "${builder_repo}" "${containerization_repo}" "${co
     exit 2
   fi
 done
+compose_repo="$(cd "${compose_repo}" && pwd -P)"
+builder_repo="$(cd "${builder_repo}" && pwd -P)"
+containerization_repo="$(cd "${containerization_repo}" && pwd -P)"
+container_repo="$(cd "${container_repo}" && pwd -P)"
+homebrew_tap_repo="$(cd "${homebrew_tap_repo}" && pwd -P)"
 if [[ ! -f "${homebrew_tap_repo}/Formula/container-compose.rb" ]]; then
   printf 'Homebrew tap formula is required at %s/Formula/container-compose.rb\n' "${homebrew_tap_repo}" >&2
   exit 2
@@ -314,7 +319,7 @@ if [[ -n "${checkpoint_directory}" ]]; then
         "${RELEASE_GATE_INHERITED_ENVIRONMENT_FINGERPRINT:-}"
       printf 'environment=RELEASE_GATE_TOOL_FINGERPRINT=%s\n' \
         "${RELEASE_GATE_TOOL_FINGERPRINT:-}"
-      for tool_name in git make swift clang go ruby python3 docker hawkeye shellcheck xcodebuild; do
+      for tool_name in git make swift clang go ruby python3 hawkeye shellcheck xcodebuild; do
         tool_path=$(command -v "${tool_name}" 2>/dev/null || true)
         printf 'tool=%s:path=%s\n' "${tool_name}" "${tool_path:-missing}"
         if [[ -n "${tool_path}" && -f "${tool_path}" ]]; then
@@ -338,8 +343,6 @@ if [[ -n "${checkpoint_directory}" ]]; then
         fi
         printf 'tool=%s:version=%s\n' "${tool_name}" "${tool_version}"
       done
-      printf 'docker:buildx=%s\n' "$(docker buildx version 2>&1 || true)"
-      printf 'docker:compose=%s\n' "$(docker compose version 2>&1 || true)"
       uname -a
     } | shasum -a 256 | awk '{print $1}'
   )
@@ -546,6 +549,33 @@ validation_fingerprint_for_stage() {
 }
 
 # Runs one stage unless its own exact inputs already have a successful stamp.
+stage_output_identity() {
+  local stage="$1" path
+  local paths=()
+  case "${stage}" in
+    builder-build) paths+=("${builder_repo}/bin/container-builder-shim") ;;
+    builder-coverage) paths+=("${builder_repo}/coverage.out") ;;
+    containerization-containerization)
+      paths+=("${containerization_repo}/bin/cctl")
+      paths+=("${containerization_repo}/bin/containerization-integration")
+      ;;
+    containerization-docs) paths+=("${containerization_repo}/_site/index.html") ;;
+    container-container) paths+=("${container_repo}/bin/container") ;;
+    container-docs) paths+=("${container_repo}/_site/index.html") ;;
+    *) printf 'none\n'; return ;;
+  esac
+  for path in "${paths[@]}"; do
+    if [[ -f "${path}" && ! -L "${path}" ]]; then
+      printf '%s:%s:%s\n' "${path}" \
+        "$(/usr/bin/stat -f '%Lp:%z' "${path}" 2>/dev/null || /usr/bin/stat -c '%a:%s' "${path}")" \
+        "$(shasum -a 256 "${path}" | awk '{print $1}')"
+    else
+      printf '%s:missing\n' "${path}"
+    fi
+  done | shasum -a 256 | awk '{print $1}'
+}
+
+# Runs one stage unless its exact inputs and declared products remain valid.
 run_checkpointed() {
   local stage=$1
   shift
@@ -558,8 +588,9 @@ run_checkpointed() {
 
   mkdir -p "${checkpoint_directory}"
   local stamp="${checkpoint_directory}/${mode}-${stage}.sha256"
-  local expected_before
-  expected_before="$(validation_fingerprint_for_stage "${stage}"):${stage}"
+  local fingerprint_before expected_before
+  fingerprint_before="$(validation_fingerprint_for_stage "${stage}")"
+  expected_before="${fingerprint_before}:${stage}:$(stage_output_identity "${stage}")"
   local actual=""
   if [[ -f "${stamp}" ]]; then
     IFS= read -r actual <"${stamp}" || true
@@ -572,9 +603,10 @@ run_checkpointed() {
 
   "$@"
   verify_runtime_cli_identity
-  local expected_after
-  expected_after="$(validation_fingerprint_for_stage "${stage}"):${stage}"
-  if [[ "${expected_after}" != "${expected_before}" ]]; then
+  local fingerprint_after expected_after
+  fingerprint_after="$(validation_fingerprint_for_stage "${stage}")"
+  expected_after="${fingerprint_after}:${stage}:$(stage_output_identity "${stage}")"
+  if [[ "${fingerprint_after}" != "${fingerprint_before}" ]]; then
     printf 'stack validation inputs changed while stage ran; refusing stale success: %s\n' \
       "${stage}" >&2
     return 75

--- a/Tools/ci/test_classify_ci_changes.py
+++ b/Tools/ci/test_classify_ci_changes.py
@@ -61,12 +61,13 @@ class ClassifyCIChangesTests(unittest.TestCase):
         self.assertTrue(scope.runtime)
         self.assertFalse(scope.tools)
 
-    def test_recoverable_stack_tools_select_tool_tests(self) -> None:
-        scope = CLASSIFIER.classify(["Tools/build/stack-pin.py"])
-
-        self.assertTrue(scope.heavy)
-        self.assertTrue(scope.tools)
-        self.assertFalse(scope.runtime)
+    def test_recoverable_stack_inputs_select_runtime_and_tool_tests(self) -> None:
+        for path in ("Tools/build/stack-pin.py", "Tools/release/stack-refs.json"):
+            with self.subTest(path=path):
+                scope = CLASSIFIER.classify([path])
+                self.assertTrue(scope.heavy)
+                self.assertTrue(scope.tools)
+                self.assertTrue(scope.runtime)
 
     def test_swift_runtime_drivers_select_both_scopes(self) -> None:
         for path in sorted(CLASSIFIER.RUNTIME_DRIVER_PATHS):

--- a/Tools/ci/test_doc_site_manifest.py
+++ b/Tools/ci/test_doc_site_manifest.py
@@ -86,6 +86,18 @@ class DocSiteManifestTests(unittest.TestCase):
         with self.assertRaisesRegex(MODULE.ManifestError, "unsafe"):
             MODULE.verify_archive(archive)
 
+    def test_semantic_context_rejects_wrong_site_or_source(self) -> None:
+        context = {
+            "site": "compose",
+            "source_ref": "a" * 40,
+            "toolchain_digest": "b" * 64,
+            "hosting_base_path": "container-compose",
+        }
+        MODULE.create(self.root, context)
+        MODULE.verify(self.root, context)
+        with self.assertRaisesRegex(MODULE.ManifestError, "context changed"):
+            MODULE.verify(self.root, {**context, "source_ref": "c" * 40})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/ci/test_doc_site_manifest.py
+++ b/Tools/ci/test_doc_site_manifest.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("doc-site-manifest.py")
+SPEC = importlib.util.spec_from_file_location("doc_site_manifest", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class DocSiteManifestTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        (self.root / "documentation/module").mkdir(parents=True)
+        (self.root / "index.html").write_text("index", encoding="utf-8")
+        (self.root / "theme-settings.json").write_text("{}", encoding="utf-8")
+        (self.root / "documentation/module/index.html").write_text(
+            "module", encoding="utf-8"
+        )
+
+    def test_complete_site_round_trips(self) -> None:
+        MODULE.create(self.root)
+        MODULE.verify(self.root)
+
+    def test_complete_site_archive_round_trips_without_extraction(self) -> None:
+        MODULE.create(self.root)
+        archive = self.root.parent / "site.tgz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            for path in self.root.rglob("*"):
+                bundle.add(
+                    path,
+                    arcname=f"./{path.relative_to(self.root)}",
+                    recursive=False,
+                )
+        MODULE.verify_archive(archive)
+
+    def test_changed_or_missing_payload_is_rejected(self) -> None:
+        MODULE.create(self.root)
+        (self.root / "documentation/module/index.html").unlink()
+        with self.assertRaisesRegex(MODULE.ManifestError, "does not match"):
+            MODULE.verify(self.root)
+
+    def test_site_without_documentation_payload_is_rejected(self) -> None:
+        (self.root / "documentation/module/index.html").unlink()
+        with self.assertRaisesRegex(MODULE.ManifestError, "no documentation payload"):
+            MODULE.create(self.root)
+
+    def test_symlink_is_rejected(self) -> None:
+        (self.root / "documentation/link").symlink_to(self.root / "index.html")
+        with self.assertRaisesRegex(MODULE.ManifestError, "symbolic link"):
+            MODULE.create(self.root)
+
+    def test_archive_path_traversal_is_rejected(self) -> None:
+        archive = self.root.parent / "unsafe.tgz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            payload = b"unsafe"
+            member = tarfile.TarInfo("../outside")
+            member.size = len(payload)
+            bundle.addfile(member, io.BytesIO(payload))
+        with self.assertRaisesRegex(MODULE.ManifestError, "unsafe"):
+            MODULE.verify_archive(archive)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/test_documentation_workflow.py
+++ b/Tools/ci/test_documentation_workflow.py
@@ -36,7 +36,7 @@ class DocumentationWorkflowTests(unittest.TestCase):
         self.assertIn("    timeout-minutes: 60\n", build_job)
         self.assertNotIn("    timeout-minutes: 45\n", build_job)
 
-    def test_documentation_is_release_only_and_fans_out_fail_fast(self) -> None:
+    def test_documentation_is_release_only_and_preserves_independent_sites(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         triggers = workflow[
             workflow.index("on:\n") : workflow.index("permissions:\n")
@@ -56,7 +56,16 @@ class DocumentationWorkflowTests(unittest.TestCase):
         self.assertIn("Require exact published release inputs", resolve_job)
         self.assertIn("Checkout tagged container-compose source", resolve_job)
         self.assertIn("    needs: resolve-release\n", build_job)
-        self.assertIn("      fail-fast: true\n", build_job)
+        self.assertIn("      fail-fast: false\n", build_job)
+        self.assertIn("Restore SwiftPM documentation cache", build_job)
+        self.assertIn("Restore exact DocC site", build_job)
+        self.assertIn("steps.site-cache.outputs.cache-hit != 'true'", build_job)
+        self.assertIn("Verify reusable DocC site", build_job)
+
+    def test_release_work_is_queued_instead_of_discarding_pending_runs(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("  queue: max\n", workflow)
 
 
 if __name__ == "__main__":

--- a/Tools/ci/test_documentation_workflow.py
+++ b/Tools/ci/test_documentation_workflow.py
@@ -59,13 +59,23 @@ class DocumentationWorkflowTests(unittest.TestCase):
         self.assertIn("      fail-fast: false\n", build_job)
         self.assertIn("Restore SwiftPM documentation cache", build_job)
         self.assertIn("Restore exact DocC site", build_job)
-        self.assertIn("steps.site-cache.outputs.cache-hit != 'true'", build_job)
+        self.assertIn("Resolve documentation toolchain identity", build_job)
+        self.assertIn("Inspect restored DocC site", build_job)
+        self.assertIn("steps.site.outputs.reusable != 'true'", build_job)
+        self.assertIn("doc-site-manifest.py create _site", build_job)
+        self.assertIn("doc-site-manifest.py verify _site", build_job)
         self.assertIn("Verify reusable DocC site", build_job)
 
     def test_release_work_is_queued_instead_of_discarding_pending_runs(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
 
+        self.assertNotIn("concurrency:", workflow[: workflow.index("\njobs:")])
+        self.assertIn("group: documentation-pages", workflow)
         self.assertIn("  queue: max\n", workflow)
+        self.assertIn("Confirm release still owns Pages", workflow)
+        self.assertEqual(
+            workflow.count("if: steps.latest.outputs.deploy == 'true'"), 3
+        )
 
 
 if __name__ == "__main__":

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -188,6 +188,18 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         )
         self.assertNotIn("self-hosted", runtime_validation)
 
+    def test_control_only_main_changes_do_not_repeat_runtime_validation(self) -> None:
+        runtime_validation = CI_WORKFLOW.split("  validate_runtime:", 1)[1].split(
+            "  prebuilt_binaries:", 1
+        )[0]
+        canonical_main = CI_WORKFLOW.split("  resolve-canonical-main:", 1)[1].split(
+            "  validate:", 1
+        )[0]
+
+        self.assertIn("needs.changes.outputs.runtime == 'true' &&", runtime_validation)
+        self.assertNotIn("|| github.ref == 'refs/heads/main'", runtime_validation)
+        self.assertIn("if: needs.changes.outputs.runtime == 'true'", canonical_main)
+
     def test_stable_gate_uses_candidate_keyed_checkpoint_state(self) -> None:
         self.assertIn("RELEASE_BUILD_STATE_ROOT", STABLE_RELEASE_WORKFLOW)
         self.assertIn(

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -23,6 +23,9 @@ import unittest
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 MAKEFILE = (REPOSITORY_ROOT / "Makefile").read_text(encoding="utf-8")
+STACK_STORAGE = (REPOSITORY_ROOT / "Tools/build/stack-storage.py").read_text(
+    encoding="utf-8"
+)
 STABLE_RELEASE_WORKFLOW = (
     REPOSITORY_ROOT / ".github/workflows/stable-release-gate.yml"
 ).read_text(encoding="utf-8")
@@ -84,7 +87,7 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         self.assertIn("/container-compose", compose)
         self.assertIn('--scratch-path "$$scratch"', compose)
         self.assertIn('--source "$$bin_path/compose"', compose)
-        self.assertIn('--artifact "$$artifact"', compose)
+        self.assertIn('--artifact-map "compose/bin/compose=$$compose_artifact"', compose)
         self.assertIn('STACK_ARTIFACT_ROOT := $(STACK_RETAINED_ROOT)', MAKEFILE)
 
     def test_build_contract_does_not_hash_unrelated_make_targets(self) -> None:
@@ -149,12 +152,13 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         self.assertIn("Library/Application Support/ContainerFamily/retained/build", MAKEFILE)
         self.assertIn("STACK_TRANSIENT_ROOT ?= /Volumes/SSD/cf/build", MAKEFILE)
         state_init = make_target("stack-state-init", "stack-preflight")
-        self.assertIn("stack storage root must be absolute", state_init)
-        self.assertIn("must be on separate filesystems", state_init)
-        self.assertIn("must not be a symbolic link", state_init)
+        self.assertIn('"$(STACK_STORAGE_TOOL)"', state_init)
+        self.assertIn("stack storage path must be absolute", STACK_STORAGE)
+        self.assertIn("separate filesystems", STACK_STORAGE)
+        self.assertIn("symbolic link", STACK_STORAGE)
         self.assertIn(".container-family-retained-root", state_init)
         self.assertIn(".container-family-transient-root", state_init)
-        self.assertIn("/bin/mv", state_init)
+        self.assertIn("initialize_root", STACK_STORAGE)
 
     def test_unattended_make_never_discovers_a_keychain_identity(self) -> None:
         self.assertIn("CONTAINER_RUNTIME_CODESIGN_IDENTITY ?=\n", MAKEFILE)

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -83,7 +83,9 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         compose = make_target("stack-compose-build", "local-build")
         self.assertIn("/container-compose", compose)
         self.assertIn('--scratch-path "$$scratch"', compose)
-        self.assertIn('--artifact "$$bin_path/compose"', compose)
+        self.assertIn('--source "$$bin_path/compose"', compose)
+        self.assertIn('--artifact "$$artifact"', compose)
+        self.assertIn('STACK_ARTIFACT_ROOT := $(STACK_RETAINED_ROOT)', MAKEFILE)
 
     def test_build_contract_does_not_hash_unrelated_make_targets(self) -> None:
         contracts = MAKEFILE.split("STACK_SWIFT_CONTRACT =", 1)[1].split(
@@ -144,12 +146,14 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
             self.assertIn(f'{source_path}="$({repository})"', compose)
 
     def test_recovery_state_is_durable_and_has_a_safe_local_fallback(self) -> None:
-        self.assertIn("/Volumes/SSD/github/.container-compose-build", MAKEFILE)
-        self.assertIn("$(abspath .build/stack)", MAKEFILE)
+        self.assertIn("Library/Application Support/ContainerFamily/retained/build", MAKEFILE)
+        self.assertIn("STACK_TRANSIENT_ROOT ?= /Volumes/SSD/cf/build", MAKEFILE)
         state_init = make_target("stack-state-init", "stack-preflight")
-        self.assertIn("STACK_STATE_ROOT must be absolute", state_init)
+        self.assertIn("stack storage root must be absolute", state_init)
+        self.assertIn("must be on separate filesystems", state_init)
         self.assertIn("must not be a symbolic link", state_init)
-        self.assertIn(".container-compose-build-root", state_init)
+        self.assertIn(".container-family-retained-root", state_init)
+        self.assertIn(".container-family-transient-root", state_init)
         self.assertIn("/bin/mv", state_init)
 
     def test_unattended_make_never_discovers_a_keychain_identity(self) -> None:
@@ -188,7 +192,7 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         )
         self.assertNotIn("self-hosted", runtime_validation)
 
-    def test_control_only_main_changes_do_not_repeat_runtime_validation(self) -> None:
+    def test_main_changes_run_runtime_until_equivalent_evidence_is_implemented(self) -> None:
         runtime_validation = CI_WORKFLOW.split("  validate_runtime:", 1)[1].split(
             "  prebuilt_binaries:", 1
         )[0]
@@ -196,14 +200,17 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
             "  validate:", 1
         )[0]
 
-        self.assertIn("needs.changes.outputs.runtime == 'true' &&", runtime_validation)
-        self.assertNotIn("|| github.ref == 'refs/heads/main'", runtime_validation)
-        self.assertIn("if: needs.changes.outputs.runtime == 'true'", canonical_main)
+        self.assertIn("|| github.ref == 'refs/heads/main'", runtime_validation)
+        self.assertIn("|| github.ref == 'refs/heads/main'", canonical_main)
 
     def test_stable_gate_uses_candidate_keyed_checkpoint_state(self) -> None:
         self.assertIn("RELEASE_BUILD_STATE_ROOT", STABLE_RELEASE_WORKFLOW)
         self.assertIn(
             'state_root="${state_parent}/${CANDIDATE_SHA}"',
+            STABLE_RELEASE_WORKFLOW,
+        )
+        self.assertIn(
+            'state_parent="${retained_root}/release/checkpoints"',
             STABLE_RELEASE_WORKFLOW,
         )
         self.assertIn(

--- a/Tools/ci/test_run_release_checkpoint.py
+++ b/Tools/ci/test_run_release_checkpoint.py
@@ -1040,7 +1040,6 @@ class RunReleaseCheckpointTest(unittest.TestCase):
             "hawkeye": {"hawkeye": "/usr/bin/false"},
             "llvm-cov": {"llvm_cov": "/usr/bin/false"},
             "llvm-profdata": {"llvm_profdata": "/usr/bin/false"},
-            "docker-compose": {"docker_compose": "/usr/bin/false compose"},
         }
 
         for name, overrides in selectors.items():
@@ -1048,6 +1047,14 @@ class RunReleaseCheckpointTest(unittest.TestCase):
                 self.assertNotEqual(
                     self.release_gate_tool_fingerprint(**overrides), baseline
                 )
+
+        self.assertEqual(
+            self.release_gate_tool_fingerprint(
+                docker_compose="/usr/bin/false compose"
+            ),
+            baseline,
+            "normal tool observation must not probe or depend on Docker applications",
+        )
 
     def test_outer_fingerprint_tracks_runtime_compose_binary(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/ci/test_run_release_checkpoint.py
+++ b/Tools/ci/test_run_release_checkpoint.py
@@ -301,7 +301,13 @@ class RunReleaseCheckpointTest(unittest.TestCase):
         fingerprint: str,
         status: int = 0,
         seconds: int = 5,
+        required_output: Path | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        output_arguments = (
+            ["--required-output", str(required_output)]
+            if required_output is not None
+            else []
+        )
         return subprocess.run(
             [
                 sys.executable,
@@ -314,6 +320,7 @@ class RunReleaseCheckpointTest(unittest.TestCase):
                 fingerprint,
                 "--seconds",
                 str(seconds),
+                *output_arguments,
                 "--",
                 "/bin/sh",
                 "-c",
@@ -413,6 +420,52 @@ class RunReleaseCheckpointTest(unittest.TestCase):
             self.assertEqual(run_log.read_text(encoding="utf-8"), "run\n" * 3)
             self.assertIn("invalidating release checkpoint", modified.stdout)
             self.assertIn("invalidating release checkpoint", missing.stdout)
+
+    def test_required_product_content_is_part_of_checkpoint_reuse(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            checkpoints = root / "checkpoints"
+            run_log = root / "runs.log"
+            product = root / "retained-product.tar.gz"
+            product.write_bytes(b"first product")
+
+            first = self.run_stage(
+                checkpoints, run_log, "tree-a", required_output=product
+            )
+            repeated = self.run_stage(
+                checkpoints, run_log, "tree-a", required_output=product
+            )
+            product.write_bytes(b"changed product")
+            changed = self.run_stage(
+                checkpoints, run_log, "tree-a", required_output=product
+            )
+
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertEqual(repeated.returncode, 0, repeated.stderr)
+            self.assertEqual(changed.returncode, 0, changed.stderr)
+            self.assertEqual(run_log.read_text(encoding="utf-8"), "run\nrun\n")
+            self.assertIn("reusing exact-input release checkpoint", repeated.stdout)
+            self.assertIn("invalidating release checkpoint", changed.stdout)
+            checkpoint = json.loads(
+                (checkpoints / "compose-ci.success.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                checkpoint["required_outputs"][0]["sha256"],
+                hashlib.sha256(product.read_bytes()).hexdigest(),
+            )
+
+    def test_missing_required_product_cannot_record_success(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            completed = self.run_stage(
+                root / "checkpoints",
+                root / "runs.log",
+                "tree-a",
+                required_output=root / "missing.tar.gz",
+            )
+
+            self.assertEqual(completed.returncode, 74)
+            self.assertIn("could not verify release checkpoint products", completed.stderr)
 
     def test_failed_rerun_cannot_revalidate_an_invalidated_checkpoint(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/ci/test_validate_actions_workflows.py
+++ b/Tools/ci/test_validate_actions_workflows.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("validate-actions-workflows.py")
+SPEC = importlib.util.spec_from_file_location("validate_actions_workflows", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ValidateActionsWorkflowsTests(unittest.TestCase):
+    def workflow(self, source: str) -> Path:
+        temporary = tempfile.NamedTemporaryFile(suffix=".yml", delete=False)
+        self.addCleanup(Path(temporary.name).unlink, missing_ok=True)
+        path = Path(temporary.name)
+        temporary.close()
+        path.write_text(source, encoding="utf-8")
+        return path
+
+    def test_removes_only_valid_queue_extension_for_actionlint(self) -> None:
+        source = "name: CI\nconcurrency:\n  group: release\n  queue: max\njobs: {}\n"
+        self.assertNotIn("queue:", MODULE.compatible_source(self.workflow(source)))
+
+    def test_rejects_unknown_queue_value_or_location(self) -> None:
+        for source in (
+            "concurrency:\n  queue: newest\n",
+            "jobs:\n  queue: max\n",
+        ):
+            with self.subTest(source=source):
+                with self.assertRaises(MODULE.WorkflowError):
+                    MODULE.compatible_source(self.workflow(source))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/ci/validate-actions-workflows.py
+++ b/Tools/ci/validate-actions-workflows.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Run actionlint while validating GitHub's newer concurrency queue extension."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+class WorkflowError(RuntimeError):
+    """A workflow uses an invalid queue extension."""
+
+
+def compatible_source(path: Path) -> str:
+    lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    output: list[str] = []
+    for index, line in enumerate(lines):
+        stripped = line.lstrip(" ")
+        if not stripped.startswith("queue:"):
+            output.append(line)
+            continue
+        indentation = len(line) - len(stripped)
+        if stripped.strip() != "queue: max":
+            raise WorkflowError(f"{path}:{index + 1}: concurrency queue must be max")
+        parent_found = False
+        for previous in reversed(lines[:index]):
+            previous_stripped = previous.lstrip(" ")
+            if not previous_stripped.strip() or previous_stripped.startswith("#"):
+                continue
+            previous_indentation = len(previous) - len(previous_stripped)
+            if previous_indentation < indentation:
+                parent_found = previous_stripped.strip() == "concurrency:"
+                break
+        if not parent_found:
+            raise WorkflowError(
+                f"{path}:{index + 1}: queue is not directly inside concurrency"
+            )
+        # actionlint 1.7.12 predates GitHub's queue extension. Validate the
+        # extension narrowly above and lint every remaining byte normally.
+    return "".join(output)
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--actionlint", default="actionlint")
+    parser.add_argument("--config", type=Path, default=Path(".github/actionlint.yaml"))
+    parser.add_argument("workflow", type=Path, nargs="+")
+    options = parser.parse_args(arguments)
+    try:
+        with tempfile.TemporaryDirectory() as directory:
+            temporary = Path(directory)
+            lint_paths: list[str] = []
+            for index, workflow in enumerate(options.workflow):
+                destination = temporary / f"{index}-{workflow.name}"
+                destination.write_text(compatible_source(workflow), encoding="utf-8")
+                lint_paths.append(str(destination))
+            command = [options.actionlint]
+            if options.config.is_file():
+                command.extend(("-config-file", str(options.config.resolve())))
+            result = subprocess.run([*command, *lint_paths], check=False)
+            return result.returncode
+    except (OSError, UnicodeError, WorkflowError) as error:
+        print(f"validate-actions-workflows: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -123,14 +123,28 @@ def packaging_run_candidates(
     runs: Iterable[dict[str, object]], version: str
 ) -> list[dict[str, object]]:
     version_tuple(version)
-    titles = {
+    legacy_titles = {
         f"Prebuilt Binaries · {version}",
         f"Prebuilt Binaries · {version} · package",
     }
+    request_id = re.compile(
+        r"(?:automatic|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-"
+        r"[0-9a-f]{4}-[0-9a-f]{12})"
+    )
+    current_title = re.compile(
+        rf"Prebuilt Binaries · {re.escape(version)} · package · "
+        rf"{request_id.pattern}"
+    )
     candidates: list[tuple[str, int, str, str]] = []
     for run in runs:
         if (
-            run.get("displayTitle") not in titles
+            (
+                run.get("displayTitle") not in legacy_titles
+                and (
+                    not isinstance(run.get("displayTitle"), str)
+                    or current_title.fullmatch(run["displayTitle"]) is None
+                )
+            )
             or run.get("event") != "workflow_dispatch"
             or run.get("status") != "completed"
             or run.get("conclusion") != "success"

--- a/Tools/parity/published_release_benchmark.py
+++ b/Tools/parity/published_release_benchmark.py
@@ -123,11 +123,14 @@ def packaging_run_candidates(
     runs: Iterable[dict[str, object]], version: str
 ) -> list[dict[str, object]]:
     version_tuple(version)
-    title = f"Prebuilt Binaries · {version}"
+    titles = {
+        f"Prebuilt Binaries · {version}",
+        f"Prebuilt Binaries · {version} · package",
+    }
     candidates: list[tuple[str, int, str, str]] = []
     for run in runs:
         if (
-            run.get("displayTitle") != title
+            run.get("displayTitle") not in titles
             or run.get("event") != "workflow_dispatch"
             or run.get("status") != "completed"
             or run.get("conclusion") != "success"

--- a/Tools/parity/test_historical_reconstruction_benchmark.py
+++ b/Tools/parity/test_historical_reconstruction_benchmark.py
@@ -309,18 +309,27 @@ class HistoricalWorkflowTests(unittest.TestCase):
 
     def test_workflow_keeps_runtime_inputs_local_and_noninteractive(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn('"${RUNNER_TEMP}" "${GITHUB_RUN_ID}"', workflow)
-        self.assertIn("BUILD_STATE_ROOT: /Volumes/SSD/github/", workflow)
+        self.assertIn("BUILD_TRANSIENT_ROOT: /Volumes/SSD/cf/build", workflow)
+        self.assertIn(
+            'retained_base="${HOME}/Library/Application Support/ContainerFamily/retained"',
+            workflow,
+        )
+        self.assertIn('STACK_RETAINED_ROOT="${BUILD_RETAINED_ROOT}"', workflow)
+        self.assertIn('STACK_TRANSIENT_ROOT="${BUILD_TRANSIENT_ROOT}"', workflow)
+        self.assertIn("container-compose retained build v2", workflow)
+        self.assertIn("container-compose transient build v2", workflow)
         self.assertIn("PARITY_INCLUDE_REMOTE_LOGGING=0", workflow)
         self.assertIn("CONTAINER_RUNTIME_LOCAL_EXECUTION_ROOT=/private/tmp", workflow)
         self.assertIn("ssh-keygen -y -P ''", workflow)
         self.assertNotIn("security import", workflow)
         self.assertNotIn("crane auth", workflow)
 
-    def test_workflow_preloads_a_pinned_fixture_without_registry_access(self) -> None:
+    def test_workflow_reuses_a_pinned_fixture_and_isolates_docker_as_oracle(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         makefile = MAKEFILE.read_text(encoding="utf-8")
-        prepare = workflow.index("Prepare pinned offline fixture image")
+        prepare = workflow.index(
+            "Prepare pinned fixture for candidate and Docker oracle"
+        )
         quiet_host = workflow.index("Require a quiet benchmark host")
 
         self.assertLess(prepare, quiet_host)
@@ -335,22 +344,20 @@ class HistoricalWorkflowTests(unittest.TestCase):
             "application/vnd.oci.image.manifest.v1+json",
             workflow,
         )
-        self.assertIn("docker-daemon:${FIXTURE_IMAGE}", workflow)
+        self.assertIn('"docker://${expected_reference}"', workflow)
+        self.assertIn('"docker-daemon:${FIXTURE_IMAGE}"', workflow)
         self.assertIn(
-            'if ! docker image inspect "${FIXTURE_IMAGE}" > "${docker_metadata}"; then',
+            "Docker is retained only as this benchmark's isolated reference",
             workflow,
         )
-        self.assertIn("docker pull ${expected_reference}", workflow)
-        self.assertIn(
-            "docker image tag ${expected_reference} ${FIXTURE_IMAGE}", workflow
-        )
-        self.assertNotIn(
-            "recover before retrying with: docker pull %s", workflow
-        )
+        self.assertNotIn("docker pull", workflow)
+        self.assertNotIn("docker image tag", workflow)
+        self.assertNotIn("docker image inspect", workflow)
         self.assertIn("skopeo copy --format oci", workflow)
         self.assertNotIn("--preserve-digests", workflow)
-        self.assertIn("--src-daemon-host", workflow)
-        self.assertIn("docker context inspect", workflow)
+        self.assertNotIn("--src-daemon-host", workflow)
+        self.assertNotIn("docker context inspect", workflow)
+        self.assertIn('cached_archive="${BENCHMARK_CACHE_ROOT}/fixtures/', workflow)
         self.assertIn("expected exactly one manifest", workflow)
         self.assertIn(
             '[[ "${archive_media_type}" == "${FIXTURE_IMAGE_MANIFEST_MEDIA_TYPE}" ]]',
@@ -396,10 +403,12 @@ class HistoricalWorkflowTests(unittest.TestCase):
 
     def test_recoverable_build_uses_native_cache_and_authenticated_pin(self) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn('scratch="${BUILD_STATE_ROOT}/scratch/', workflow)
+        self.assertIn('scratch="${BUILD_TRANSIENT_ROOT}/scratch/', workflow)
         self.assertIn("--disable-automatic-resolution", workflow)
         self.assertIn("--repository containerization", workflow)
-        self.assertIn('--artifact "${version_root}/cctl"', workflow)
+        self.assertIn('cctl_cache="${BENCHMARK_CACHE_ROOT}/cctl/', workflow)
+        self.assertIn("Tools/build/stack-artifact.py", workflow)
+        self.assertIn('--artifact "${retained_cctl}"', workflow)
         self.assertNotIn("nextflow", workflow.lower())
 
     def test_cleanup_unregisters_temporary_git_worktrees(self) -> None:
@@ -413,6 +422,12 @@ class HistoricalWorkflowTests(unittest.TestCase):
         self.assertIn("git -C containerization-source worktree prune", workflow)
         self.assertIn(
             "refusing to remove symbolic-link benchmark worktree", workflow
+        )
+        self.assertNotIn(
+            'find "${BENCHMARK_RETAINED_ROOT}" -depth -delete', workflow
+        )
+        self.assertIn(
+            '${{ env.BENCHMARK_RETAINED_ROOT }}/evidence', workflow
         )
 
 

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -96,7 +96,10 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
             },
             {
                 "databaseId": 12,
-                "displayTitle": "Prebuilt Binaries · 0.13.0 · package",
+                "displayTitle": (
+                    "Prebuilt Binaries · 0.13.0 · package · "
+                    "01234567-89ab-cdef-0123-456789abcdef"
+                ),
                 "event": "workflow_dispatch",
                 "status": "completed",
                 "conclusion": "success",
@@ -134,6 +137,42 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
             ],
             [12, 10],
         )
+
+    def test_current_package_run_name_accepts_only_a_safe_request_suffix(self) -> None:
+        base = {
+            "databaseId": 12,
+            "event": "workflow_dispatch",
+            "status": "completed",
+            "conclusion": "success",
+            "createdAt": "2026-08-24T11:00:00Z",
+            "url": "https://github.com/stephenlclarke/container-compose/actions/runs/12",
+            "headBranch": "main",
+            "headSha": "c" * 40,
+        }
+        accepted = []
+        for suffix in (
+            "automatic",
+            "01234567-89ab-cdef-0123-456789abcdef",
+        ):
+            run = {
+                **base,
+                "displayTitle": f"Prebuilt Binaries · 0.13.0 · package · {suffix}",
+            }
+            accepted.extend(MODULE.packaging_run_candidates([run], "0.13.0"))
+        self.assertEqual([candidate["runId"] for candidate in accepted], [12, 12])
+
+        for title in (
+            "Prebuilt Binaries · 0.13.0 · package · arbitrary",
+            "Prebuilt Binaries · 0.13.0 · package · 01234567-89ab-cdef",
+            "Prebuilt Binaries · 0.13.1 · package · automatic",
+            "Prebuilt Binaries · 0.13.0 · tap-repair · automatic",
+        ):
+            with self.subTest(title=title), self.assertRaisesRegex(
+                MODULE.BenchmarkInputError, "no successful immutable package run"
+            ):
+                MODULE.packaging_run_candidates(
+                    [{**base, "displayTitle": title}], "0.13.0"
+                )
 
     def test_package_run_from_side_branch_is_rejected(self) -> None:
         run = {

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -96,7 +96,7 @@ class ResolvePublishedArtifactsTests(unittest.TestCase):
             },
             {
                 "databaseId": 12,
-                "displayTitle": "Prebuilt Binaries · 0.13.0",
+                "displayTitle": "Prebuilt Binaries · 0.13.0 · package",
                 "event": "workflow_dispatch",
                 "status": "completed",
                 "conclusion": "success",

--- a/Tools/parity/test_published_release_benchmark.py
+++ b/Tools/parity/test_published_release_benchmark.py
@@ -983,29 +983,45 @@ class PublishedBenchmarkWorkflowTests(unittest.TestCase):
         self.assertIn("if: always()", retain)
         self.assertIn("if-no-files-found: warn", retain)
 
-    def test_workflow_keeps_bind_mounted_fixtures_on_docker_shared_storage(
+    def test_workflow_refuses_to_time_on_a_busy_host(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        quiet = workflow.index("Require a quiet benchmark host")
+        benchmark = workflow.index("Run same-host published comparisons")
+
+        self.assertLess(quiet, benchmark)
+        self.assertIn('pgrep -x "${process_name}"', workflow)
+        self.assertIn("load <= cpus / 2", workflow)
+        self.assertIn("thermal-before.txt", workflow)
+        self.assertIn("thermal-after.txt", workflow)
+
+    def test_workflow_keeps_transient_and_retained_benchmark_data_separate(
         self,
     ) -> None:
         workflow = WORKFLOW.read_text(encoding="utf-8")
         root_selection = workflow[
-            workflow.index("Select Docker-shared local benchmark root") :
+            workflow.index("Select separated Docker-oracle benchmark storage") :
             workflow.index("Checkout documentation and benchmark controls")
         ]
 
-        self.assertIn('case "${RUNNER_TEMP}"', root_selection)
-        self.assertIn('"${HOME}"/*', root_selection)
         self.assertIn(
-            '"${RUNNER_TEMP}" "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}"',
+            "transient_base=/Volumes/SSD/cf/build", root_selection
+        )
+        self.assertIn(
+            'retained_base="${HOME}/Library/Application Support/'
+            'ContainerFamily/retained/build"',
             root_selection,
         )
         self.assertNotIn("/private/tmp", root_selection)
         self.assertIn(
-            "${{ runner.temp }}/container-compose-published-benchmark-",
+            "${{ env.BENCHMARK_RETAINED_ROOT }}/evidence",
             workflow,
         )
         self.assertNotIn(
             "BENCHMARK_ROOT: /private/tmp/container-compose-published-benchmark",
             workflow,
+        )
+        self.assertNotIn(
+            'find "${BENCHMARK_RETAINED_ROOT}" -depth -delete', workflow
         )
 
     def test_workflow_rejects_interactive_documentation_signing(self) -> None:

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -72,7 +72,7 @@ fi
 release_state() {
   local output status
   set +e
-  output="$("${GH}" api --silent "repos/${RELEASE_REPOSITORY}/releases/tags/${RELEASE_TAG}" 2>&1)"
+  output="$("${GH}" api "repos/${RELEASE_REPOSITORY}/releases/tags/${RELEASE_TAG}" 2>&1)"
   status=$?
   set -e
 

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -77,7 +77,13 @@ release_state() {
   set -e
 
   if (( status == 0 )); then
-    printf 'exists\n'
+    if [[ -n "${output}" ]] && \
+      [[ "$(jq -r 'if .draft == true then "draft" else "published" end' \
+        <<<"${output}" 2>/dev/null || true)" == draft ]]; then
+      printf 'draft\n'
+    else
+      printf 'exists\n'
+    fi
     return 0
   fi
   if [[ "${output}" == *"HTTP 404"* ]]; then
@@ -99,6 +105,12 @@ fi
 
 case "${PUBLISH_REF_TYPE}:${RELEASE_MUTABLE}" in
   tag:false)
+    if [[ -z "${RELEASE_RETAINED_COMPLETE_MANIFEST:-}" || \
+      ! -f "${RELEASE_RETAINED_COMPLETE_MANIFEST}" || \
+      -L "${RELEASE_RETAINED_COMPLETE_MANIFEST}" ]]; then
+      printf 'stable publication requires a durable retained-complete manifest\n' >&2
+      exit 2
+    fi
     ;;
   branch:true)
     if [[ "${RELEASE_TAG}" != "current" ]]; then
@@ -196,6 +208,54 @@ create_release() {
   "${GH}" release create "${RELEASE_TAG}" "${create_args[@]}"
 }
 
+create_stable_draft() {
+  "${GH}" release create "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
+    --title "${RELEASE_TITLE}" --notes-file "${RELEASE_NOTES_FILE}" \
+    --verify-tag "${release_flags[@]}" --draft
+}
+
+reconcile_stable_draft() {
+  local temporary remote_names asset name downloaded
+  if [[ "$("${GIT}" rev-list -n 1 "refs/tags/${RELEASE_TAG}")" != "${PUBLISH_SHA}" ]]; then
+    printf 'stable draft tag no longer resolves to the requested candidate: %s\n' \
+      "${RELEASE_TAG}" >&2
+    return 1
+  fi
+  remote_names="$("${GH}" release view "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" --json assets --jq '.assets[].name')"
+  temporary="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/stable-draft-assets.XXXXXX")"
+  trap 'find "${temporary}" -depth -delete >/dev/null 2>&1 || true' RETURN
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    if grep -Fqx "${name}" <<<"${remote_names}"; then
+      "${GH}" release download "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
+        --pattern "${name}" --dir "${temporary}"
+      downloaded="${temporary}/${name}"
+      if [[ ! -f "${downloaded}" ]] || \
+        [[ "$(shasum -a 256 "${downloaded}" | awk '{print $1}')" != \
+          "$(shasum -a 256 "${asset}" | awk '{print $1}')" ]]; then
+        printf 'stable draft asset conflicts with retained candidate: %s\n' \
+          "${name}" >&2
+        return 1
+      fi
+    else
+      "${GH}" release upload "${RELEASE_TAG}" "${asset}" \
+        --repo "${RELEASE_REPOSITORY}"
+    fi
+  done
+  "${GH}" release edit "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
+    --draft=false "${release_flags[@]}"
+}
+
+if [[ "${published_release_state}" == "draft" ]]; then
+  if [[ "${RELEASE_MUTABLE}" == "true" ]]; then
+    printf 'mutable current release unexpectedly exists as a draft\n' >&2
+    exit 1
+  fi
+  reconcile_stable_draft
+  exit 0
+fi
+
 if [[ "${published_release_state}" == "exists" ]]; then
   if [[ "${RELEASE_MUTABLE}" != "true" ]]; then
     printf 'release %s already exists; published releases are immutable\n' \
@@ -229,7 +289,12 @@ if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
   move_current_tag
 fi
 
-create_release
+if [[ "${PUBLISH_REF_TYPE}" == "tag" ]]; then
+  create_stable_draft
+  reconcile_stable_draft
+else
+  create_release
+fi
 
 if [[ "${PUBLISH_REF_TYPE}" == "branch" && "${RELEASE_PHASE}" == "finalize" ]]; then
   "${GH}" release edit "${RELEASE_TAG}" \

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -125,9 +125,10 @@ esac
 #
 #   stage    upload immutable, commit-addressed assets while the existing tap
 #            formulae and current tag remain usable;
-#   finalize advance the current tag, then replace the mutable release object
-#            after the matching Homebrew formula pair has been committed. This
-#            gives GitHub a publication timestamp for the build being released.
+#   finalize advance the current tag and edit the existing mutable release
+#            after the matching Homebrew formula pair has been committed. The
+#            release object remains available throughout interruption recovery;
+#            build freshness is carried by explicit metadata, not published_at.
 #
 # GitHub releases and the Homebrew tap are separate repositories, so this is
 # not a distributed transaction. It does guarantee that an interrupted current
@@ -209,17 +210,16 @@ if [[ "${published_release_state}" == "exists" ]]; then
   fi
 
   move_current_tag
-  # GitHub retains `published_at` when a release is edited. Delete only the
-  # mutable release object (not its source tag), then create it from the staged
-  # assets so the release page shows when this Current build was published.
-  "${GH}" release delete "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" --yes
-  create_release
-  # `--verify-tag` preserves the already-validated source tag; set the release
-  # target explicitly too, so GitHub's release metadata records the commit.
+  # Re-uploading is idempotent and makes finalization recover from a partially
+  # staged asset set without creating an availability window.
+  "${GH}" release upload "${RELEASE_TAG}" "${release_assets[@]}" \
+    --repo "${RELEASE_REPOSITORY}" --clobber
   "${GH}" release edit "${RELEASE_TAG}" \
     --repo "${RELEASE_REPOSITORY}" \
     --target "${PUBLISH_SHA}" \
-    --prerelease
+    --title "${RELEASE_TITLE}" \
+    --notes-file "${RELEASE_NOTES_FILE}" \
+    "${release_flags[@]}"
   exit 0
 fi
 

--- a/Tools/release/release-dispatch-journal.py
+++ b/Tools/release/release-dispatch-journal.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Atomically retain workflow dispatch intent and acknowledgement records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+REQUEST_PATTERN = re.compile(r"[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}")
+VERSION_PATTERN = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
+
+
+class JournalError(RuntimeError):
+    """The dispatch journal operation is invalid or unsafe."""
+
+
+def write(path: Path, value: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+    descriptor, name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+    temporary = Path(name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, sort_keys=True, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def record_path(root: Path, request_id: str) -> Path:
+    if not root.is_absolute() or root == Path("/") or root.is_symlink():
+        raise JournalError(f"unsafe dispatch journal root: {root}")
+    if not REQUEST_PATTERN.fullmatch(request_id):
+        raise JournalError(f"invalid dispatch request ID: {request_id}")
+    return root / "release" / "dispatches" / f"{request_id}.json"
+
+
+def validate_record(value: object, request_id: str) -> dict[str, object]:
+    if not isinstance(value, dict) or value.get("schema") != 1:
+        raise JournalError("dispatch journal has an unsupported schema")
+    if value.get("request_id") != request_id:
+        raise JournalError("dispatch journal request ID does not match its path")
+    if not VERSION_PATTERN.fullmatch(str(value.get("version", ""))):
+        raise JournalError("dispatch journal has an invalid release version")
+    if not re.fullmatch(r"[0-9a-f]{40}", str(value.get("control_sha", ""))):
+        raise JournalError("dispatch journal has an invalid control SHA")
+    workflow = value.get("workflow")
+    if not isinstance(workflow, str) or not workflow or len(workflow) > 200:
+        raise JournalError("dispatch journal has an invalid workflow")
+    if value.get("state") not in {
+        "dispatch-intent",
+        "dispatch-unknown",
+        "dispatched",
+    }:
+        raise JournalError("dispatch journal has an invalid state")
+    return value
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("intent", "unknown", "ack"))
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--request-id", required=True)
+    parser.add_argument("--workflow")
+    parser.add_argument("--version")
+    parser.add_argument("--control-sha")
+    parser.add_argument("--run-id")
+    options = parser.parse_args(arguments)
+    try:
+        path = record_path(options.root, options.request_id)
+        if options.action == "intent":
+            if path.exists():
+                raise JournalError(f"dispatch request already exists: {options.request_id}")
+            if (
+                not options.workflow
+                or len(options.workflow) > 200
+                or VERSION_PATTERN.fullmatch(options.version or "") is None
+                or not re.fullmatch(r"[0-9a-f]{40}", options.control_sha or "")
+            ):
+                raise JournalError("dispatch intent is missing workflow/version/control")
+            value: dict[str, object] = {
+                "control_sha": options.control_sha,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "request_id": options.request_id,
+                "schema": 1,
+                "state": "dispatch-intent",
+                "version": options.version,
+                "workflow": options.workflow,
+            }
+        elif options.action == "unknown":
+            if not path.is_file() or path.is_symlink():
+                raise JournalError(f"dispatch intent is unavailable: {options.request_id}")
+            value = validate_record(
+                json.loads(path.read_text(encoding="utf-8")), options.request_id
+            )
+            if value.get("state") != "dispatch-intent":
+                raise JournalError("dispatch journal is not awaiting a response")
+            value["unknown_at"] = datetime.now(timezone.utc).isoformat()
+            value["state"] = "dispatch-unknown"
+        else:
+            if not path.is_file() or path.is_symlink():
+                raise JournalError(f"dispatch intent is unavailable: {options.request_id}")
+            value = validate_record(
+                json.loads(path.read_text(encoding="utf-8")), options.request_id
+            )
+            if value.get("state") not in {
+                "dispatch-intent",
+                "dispatch-unknown",
+            }:
+                raise JournalError("dispatch journal is not awaiting acknowledgement")
+            if not re.fullmatch(r"[0-9]+", options.run_id or ""):
+                raise JournalError(f"invalid workflow run ID: {options.run_id}")
+            value["acknowledged_at"] = datetime.now(timezone.utc).isoformat()
+            value["run_id"] = options.run_id
+            value["state"] = "dispatched"
+        write(path, value)
+    except (JournalError, OSError, UnicodeError, json.JSONDecodeError) as error:
+        print(f"release-dispatch-journal: {error}", file=sys.stderr)
+        return 2
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/release/release-dispatch-journal.py
+++ b/Tools/release/release-dispatch-journal.py
@@ -75,6 +75,10 @@ def validate_record(value: object, request_id: str) -> dict[str, object]:
         raise JournalError("dispatch journal has an invalid release version")
     if not re.fullmatch(r"[0-9a-f]{40}", str(value.get("control_sha", ""))):
         raise JournalError("dispatch journal has an invalid control SHA")
+    if "previous_request_id" in value and REQUEST_PATTERN.fullmatch(
+        str(value["previous_request_id"])
+    ) is None:
+        raise JournalError("dispatch journal has an invalid previous request ID")
     workflow = value.get("workflow")
     if not isinstance(workflow, str) or not workflow or len(workflow) > 200:
         raise JournalError("dispatch journal has an invalid workflow")

--- a/Tools/release/release-dispatch-journal.py
+++ b/Tools/release/release-dispatch-journal.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import argparse
+import fcntl
 import json
 import os
 import re
@@ -66,7 +67,7 @@ def record_path(root: Path, request_id: str) -> Path:
 
 
 def validate_record(value: object, request_id: str) -> dict[str, object]:
-    if not isinstance(value, dict) or value.get("schema") != 1:
+    if not isinstance(value, dict) or value.get("schema") not in {1, 2}:
         raise JournalError("dispatch journal has an unsupported schema")
     if value.get("request_id") != request_id:
         raise JournalError("dispatch journal request ID does not match its path")
@@ -77,46 +78,114 @@ def validate_record(value: object, request_id: str) -> dict[str, object]:
     workflow = value.get("workflow")
     if not isinstance(workflow, str) or not workflow or len(workflow) > 200:
         raise JournalError("dispatch journal has an invalid workflow")
+    mode = value.get("mode", "")
+    if not isinstance(mode, str) or len(mode) > 100:
+        raise JournalError("dispatch journal has an invalid mode")
     if value.get("state") not in {
         "dispatch-intent",
         "dispatch-unknown",
         "dispatched",
+        "failed",
     }:
         raise JournalError("dispatch journal has an invalid state")
     return value
 
 
+def matching_records(
+    root: Path, workflow: str, version: str, control_sha: str, mode: str
+) -> list[dict[str, object]]:
+    directory = root / "release/dispatches"
+    matches: list[dict[str, object]] = []
+    if directory.exists():
+        if directory.is_symlink() or not directory.is_dir():
+            raise JournalError(f"unsafe dispatch journal directory: {directory}")
+        for candidate in directory.glob("*.json"):
+            record = validate_record(
+                json.loads(candidate.read_text(encoding="utf-8")), candidate.stem
+            )
+            if (
+                record.get("workflow") == workflow
+                and record.get("version") == version
+                and record.get("control_sha") == control_sha
+                and record.get("mode", "") == mode
+            ):
+                matches.append(record)
+    matches.sort(key=lambda value: str(value.get("created_at", "")), reverse=True)
+    return matches
+
+
+def intent_value(options: argparse.Namespace) -> dict[str, object]:
+    if (
+        not options.workflow
+        or len(options.workflow) > 200
+        or VERSION_PATTERN.fullmatch(options.version or "") is None
+        or not re.fullmatch(r"[0-9a-f]{40}", options.control_sha or "")
+    ):
+        raise JournalError("dispatch intent is missing workflow/version/control")
+    return {
+        "control_sha": options.control_sha,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "request_id": options.request_id,
+        "mode": options.mode,
+        "schema": 2,
+        "state": "dispatch-intent",
+        "version": options.version,
+        "workflow": options.workflow,
+    }
+
+
 def main(arguments: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("action", choices=("intent", "unknown", "ack"))
+    parser.add_argument("action", choices=("intent", "unknown", "ack", "fail", "find", "claim"))
     parser.add_argument("--root", type=Path, required=True)
-    parser.add_argument("--request-id", required=True)
+    parser.add_argument("--request-id")
     parser.add_argument("--workflow")
     parser.add_argument("--version")
     parser.add_argument("--control-sha")
     parser.add_argument("--run-id")
+    parser.add_argument("--mode", default="")
     options = parser.parse_args(arguments)
     try:
+        if options.action in {"find", "claim"}:
+            if (
+                not options.workflow
+                or VERSION_PATTERN.fullmatch(options.version or "") is None
+                or not re.fullmatch(r"[0-9a-f]{40}", options.control_sha or "")
+            ):
+                raise JournalError("dispatch lookup is missing workflow/version/control")
+            if options.action == "find":
+                matches = matching_records(
+                    options.root, options.workflow, options.version,
+                    options.control_sha, options.mode,
+                )
+                print(json.dumps(matches[0] if matches else {}, sort_keys=True))
+                return 0
+            if not options.request_id:
+                raise JournalError("claim requires --request-id")
+            path = record_path(options.root, options.request_id)
+            path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+            lock_path = path.parent / ".logical-operation.lock"
+            with lock_path.open("a+b") as lock_stream:
+                fcntl.flock(lock_stream.fileno(), fcntl.LOCK_EX)
+                matches = matching_records(
+                    options.root, options.workflow, options.version,
+                    options.control_sha, options.mode,
+                )
+                active = [record for record in matches if record.get("state") != "failed"]
+                value = active[0] if active else intent_value(options)
+                if not active:
+                    if matches:
+                        value["previous_request_id"] = matches[0]["request_id"]
+                    write(path, value)
+                print(json.dumps(value, sort_keys=True))
+            return 0
+        if not options.request_id:
+            raise JournalError(f"{options.action} requires --request-id")
         path = record_path(options.root, options.request_id)
         if options.action == "intent":
             if path.exists():
                 raise JournalError(f"dispatch request already exists: {options.request_id}")
-            if (
-                not options.workflow
-                or len(options.workflow) > 200
-                or VERSION_PATTERN.fullmatch(options.version or "") is None
-                or not re.fullmatch(r"[0-9a-f]{40}", options.control_sha or "")
-            ):
-                raise JournalError("dispatch intent is missing workflow/version/control")
-            value: dict[str, object] = {
-                "control_sha": options.control_sha,
-                "created_at": datetime.now(timezone.utc).isoformat(),
-                "request_id": options.request_id,
-                "schema": 1,
-                "state": "dispatch-intent",
-                "version": options.version,
-                "workflow": options.workflow,
-            }
+            value = intent_value(options)
         elif options.action == "unknown":
             if not path.is_file() or path.is_symlink():
                 raise JournalError(f"dispatch intent is unavailable: {options.request_id}")
@@ -127,7 +196,7 @@ def main(arguments: list[str] | None = None) -> int:
                 raise JournalError("dispatch journal is not awaiting a response")
             value["unknown_at"] = datetime.now(timezone.utc).isoformat()
             value["state"] = "dispatch-unknown"
-        else:
+        elif options.action == "ack":
             if not path.is_file() or path.is_symlink():
                 raise JournalError(f"dispatch intent is unavailable: {options.request_id}")
             value = validate_record(
@@ -143,6 +212,16 @@ def main(arguments: list[str] | None = None) -> int:
             value["acknowledged_at"] = datetime.now(timezone.utc).isoformat()
             value["run_id"] = options.run_id
             value["state"] = "dispatched"
+        else:
+            if not path.is_file() or path.is_symlink():
+                raise JournalError(f"dispatch record is unavailable: {options.request_id}")
+            value = validate_record(
+                json.loads(path.read_text(encoding="utf-8")), options.request_id
+            )
+            if value.get("state") != "dispatched":
+                raise JournalError("only an acknowledged dispatch can fail")
+            value["failed_at"] = datetime.now(timezone.utc).isoformat()
+            value["state"] = "failed"
         write(path, value)
     except (JournalError, OSError, UnicodeError, json.JSONDecodeError) as error:
         print(f"release-dispatch-journal: {error}", file=sys.stderr)

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -74,7 +74,7 @@ def dispatch_records(root: Path, version: str) -> list[dict[str, Any]]:
             raise StateError(f"invalid dispatch journal record: {path}") from error
         if (
             not isinstance(value, dict)
-            or value.get("schema") != 1
+            or value.get("schema") not in {1, 2}
             or value.get("request_id") != path.stem
             or REQUEST_ID.fullmatch(path.stem) is None
             or SEMVER.fullmatch(str(value.get("version", ""))) is None
@@ -83,9 +83,9 @@ def dispatch_records(root: Path, version: str) -> list[dict[str, Any]]:
             or not isinstance(value.get("workflow"), str)
             or not value["workflow"]
             or value.get("state")
-            not in {"dispatch-intent", "dispatch-unknown", "dispatched"}
+            not in {"dispatch-intent", "dispatch-unknown", "dispatched", "failed"}
             or (
-                value.get("state") == "dispatched"
+                value.get("state") in {"dispatched", "failed"}
                 and re.fullmatch(r"[0-9]+", str(value.get("run_id", ""))) is None
             )
         ):
@@ -95,12 +95,31 @@ def dispatch_records(root: Path, version: str) -> list[dict[str, Any]]:
     return records
 
 
-def retained_assets(root: Path, version: str) -> tuple[list[str], list[str]]:
+def retained_assets(
+    root: Path, version: str, deep: bool = False
+) -> tuple[list[str], list[str]]:
     present: list[str] = []
     missing: list[str] = []
+    try:
+        manifest = LOCAL_STORE.read_manifest(LOCAL_STORE.manifest_path(root, version))
+    except (LOCAL_STORE.RetentionError, OSError, json.JSONDecodeError):
+        return present, list(EXPECTED_ASSETS)
     for name in EXPECTED_ASSETS:
         try:
-            LOCAL_STORE.retained_path(root, version, name)
+            record = manifest["assets"].get(name)
+            if not isinstance(record, dict) or not isinstance(record.get("path"), str):
+                raise LOCAL_STORE.RetentionError("missing asset record")
+            path = Path(record["path"])
+            artifact_root = (root / "release/artifacts").resolve(strict=True)
+            if (
+                not path.is_absolute()
+                or artifact_root not in path.resolve(strict=False).parents
+                or path.is_symlink()
+                or not path.is_file()
+                or path.stat().st_size != record.get("size")
+                or (deep and LOCAL_STORE.sha256(path) != record.get("sha256"))
+            ):
+                raise LOCAL_STORE.RetentionError("invalid asset record")
         except (LOCAL_STORE.RetentionError, OSError, json.JSONDecodeError):
             missing.append(name)
         else:
@@ -118,7 +137,10 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
+            timeout=30,
         )
+    except subprocess.TimeoutExpired:
+        return {"reason": "GitHub release query timed out", "state": "unavailable"}
     except (FileNotFoundError, PermissionError, OSError):
         return {"reason": "GitHub CLI is unavailable", "state": "unavailable"}
     if completed.returncode != 0:
@@ -135,13 +157,22 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
     if not isinstance(release, dict):
         return {"reason": "GitHub returned a non-object", "state": "unavailable"}
     assets = release.get("assets", [])
+    if not isinstance(assets, list):
+        return {"reason": "GitHub returned malformed release assets", "state": "unavailable"}
     names = sorted(
         asset["name"]
         for asset in assets
         if isinstance(asset, dict) and isinstance(asset.get("name"), str)
     )
-    return {
+    result = {
         "assets": names,
+        "asset_digests": {
+            asset["name"]: asset.get("digest")
+            for asset in assets
+            if isinstance(asset, dict)
+            and isinstance(asset.get("name"), str)
+            and isinstance(asset.get("digest"), str)
+        },
         "draft": release.get("draft"),
         "id": release.get("id"),
         "prerelease": release.get("prerelease"),
@@ -149,6 +180,8 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
         if release.get("draft") is False and release.get("prerelease") is False
         else "invalid",
     }
+    result["missing_assets"] = sorted(set(EXPECTED_ASSETS) - set(names))
+    return result
 
 
 def observe_dispatches(
@@ -179,7 +212,15 @@ def observe_dispatches(
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                timeout=30,
             )
+        except subprocess.TimeoutExpired:
+            record["observed"] = {
+                "reason": "GitHub run query timed out",
+                "state": "unavailable",
+            }
+            observed.append(record)
+            continue
         except (FileNotFoundError, PermissionError, OSError):
             record["observed"] = {
                 "reason": "GitHub CLI is unavailable",
@@ -212,14 +253,76 @@ def observe_dispatches(
     return observed
 
 
-def inspect(root: Path, version: str, repo: str, offline: bool) -> dict[str, Any]:
+def remote_postconditions(repo: str, offline: bool) -> dict[str, Any]:
+    if offline:
+        return {"formulae": {"state": "not-inspected"}, "pages": {"state": "not-inspected"}}
+    observations: dict[str, Any] = {}
+    formulae: dict[str, Any] = {"members": {}}
+    for name in ("container.rb", "container-compose.rb"):
+        try:
+            result = subprocess.run(
+                ["gh", "api", f"repos/stephenlclarke/homebrew-tap/contents/Formula/{name}"],
+                check=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                text=True, timeout=30,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError, OSError):
+            formulae = {"reason": "Homebrew formula observation unavailable", "state": "unavailable"}
+            break
+        if result.returncode != 0:
+            formulae = {
+                "reason": f"Homebrew formula query failed with exit {result.returncode}",
+                "state": "absent" if "HTTP 404" in result.stderr else "unavailable",
+            }
+            break
+        try:
+            value = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            value = None
+        if not isinstance(value, dict) or not isinstance(value.get("sha"), str):
+            formulae = {"reason": "GitHub returned malformed formula metadata", "state": "unavailable"}
+            break
+        formulae["members"][name] = value["sha"]
+    else:
+        formulae["state"] = "observed"
+    observations["formulae"] = formulae
+    try:
+        result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/pages"], check=False,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError, OSError):
+        observations["pages"] = {"reason": "Pages observation unavailable", "state": "unavailable"}
+    else:
+        try:
+            value = json.loads(result.stdout) if result.returncode == 0 else None
+        except json.JSONDecodeError:
+            value = None
+        if not isinstance(value, dict):
+            observations["pages"] = {
+                "reason": f"Pages query failed with exit {result.returncode}",
+                "state": "absent" if "HTTP 404" in result.stderr else "unavailable",
+            }
+        else:
+            observations["pages"] = {
+                "build_type": value.get("build_type"),
+                "html_url": value.get("html_url"),
+                "state": "observed",
+                "status": value.get("status"),
+            }
+    return observations
+
+
+def inspect(
+    root: Path, version: str, repo: str, offline: bool, deep: bool = False
+) -> dict[str, Any]:
     if not root.is_absolute() or root == Path("/") or root.is_symlink():
         raise StateError(f"unsafe retained release root: {root}")
     if not SEMVER.fullmatch(version):
         raise StateError(f"invalid stable release version: {version}")
-    present, missing = retained_assets(root, version)
+    present, missing = retained_assets(root, version, deep)
     records = observe_dispatches(dispatch_records(root, version), repo, offline)
     remote = remote_release(repo, version, offline)
+    postconditions = remote_postconditions(repo, offline)
     waiting = [
         record
         for record in records
@@ -232,22 +335,60 @@ def inspect(root: Path, version: str, repo: str, offline: bool) -> dict[str, Any
             )
         )
     ]
+    failed = [
+        record
+        for record in records
+        if record.get("state") == "failed"
+        or (
+            record.get("state") == "dispatched"
+            and isinstance(record.get("observed"), dict)
+            and record["observed"].get("state") == "completed"
+            and record["observed"].get("conclusion") != "success"
+        )
+    ]
     if any(record.get("state") == "dispatch-unknown" for record in waiting):
         next_action = "reconcile the unknown request ID; do not redispatch"
     elif waiting:
         next_action = "inspect the acknowledged workflow run before resuming"
+    elif failed:
+        next_action = "record the failed operation and explicitly authorize a new attempt"
+    elif remote.get("state") == "unavailable":
+        next_action = "restore remote observation before planning a mutation"
+    elif remote.get("state") == "invalid":
+        next_action = "resolve the conflicting remote release state"
+    elif (
+        not missing
+        and remote.get("state") == "published"
+        and remote.get("missing_assets")
+    ):
+        next_action = "reconcile the incomplete remote release from exact retained bytes"
     elif missing and remote.get("state") == "published":
         next_action = "import and verify exact published bytes; do not rebuild"
+    elif missing and remote.get("state") == "absent":
+        next_action = "produce or restore the missing retained release closure before publication"
     elif missing:
         next_action = "restore exact authenticated bytes or report the release blocked"
+    elif remote.get("state") == "absent":
+        next_action = "publish the verified retained release closure"
+    elif any(
+        value.get("state") == "unavailable" for value in postconditions.values()
+    ):
+        next_action = "restore formula and Pages observation before declaring recovery complete"
+    elif postconditions["formulae"].get("state") != "observed":
+        next_action = "restore or reconcile the paired Homebrew formulae; no build is required"
+    elif postconditions["pages"].get("state") != "observed":
+        next_action = "restore or reconcile Pages deployment; no build is required"
     else:
-        next_action = "verify remote formula and Pages postconditions; no build is required"
+        next_action = "verify candidate-bound formula and Pages identities; no build is required"
     return {
         "dispatches": records,
+        "failed": failed,
         "next_action": next_action,
         "remote_release": remote,
+        "remote_postconditions": postconditions,
         "retained": {"missing": missing, "verified": present},
         "root": str(root),
+        "verification": "deep" if deep else "shallow",
         "schema": 1,
         "version": version,
         "waiting": waiting,
@@ -285,9 +426,15 @@ def main(arguments: list[str] | None = None) -> int:
     parser.add_argument("--repo", default="stephenlclarke/container-compose")
     parser.add_argument("--format", choices=("text", "json"), default="text")
     parser.add_argument("--offline", action="store_true")
+    parser.add_argument(
+        "--deep", action="store_true",
+        help="rehash every retained payload instead of using manifest metadata",
+    )
     options = parser.parse_args(arguments)
     try:
-        state = inspect(options.root, options.version, options.repo, options.offline)
+        state = inspect(
+            options.root, options.version, options.repo, options.offline, options.deep
+        )
     except (StateError, OSError, UnicodeError) as error:
         print(f"release-state: {error}", file=sys.stderr)
         return 2

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -20,11 +20,13 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import importlib.util
 import json
 import re
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +36,13 @@ SPEC = importlib.util.spec_from_file_location("retain_local_release_assets", LOC
 assert SPEC is not None and SPEC.loader is not None
 LOCAL_STORE = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(LOCAL_STORE)
+FORMULA_TOOL = Path(__file__).with_name("verify-homebrew-formula-pair.py")
+FORMULA_SPEC = importlib.util.spec_from_file_location(
+    "verify_homebrew_formula_pair", FORMULA_TOOL
+)
+assert FORMULA_SPEC is not None and FORMULA_SPEC.loader is not None
+FORMULA = importlib.util.module_from_spec(FORMULA_SPEC)
+FORMULA_SPEC.loader.exec_module(FORMULA)
 SEMVER = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
 REQUEST_ID = re.compile(r"[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}")
 EXPECTED_ASSETS = (
@@ -52,6 +61,7 @@ EXPECTED_ASSETS = (
     "containerization.tgz",
     "k8s.tgz",
 )
+UNREAD_MANIFEST = object()
 
 
 class StateError(RuntimeError):
@@ -96,13 +106,16 @@ def dispatch_records(root: Path, version: str) -> list[dict[str, Any]]:
 
 
 def retained_assets(
-    root: Path, version: str, deep: bool = False
+    root: Path,
+    version: str,
+    deep: bool = False,
+    manifest: dict[str, Any] | None | object = UNREAD_MANIFEST,
 ) -> tuple[list[str], list[str]]:
     present: list[str] = []
     missing: list[str] = []
-    try:
-        manifest = LOCAL_STORE.read_manifest(LOCAL_STORE.manifest_path(root, version))
-    except (LOCAL_STORE.RetentionError, OSError, json.JSONDecodeError):
+    if manifest is UNREAD_MANIFEST:
+        manifest = load_retained_manifest(root, version)
+    if not isinstance(manifest, dict):
         return present, list(EXPECTED_ASSETS)
     for name in EXPECTED_ASSETS:
         try:
@@ -125,6 +138,40 @@ def retained_assets(
         else:
             present.append(name)
     return present, missing
+
+
+def load_retained_manifest(root: Path, version: str) -> dict[str, Any] | None:
+    """Load and validate the retained manifest exactly once per inspection."""
+    try:
+        return LOCAL_STORE.read_manifest(LOCAL_STORE.manifest_path(root, version))
+    except (LOCAL_STORE.RetentionError, OSError, json.JSONDecodeError):
+        return None
+
+
+def formula_expectations(
+    manifest: dict[str, Any] | None, version: str, repo: str
+) -> dict[str, str] | None:
+    """Return formula inputs rooted in the retained release manifest."""
+    if manifest is None:
+        return None
+    names = {
+        "compose": "container-compose-plugin-release-arm64.tar.gz",
+        "runtime": "container-release-arm64.tar.gz",
+    }
+    values: dict[str, str] = {}
+    for label, name in names.items():
+        record = manifest["assets"].get(name)
+        if (
+            not isinstance(record, dict)
+            or re.fullmatch(r"[0-9a-f]{64}", str(record.get("sha256", ""))) is None
+        ):
+            return None
+        values[f"{label}_sha256"] = record["sha256"]
+        values[f"{label}_url"] = (
+            f"https://github.com/{repo}/releases/"
+            f"download/{version}/{name}"
+        )
+    return values
 
 
 def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
@@ -181,6 +228,49 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
         else "invalid",
     }
     result["missing_assets"] = sorted(set(EXPECTED_ASSETS) - set(names))
+    return result
+
+
+def reconcile_remote_digests(
+    remote: dict[str, Any], manifest: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Bind API-provided remote asset digests to the retained manifest."""
+    result = dict(remote)
+    if remote.get("state") != "published" or manifest is None:
+        return result
+    observed = remote.get("asset_digests")
+    if not isinstance(observed, dict):
+        result.update(
+            reason="remote release digest inventory is malformed",
+            state="unavailable",
+        )
+        return result
+    conflicts: dict[str, dict[str, str]] = {}
+    unavailable: list[str] = []
+    for name in EXPECTED_ASSETS:
+        record = manifest["assets"].get(name)
+        if not isinstance(record, dict) or not isinstance(record.get("sha256"), str):
+            continue
+        digest = observed.get(name)
+        if digest is None:
+            unavailable.append(name)
+        elif digest != f"sha256:{record['sha256']}":
+            conflicts[name] = {
+                "expected": f"sha256:{record['sha256']}",
+                "observed": str(digest),
+            }
+    result["digest_conflicts"] = conflicts
+    result["unverified_digests"] = unavailable
+    if conflicts:
+        result.update(
+            reason="remote release asset digests conflict with retained bytes",
+            state="conflicting",
+        )
+    elif unavailable and not result.get("missing_assets"):
+        result.update(
+            reason="remote release asset digests are unavailable",
+            state="unavailable",
+        )
     return result
 
 
@@ -253,12 +343,57 @@ def observe_dispatches(
     return observed
 
 
-def remote_postconditions(repo: str, offline: bool) -> dict[str, Any]:
+def remote_postconditions(
+    repo: str,
+    version: str,
+    offline: bool,
+    expected_formulae: dict[str, str] | None,
+) -> dict[str, Any]:
     if offline:
-        return {"formulae": {"state": "not-inspected"}, "pages": {"state": "not-inspected"}}
+        return {
+            "formulae": {"state": "not-inspected"},
+            "pages": {"state": "not-inspected"},
+        }
+    try:
+        latest_result = subprocess.run(
+            ["gh", "api", f"repos/{repo}/releases/latest"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError, OSError):
+        unavailable = {
+            "reason": "latest stable release observation unavailable",
+            "state": "unavailable",
+        }
+        return {"formulae": dict(unavailable), "pages": dict(unavailable)}
+    try:
+        latest = json.loads(latest_result.stdout) if latest_result.returncode == 0 else None
+    except json.JSONDecodeError:
+        latest = None
+    if not isinstance(latest, dict) or not isinstance(latest.get("tag_name"), str):
+        unavailable = {
+            "reason": f"latest stable release query failed with exit {latest_result.returncode}",
+            "state": "unavailable",
+        }
+        return {"formulae": dict(unavailable), "pages": dict(unavailable)}
+    latest_version = latest["tag_name"]
+    if latest_version != version:
+        superseded = {"latest_version": latest_version, "state": "superseded"}
+        return {"formulae": dict(superseded), "pages": dict(superseded)}
     observations: dict[str, Any] = {}
-    formulae: dict[str, Any] = {"members": {}}
+    if expected_formulae is None:
+        formulae: dict[str, Any] = {
+            "reason": "retained archive identities are unavailable",
+            "state": "unavailable",
+        }
+    else:
+        formulae = {"members": {}}
     for name in ("container.rb", "container-compose.rb"):
+        if expected_formulae is None:
+            break
         try:
             result = subprocess.run(
                 ["gh", "api", f"repos/stephenlclarke/homebrew-tap/contents/Formula/{name}"],
@@ -266,7 +401,10 @@ def remote_postconditions(repo: str, offline: bool) -> dict[str, Any]:
                 text=True, timeout=30,
             )
         except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError, OSError):
-            formulae = {"reason": "Homebrew formula observation unavailable", "state": "unavailable"}
+            formulae = {
+                "reason": "Homebrew formula observation unavailable",
+                "state": "unavailable",
+            }
             break
         if result.returncode != 0:
             formulae = {
@@ -278,12 +416,41 @@ def remote_postconditions(repo: str, offline: bool) -> dict[str, Any]:
             value = json.loads(result.stdout)
         except json.JSONDecodeError:
             value = None
-        if not isinstance(value, dict) or not isinstance(value.get("sha"), str):
-            formulae = {"reason": "GitHub returned malformed formula metadata", "state": "unavailable"}
+        if (
+            not isinstance(value, dict)
+            or not isinstance(value.get("sha"), str)
+            or value.get("encoding") != "base64"
+            or not isinstance(value.get("content"), str)
+        ):
+            formulae = {
+                "reason": "GitHub returned malformed formula metadata",
+                "state": "unavailable",
+            }
             break
-        formulae["members"][name] = value["sha"]
+        try:
+            encoded = re.sub(r"\s+", "", value["content"])
+            body = base64.b64decode(encoded, validate=True).decode("utf-8")
+        except (ValueError, UnicodeError):
+            formulae = {
+                "reason": "GitHub returned malformed formula content",
+                "state": "unavailable",
+            }
+            break
+        formulae["members"][name] = {"blob_sha": value["sha"], "body": body}
     else:
-        formulae["state"] = "observed"
+        try:
+            FORMULA.verify_texts(
+                formulae["members"]["container-compose.rb"].pop("body"),
+                formulae["members"]["container.rb"].pop("body"),
+                expected_formulae["compose_url"],
+                expected_formulae["runtime_url"],
+                expected_formulae["compose_sha256"],
+                expected_formulae["runtime_sha256"],
+            )
+        except FORMULA.FormulaError as error:
+            formulae = {"reason": str(error), "state": "conflict"}
+        else:
+            formulae["state"] = "verified"
     observations["formulae"] = formulae
     try:
         result = subprocess.run(
@@ -291,7 +458,10 @@ def remote_postconditions(repo: str, offline: bool) -> dict[str, Any]:
             stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, timeout=30,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError, OSError):
-        observations["pages"] = {"reason": "Pages observation unavailable", "state": "unavailable"}
+        observations["pages"] = {
+            "reason": "Pages observation unavailable",
+            "state": "unavailable",
+        }
     else:
         try:
             value = json.loads(result.stdout) if result.returncode == 0 else None
@@ -303,13 +473,307 @@ def remote_postconditions(repo: str, offline: bool) -> dict[str, Any]:
                 "state": "absent" if "HTTP 404" in result.stderr else "unavailable",
             }
         else:
-            observations["pages"] = {
+            pages: dict[str, Any] = {
                 "build_type": value.get("build_type"),
                 "html_url": value.get("html_url"),
-                "state": "observed",
                 "status": value.get("status"),
             }
+            try:
+                runs_result = subprocess.run(
+                    [
+                        "gh",
+                        "api",
+                        f"repos/{repo}/actions/workflows/docs.yml/runs"
+                        "?event=workflow_dispatch&per_page=100",
+                    ],
+                    check=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=30,
+                )
+                deployments_result = subprocess.run(
+                    [
+                        "gh",
+                        "api",
+                        f"repos/{repo}/deployments"
+                        "?environment=github-pages&per_page=100",
+                    ],
+                    check=False,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    timeout=30,
+                )
+            except (
+                subprocess.TimeoutExpired,
+                FileNotFoundError,
+                PermissionError,
+                OSError,
+            ):
+                pages.update(
+                    reason="documentation deployment observation unavailable",
+                    state="unavailable",
+                )
+            else:
+                try:
+                    runs_value = (
+                        json.loads(runs_result.stdout)
+                        if runs_result.returncode == 0
+                        else None
+                    )
+                    deployments = (
+                        json.loads(deployments_result.stdout)
+                        if deployments_result.returncode == 0
+                        else None
+                    )
+                except json.JSONDecodeError:
+                    runs_value = deployments = None
+                runs = runs_value.get("workflow_runs") if isinstance(runs_value, dict) else None
+                prefix = f"Documentation · {version} · "
+                matches = [
+                    run
+                    for run in runs or []
+                    if isinstance(run, dict)
+                    and isinstance(run.get("display_title"), str)
+                    and run["display_title"].startswith(prefix)
+                    and run.get("status") == "completed"
+                    and run.get("conclusion") == "success"
+                    and isinstance(run.get("head_sha"), str)
+                ]
+                if not isinstance(runs, list) or not isinstance(deployments, list):
+                    pages.update(
+                        reason="GitHub returned malformed documentation deployment data",
+                        state="unavailable",
+                    )
+                elif not matches:
+                    pages.update(
+                        reason="no successful exact-version Documentation run exists",
+                        state="absent",
+                    )
+                elif not deployments or not isinstance(deployments[0], dict):
+                    pages.update(reason="no active github-pages deployment exists", state="absent")
+                elif deployments[0].get("sha") != matches[0]["head_sha"]:
+                    pages.update(
+                        reason=(
+                            "active Pages deployment does not match the "
+                            "exact-version Documentation run"
+                        ),
+                        state="conflict",
+                    )
+                elif value.get("status") != "built":
+                    pages.update(reason="GitHub Pages is not built", state="conflict")
+                elif not isinstance(deployments[0].get("id"), (int, str)):
+                    pages.update(
+                        reason="active Pages deployment has no identity",
+                        state="unavailable",
+                    )
+                else:
+                    deployment_id = deployments[0]["id"]
+                    try:
+                        status_result = subprocess.run(
+                            [
+                                "gh",
+                                "api",
+                                f"repos/{repo}/deployments/{deployment_id}/statuses"
+                                "?per_page=1",
+                            ],
+                            check=False,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                            timeout=30,
+                        )
+                    except (
+                        subprocess.TimeoutExpired,
+                        FileNotFoundError,
+                        PermissionError,
+                        OSError,
+                    ):
+                        pages.update(
+                            reason="Pages deployment status observation unavailable",
+                            state="unavailable",
+                        )
+                    else:
+                        try:
+                            statuses = (
+                                json.loads(status_result.stdout)
+                                if status_result.returncode == 0
+                                else None
+                            )
+                        except json.JSONDecodeError:
+                            statuses = None
+                        if not isinstance(statuses, list) or not statuses:
+                            pages.update(
+                                reason="Pages deployment status is unavailable",
+                                state="unavailable",
+                            )
+                        elif (
+                            not isinstance(statuses[0], dict)
+                            or statuses[0].get("state") != "success"
+                        ):
+                            pages.update(
+                                reason="Pages deployment did not complete successfully",
+                                state="conflict",
+                            )
+                        else:
+                            pages.update(
+                                control_sha=matches[0]["head_sha"],
+                                deployment_id=deployment_id,
+                                run_id=matches[0].get("id"),
+                                state="verified",
+                            )
+            observations["pages"] = pages
     return observations
+
+
+def recovery_action(
+    name: str,
+    summary: str,
+    *,
+    prerequisites: list[str],
+    side_effects: list[str],
+    authority: str,
+    invalidates: list[str] | None = None,
+) -> dict[str, Any]:
+    """Construct one deterministic recovery action record."""
+    return {
+        "invalidated_descendants": invalidates or [],
+        "name": name,
+        "prerequisites": prerequisites,
+        "reason": summary,
+        "required_authority": authority,
+        "side_effects": side_effects,
+        "summary": summary,
+    }
+
+
+def plan_recovery(
+    waiting: list[dict[str, Any]],
+    failed: list[dict[str, Any]],
+    missing: list[str],
+    remote: dict[str, Any],
+    postconditions: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a pure, single-next-step recovery plan from typed observations."""
+    if any(record.get("state") == "dispatch-unknown" for record in waiting):
+        return recovery_action(
+            "reconcile-dispatch",
+            "reconcile the unknown request ID; do not redispatch",
+            prerequisites=["bounded request-ID workflow search"],
+            side_effects=[],
+            authority="recorded logical dispatch claim",
+        )
+    if waiting:
+        return recovery_action(
+            "inspect-run",
+            "inspect the acknowledged workflow run before resuming",
+            prerequisites=["recorded workflow run identity"],
+            side_effects=[],
+            authority="dispatch journal",
+        )
+    if failed:
+        return recovery_action(
+            "authorize-retry",
+            "record the failed operation and explicitly authorize a new attempt",
+            prerequisites=["terminal failed run evidence"],
+            side_effects=["create a linked dispatch attempt"],
+            authority="operator retry authorization",
+        )
+    if remote.get("state") == "unavailable":
+        return recovery_action(
+            "restore-observation",
+            "restore remote observation before planning a mutation",
+            prerequisites=["bounded authenticated GitHub observation"],
+            side_effects=[],
+            authority="read-only remote access",
+        )
+    if remote.get("state") in {"invalid", "conflicting"}:
+        return recovery_action(
+            "resolve-release-conflict",
+            "resolve the conflicting remote release state",
+            prerequisites=["retained manifest", "remote release identity and digests"],
+            side_effects=[],
+            authority="release maintainer decision",
+            invalidates=["formulae", "pages"],
+        )
+    if not missing and remote.get("state") == "published" and remote.get(
+        "missing_assets"
+    ):
+        return recovery_action(
+            "upload-missing-assets",
+            "reconcile the incomplete remote release from exact retained bytes",
+            prerequisites=["retained-complete manifest", "resumable release draft"],
+            side_effects=["upload missing byte-identical assets"],
+            authority="retained publication authority",
+            invalidates=["formulae", "pages"],
+        )
+    if missing and remote.get("state") == "published":
+        return recovery_action(
+            "import-published-assets",
+            "import and verify exact published bytes; do not rebuild",
+            prerequisites=["published immutable release assets"],
+            side_effects=["write verified objects to retained storage"],
+            authority="published release identity and checksums",
+        )
+    if missing and remote.get("state") == "absent":
+        return recovery_action(
+            "restore-retained-closure",
+            "produce or restore the missing retained release closure before publication",
+            prerequisites=["authenticated source or exact recovery objects"],
+            side_effects=["materialize only missing release nodes"],
+            authority="release build authority",
+        )
+    if missing:
+        return recovery_action(
+            "restore-exact-assets",
+            "restore exact authenticated bytes or report the release blocked",
+            prerequisites=["authenticated object source"],
+            side_effects=["repair missing retained objects"],
+            authority="retained or published checksum authority",
+        )
+    if remote.get("state") == "absent":
+        return recovery_action(
+            "publish-retained-release",
+            "publish the verified retained release closure",
+            prerequisites=["retained-complete manifest", "stable gate authority"],
+            side_effects=["create or resume draft", "publish stable release"],
+            authority="retained publication authority",
+            invalidates=["formulae", "pages"],
+        )
+    if any(
+        value.get("state") == "unavailable" for value in postconditions.values()
+    ):
+        return recovery_action(
+            "restore-postcondition-observation",
+            "restore formula and Pages observation before declaring recovery complete",
+            prerequisites=["authenticated tap and Pages read access"],
+            side_effects=[],
+            authority="read-only remote access",
+        )
+    if postconditions["formulae"].get("state") not in {"verified", "superseded"}:
+        return recovery_action(
+            "repair-formulae",
+            "restore or reconcile the paired Homebrew formulae; no build is required",
+            prerequisites=["retained archive URLs and digests"],
+            side_effects=["atomically update the paired stable formulae"],
+            authority="tap publication authority",
+        )
+    if postconditions["pages"].get("state") not in {"verified", "superseded"}:
+        return recovery_action(
+            "redeploy-pages",
+            "restore or reconcile Pages deployment; no build is required",
+            prerequisites=["retained context-bound DocC sites"],
+            side_effects=["assemble and deploy GitHub Pages"],
+            authority="latest-stable documentation authority",
+        )
+    return recovery_action(
+        "complete",
+        "release recovery state is complete; no mutation or rebuild is required",
+        prerequisites=[],
+        side_effects=[],
+        authority="verified retained and remote observations",
+    )
 
 
 def inspect(
@@ -319,10 +783,29 @@ def inspect(
         raise StateError(f"unsafe retained release root: {root}")
     if not SEMVER.fullmatch(version):
         raise StateError(f"invalid stable release version: {version}")
-    present, missing = retained_assets(root, version, deep)
+    observed_at = datetime.now(timezone.utc).isoformat()
+    manifest = load_retained_manifest(root, version)
+    present, missing = retained_assets(root, version, deep, manifest)
     records = observe_dispatches(dispatch_records(root, version), repo, offline)
-    remote = remote_release(repo, version, offline)
-    postconditions = remote_postconditions(repo, offline)
+    remote = reconcile_remote_digests(
+        remote_release(repo, version, offline), manifest
+    )
+    remote["evidence_source"] = "none" if offline else "github-api"
+    remote["observed_at"] = observed_at
+    if remote.get("state") == "published" and not missing:
+        postconditions = remote_postconditions(
+            repo, version, offline, formula_expectations(manifest, version, repo)
+        )
+    else:
+        postconditions = {
+            "formulae": {"state": "deferred"},
+            "pages": {"state": "deferred"},
+        }
+    for observation in postconditions.values():
+        observation["evidence_source"] = (
+            "none" if offline or observation.get("state") == "deferred" else "github-api"
+        )
+        observation["observed_at"] = observed_at
     waiting = [
         record
         for record in records
@@ -346,50 +829,24 @@ def inspect(
             and record["observed"].get("conclusion") != "success"
         )
     ]
-    if any(record.get("state") == "dispatch-unknown" for record in waiting):
-        next_action = "reconcile the unknown request ID; do not redispatch"
-    elif waiting:
-        next_action = "inspect the acknowledged workflow run before resuming"
-    elif failed:
-        next_action = "record the failed operation and explicitly authorize a new attempt"
-    elif remote.get("state") == "unavailable":
-        next_action = "restore remote observation before planning a mutation"
-    elif remote.get("state") == "invalid":
-        next_action = "resolve the conflicting remote release state"
-    elif (
-        not missing
-        and remote.get("state") == "published"
-        and remote.get("missing_assets")
-    ):
-        next_action = "reconcile the incomplete remote release from exact retained bytes"
-    elif missing and remote.get("state") == "published":
-        next_action = "import and verify exact published bytes; do not rebuild"
-    elif missing and remote.get("state") == "absent":
-        next_action = "produce or restore the missing retained release closure before publication"
-    elif missing:
-        next_action = "restore exact authenticated bytes or report the release blocked"
-    elif remote.get("state") == "absent":
-        next_action = "publish the verified retained release closure"
-    elif any(
-        value.get("state") == "unavailable" for value in postconditions.values()
-    ):
-        next_action = "restore formula and Pages observation before declaring recovery complete"
-    elif postconditions["formulae"].get("state") != "observed":
-        next_action = "restore or reconcile the paired Homebrew formulae; no build is required"
-    elif postconditions["pages"].get("state") != "observed":
-        next_action = "restore or reconcile Pages deployment; no build is required"
-    else:
-        next_action = "verify candidate-bound formula and Pages identities; no build is required"
+    action = plan_recovery(waiting, failed, missing, remote, postconditions)
     return {
+        "actions": [action],
         "dispatches": records,
         "failed": failed,
-        "next_action": next_action,
+        "next_action": action["summary"],
+        "observed_at": observed_at,
         "remote_release": remote,
         "remote_postconditions": postconditions,
-        "retained": {"missing": missing, "verified": present},
+        "retained": {
+            "evidence_source": "internal-retained-manifest",
+            "missing": missing,
+            "observed_at": observed_at,
+            "verified": present,
+        },
         "root": str(root),
         "verification": "deep" if deep else "shallow",
-        "schema": 1,
+        "schema": 2,
         "version": version,
         "waiting": waiting,
     }

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -45,7 +45,7 @@ FORMULA = importlib.util.module_from_spec(FORMULA_SPEC)
 FORMULA_SPEC.loader.exec_module(FORMULA)
 SEMVER = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
 REQUEST_ID = re.compile(r"[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}")
-EXPECTED_ASSETS = (
+EXPECTED_RELEASE_ASSETS = (
     "container-compose-plugin-release-arm64.tar.gz",
     "container-compose-plugin-release-arm64.tar.gz.sha256",
     "container-release-arm64.tar.gz",
@@ -56,11 +56,14 @@ EXPECTED_ASSETS = (
     "stable-release-authority.tar.gz.sha256",
     "release-highlights.json",
     "quality-snapshot.svg",
+)
+EXPECTED_DOCUMENTATION_ASSETS = (
     "compose.tgz",
     "container.tgz",
     "containerization.tgz",
     "k8s.tgz",
 )
+EXPECTED_RETAINED_ASSETS = EXPECTED_RELEASE_ASSETS + EXPECTED_DOCUMENTATION_ASSETS
 UNREAD_MANIFEST = object()
 
 
@@ -116,8 +119,8 @@ def retained_assets(
     if manifest is UNREAD_MANIFEST:
         manifest = load_retained_manifest(root, version)
     if not isinstance(manifest, dict):
-        return present, list(EXPECTED_ASSETS)
-    for name in EXPECTED_ASSETS:
+        return present, list(EXPECTED_RETAINED_ASSETS)
+    for name in EXPECTED_RETAINED_ASSETS:
         try:
             record = manifest["assets"].get(name)
             if not isinstance(record, dict) or not isinstance(record.get("path"), str):
@@ -227,7 +230,7 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
         if release.get("draft") is False and release.get("prerelease") is False
         else "invalid",
     }
-    result["missing_assets"] = sorted(set(EXPECTED_ASSETS) - set(names))
+    result["missing_assets"] = sorted(set(EXPECTED_RELEASE_ASSETS) - set(names))
     return result
 
 
@@ -247,7 +250,7 @@ def reconcile_remote_digests(
         return result
     conflicts: dict[str, dict[str, str]] = {}
     unavailable: list[str] = []
-    for name in EXPECTED_ASSETS:
+    for name in EXPECTED_RELEASE_ASSETS:
         record = manifest["assets"].get(name)
         if not isinstance(record, dict) or not isinstance(record.get("sha256"), str):
             continue
@@ -858,7 +861,8 @@ def render_text(state: dict[str, Any], planning: bool) -> str:
     lines = [f"Release {state['version']}: read-only {'plan' if planning else 'status'}"]
     lines.append(f"Remote release: {remote['state']}")
     lines.append(
-        f"Retained artifacts: {len(retained['verified'])}/{len(EXPECTED_ASSETS)} verified"
+        "Retained artifacts: "
+        f"{len(retained['verified'])}/{len(EXPECTED_RETAINED_ASSETS)} verified"
     )
     if retained["missing"]:
         lines.append("Missing locally: " + ", ".join(retained["missing"]))

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Inspect retained and remote release recovery state without mutating it."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+LOCAL_STORE_TOOL = Path(__file__).with_name("retain-local-release-assets.py")
+SPEC = importlib.util.spec_from_file_location("retain_local_release_assets", LOCAL_STORE_TOOL)
+assert SPEC is not None and SPEC.loader is not None
+LOCAL_STORE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(LOCAL_STORE)
+SEMVER = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
+REQUEST_ID = re.compile(r"[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}")
+EXPECTED_ASSETS = (
+    "container-compose-plugin-release-arm64.tar.gz",
+    "container-compose-plugin-release-arm64.tar.gz.sha256",
+    "container-release-arm64.tar.gz",
+    "container-release-arm64.tar.gz.sha256",
+    "container-vminit-arm64.oci.tar",
+    "container-vminit-arm64.oci.tar.sha256",
+    "stable-release-authority.tar.gz",
+    "stable-release-authority.tar.gz.sha256",
+    "release-highlights.json",
+    "quality-snapshot.svg",
+    "compose.tgz",
+    "container.tgz",
+    "containerization.tgz",
+    "k8s.tgz",
+)
+
+
+class StateError(RuntimeError):
+    """The retained release state is unsafe or malformed."""
+
+
+def dispatch_records(root: Path, version: str) -> list[dict[str, Any]]:
+    directory = root / "release/dispatches"
+    if not directory.exists():
+        return []
+    if directory.is_symlink() or not directory.is_dir():
+        raise StateError(f"unsafe dispatch journal directory: {directory}")
+    records: list[dict[str, Any]] = []
+    for path in sorted(directory.glob("*.json")):
+        if path.is_symlink() or not path.is_file():
+            raise StateError(f"unsafe dispatch journal record: {path}")
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as error:
+            raise StateError(f"invalid dispatch journal record: {path}") from error
+        if (
+            not isinstance(value, dict)
+            or value.get("schema") != 1
+            or value.get("request_id") != path.stem
+            or REQUEST_ID.fullmatch(path.stem) is None
+            or SEMVER.fullmatch(str(value.get("version", ""))) is None
+            or re.fullmatch(r"[0-9a-f]{40}", str(value.get("control_sha", "")))
+            is None
+            or not isinstance(value.get("workflow"), str)
+            or not value["workflow"]
+            or value.get("state")
+            not in {"dispatch-intent", "dispatch-unknown", "dispatched"}
+            or (
+                value.get("state") == "dispatched"
+                and re.fullmatch(r"[0-9]+", str(value.get("run_id", ""))) is None
+            )
+        ):
+            raise StateError(f"unsupported dispatch journal record: {path}")
+        if value.get("version") == version:
+            records.append(value)
+    return records
+
+
+def retained_assets(root: Path, version: str) -> tuple[list[str], list[str]]:
+    present: list[str] = []
+    missing: list[str] = []
+    for name in EXPECTED_ASSETS:
+        try:
+            LOCAL_STORE.retained_path(root, version, name)
+        except (LOCAL_STORE.RetentionError, OSError, json.JSONDecodeError):
+            missing.append(name)
+        else:
+            present.append(name)
+    return present, missing
+
+
+def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
+    if offline:
+        return {"state": "not-inspected"}
+    try:
+        completed = subprocess.run(
+            ["gh", "api", f"repos/{repo}/releases/tags/{version}"],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+    except (FileNotFoundError, PermissionError, OSError):
+        return {"reason": "GitHub CLI is unavailable", "state": "unavailable"}
+    if completed.returncode != 0:
+        if "HTTP 404" in completed.stderr:
+            return {"state": "absent"}
+        return {
+            "reason": f"GitHub release query failed with exit {completed.returncode}",
+            "state": "unavailable",
+        }
+    try:
+        release = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        return {"reason": "GitHub returned malformed JSON", "state": "unavailable"}
+    if not isinstance(release, dict):
+        return {"reason": "GitHub returned a non-object", "state": "unavailable"}
+    assets = release.get("assets", [])
+    names = sorted(
+        asset["name"]
+        for asset in assets
+        if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+    )
+    return {
+        "assets": names,
+        "draft": release.get("draft"),
+        "id": release.get("id"),
+        "prerelease": release.get("prerelease"),
+        "state": "published"
+        if release.get("draft") is False and release.get("prerelease") is False
+        else "invalid",
+    }
+
+
+def observe_dispatches(
+    records: list[dict[str, Any]], repo: str, offline: bool
+) -> list[dict[str, Any]]:
+    observed: list[dict[str, Any]] = []
+    for original in records:
+        record = dict(original)
+        run_id = record.get("run_id")
+        if offline or record.get("state") != "dispatched" or not isinstance(
+            run_id, str
+        ):
+            observed.append(record)
+            continue
+        try:
+            completed = subprocess.run(
+                [
+                    "gh",
+                    "run",
+                    "view",
+                    run_id,
+                    "--repo",
+                    repo,
+                    "--json",
+                    "status,conclusion,url",
+                ],
+                check=False,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+        except (FileNotFoundError, PermissionError, OSError):
+            record["observed"] = {
+                "reason": "GitHub CLI is unavailable",
+                "state": "unavailable",
+            }
+            observed.append(record)
+            continue
+        if completed.returncode != 0:
+            record["observed"] = {
+                "reason": f"GitHub run query failed with exit {completed.returncode}",
+                "state": "unavailable",
+            }
+        else:
+            try:
+                value = json.loads(completed.stdout)
+            except json.JSONDecodeError:
+                value = None
+            if isinstance(value, dict):
+                record["observed"] = {
+                    "conclusion": value.get("conclusion"),
+                    "state": value.get("status"),
+                    "url": value.get("url"),
+                }
+            else:
+                record["observed"] = {
+                    "reason": "GitHub returned malformed run JSON",
+                    "state": "unavailable",
+                }
+        observed.append(record)
+    return observed
+
+
+def inspect(root: Path, version: str, repo: str, offline: bool) -> dict[str, Any]:
+    if not root.is_absolute() or root == Path("/") or root.is_symlink():
+        raise StateError(f"unsafe retained release root: {root}")
+    if not SEMVER.fullmatch(version):
+        raise StateError(f"invalid stable release version: {version}")
+    present, missing = retained_assets(root, version)
+    records = observe_dispatches(dispatch_records(root, version), repo, offline)
+    remote = remote_release(repo, version, offline)
+    waiting = [
+        record
+        for record in records
+        if record.get("state") in {"dispatch-intent", "dispatch-unknown"}
+        or (
+            record.get("state") == "dispatched"
+            and (
+                not isinstance(record.get("observed"), dict)
+                or record["observed"].get("state") != "completed"
+            )
+        )
+    ]
+    if any(record.get("state") == "dispatch-unknown" for record in waiting):
+        next_action = "reconcile the unknown request ID; do not redispatch"
+    elif waiting:
+        next_action = "inspect the acknowledged workflow run before resuming"
+    elif missing and remote.get("state") == "published":
+        next_action = "import and verify exact published bytes; do not rebuild"
+    elif missing:
+        next_action = "restore exact authenticated bytes or report the release blocked"
+    else:
+        next_action = "verify remote formula and Pages postconditions; no build is required"
+    return {
+        "dispatches": records,
+        "next_action": next_action,
+        "remote_release": remote,
+        "retained": {"missing": missing, "verified": present},
+        "root": str(root),
+        "schema": 1,
+        "version": version,
+        "waiting": waiting,
+    }
+
+
+def render_text(state: dict[str, Any], planning: bool) -> str:
+    retained = state["retained"]
+    remote = state["remote_release"]
+    lines = [f"Release {state['version']}: read-only {'plan' if planning else 'status'}"]
+    lines.append(f"Remote release: {remote['state']}")
+    lines.append(
+        f"Retained artifacts: {len(retained['verified'])}/{len(EXPECTED_ASSETS)} verified"
+    )
+    if retained["missing"]:
+        lines.append("Missing locally: " + ", ".join(retained["missing"]))
+    if state["waiting"]:
+        lines.append(
+            "Waiting/unknown requests: "
+            + ", ".join(
+                f"{record['request_id']}={record['state']}"
+                for record in state["waiting"]
+            )
+        )
+    lines.append("Next: " + state["next_action"])
+    lines.append("Mutation: none (inspection is read-only)")
+    return "\n".join(lines)
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("inspect", "plan"))
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--repo", default="stephenlclarke/container-compose")
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--offline", action="store_true")
+    options = parser.parse_args(arguments)
+    try:
+        state = inspect(options.root, options.version, options.repo, options.offline)
+    except (StateError, OSError, UnicodeError) as error:
+        print(f"release-state: {error}", file=sys.stderr)
+        return 2
+    if options.format == "json":
+        print(json.dumps(state, sort_keys=True, indent=2))
+    else:
+        print(render_text(state, options.action == "plan"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -93,6 +93,10 @@ def dispatch_records(root: Path, version: str) -> list[dict[str, Any]]:
             or SEMVER.fullmatch(str(value.get("version", ""))) is None
             or re.fullmatch(r"[0-9a-f]{40}", str(value.get("control_sha", "")))
             is None
+            or (
+                "previous_request_id" in value
+                and REQUEST_ID.fullmatch(str(value["previous_request_id"])) is None
+            )
             or not isinstance(value.get("workflow"), str)
             or not value["workflow"]
             or value.get("state")
@@ -659,6 +663,10 @@ def plan_recovery(
     postconditions: dict[str, Any],
 ) -> dict[str, Any]:
     """Return a pure, single-next-step recovery plan from typed observations."""
+    missing_release_assets = sorted(set(missing) & set(EXPECTED_RELEASE_ASSETS))
+    missing_documentation = sorted(
+        set(missing) & set(EXPECTED_DOCUMENTATION_ASSETS)
+    )
     if any(record.get("state") == "dispatch-unknown" for record in waiting):
         return recovery_action(
             "reconcile-dispatch",
@@ -700,8 +708,10 @@ def plan_recovery(
             authority="release maintainer decision",
             invalidates=["formulae", "pages"],
         )
-    if not missing and remote.get("state") == "published" and remote.get(
-        "missing_assets"
+    if (
+        not missing_release_assets
+        and remote.get("state") == "published"
+        and remote.get("missing_assets")
     ):
         return recovery_action(
             "upload-missing-assets",
@@ -711,7 +721,7 @@ def plan_recovery(
             authority="retained publication authority",
             invalidates=["formulae", "pages"],
         )
-    if missing and remote.get("state") == "published":
+    if missing_release_assets and remote.get("state") == "published":
         return recovery_action(
             "import-published-assets",
             "import and verify exact published bytes; do not rebuild",
@@ -719,7 +729,7 @@ def plan_recovery(
             side_effects=["write verified objects to retained storage"],
             authority="published release identity and checksums",
         )
-    if missing and remote.get("state") == "absent":
+    if missing_release_assets and remote.get("state") == "absent":
         return recovery_action(
             "restore-retained-closure",
             "produce or restore the missing retained release closure before publication",
@@ -727,7 +737,7 @@ def plan_recovery(
             side_effects=["materialize only missing release nodes"],
             authority="release build authority",
         )
-    if missing:
+    if missing_release_assets:
         return recovery_action(
             "restore-exact-assets",
             "restore exact authenticated bytes or report the release blocked",
@@ -743,6 +753,14 @@ def plan_recovery(
             side_effects=["create or resume draft", "publish stable release"],
             authority="retained publication authority",
             invalidates=["formulae", "pages"],
+        )
+    if missing_documentation:
+        return recovery_action(
+            "restore-documentation-artifacts",
+            "recover the missing DocC archives from the exact documentation run",
+            prerequisites=["successful exact-input documentation run or regeneration"],
+            side_effects=["retain verified context-bound DocC archives"],
+            authority="stable documentation run identity",
         )
     if any(
         value.get("state") == "unavailable" for value in postconditions.values()
@@ -779,6 +797,56 @@ def plan_recovery(
     )
 
 
+def dispatch_succeeded(record: dict[str, Any]) -> bool:
+    """Return whether one acknowledged dispatch completed successfully."""
+    observed = record.get("observed")
+    return (
+        record.get("state") == "dispatched"
+        and isinstance(observed, dict)
+        and observed.get("state") == "completed"
+        and observed.get("conclusion") == "success"
+    )
+
+
+def unresolved_failed_dispatches(
+    records: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Exclude failed attempts superseded by a successful linked retry."""
+    records_by_id = {
+        record["request_id"]: record
+        for record in records
+        if isinstance(record.get("request_id"), str)
+    }
+    superseded: set[str] = set()
+    for record in records:
+        if not dispatch_succeeded(record):
+            continue
+        previous = record.get("previous_request_id")
+        while isinstance(previous, str) and previous not in superseded:
+            superseded.add(previous)
+            predecessor = records_by_id.get(previous)
+            previous = (
+                predecessor.get("previous_request_id")
+                if isinstance(predecessor, dict)
+                else None
+            )
+
+    return [
+        record
+        for record in records
+        if record.get("request_id") not in superseded
+        and (
+            record.get("state") == "failed"
+            or (
+                record.get("state") == "dispatched"
+                and isinstance(record.get("observed"), dict)
+                and record["observed"].get("state") == "completed"
+                and record["observed"].get("conclusion") != "success"
+            )
+        )
+    ]
+
+
 def inspect(
     root: Path, version: str, repo: str, offline: bool, deep: bool = False
 ) -> dict[str, Any]:
@@ -795,7 +863,8 @@ def inspect(
     )
     remote["evidence_source"] = "none" if offline else "github-api"
     remote["observed_at"] = observed_at
-    if remote.get("state") == "published" and not missing:
+    missing_release_assets = sorted(set(missing) & set(EXPECTED_RELEASE_ASSETS))
+    if remote.get("state") == "published" and not missing_release_assets:
         postconditions = remote_postconditions(
             repo, version, offline, formula_expectations(manifest, version, repo)
         )
@@ -821,17 +890,7 @@ def inspect(
             )
         )
     ]
-    failed = [
-        record
-        for record in records
-        if record.get("state") == "failed"
-        or (
-            record.get("state") == "dispatched"
-            and isinstance(record.get("observed"), dict)
-            and record["observed"].get("state") == "completed"
-            and record["observed"].get("conclusion") != "success"
-        )
-    ]
+    failed = unresolved_failed_dispatches(records)
     action = plan_recovery(waiting, failed, missing, remote, postconditions)
     return {
         "actions": [action],

--- a/Tools/release/retain-local-release-assets.py
+++ b/Tools/release/retain-local-release-assets.py
@@ -28,6 +28,7 @@ import re
 import stat
 import sys
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -110,18 +111,32 @@ def retain(root: Path, version: str, candidates: list[Path]) -> None:
                     f"release asset must be an absolute regular file: {candidate}"
                 )
             STACK_ARTIFACT.validate_name(name)
-            digest = sha256(candidate)
             existing = assets.get(name)
             if existing is not None:
-                if not isinstance(existing, dict) or existing.get("sha256") != digest:
+                if not isinstance(existing, dict):
                     raise RetentionError(
                         f"retained stable asset conflicts for {version}: {name}"
                     )
-                retained_path(root, version, name)
-                continue
+                expected_digest = existing.get("sha256")
+                candidate_digest = sha256(candidate)
+                if expected_digest != candidate_digest:
+                    raise RetentionError(
+                        f"retained stable asset conflicts for {version}: {name}"
+                    )
+                try:
+                    retained_path(root, version, name)
+                except (RetentionError, OSError):
+                    quarantine_invalid_object(root, version, name, existing)
+                else:
+                    continue
             retained = STACK_ARTIFACT.promote(
                 candidate, root / "release/artifacts", name
             )
+            digest = sha256(retained)
+            if existing is not None and digest != existing.get("sha256"):
+                raise RetentionError(
+                    f"retained stable asset changed while repairing {version}: {name}"
+                )
             record = {
                 "mode": stat.S_IMODE(retained.stat(follow_symlinks=False).st_mode),
                 "path": str(retained),
@@ -130,6 +145,28 @@ def retain(root: Path, version: str, candidates: list[Path]) -> None:
             }
             assets[name] = record
         write_manifest(path, manifest)
+
+
+def quarantine_invalid_object(
+    root: Path, version: str, name: str, record: dict[str, Any]
+) -> None:
+    """Move an invalid recorded object aside before exact-byte repair."""
+    value = record.get("path")
+    if not isinstance(value, str):
+        return
+    path = Path(value)
+    artifact_root = (root / "release/artifacts").resolve(strict=True)
+    if not path.is_absolute() or artifact_root not in path.resolve(strict=False).parents:
+        raise RetentionError(f"retained stable asset path is unsafe: {version}/{name}")
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return
+    quarantine = root / "release/quarantine" / version
+    quarantine.mkdir(parents=True, mode=0o700, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    destination = quarantine / f"{timestamp}-{name}"
+    os.replace(path, destination)
 
 
 def retained_path(root: Path, version: str, name: str) -> Path:

--- a/Tools/release/retain-local-release-assets.py
+++ b/Tools/release/retain-local-release-assets.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Retain verified release bytes locally and publish an atomic version manifest."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import importlib.util
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ARTIFACT_TOOL = Path(__file__).resolve().parents[1] / "build/stack-artifact.py"
+SPEC = importlib.util.spec_from_file_location("stack_artifact", ARTIFACT_TOOL)
+assert SPEC is not None and SPEC.loader is not None
+STACK_ARTIFACT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(STACK_ARTIFACT)
+VERSION = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+
+
+class RetentionError(RuntimeError):
+    """A retained release manifest or candidate asset is unsafe."""
+
+
+def sha256(path: Path) -> str:
+    return STACK_ARTIFACT.digest_file(path)
+
+
+def manifest_path(root: Path, version: str) -> Path:
+    if not root.is_absolute() or root == Path("/") or root.is_symlink():
+        raise RetentionError(f"unsafe retained release root: {root}")
+    if not VERSION.fullmatch(version):
+        raise RetentionError(f"invalid semantic release version: {version}")
+    return root / "release" / "releases" / version / "assets.json"
+
+
+def read_manifest(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"assets": {}, "schema": 1}
+    if path.is_symlink() or not path.is_file():
+        raise RetentionError(f"unsafe retained release manifest: {path}")
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict) or value.get("schema") != 1 or not isinstance(
+        value.get("assets"), dict
+    ):
+        raise RetentionError(f"invalid retained release manifest: {path}")
+    return value
+
+
+def write_manifest(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+    descriptor, name = tempfile.mkstemp(dir=path.parent, prefix=".assets-", suffix=".tmp")
+    temporary = Path(name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, sort_keys=True, indent=2)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def retain(root: Path, version: str, candidates: list[Path]) -> None:
+    path = manifest_path(root, version)
+    path.parent.mkdir(parents=True, mode=0o700, exist_ok=True)
+    lock_path = path.with_suffix(".lock")
+    if lock_path.is_symlink():
+        raise RetentionError(f"unsafe retained release lock: {lock_path}")
+    with lock_path.open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock.fileno(), fcntl.LOCK_EX)
+        manifest = read_manifest(path)
+        assets: dict[str, Any] = manifest["assets"]
+        for candidate in candidates:
+            name = candidate.name
+            if (
+                not candidate.is_absolute()
+                or candidate.is_symlink()
+                or not candidate.is_file()
+            ):
+                raise RetentionError(
+                    f"release asset must be an absolute regular file: {candidate}"
+                )
+            STACK_ARTIFACT.validate_name(name)
+            digest = sha256(candidate)
+            existing = assets.get(name)
+            if existing is not None:
+                if not isinstance(existing, dict) or existing.get("sha256") != digest:
+                    raise RetentionError(
+                        f"retained stable asset conflicts for {version}: {name}"
+                    )
+                retained_path(root, version, name)
+                continue
+            retained = STACK_ARTIFACT.promote(
+                candidate, root / "release/artifacts", name
+            )
+            record = {
+                "mode": stat.S_IMODE(retained.stat(follow_symlinks=False).st_mode),
+                "path": str(retained),
+                "sha256": digest,
+                "size": retained.stat().st_size,
+            }
+            assets[name] = record
+        write_manifest(path, manifest)
+
+
+def retained_path(root: Path, version: str, name: str) -> Path:
+    STACK_ARTIFACT.validate_name(name)
+    manifest = read_manifest(manifest_path(root, version))
+    record = manifest["assets"].get(name)
+    if not isinstance(record, dict) or not isinstance(record.get("path"), str):
+        raise RetentionError(f"retained stable asset is unavailable: {version}/{name}")
+    path = Path(record["path"])
+    artifact_root = (root / "release/artifacts").resolve(strict=True)
+    if (
+        not path.is_absolute()
+        or artifact_root not in path.resolve(strict=False).parents
+        or path.is_symlink()
+        or not path.is_file()
+        or sha256(path) != record.get("sha256")
+        or path.stat().st_size != record.get("size")
+        or stat.S_IMODE(path.stat(follow_symlinks=False).st_mode) != record.get("mode")
+    ):
+        raise RetentionError(f"retained stable asset is invalid: {version}/{name}")
+    return path
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=("retain", "path"))
+    parser.add_argument("--root", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--asset", type=Path, action="append", default=[])
+    parser.add_argument("--name")
+    options = parser.parse_args(arguments)
+    try:
+        if options.action == "retain":
+            if not options.asset:
+                raise RetentionError("retain requires at least one --asset")
+            retain(options.root, options.version, options.asset)
+        else:
+            if not options.name:
+                raise RetentionError("path requires --name")
+            print(retained_path(options.root, options.version, options.name))
+    except (RetentionError, STACK_ARTIFACT.ArtifactError, OSError, json.JSONDecodeError) as error:
+        print(f"retain-release-assets: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2428,7 +2428,7 @@ github_cli() {{
         self.assertNotIn("Attest release package", repair)
 
     def test_release_helper_tracks_the_stable_package_dispatch_by_tag(self) -> None:
-        self.assertIn('title="Prebuilt Binaries · ${version} · ${mode}"', self.script)
+        self.assertIn('title="Prebuilt Binaries · ${version} · ${mode} · "', self.script)
         self.assertIn("databaseId,displayTitle,headSha,status,conclusion", self.script)
         self.assertIn('"${version}" "${repair_tap}" "${control_sha}"', self.script)
 
@@ -2440,9 +2440,9 @@ github_cli() {{
         ]
 
         self.assertIn("run-name: Stable Release Gate · ${{ inputs.ref }}", workflow)
-        self.assertIn('title="Stable Release Gate · ${version}"', lookup)
+        self.assertIn('title="Stable Release Gate · ${version} · "', lookup)
         self.assertIn("databaseId,displayTitle", lookup)
-        self.assertIn("map(select(.displayTitle", lookup)
+        self.assertIn(".displayTitle | startswith", lookup)
 
     def test_non_discardable_release_workflows_use_a_real_queue(self) -> None:
         for workflow_path in (PACKAGE_WORKFLOW, STABLE_GATE_WORKFLOW, DOCS_WORKFLOW):
@@ -4622,7 +4622,7 @@ github_cli() {{
 
     def test_hosted_stack_validation_excludes_virtualization_commands(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             compose = root / "container-compose"
             builder = root / "container-builder-shim"
             containerization = root / "containerization"
@@ -4804,7 +4804,7 @@ github_cli() {{
                     )
 
             self.assertIn(
-                f"make:-C {containerization} PATH={candidate_tools_resolved}{os.pathsep}{tools}",
+                f"make:-C {containerization.resolve()} PATH={candidate_tools_resolved}{os.pathsep}{tools}",
                 full_commands,
             )
             assert_make_targets(
@@ -9391,6 +9391,7 @@ esac
                     "ensure_stable_init_image_authority_tag() { :; }",
                     "remote_main_commit() { printf '%s\\n' control; }",
                     "latest_stable_release_gate_dispatch_run() { printf '912\\tcompleted\\tsuccess\\n'; }",
+                    "retain_stable_gate_authority() { :; }",
                     "github_cli() { exit 99; }",
                 ]
             ),
@@ -9425,10 +9426,18 @@ esac
     def test_ambiguous_dispatch_is_journalled_and_never_blindly_retried(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
+            posts = root / "posts"
+            setup = (
+                f"export TEST_POSTS={shlex.quote(str(posts))}\n"
+                "github_cli() { if [[ \"$*\" == *\"runs?event=workflow_dispatch\"* ]]; "
+                "then printf '{\\\"workflow_runs\\\":[]}\\n'; return 0; fi; "
+                "printf 'post\\n' >> \"${TEST_POSTS}\"; "
+                "printf 'connection lost\\n' >&2; return 1; }"
+            )
             dispatched = self.run_release_function(
                 root,
                 f"dispatch_github_workflow_run docs.yml 0.15.0 {'a' * 40}",
-                shell_setup="github_cli() { printf 'connection lost\\n' >&2; return 1; }",
+                shell_setup=setup,
             )
 
             self.assertEqual(dispatched.returncode, 75)
@@ -9438,6 +9447,14 @@ esac
             record = json.loads(journals[0].read_text(encoding="utf-8"))
             self.assertEqual(record["state"], "dispatch-unknown")
             self.assertEqual(record["workflow"], "docs.yml")
+            retried = self.run_release_function(
+                root,
+                f"dispatch_github_workflow_run docs.yml 0.15.0 {'a' * 40}",
+                shell_setup=setup,
+            )
+            self.assertEqual(retried.returncode, 75)
+            self.assertIn("refusing a duplicate request", retried.stderr)
+            self.assertEqual(posts.read_text(encoding="utf-8").splitlines(), ["post"])
 
     def test_past_success_does_not_suppress_newly_needed_tap_repair(self) -> None:
         repaired = self.run_release_function(
@@ -9489,7 +9506,7 @@ esac
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             retained = root / "retained"
             candidates = root / "candidates"
             candidates.mkdir()
@@ -9560,7 +9577,7 @@ esac
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             fixtures = root / "documentation-fixtures"
             fixtures.mkdir()
             for site in ("compose", "container", "containerization", "k8s"):
@@ -9577,6 +9594,14 @@ esac
                         str(ROOT / "Tools/ci/doc-site-manifest.py"),
                         "create",
                         str(source),
+                        "--site",
+                        site,
+                        "--source-ref",
+                        "a" * 40,
+                        "--hosting-base-path",
+                        "container-compose"
+                        if site == "compose"
+                        else f"container-compose/{site}",
                     ],
                     check=True,
                 )
@@ -9591,6 +9616,7 @@ esac
                 [
                     f"export TEST_DOCUMENTATION_FIXTURES={shlex.quote(str(fixtures))}",
                     "github_repo() { printf '%s\\n' owner/repo; }",
+                    f"stable_documentation_source_ref() {{ printf '%s\\n' {'a' * 40}; }}",
                     "github_cli() {",
                     "  if [[ \"$1:$2\" != run:download ]]; then return 64; fi",
                     "  local destination='' previous='' argument",
@@ -9613,7 +9639,10 @@ esac
             reused = self.run_release_function(
                 root,
                 "retain_stable_documentation_artifacts 1.2.3 987",
-                shell_setup="github_cli() { return 99; }",
+                shell_setup=(
+                    f"stable_documentation_source_ref() {{ printf '%s\\n' {'a' * 40}; }}; "
+                    "github_cli() { return 99; }"
+                ),
             )
             self.assertEqual(reused.returncode, 0, reused.stderr)
             self.assertIn("already retained locally", reused.stdout)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -54,6 +54,9 @@ SONAR_RESTORE_WORKFLOW = ROOT / ".github" / "workflows" / "sonar-main-restore.ym
 CODEQL_WORKFLOW = ROOT / ".github" / "workflows" / "codeql.yml"
 STACK_RELEASE_VALIDATION = ROOT / "Tools" / "ci" / "run-stack-release-validation.sh"
 FORMULA_RENDERER = ROOT / "Tools" / "release" / "render-homebrew-stack-formulae.sh"
+FORMULA_PAIR_VALIDATOR = (
+    ROOT / "Tools" / "release" / "verify-homebrew-formula-pair.py"
+)
 STABLE_RELEASE_LANE_CLASSIFIER = (
     ROOT / "Tools" / "release" / "stable-release-default-lane.py"
 )
@@ -1879,9 +1882,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "# Dispatch and verify one stable package workflow mode"
             )
         ]
+        validator = FORMULA_PAIR_VALIDATOR.read_text(encoding="utf-8")
 
-        self.assertIn('if [[ -n "${formula_version}" ]]', verifier)
-        self.assertIn("stable Homebrew formula must derive version", verifier)
+        self.assertIn('python3 "${FORMULA_PAIR_VALIDATOR}"', verifier)
+        self.assertIn("stable compose formula must derive its version", validator)
         self.assertNotIn('if [[ "${formula_version}" != "${version}" ]]', verifier)
 
     def test_stable_release_lane_classifier_preserves_newer_consumer_pointers(
@@ -2018,6 +2022,9 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('find "${tmp}" -depth -delete', unauthorized)
         self.assertLess(unauthorized.index('find "${tmp}"'), unauthorized.index("exit 1"))
         self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${init_asset}"', verifier)
+        self.assertIn("release-highlights.json", verifier)
+        self.assertIn("quality-snapshot.svg", verifier)
+        self.assertIn('python3 "${FORMULA_PAIR_VALIDATOR}"', verifier)
 
     def test_stable_guest_publisher_binds_the_validated_snapshot_to_gate_evidence(
         self,
@@ -2484,6 +2491,10 @@ github_cli() {{
                         "printf '731\\tcompleted\\tsuccess\\n'; }"
                     ),
                     "remote_main_commit() { printf '%s\\n' control; }",
+                    (
+                        "retain_stable_documentation_artifacts() { "
+                        "printf 'retained %s %s\\n' \"$1\" \"$2\"; }"
+                    ),
                     "github_cli() { exit 99; }",
                 ]
             ),
@@ -2495,6 +2506,7 @@ github_cli() {{
             "0.15.0 (run 731)",
             completed.stdout,
         )
+        self.assertIn("retained 0.15.0 731", completed.stdout)
 
     def test_release_helper_waits_for_an_active_exact_docc_checkpoint(self) -> None:
         active = self.run_release_function(
@@ -2511,6 +2523,10 @@ github_cli() {{
                         "printf 'wait %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }"
                     ),
                     "remote_main_commit() { printf '%s\\n' control; }",
+                    (
+                        "retain_stable_documentation_artifacts() { "
+                        "printf 'retained %s %s\\n' \"$1\" \"$2\"; }"
+                    ),
                     "github_cli() { exit 99; }",
                 ]
             ),
@@ -2519,6 +2535,7 @@ github_cli() {{
         self.assertEqual(active.returncode, 0, active.stderr)
         self.assertIn("stable documentation is already running", active.stdout)
         self.assertIn("wait 812 stable documentation and Pages deployment", active.stdout)
+        self.assertIn("retained 0.15.0 812", active.stdout)
 
     def test_release_helper_writes_the_published_k8s_documentation_authority(
         self,
@@ -3337,14 +3354,8 @@ github_cli() {{
         )
         trigger = workflow[workflow.index("\non:") : workflow.index("\npermissions:")]
         self.assertNotIn("k8s_ref:", trigger)
-        concurrency = workflow[
-            workflow.index("concurrency:") : workflow.index("\njobs:")
-        ]
-        self.assertIn(
-            "group: documentation-${{ inputs.ref }}",
-            concurrency,
-        )
-        self.assertIn("cancel-in-progress: false", concurrency)
+        pre_jobs = workflow[: workflow.index("\njobs:")]
+        self.assertNotIn("concurrency:", pre_jobs)
         self.assertIn("name: Resolve Released Documentation Inputs", workflow)
         self.assertIn("stable release ref must be a bare semantic tag", workflow)
         self.assertIn(
@@ -3376,10 +3387,14 @@ github_cli() {{
         self.assertIn("name: Build ${{ matrix.site }} DocC Site", workflow)
         self.assertIn("DOCS_SOURCE_REFERENCE: ${{ matrix.ref }}", workflow)
         self.assertIn("runs-on: macos-26", workflow)
-        self.assertIn("needs: build-sites", workflow)
+        self.assertIn("      - build-sites", workflow)
         self.assertIn("merge-multiple: true", workflow)
         self.assertIn("Assemble DocC portal", workflow)
         self.assertIn("Re-resolve documentation authority before deployment", workflow)
+        self.assertIn("Confirm release still owns Pages", workflow)
+        self.assertIn("group: documentation-pages", workflow)
+        self.assertIn("queue: max", workflow)
+        self.assertEqual(workflow.count("if: steps.latest.outputs.deploy == 'true'"), 3)
         self.assertIn("Verify documentation authority after deployment", workflow)
         self.assertEqual(workflow.count("documentation-authority.py"), 2)
         self.assertLess(
@@ -5316,6 +5331,10 @@ github_cli() {{
             workflow,
         )
         self.assertNotIn("RELEASE_BUILD_STATE_ROOT: /Volumes/", workflow)
+        self.assertIn(
+            'state_parent="${retained_root}/release/checkpoints"', workflow
+        )
+        self.assertIn("path: ${{ env.RELEASE_AUTHORITY_ROOT }}", workflow)
         self.assertNotIn("nextflow", workflow.lower())
         self.assertNotIn("make -C container-compose ci", workflow)
         self.assertNotIn("Use pinned container dependency", workflow)
@@ -5434,7 +5453,12 @@ github_cli() {{
             self.script,
         )
         self.assertIn("CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS", self.script)
-        self.assertIn("deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))", dispatch)
+        waiter = self.script[
+            self.script.index("wait_for_github_run_success() {") : self.script.index(
+                "# Print the Containerization repository",
+            )
+        ]
+        self.assertIn("deadline=$((SECONDS + wait_seconds))", waiter)
         self.assertIn(
             '"${run_id}" "hosted stable release gate" "${STABLE_RELEASE_GATE_WAIT_SECONDS}"',
             dispatch,
@@ -8900,7 +8924,8 @@ esac
         self.assertIn("github_cli() {", self.script)
         self.assertIn("github_cli pr create", self.script)
         self.assertIn('--add-assignee "@me"', self.script)
-        self.assertIn("run github_cli workflow run", self.script)
+        self.assertIn("github_cli api --method POST", self.script)
+        self.assertIn("--jq '.workflow_run_id'", self.script)
         self.assertNotIn("env -u GITHUB_TOKEN -u GH_TOKEN gh", self.script)
 
     def test_release_helper_describes_the_hosted_stable_gate(self) -> None:
@@ -9374,6 +9399,225 @@ esac
         self.assertEqual(reused.returncode, 0, reused.stderr)
         self.assertIn("already passed for the exact release controls: 912", reused.stdout)
 
+    def test_dispatch_api_returns_exact_run_id_and_binds_expected_controls(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            arguments = root / "arguments"
+            dispatched = self.run_release_function(
+                root,
+                f"dispatch_github_workflow_run docs.yml 0.15.0 {'a' * 40}",
+                shell_setup="\n".join(
+                    [
+                        f"export TEST_ARGUMENTS={shlex.quote(str(arguments))}",
+                        "github_cli() { printf '%q ' \"$@\" > \"${TEST_ARGUMENTS}\"; printf '987\\n'; }",
+                    ]
+                ),
+            )
+
+            self.assertEqual(dispatched.returncode, 0, dispatched.stderr)
+            self.assertEqual(dispatched.stdout.strip(), "987")
+            recorded = arguments.read_text(encoding="utf-8")
+            self.assertIn("actions/workflows/docs.yml/dispatches", recorded)
+            self.assertIn(f"inputs\\[expected_control_sha\\]={'a' * 40}", recorded)
+            self.assertIn("inputs\\[request_id\\]=", recorded)
+            self.assertIn("X-GitHub-Api-Version", recorded)
+
+    def test_ambiguous_dispatch_is_journalled_and_never_blindly_retried(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dispatched = self.run_release_function(
+                root,
+                f"dispatch_github_workflow_run docs.yml 0.15.0 {'a' * 40}",
+                shell_setup="github_cli() { printf 'connection lost\\n' >&2; return 1; }",
+            )
+
+            self.assertEqual(dispatched.returncode, 75)
+            self.assertIn("result is unknown", dispatched.stderr)
+            journals = list((root / "retained/release/dispatches").glob("*.json"))
+            self.assertEqual(len(journals), 1)
+            record = json.loads(journals[0].read_text(encoding="utf-8"))
+            self.assertEqual(record["state"], "dispatch-unknown")
+            self.assertEqual(record["workflow"], "docs.yml")
+
+    def test_past_success_does_not_suppress_newly_needed_tap_repair(self) -> None:
+        repaired = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            "dispatch_compose_stable_tap_repair 0.15.0",
+            shell_setup="\n".join(
+                [
+                    "print_header() { :; }",
+                    "need_command() { :; }",
+                    "stable_version_promotes_default_lane() { printf 'true\\n'; }",
+                    "remote_main_commit() { printf 'control\\n'; }",
+                    "latest_compose_package_dispatch_run() { printf '123\\tcompleted\\tsuccess\\n'; }",
+                    "dispatch_github_workflow_run() { printf '124\\n'; }",
+                    "wait_for_github_run_success() { printf 'waited %s\\n' \"$1\"; }",
+                    "complete_compose_stable_workflow() { printf 'verified %s\\n' \"$1\"; }",
+                ]
+            ),
+        )
+
+        self.assertEqual(repaired.returncode, 0, repaired.stderr)
+        self.assertIn("started: 124", repaired.stdout)
+        self.assertIn("waited 124", repaired.stdout)
+        self.assertNotIn("already passed", repaired.stdout)
+
+    def test_formula_probe_distinguishes_absence_from_api_failure(self) -> None:
+        missing = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            f"github_formula_at_ref container-compose {'a' * 40}",
+            shell_setup="github_cli() { printf '%s\\n' 'gh: Not Found (HTTP 404)'; return 1; }",
+        )
+        outage = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            f"github_formula_at_ref container-compose {'a' * 40}",
+            shell_setup="github_cli() { printf '%s\\n' 'temporary service failure'; return 1; }",
+        )
+        present = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            f"github_formula_at_ref container-compose {'a' * 40}",
+            shell_setup="github_cli() { printf '%s\\n' 'Zm9ybXVsYQ=='; }",
+        )
+
+        self.assertEqual(missing.returncode, 1)
+        self.assertEqual(outage.returncode, 2)
+        self.assertIn("temporary service failure", outage.stderr)
+        self.assertEqual(present.returncode, 0, present.stderr)
+        self.assertEqual(present.stdout.strip(), "formula")
+
+    def test_published_recovery_restores_missing_archives_from_local_retention(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            retained = root / "retained"
+            candidates = root / "candidates"
+            candidates.mkdir()
+            compose = candidates / "container-compose-plugin-release-arm64.tar.gz"
+            runtime = candidates / "container-release-arm64.tar.gz"
+            highlights = candidates / "release-highlights.json"
+            quality = candidates / "quality-snapshot.svg"
+            compose.write_bytes(b"retained compose archive")
+            runtime.write_bytes(b"retained runtime archive")
+            highlights.write_text("{}\n", encoding="utf-8")
+            quality.write_text("<svg/>\n", encoding="utf-8")
+            retained_result = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "Tools/release/retain-local-release-assets.py"),
+                    "retain",
+                    "--root",
+                    str(retained),
+                    "--version",
+                    "0.15.0",
+                    "--asset",
+                    str(compose),
+                    "--asset",
+                    str(runtime),
+                    "--asset",
+                    str(highlights),
+                    "--asset",
+                    str(quality),
+                ],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(retained_result.returncode, 0, retained_result.stderr)
+
+            recovered = self.run_release_function(
+                root,
+                "recover_published_stable_binary_assets 0.15.0",
+                shell_setup="\n".join(
+                    [
+                        "github_repo() { printf '%s\\n' owner/repo; }",
+                        "github_cli() {",
+                        "  case \"$1:$2\" in",
+                        "    release:view) : ;;",
+                        "    release:upload) printf 'uploaded:%s\\n' \"$*\" ;;",
+                        "    *) printf 'unexpected GitHub operation: %s\\n' \"$*\" >&2; return 64 ;;",
+                        "  esac",
+                        "}",
+                    ]
+                ),
+            )
+
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            self.assertEqual(recovered.stdout.count("uploaded:release upload"), 4)
+            self.assertIn(compose.name, recovered.stdout)
+            self.assertIn(runtime.name, recovered.stdout)
+            manifest = json.loads(
+                (retained / "release/releases/0.15.0/assets.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            self.assertIn(f"{compose.name}.sha256", manifest["assets"])
+            self.assertIn(f"{runtime.name}.sha256", manifest["assets"])
+            self.assertIn(highlights.name, manifest["assets"])
+            self.assertIn(quality.name, manifest["assets"])
+
+    def test_documentation_archives_are_retained_before_run_artifacts_expire(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            fixtures = root / "documentation-fixtures"
+            fixtures.mkdir()
+            for site in ("compose", "container", "containerization", "k8s"):
+                source = root / f"{site}-site"
+                (source / "documentation/module").mkdir(parents=True)
+                (source / "index.html").write_text("index", encoding="utf-8")
+                (source / "theme-settings.json").write_text("{}", encoding="utf-8")
+                (source / "documentation/module/index.html").write_text(
+                    site, encoding="utf-8"
+                )
+                subprocess.run(
+                    [
+                        sys.executable,
+                        str(ROOT / "Tools/ci/doc-site-manifest.py"),
+                        "create",
+                        str(source),
+                    ],
+                    check=True,
+                )
+                with tarfile.open(fixtures / f"{site}.tgz", "w:gz") as archive:
+                    for path in source.rglob("*"):
+                        archive.add(
+                            path,
+                            arcname=f"./{path.relative_to(source)}",
+                            recursive=False,
+                        )
+            shell_setup = "\n".join(
+                [
+                    f"export TEST_DOCUMENTATION_FIXTURES={shlex.quote(str(fixtures))}",
+                    "github_repo() { printf '%s\\n' owner/repo; }",
+                    "github_cli() {",
+                    "  if [[ \"$1:$2\" != run:download ]]; then return 64; fi",
+                    "  local destination='' previous='' argument",
+                    "  for argument in \"$@\"; do",
+                    "    if [[ \"${previous}\" == --dir ]]; then destination=\"${argument}\"; fi",
+                    "    previous=\"${argument}\"",
+                    "  done",
+                    "  mkdir -p \"${destination}/downloaded\"",
+                    "  cp \"${TEST_DOCUMENTATION_FIXTURES}\"/*.tgz \"${destination}/downloaded/\"",
+                    "}",
+                ]
+            )
+            retained = self.run_release_function(
+                root,
+                "retain_stable_documentation_artifacts 1.2.3 987",
+                shell_setup=shell_setup,
+            )
+            self.assertEqual(retained.returncode, 0, retained.stderr)
+            shutil.rmtree(fixtures)
+            reused = self.run_release_function(
+                root,
+                "retain_stable_documentation_artifacts 1.2.3 987",
+                shell_setup="github_cli() { return 99; }",
+            )
+            self.assertEqual(reused.returncode, 0, reused.stderr)
+            self.assertIn("already retained locally", reused.stdout)
+
     def test_resume_recovers_published_maintenance_assets_without_moving_stable_formulae(
         self,
     ) -> None:
@@ -9432,10 +9676,25 @@ esac
             tag_sha = "a" * 40
             init_digest = "b" * 64
             authority_object = "c" * 40
+            authority_archive = root / "stable-release-authority.tar.gz"
+            authority_archive.write_bytes(b"verified authority fixture")
             shell_setup = "\n".join(
                 [
                     "repo_path() { printf '%s\\n' /tmp/container-compose-test; }",
                     "github_repo() { printf '%s\\n' owner/repo; }",
+                    (
+                        "stable_stack_component_refs() { printf '%s\\n%s\\n%s\\n' "
+                        f"{'1' * 40} {'2' * 40} {'3' * 40}; }}"
+                    ),
+                    "python3() {",
+                    "  if [[ \"$1\" == *retain-local-release-assets.py && \"$2\" == path ]]; then",
+                    f"    printf '%s\\n' {shlex.quote(str(authority_archive))}",
+                    "  elif [[ \"$1\" == *verify-stable-authority-bundle.py ]]; then",
+                    "    :",
+                    "  else",
+                    "    command python3 \"$@\"",
+                    "  fi",
+                    "}",
                     "git() {",
                     "  if [[ \"$*\" == *'rev-list -n 1 refs/tags/0.13.1'* ]]; then",
                     "    printf '%s\\n' \"${TEST_TAG_SHA:-" + tag_sha + "}\"",
@@ -9463,9 +9722,11 @@ esac
                         f'"${{TEST_SIGNED_DIGEST:-{init_digest}}}"'
                     ),
                     "  elif [[ \"$1\" == api ]]; then",
-                    "    printf '%s\\t%s\\n' \"${TEST_AUTHORITY_RUN_ID:-29288195238}\" \"${TEST_AUTHORITY_SUMMARY:-Guest init image SHA-256: " + init_digest + ".}\"",
+                    "    printf '%s\\t%s\\n' \"${TEST_AUTHORITY_RUN_ID:-29288195238}\" \"${TEST_AUTHORITY_SUMMARY:-Guest init image SHA-256: " + init_digest + ". Authority receipt SHA-256: " + "f" * 64 + ".}\"",
                     "  elif [[ \"$1:$2\" == run:view ]]; then",
                     "    printf '%s\\n' \"${TEST_GATE_CONCLUSION:-success}\"",
+                    "  elif [[ \"$1:$2\" == attestation:verify ]]; then",
+                    "    return \"${TEST_ATTESTATION_STATUS:-2}\"",
                     "  else",
                     "    return 2",
                     "  fi",
@@ -9490,7 +9751,23 @@ esac
                 shell_setup=f"export TEST_AUTHORITY_RUN_ID=missing\n{shell_setup}",
             )
             self.assertNotEqual(missing_gate.returncode, 0)
-            self.assertIn("candidate-bound Stable Release Authority", missing_gate.stderr)
+            self.assertIn("valid durable authority attestation", missing_gate.stderr)
+
+            durable_attestation = self.run_release_function(
+                root,
+                "ensure_published_stable_recovery_authority 0.13.1",
+                shell_setup=(
+                    "export TEST_AUTHORITY_RUN_ID=missing TEST_ATTESTATION_STATUS=0\n"
+                    + shell_setup
+                ),
+            )
+            self.assertEqual(
+                durable_attestation.returncode, 0, durable_attestation.stderr
+            )
+            self.assertEqual(
+                durable_attestation.stdout.strip().splitlines()[-1],
+                f"{authority_object}\t{init_digest}",
+            )
 
             missing_digest = self.run_release_function(
                 root,
@@ -10080,7 +10357,9 @@ gh() {
             "export CONTAINER_STACK_RELEASE_LIBRARY=1",
             f"source {shlex.quote(str(SCRIPT))}",
             f"ROOT={shlex.quote(str(root))}",
+            f"RELEASE_BUILD_ROOT={shlex.quote(str(root / 'transient'))}",
             f"RELEASE_HOST_STATE_ROOT={shlex.quote(str(root / 'host-state'))}",
+            f"RELEASE_RETAINED_ROOT={shlex.quote(str(root / 'retained'))}",
             "EXECUTE=1",
             "COMPOSE_MAIN_PROMOTION_MODE=pr",
             "COMPOSE_MAIN_MERGE_MODE=checked-admin",
@@ -10139,6 +10418,57 @@ gh() {
 
         for variable in recursive_make_environment:
             self.assertNotIn(variable, environment)
+
+    def test_release_storage_claims_only_an_exact_marked_build_child(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            retained = root / "retained"
+            build = retained / "build"
+            build.mkdir(parents=True)
+            (build / ".container-family-retained-root").write_text(
+                "container-compose retained build v2\n", encoding="utf-8"
+            )
+
+            accepted = self.run_release_function(
+                root,
+                'retained_release_root_is_claimable "${RELEASE_RETAINED_ROOT}"',
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            (retained / "foreign").write_text("unowned\n", encoding="utf-8")
+            rejected = self.run_release_function(
+                root,
+                'retained_release_root_is_claimable "${RELEASE_RETAINED_ROOT}"',
+            )
+            self.assertNotEqual(rejected.returncode, 0, rejected.stderr)
+
+    def test_release_storage_accepts_only_the_exact_legacy_owner_marker(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transient = root / "transient"
+            transient.mkdir()
+            marker = transient / ".container-compose-release-root.json"
+            marker.write_text(
+                json.dumps({"owner": "container-compose", "schemaVersion": 1}),
+                encoding="utf-8",
+            )
+            (transient / "legacy-workspace").mkdir()
+
+            accepted = self.run_release_function(
+                root,
+                'transient_release_root_is_claimable "${RELEASE_BUILD_ROOT}"',
+            )
+            self.assertEqual(accepted.returncode, 0, accepted.stderr)
+
+            marker.write_text(
+                json.dumps({"owner": "someone-else", "schemaVersion": 1}),
+                encoding="utf-8",
+            )
+            rejected = self.run_release_function(
+                root,
+                'transient_release_root_is_claimable "${RELEASE_BUILD_ROOT}"',
+            )
+            self.assertNotEqual(rejected.returncode, 0, rejected.stderr)
 
 
 if __name__ == "__main__":

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -93,6 +93,18 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("stable tag already exists locally", self.script)
         self.assertIn("stable tag already exists remotely", self.script)
 
+    def test_stable_publish_uses_the_retained_assets_manifest(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn(
+            'retained_complete_manifest="${retained_root}/release/releases/'
+            '${COMPOSE_VERSION}/assets.json"',
+            workflow,
+        )
+        self.assertNotIn(
+            'retained_complete_manifest="${retained_root}/release/manifests/',
+            workflow,
+        )
+
     def test_stable_tags_are_signed_and_verified_by_github(self) -> None:
         self.assertIn('tag -s "${version}" main', self.script)
         self.assertIn('verify_github_stable_tag_signature "${version}"', self.script)
@@ -7939,7 +7951,14 @@ esac
                     self.fail("runtime candidate package build did not start")
                 time.sleep(0.05)
 
-            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                os.killpg(process.pid, signal.SIGTERM)
+            except ProcessLookupError:
+                # The process group can finish between the readiness/poll check
+                # and delivery. Preserve the cleanup assertions below and let
+                # the exit-status assertion distinguish expected termination
+                # from an unexpected early build failure.
+                pass
             stdout, stderr = process.communicate(timeout=10)
 
             self.assertEqual(process.returncode, 143, stdout + stderr)

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2593,6 +2593,38 @@ github_cli() {{
                 },
             )
 
+    def test_stable_k8s_documentation_ref_comes_from_the_release_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose"
+            manifest = compose / "Tools/release/documentation-refs.json"
+            manifest.parent.mkdir(parents=True)
+            tagged_ref = "a" * 40
+            current_ref = "b" * 40
+            manifest.write_text(
+                json.dumps({"sites": {"k8s": {"ref": tagged_ref}}}),
+                encoding="utf-8",
+            )
+            self.git(compose, "init", "--quiet")
+            self.git(compose, "config", "user.email", "test@example.com")
+            self.git(compose, "config", "user.name", "Container Test")
+            self.git(compose, "add", ".")
+            self.git(compose, "commit", "--quiet", "-m", "tagged refs")
+            self.git(compose, "tag", "1.2.3")
+            manifest.write_text(
+                json.dumps({"sites": {"k8s": {"ref": current_ref}}}),
+                encoding="utf-8",
+            )
+            self.git(compose, "add", ".")
+            self.git(compose, "commit", "--quiet", "-m", "new refs")
+
+            resolved = self.run_release_function(
+                root, "stable_documentation_source_ref 1.2.3 k8s"
+            )
+
+            self.assertEqual(resolved.returncode, 0, resolved.stderr)
+            self.assertEqual(resolved.stdout.strip(), tagged_ref)
+
     def test_current_formulae_use_the_matched_runtime_in_the_single_prerelease(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn('runtime_asset="container-current-${PUBLISH_SHA:0:12}-arm64.tar.gz"', workflow)
@@ -7926,6 +7958,7 @@ esac
                     "export CONTAINER_STACK_RELEASE_LIBRARY=1",
                     f"source {shlex.quote(str(SCRIPT))}",
                     f"ROOT={shlex.quote(str(root))}",
+                    f"RELEASE_BUILD_ROOT={shlex.quote(str(root / 'transient'))}",
                     "EXECUTE=1",
                     f"export PATH={shlex.quote(str(bin_directory))}:$PATH",
                     f"export BUILD_READY={shlex.quote(str(ready))}",

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -9262,13 +9262,18 @@ if [[ "$1" != "release" || "$2" != "view" ]]; then
   exit 1
 fi
 
-if [[ "${GH_RELEASE_STATE}" == "published" ]]; then
-  printf '%s\\n' '{"id": 1}'
-  exit 0
-fi
-
-printf '%s\\n' 'release not found' >&2
-exit 1
+case "${GH_RELEASE_STATE}" in
+  published)
+    printf '%s\\t%s\\n' false false
+    ;;
+  draft)
+    printf '%s\\t%s\\n' true false
+    ;;
+  *)
+    printf '%s\\n' 'release not found' >&2
+    exit 1
+    ;;
+esac
 """,
                 encoding="utf-8",
             )
@@ -9295,6 +9300,13 @@ exit 1
             self.assertNotEqual(published.returncode, 0)
             self.assertIn("stable release 0.6.70 already exists and is immutable", published.stderr)
 
+            draft = self.run_release_function(
+                root,
+                "ensure_stable_release_is_unpublished 0.6.70",
+                shell_setup=shell_setup.replace("unpublished", "draft"),
+            )
+            self.assertEqual(draft.returncode, 0, draft.stderr)
+
     def test_stable_release_state_requires_a_published_nonprerelease(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -9312,6 +9324,9 @@ fi
 case "${GH_RELEASE_STATE}" in
   published)
     printf '%s\\t%s\\n' false false
+    ;;
+  draft)
+    printf '%s\\t%s\\n' true false
     ;;
   prerelease)
     printf '%s\\t%s\\n' false true
@@ -9349,6 +9364,13 @@ esac
             )
             self.assertNotEqual(missing.returncode, 0)
 
+            draft = self.run_release_function(
+                root,
+                "stable_release_is_published 0.6.70",
+                shell_setup=shell_setup.replace("published", "draft"),
+            )
+            self.assertEqual(draft.returncode, 1, draft.stderr)
+
             prerelease = self.run_release_function(
                 root,
                 "stable_release_is_published 0.6.70",
@@ -9356,6 +9378,29 @@ esac
             )
             self.assertNotEqual(prerelease.returncode, 0)
             self.assertIn("not published and immutable", prerelease.stderr)
+
+    def test_resume_routes_an_existing_draft_back_through_publication(self) -> None:
+        resumed = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            "resume_stable_release 0.6.70",
+            shell_setup="\n".join(
+                [
+                    "verify_github_stable_tag_signature() { :; }",
+                    "stable_release_is_published() { return 1; }",
+                    (
+                        "ensure_stable_release_is_unpublished() { "
+                        "printf 'draft %s\\n' \"$1\"; }"
+                    ),
+                    "ensure_stable_retry_source_authority() { :; }",
+                    "prepare_stable_init_image_authority() { :; }",
+                    "publish_stable_release() { printf 'resume %s\\n' \"$1\"; }",
+                ]
+            ),
+        )
+
+        self.assertEqual(resumed.returncode, 0, resumed.stderr)
+        self.assertIn("draft 0.6.70", resumed.stdout)
+        self.assertIn("resume 0.6.70", resumed.stdout)
 
     def test_resume_routes_published_tags_to_formula_only_recovery(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1801,11 +1801,12 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("unedit --force", helper)
         self.assertIn("not in edit mode", helper)
 
-    def test_release_helper_has_no_existing_stable_package_mode(self) -> None:
+    def test_release_helper_recovers_published_stable_assets_idempotently(self) -> None:
         self.assertNotIn("package VERSION", self.script)
         self.assertNotIn("package_existing_stable", self.script)
         self.assertNotIn("sync_source_homebrew_formula", self.script)
-        self.assertIn("formula-only recovery from immutable release assets", self.script)
+        self.assertIn("verified recovery from immutable release assets", self.script)
+        self.assertIn("stable_binary_assets_are_published", self.script)
         self.assertIn('repair_tap=true', self.script)
 
     def test_release_formula_is_tap_owned_and_template_backed(self) -> None:
@@ -1924,7 +1925,6 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
                 "# Dispatch and wait for a new stable package publication."
             )
         ]
-
         self.assertIn('"repos/${GITHUB_REPOSITORY}/releases/latest"', lane)
         self.assertIn('candidate_key >= latest_key else "false"', lane)
         self.assertIn('release_label="maintenance backfill"', lane)
@@ -1957,9 +1957,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             dispatcher,
         )
         self.assertIn(
-            '"${stable_formula_identities_before}" "${authority_init_digest}"',
+            '"${version}" "${promote_default_lane}"',
             dispatcher,
         )
+        self.assertIn('"${stable_formula_identities_before}"', dispatcher)
 
     def test_stable_release_publishes_and_verifies_guest_closure(self) -> None:
         asset_pair = self.script[
@@ -1975,6 +1976,11 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         dispatcher = self.script[
             self.script.index("dispatch_compose_stable_workflow() {") : self.script.index(
                 "# Dispatch and wait for a new stable package publication."
+            )
+        ]
+        completion = self.script[
+            self.script.index("complete_compose_stable_workflow() {") : self.script.index(
+                "# Return success when stable binary assets exist"
             )
         ]
         verifier = self.script[
@@ -1995,9 +2001,10 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn('"${digest}" != "${expected_digest}"', publisher)
         self.assertIn('github_cli release upload "${version}"', asset_pair)
         self.assertIn("publish_stable_asset_pair", publisher)
+        self.assertIn("complete_compose_stable_workflow", dispatcher)
         self.assertLess(
-            dispatcher.index('publish_stable_init_image_asset "${version}"'),
-            dispatcher.index("verify_compose_stable_package"),
+            completion.index('publish_stable_init_image_asset "${version}"'),
+            completion.index("verify_compose_stable_package"),
         )
         self.assertIn('init_asset="container-vminit-arm64.oci.tar"', verifier)
         self.assertIn('expected_init_digest="$4"', verifier)
@@ -2087,6 +2094,39 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 17, result.stderr)
+
+    def test_stable_guest_publisher_recovers_the_published_asset_without_local_state(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            remote_archive = root / "published.oci.tar"
+            self.create_release_guest_archive(remote_archive)
+            digest = hashlib.sha256(remote_archive.read_bytes()).hexdigest()
+            upload_marker = root / "upload"
+            shell_setup = "\n".join(
+                [
+                    "unset CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE",
+                    f"export TEST_REMOTE_ARCHIVE={shlex.quote(str(remote_archive))}",
+                    f"export TEST_UPLOAD_MARKER={shlex.quote(str(upload_marker))}",
+                    "stable_containerization_authority() { printf '%s\\n' owner/containerization ref; }",
+                    "github_repo() { printf '%s\\n' owner/container-compose; }",
+                    "github_cli() {",
+                    "  [[ \"$1:$2\" == release:download ]] || return 99",
+                    "  command cp \"${TEST_REMOTE_ARCHIVE}\" \"$9/container-vminit-arm64.oci.tar\"",
+                    "}",
+                    "publish_stable_asset_pair() { touch \"${TEST_UPLOAD_MARKER}\"; }",
+                ]
+            )
+
+            recovered = self.run_release_function(
+                root,
+                f"publish_stable_init_image_asset 0.13.1 {digest}",
+                shell_setup=shell_setup,
+            )
+
+            self.assertEqual(recovered.returncode, 0, recovered.stderr)
+            self.assertTrue(upload_marker.exists())
 
     def test_stable_guest_asset_pair_recovers_each_missing_member(self) -> None:
         asset = "container-vminit-arm64.oci.tar"
@@ -2381,9 +2421,28 @@ github_cli() {{
         self.assertNotIn("Attest release package", repair)
 
     def test_release_helper_tracks_the_stable_package_dispatch_by_tag(self) -> None:
-        self.assertIn('title="Prebuilt Binaries · ${version}"', self.script)
-        self.assertIn("--json databaseId,displayTitle", self.script)
-        self.assertIn('latest_compose_package_dispatch_run "${version}"', self.script)
+        self.assertIn('title="Prebuilt Binaries · ${version} · ${mode}"', self.script)
+        self.assertIn("databaseId,displayTitle,headSha,status,conclusion", self.script)
+        self.assertIn('"${version}" "${repair_tap}" "${control_sha}"', self.script)
+
+    def test_release_helper_tracks_stable_gate_dispatch_by_tag(self) -> None:
+        workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        lookup = self.script[
+            self.script.index("latest_stable_release_gate_dispatch_run() {") :
+            self.script.index("# Return the newest run for one immutable stable documentation manifest.")
+        ]
+
+        self.assertIn("run-name: Stable Release Gate · ${{ inputs.ref }}", workflow)
+        self.assertIn('title="Stable Release Gate · ${version}"', lookup)
+        self.assertIn("databaseId,displayTitle", lookup)
+        self.assertIn("map(select(.displayTitle", lookup)
+
+    def test_non_discardable_release_workflows_use_a_real_queue(self) -> None:
+        for workflow_path in (PACKAGE_WORKFLOW, STABLE_GATE_WORKFLOW, DOCS_WORKFLOW):
+            with self.subTest(workflow=workflow_path.name):
+                workflow = workflow_path.read_text(encoding="utf-8")
+                self.assertIn("  cancel-in-progress: false\n", workflow)
+                self.assertIn("  queue: max\n", workflow)
 
     def test_release_helper_runs_released_docc_last_from_a_durable_manifest(
         self,
@@ -2424,6 +2483,7 @@ github_cli() {{
                         "latest_stable_documentation_dispatch() { "
                         "printf '731\\tcompleted\\tsuccess\\n'; }"
                     ),
+                    "remote_main_commit() { printf '%s\\n' control; }",
                     "github_cli() { exit 99; }",
                 ]
             ),
@@ -2450,6 +2510,7 @@ github_cli() {{
                         "wait_for_github_run_success() { "
                         "printf 'wait %s %s %s\\n' \"$1\" \"$2\" \"$3\"; }"
                     ),
+                    "remote_main_commit() { printf '%s\\n' control; }",
                     "github_cli() { exit 99; }",
                 ]
             ),
@@ -3305,7 +3366,8 @@ github_cli() {{
             workflow,
         )
         self.assertIn("strategy:", workflow)
-        self.assertIn("fail-fast: true", workflow)
+        self.assertIn("fail-fast: false", workflow)
+        self.assertIn("Restore exact DocC site", workflow)
         self.assertEqual(workflow.count("- site:"), 4)
         for site in ("compose", "container", "containerization", "k8s"):
             self.assertIn(f"- site: {site}", workflow)
@@ -3953,6 +4015,11 @@ github_cli() {{
         self.assertIn('git -C release-tools rev-parse HEAD', receipt)
         self.assertIn("--candidate-sha \"${PUBLISH_SHA}\"", receipt)
         self.assertIn("stable-release-authority.tar.gz", receipt)
+        self.assertIn("'.components[\"homebrew-tap\"]'", receipt)
+        self.assertNotIn(
+            "git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git",
+            receipt,
+        )
 
     def test_stable_gate_records_the_candidate_bound_guest_digest(self) -> None:
         workflow = STABLE_GATE_WORKFLOW.read_text(encoding="utf-8")
@@ -9227,6 +9294,9 @@ esac
                         "verify_github_stable_tag_signature() { :; }",
                         "stable_release_is_published() { return 0; }",
                         "ensure_stable_release_is_unpublished() { exit 71; }",
+                        "complete_compose_stable_workflow() { return 1; }",
+                        "stable_binary_assets_are_published() { return 0; }",
+                        "stable_formula_pair_matches_release() { return 1; }",
                         "dispatch_compose_stable_tap_repair() { printf 'repair %s\\n' \"$1\"; }",
                         "dispatch_stable_documentation() { printf 'docs %s\\n' \"$1\"; }",
                         "publish_stable_release() { exit 72; }",
@@ -9237,7 +9307,7 @@ esac
             self.assertEqual(published.returncode, 0, published.stderr)
             self.assertIn("repair 0.6.70", published.stdout)
             self.assertIn("docs 0.6.70", published.stdout)
-            self.assertIn("formula-only recovery from immutable release assets", published.stdout)
+            self.assertIn("verified recovery from immutable release assets", published.stdout)
 
             unpublished = self.run_release_function(
                 root,
@@ -9257,6 +9327,52 @@ esac
             )
             self.assertEqual(unpublished.returncode, 0, unpublished.stderr)
             self.assertIn("publish 0.6.70", unpublished.stdout)
+
+    def test_resume_skips_package_workflow_when_published_outputs_verify(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            resumed = self.run_release_function(
+                root,
+                "resume_stable_release 0.6.70",
+                shell_setup="\n".join(
+                    [
+                        "stable_version_promotes_default_lane() { printf '%s\\n' true; }",
+                        "ensure_latest_stable_retry() { :; }",
+                        "verify_github_stable_tag_signature() { :; }",
+                        "stable_release_is_published() { return 0; }",
+                        "stable_binary_assets_are_published() { return 0; }",
+                        "stable_formula_pair_matches_release() { return 0; }",
+                        "complete_compose_stable_workflow() { printf 'verified %s\\n' \"$1\"; }",
+                        "dispatch_compose_stable_tap_repair() { exit 71; }",
+                        "dispatch_compose_stable_package() { exit 72; }",
+                        "dispatch_stable_documentation() { printf 'docs %s\\n' \"$1\"; }",
+                        "print_stable_release_point() { printf 'point %s %s\\n' \"$1\" \"$2\"; }",
+                    ]
+                ),
+            )
+
+            self.assertEqual(resumed.returncode, 0, resumed.stderr)
+            self.assertIn("verified 0.6.70", resumed.stdout)
+            self.assertIn("no package workflow required", resumed.stdout)
+            self.assertIn("docs 0.6.70", resumed.stdout)
+
+    def test_stable_gate_reuses_exact_successful_control_run(self) -> None:
+        reused = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            "dispatch_stable_release_gate 0.15.0",
+            shell_setup="\n".join(
+                [
+                    "retained_stable_init_image_gate_digest() { printf '%s\\n' digest; }",
+                    "ensure_stable_init_image_authority_tag() { :; }",
+                    "remote_main_commit() { printf '%s\\n' control; }",
+                    "latest_stable_release_gate_dispatch_run() { printf '912\\tcompleted\\tsuccess\\n'; }",
+                    "github_cli() { exit 99; }",
+                ]
+            ),
+        )
+
+        self.assertEqual(reused.returncode, 0, reused.stderr)
+        self.assertIn("already passed for the exact release controls: 912", reused.stdout)
 
     def test_resume_recovers_published_maintenance_assets_without_moving_stable_formulae(
         self,

--- a/Tools/release/test_publish_github_release.py
+++ b/Tools/release/test_publish_github_release.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("publish-github-release.sh")
+
+
+class PublishGitHubReleaseTests(unittest.TestCase):
+    def test_current_finalize_never_deletes_existing_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            log = root / "commands"
+            gh = root / "gh"
+            gh.write_text(
+                "#!/bin/bash\nset -euo pipefail\nprintf 'gh:%s\\n' \"$*\" >> \"${TEST_LOG}\"\nif [[ \"${1:-}:${2:-}\" == api:--silent ]]; then printf '{}\\n'; fi\n",
+                encoding="utf-8",
+            )
+            gh.chmod(0o755)
+            git = root / "git"
+            git.write_text(
+                "#!/bin/bash\nset -euo pipefail\nprintf 'git:%s\\n' \"$*\" >> \"${TEST_LOG}\"\n",
+                encoding="utf-8",
+            )
+            git.chmod(0o755)
+            notes = root / "notes.md"
+            asset = root / "current.tar.gz"
+            checksum = root / "current.tar.gz.sha256"
+            for path in (notes, asset, checksum):
+                path.write_text("data\n", encoding="utf-8")
+            environment = os.environ.copy()
+            environment.update(
+                {
+                    "GH": str(gh),
+                    "GIT": str(git),
+                    "PUBLISH_REF_TYPE": "branch",
+                    "PUBLISH_SHA": "a" * 40,
+                    "RELEASE_ASSET_PATH": str(asset),
+                    "RELEASE_CHECKSUM_PATH": str(checksum),
+                    "RELEASE_LATEST": "false",
+                    "RELEASE_MUTABLE": "true",
+                    "RELEASE_NOTES_FILE": str(notes),
+                    "RELEASE_PHASE": "finalize",
+                    "RELEASE_PRERELEASE": "true",
+                    "RELEASE_REPOSITORY": "owner/repository",
+                    "RELEASE_TAG": "current",
+                    "RELEASE_TITLE": "Current build",
+                    "TEST_LOG": str(log),
+                }
+            )
+
+            result = subprocess.run(
+                ["/bin/bash", str(SCRIPT)],
+                cwd=root,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            commands = log.read_text(encoding="utf-8")
+            self.assertIn("gh:release upload current", commands)
+            self.assertIn("gh:release edit current", commands)
+            self.assertNotIn("release delete", commands)
+            self.assertNotIn("release create", commands)
+            self.assertIn("git:push --force origin refs/tags/current", commands)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -28,6 +28,10 @@ cat > "${temporary_directory}/bin/gh" <<'EOF'
 set -Eeuo pipefail
 
 if [[ "$1" == "api" ]]; then
+  if [[ " $* " == *" --silent "* ]]; then
+    printf 'release lookup must preserve the response body\n' >&2
+    exit 64
+  fi
   case "${MOCK_RELEASE_STATE}" in
     exists)
       exit 0

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -147,11 +147,10 @@ main_finalize_calls="${temporary_directory}/main-finalize.calls"
 run_publisher branch exists "${main_finalize_calls}" "" finalize
 grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_finalize_calls}.git"
 grep -Fqx "push --force origin refs/tags/current" "${main_finalize_calls}.git"
-grep -Fqx "release delete current --repo stephenlclarke/container-compose --yes" "${main_finalize_calls}"
-grep -Fqx "release create current ${asset} ${checksum} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --verify-tag --prerelease --latest=false" "${main_finalize_calls}"
-grep -Fqx "release edit current --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --prerelease" "${main_finalize_calls}"
-if grep -Eq 'release upload' "${main_finalize_calls}" || grep -Fq -- '--cleanup-tag' "${main_finalize_calls}"; then
-  printf 'current finalization unexpectedly changed staged assets or removed the current tag\n' >&2
+grep -Fqx "release upload current ${asset} ${checksum} --repo stephenlclarke/container-compose --clobber" "${main_finalize_calls}"
+grep -Fqx "release edit current --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --title Current build --notes-file ${notes} --prerelease --latest=false" "${main_finalize_calls}"
+if grep -Eq 'release (create|delete)' "${main_finalize_calls}" || grep -Fq -- '--cleanup-tag' "${main_finalize_calls}"; then
+  printf 'current finalization replaced the release object or removed the current tag\n' >&2
   exit 1
 fi
 

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -32,6 +32,10 @@ if [[ "$1" == "api" ]]; then
     exists)
       exit 0
       ;;
+    draft)
+      printf '{"draft":true}\n'
+      exit 0
+      ;;
     missing)
       printf 'gh: Not Found (HTTP 404)\n' >&2
       exit 1
@@ -54,13 +58,17 @@ cat > "${temporary_directory}/bin/git" <<'EOF'
 set -Eeuo pipefail
 
 printf '%s\n' "$*" >> "${MOCK_GIT_CALLS}"
+if [[ "$1" == rev-list ]]; then
+  printf '0123456789012345678901234567890123456789\n'
+fi
 EOF
 chmod +x "${temporary_directory}/bin/git"
 
 asset="${temporary_directory}/container-compose-plugin-release-arm64.tar.gz"
 checksum="${asset}.sha256"
 notes="${temporary_directory}/notes.md"
-touch "${asset}" "${checksum}" "${notes}"
+retained_manifest="${temporary_directory}/retained-complete.json"
+touch "${asset}" "${checksum}" "${notes}" "${retained_manifest}"
 
 # Run the publisher with a temporary, recorded GitHub CLI implementation.
 run_publisher() {
@@ -94,6 +102,7 @@ run_publisher() {
     PUBLISH_SHA="0123456789012345678901234567890123456789" \
     RELEASE_ASSET_PATH="${asset}" \
     RELEASE_CHECKSUM_PATH="${checksum}" \
+    RELEASE_RETAINED_COMPLETE_MANIFEST="${retained_manifest}" \
     RELEASE_EXTRA_ASSETS_FILE="${4:-}" \
     MOCK_RELEASE_STATE="$2" \
     MOCK_GH_CALLS="$3" \
@@ -113,9 +122,22 @@ fi
 
 stable_create_calls="${temporary_directory}/stable-create.calls"
 run_publisher tag missing "${stable_create_calls}"
-grep -Fqx "release create 1.2.3 ${asset} ${checksum} --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --verify-tag --latest" "${stable_create_calls}"
-if grep -Eq 'release (edit|upload)|clobber' "${stable_create_calls}"; then
-  printf 'stable publication attempted a mutable release operation\n' >&2
+grep -Fqx "release create 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --verify-tag --latest --draft" "${stable_create_calls}"
+grep -Fqx "release upload 1.2.3 ${asset} --repo stephenlclarke/container-compose" "${stable_create_calls}"
+grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-compose" "${stable_create_calls}"
+grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --draft=false --latest" "${stable_create_calls}"
+if grep -Eq 'clobber|release delete' "${stable_create_calls}"; then
+  printf 'stable publication attempted to replace immutable state\n' >&2
+  exit 1
+fi
+
+stable_draft_calls="${temporary_directory}/stable-draft.calls"
+run_publisher tag draft "${stable_draft_calls}"
+grep -Fqx "release upload 1.2.3 ${asset} --repo stephenlclarke/container-compose" "${stable_draft_calls}"
+grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-compose" "${stable_draft_calls}"
+grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --draft=false --latest" "${stable_draft_calls}"
+if grep -Eq 'release create|clobber|release delete' "${stable_draft_calls}"; then
+  printf 'stable draft recovery recreated or clobbered release state\n' >&2
   exit 1
 fi
 
@@ -174,7 +196,8 @@ touch "${runtime_asset}" "${runtime_checksum}"
 printf '%s\n%s\n' "${runtime_asset}" "${runtime_checksum}" > "${extra_assets}"
 stable_extra_calls="${temporary_directory}/stable-extra.calls"
 run_publisher tag missing "${stable_extra_calls}" "${extra_assets}"
-grep -Fqx "release create 1.2.3 ${asset} ${checksum} ${runtime_asset} ${runtime_checksum} --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --verify-tag --latest" "${stable_extra_calls}"
+grep -Fqx "release upload 1.2.3 ${runtime_asset} --repo stephenlclarke/container-compose" "${stable_extra_calls}"
+grep -Fqx "release upload 1.2.3 ${runtime_checksum} --repo stephenlclarke/container-compose" "${stable_extra_calls}"
 
 current_extra_calls="${temporary_directory}/current-extra.calls"
 run_publisher branch exists "${current_extra_calls}" "${extra_assets}" stage

--- a/Tools/release/test_release_dispatch_journal.py
+++ b/Tools/release/test_release_dispatch_journal.py
@@ -118,6 +118,85 @@ class ReleaseDispatchJournalTests(unittest.TestCase):
         self.assertEqual(self.invoke("ack", "--run-id", "987"), 0)
         self.assertEqual(json.loads(path.read_text())["state"], "dispatched")
 
+    def test_find_returns_existing_logical_operation(self) -> None:
+        self.assertEqual(
+            self.invoke(
+                "intent",
+                "--workflow",
+                "docs.yml",
+                "--version",
+                "0.15.0",
+                "--control-sha",
+                "a" * 40,
+                "--mode",
+                "docs",
+            ),
+            0,
+        )
+        output = StringIO()
+        with redirect_stdout(output):
+            result = MODULE.main(
+                [
+                    "find",
+                    "--root",
+                    str(self.root),
+                    "--workflow",
+                    "docs.yml",
+                    "--version",
+                    "0.15.0",
+                    "--control-sha",
+                    "a" * 40,
+                    "--mode",
+                    "docs",
+                ]
+            )
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(output.getvalue())["request_id"], self.request)
+
+    def test_claim_reuses_one_logical_operation(self) -> None:
+        arguments = [
+            "claim", "--root", str(self.root), "--workflow", "docs.yml",
+            "--version", "0.15.0", "--control-sha", "a" * 40,
+            "--mode", "docs",
+        ]
+        first_output = StringIO()
+        with redirect_stdout(first_output):
+            self.assertEqual(
+                MODULE.main(arguments + ["--request-id", self.request]), 0
+            )
+        second_request = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        second_output = StringIO()
+        with redirect_stdout(second_output):
+            self.assertEqual(
+                MODULE.main(arguments + ["--request-id", second_request]), 0
+            )
+        self.assertEqual(
+            json.loads(second_output.getvalue())["request_id"], self.request
+        )
+        records = list((self.root / "release/dispatches").glob("*.json"))
+        self.assertEqual([record.name for record in records], [f"{self.request}.json"])
+
+    def test_failed_acknowledged_attempt_allows_linked_new_claim(self) -> None:
+        common = [
+            "--workflow", "docs.yml", "--version", "0.15.0",
+            "--control-sha", "a" * 40, "--mode", "docs",
+        ]
+        self.assertEqual(self.invoke("intent", *common), 0)
+        self.assertEqual(self.invoke("ack", "--run-id", "987"), 0)
+        self.assertEqual(self.invoke("fail"), 0)
+        replacement = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        output = StringIO()
+        with redirect_stdout(output):
+            self.assertEqual(
+                MODULE.main(
+                    ["claim", "--root", str(self.root), "--request-id", replacement, *common]
+                ),
+                0,
+            )
+        record = json.loads(output.getvalue())
+        self.assertEqual(record["request_id"], replacement)
+        self.assertEqual(record["previous_request_id"], self.request)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/release/test_release_dispatch_journal.py
+++ b/Tools/release/test_release_dispatch_journal.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("release-dispatch-journal.py")
+SPEC = importlib.util.spec_from_file_location("release_dispatch_journal", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ReleaseDispatchJournalTests(unittest.TestCase):
+    def setUp(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name) / "retained"
+        self.request = "12345678-1234-1234-1234-123456789abc"
+
+    def invoke(self, *arguments: str) -> int:
+        with redirect_stdout(StringIO()):
+            return MODULE.main([*arguments, "--root", str(self.root), "--request-id", self.request])
+
+    def test_intent_then_ack_is_atomic_and_durable(self) -> None:
+        self.assertEqual(
+            self.invoke(
+                "intent",
+                "--workflow",
+                "docs.yml",
+                "--version",
+                "0.15.0",
+                "--control-sha",
+                "a" * 40,
+            ),
+            0,
+        )
+        path = MODULE.record_path(self.root, self.request)
+        self.assertEqual(json.loads(path.read_text())["state"], "dispatch-intent")
+        self.assertEqual(self.invoke("ack", "--run-id", "987"), 0)
+        record = json.loads(path.read_text())
+        self.assertEqual(record["state"], "dispatched")
+        self.assertEqual(record["run_id"], "987")
+
+    def test_ack_without_intent_is_rejected(self) -> None:
+        self.assertEqual(self.invoke("ack", "--run-id", "987"), 2)
+
+    def test_invalid_version_and_tampered_intent_are_rejected(self) -> None:
+        self.assertEqual(
+            self.invoke(
+                "intent",
+                "--workflow",
+                "docs.yml",
+                "--version",
+                "latest",
+                "--control-sha",
+                "a" * 40,
+            ),
+            2,
+        )
+        self.assertEqual(
+            self.invoke(
+                "intent",
+                "--workflow",
+                "docs.yml",
+                "--version",
+                "0.15.0",
+                "--control-sha",
+                "a" * 40,
+            ),
+            0,
+        )
+        path = MODULE.record_path(self.root, self.request)
+        record = json.loads(path.read_text())
+        record["request_id"] = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        path.write_text(json.dumps(record))
+
+        self.assertEqual(self.invoke("ack", "--run-id", "987"), 2)
+
+    def test_unknown_response_is_durable_and_can_be_reconciled(self) -> None:
+        self.assertEqual(
+            self.invoke(
+                "intent",
+                "--workflow",
+                "docs.yml",
+                "--version",
+                "0.15.0",
+                "--control-sha",
+                "a" * 40,
+            ),
+            0,
+        )
+        self.assertEqual(self.invoke("unknown"), 0)
+        path = MODULE.record_path(self.root, self.request)
+        self.assertEqual(json.loads(path.read_text())["state"], "dispatch-unknown")
+        self.assertEqual(self.invoke("ack", "--run-id", "987"), 0)
+        self.assertEqual(json.loads(path.read_text())["state"], "dispatched")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+SCRIPT = Path(__file__).with_name("release-state.py")
+SPEC = importlib.util.spec_from_file_location("release_state", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ReleaseStateTests(unittest.TestCase):
+    def test_unknown_dispatch_is_actionable_and_never_reported_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "retained"
+            request_id = "12345678-1234-1234-1234-123456789abc"
+            journal = root / f"release/dispatches/{request_id}.json"
+            journal.parent.mkdir(parents=True)
+            journal.write_text(
+                json.dumps(
+                    {
+                        "control_sha": "a" * 40,
+                        "created_at": "2026-09-10T00:00:00+00:00",
+                        "request_id": request_id,
+                        "schema": 1,
+                        "state": "dispatch-unknown",
+                        "version": "1.2.3",
+                        "workflow": "docs.yml",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            state = MODULE.inspect(
+                root, "1.2.3", "stephenlclarke/container-compose", True
+            )
+
+            self.assertEqual(state["remote_release"]["state"], "not-inspected")
+            self.assertIn("do not redispatch", state["next_action"])
+            rendered = MODULE.render_text(state, True)
+            self.assertIn("Mutation: none", rendered)
+            self.assertIn("dispatch-unknown", rendered)
+
+    def test_tampered_dispatch_record_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "retained"
+            journal = (
+                root
+                / "release/dispatches/12345678-1234-1234-1234-123456789abc.json"
+            )
+            journal.parent.mkdir(parents=True)
+            journal.write_text(
+                json.dumps(
+                    {
+                        "control_sha": "a" * 40,
+                        "request_id": "different",
+                        "schema": 1,
+                        "state": "dispatch-unknown",
+                        "version": "1.2.3",
+                        "workflow": "docs.yml",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(MODULE.StateError, "unsupported"):
+                MODULE.inspect(
+                    root, "1.2.3", "stephenlclarke/container-compose", True
+                )
+
+    def test_offline_missing_artifacts_never_claim_success(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "retained"
+            state = MODULE.inspect(
+                root, "1.2.3", "stephenlclarke/container-compose", True
+            )
+
+            self.assertEqual(state["retained"]["verified"], [])
+            self.assertEqual(
+                len(state["retained"]["missing"]), len(MODULE.EXPECTED_ASSETS)
+            )
+            self.assertIn("blocked", state["next_action"])
+
+    def test_acknowledged_run_observation_is_read_only(self) -> None:
+        record = {"run_id": "987", "state": "dispatched"}
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "conclusion": "success",
+                    "status": "completed",
+                    "url": "https://example.invalid/run/987",
+                }
+            ),
+            stderr="",
+        )
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed):
+            observed = MODULE.observe_dispatches([record], "owner/repo", False)
+
+        self.assertEqual(observed[0]["observed"]["state"], "completed")
+        self.assertNotIn("observed", record)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import importlib.util
+import base64
 import json
 import subprocess
 import tempfile
@@ -34,6 +35,12 @@ SPEC.loader.exec_module(MODULE)
 
 
 class ReleaseStateTests(unittest.TestCase):
+    @staticmethod
+    def completed(value: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=[], returncode=0, stdout=json.dumps(value), stderr=""
+        )
+
     def test_unknown_dispatch_is_actionable_and_never_reported_absent(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory) / "retained"
@@ -155,6 +162,7 @@ class ReleaseStateTests(unittest.TestCase):
                 "remote_release",
                 return_value={
                     "assets": [],
+                    "asset_digests": {},
                     "missing_assets": list(MODULE.EXPECTED_ASSETS),
                     "state": "published",
                 },
@@ -165,6 +173,188 @@ class ReleaseStateTests(unittest.TestCase):
             )
 
         self.assertIn("incomplete remote release", state["next_action"])
+        self.assertEqual(state["actions"][0]["name"], "upload-missing-assets")
+        self.assertIn("side_effects", state["actions"][0])
+
+    def test_latest_postconditions_are_bound_to_formulae_and_docs_run(self) -> None:
+        compose_url = (
+            "https://github.com/owner/repo/releases/download/1.2.3/"
+            "container-compose-plugin-release-arm64.tar.gz"
+        )
+        runtime_url = (
+            "https://github.com/owner/repo/releases/download/1.2.3/"
+            "container-release-arm64.tar.gz"
+        )
+        formulae = {
+            "compose_url": compose_url,
+            "runtime_url": runtime_url,
+            "compose_sha256": "a" * 64,
+            "runtime_sha256": "b" * 64,
+        }
+        compose = (
+            f'  url "{compose_url}"\n  sha256 "{"a" * 64}"\n'
+            '  depends_on "stephenlclarke/tap/container"\n'
+        )
+        runtime = (
+            f'  url "{runtime_url}"\n  sha256 "{"b" * 64}"\n'
+            "  plugin = opt/container-compose/libexec/container-plugins/compose\n"
+        )
+        def metadata(body: str, sha: str) -> dict[str, str]:
+            return {
+                "content": base64.encodebytes(body.encode()).decode(),
+                "encoding": "base64",
+                "sha": sha,
+            }
+        control_sha = "c" * 40
+        responses = [
+            self.completed({"tag_name": "1.2.3"}),
+            self.completed(metadata(runtime, "runtime-blob")),
+            self.completed(metadata(compose, "compose-blob")),
+            self.completed(
+                {
+                    "build_type": "workflow",
+                    "html_url": "https://docs.test",
+                    "status": "built",
+                }
+            ),
+            self.completed(
+                {
+                    "workflow_runs": [
+                        {
+                            "conclusion": "success",
+                            "display_title": "Documentation · 1.2.3 · request",
+                            "head_sha": control_sha,
+                            "id": 123,
+                            "status": "completed",
+                        }
+                    ]
+                }
+            ),
+            self.completed([{"id": 456, "sha": control_sha}]),
+            self.completed([{"state": "success"}]),
+        ]
+        with mock.patch.object(MODULE.subprocess, "run", side_effect=responses):
+            observed = MODULE.remote_postconditions(
+                "owner/repo", "1.2.3", False, formulae
+            )
+
+        self.assertEqual(observed["formulae"]["state"], "verified")
+        self.assertEqual(observed["pages"]["state"], "verified")
+        self.assertEqual(observed["pages"]["control_sha"], control_sha)
+        self.assertNotIn(
+            "body", observed["formulae"]["members"]["container-compose.rb"]
+        )
+
+    def test_superseded_release_does_not_compare_current_postconditions(
+        self,
+    ) -> None:
+        with mock.patch.object(
+            MODULE.subprocess,
+            "run",
+            return_value=self.completed({"tag_name": "2.0.0"}),
+        ) as run:
+            observed = MODULE.remote_postconditions(
+                "owner/repo", "1.2.3", False, None
+            )
+
+        self.assertEqual(observed["formulae"]["state"], "superseded")
+        self.assertEqual(observed["pages"]["latest_version"], "2.0.0")
+        run.assert_called_once()
+
+    def test_formula_conflict_fails_candidate_bound_postcondition(self) -> None:
+        wrong = '  url "https://wrong.test/archive"\n  sha256 "' + "a" * 64 + '"\n'
+        runtime = (
+            '  url "https://example.test/runtime"\n  sha256 "'
+            + "b" * 64
+            + '"\n  plugin = opt/container-compose/libexec/container-plugins/compose\n'
+        )
+        responses = [
+            self.completed({"tag_name": "1.2.3"}),
+            self.completed(
+                {
+                    "content": base64.b64encode(runtime.encode()).decode(),
+                    "encoding": "base64",
+                    "sha": "runtime-blob",
+                }
+            ),
+            self.completed(
+                {
+                    "content": base64.b64encode(wrong.encode()).decode(),
+                    "encoding": "base64",
+                    "sha": "compose-blob",
+                }
+            ),
+            self.completed({"status": "built"}),
+            self.completed({"workflow_runs": []}),
+            self.completed([]),
+        ]
+        expected = {
+            "compose_url": "https://example.test/compose",
+            "runtime_url": "https://example.test/runtime",
+            "compose_sha256": "a" * 64,
+            "runtime_sha256": "b" * 64,
+        }
+        with mock.patch.object(MODULE.subprocess, "run", side_effect=responses):
+            observed = MODULE.remote_postconditions(
+                "owner/repo", "1.2.3", False, expected
+            )
+
+        self.assertEqual(observed["formulae"]["state"], "conflict")
+        self.assertIn("URL", observed["formulae"]["reason"])
+
+    def test_remote_digest_conflict_is_not_reported_as_published(self) -> None:
+        name = MODULE.EXPECTED_ASSETS[0]
+        assets = {
+            asset: {"sha256": "a" * 64}
+            for asset in MODULE.EXPECTED_ASSETS
+        }
+        remote = {
+            "asset_digests": {name: "sha256:" + "b" * 64},
+            "state": "published",
+        }
+
+        observed = MODULE.reconcile_remote_digests(
+            remote, {"assets": assets}
+        )
+
+        self.assertEqual(observed["state"], "conflicting")
+        self.assertIn(name, observed["digest_conflicts"])
+        self.assertEqual(remote["state"], "published")
+
+    def test_missing_remote_digests_fail_closed_for_complete_inventory(self) -> None:
+        assets = {
+            asset: {"sha256": "a" * 64}
+            for asset in MODULE.EXPECTED_ASSETS
+        }
+
+        observed = MODULE.reconcile_remote_digests(
+            {"asset_digests": {}, "missing_assets": [], "state": "published"},
+            {"assets": assets},
+        )
+
+        self.assertEqual(observed["state"], "unavailable")
+        self.assertEqual(
+            observed["unverified_digests"], list(MODULE.EXPECTED_ASSETS)
+        )
+
+    def test_pure_plan_declares_authority_and_invalidated_descendants(self) -> None:
+        action = MODULE.plan_recovery(
+            [],
+            [],
+            [],
+            {
+                "missing_assets": ["asset"],
+                "state": "published",
+            },
+            {
+                "formulae": {"state": "deferred"},
+                "pages": {"state": "deferred"},
+            },
+        )
+
+        self.assertEqual(action["name"], "upload-missing-assets")
+        self.assertEqual(action["invalidated_descendants"], ["formulae", "pages"])
+        self.assertEqual(action["required_authority"], "retained publication authority")
 
 
 if __name__ == "__main__":

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -107,7 +107,8 @@ class ReleaseStateTests(unittest.TestCase):
 
             self.assertEqual(state["retained"]["verified"], [])
             self.assertEqual(
-                len(state["retained"]["missing"]), len(MODULE.EXPECTED_ASSETS)
+                len(state["retained"]["missing"]),
+                len(MODULE.EXPECTED_RETAINED_ASSETS),
             )
             self.assertIn("blocked", state["next_action"])
 
@@ -154,7 +155,7 @@ class ReleaseStateTests(unittest.TestCase):
             mock.patch.object(
                 MODULE,
                 "retained_assets",
-                return_value=(list(MODULE.EXPECTED_ASSETS), []),
+                return_value=(list(MODULE.EXPECTED_RETAINED_ASSETS), []),
             ),
             mock.patch.object(MODULE, "dispatch_records", return_value=[]),
             mock.patch.object(
@@ -163,7 +164,7 @@ class ReleaseStateTests(unittest.TestCase):
                 return_value={
                     "assets": [],
                     "asset_digests": {},
-                    "missing_assets": list(MODULE.EXPECTED_ASSETS),
+                    "missing_assets": list(MODULE.EXPECTED_RELEASE_ASSETS),
                     "state": "published",
                 },
             ),
@@ -303,10 +304,10 @@ class ReleaseStateTests(unittest.TestCase):
         self.assertIn("URL", observed["formulae"]["reason"])
 
     def test_remote_digest_conflict_is_not_reported_as_published(self) -> None:
-        name = MODULE.EXPECTED_ASSETS[0]
+        name = MODULE.EXPECTED_RELEASE_ASSETS[0]
         assets = {
             asset: {"sha256": "a" * 64}
-            for asset in MODULE.EXPECTED_ASSETS
+            for asset in MODULE.EXPECTED_RETAINED_ASSETS
         }
         remote = {
             "asset_digests": {name: "sha256:" + "b" * 64},
@@ -324,7 +325,7 @@ class ReleaseStateTests(unittest.TestCase):
     def test_missing_remote_digests_fail_closed_for_complete_inventory(self) -> None:
         assets = {
             asset: {"sha256": "a" * 64}
-            for asset in MODULE.EXPECTED_ASSETS
+            for asset in MODULE.EXPECTED_RETAINED_ASSETS
         }
 
         observed = MODULE.reconcile_remote_digests(
@@ -334,8 +335,39 @@ class ReleaseStateTests(unittest.TestCase):
 
         self.assertEqual(observed["state"], "unavailable")
         self.assertEqual(
-            observed["unverified_digests"], list(MODULE.EXPECTED_ASSETS)
+            observed["unverified_digests"], list(MODULE.EXPECTED_RELEASE_ASSETS)
         )
+
+    def test_remote_release_inventory_excludes_locally_retained_docs(self) -> None:
+        assets = [
+            {"digest": f"sha256:{'a' * 64}", "name": name}
+            for name in MODULE.EXPECTED_RELEASE_ASSETS
+        ]
+        completed = self.completed(
+            {
+                "assets": assets,
+                "draft": False,
+                "id": 123,
+                "prerelease": False,
+            }
+        )
+
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed):
+            remote = MODULE.remote_release("owner/repo", "1.2.3", False)
+
+        self.assertEqual(remote["state"], "published")
+        self.assertEqual(remote["missing_assets"], [])
+        self.assertTrue(
+            set(MODULE.EXPECTED_DOCUMENTATION_ASSETS).isdisjoint(remote["assets"])
+        )
+        action = MODULE.plan_recovery(
+            [],
+            [],
+            [],
+            remote,
+            {"formulae": {"state": "verified"}, "pages": {"state": "verified"}},
+        )
+        self.assertEqual(action["name"], "complete")
 
     def test_pure_plan_declares_authority_and_invalidated_descendants(self) -> None:
         action = MODULE.plan_recovery(

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -124,6 +124,48 @@ class ReleaseStateTests(unittest.TestCase):
         self.assertEqual(observed[0]["observed"]["state"], "completed")
         self.assertNotIn("observed", record)
 
+    def test_malformed_remote_assets_are_reported_unavailable(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(
+                {"assets": None, "draft": False, "prerelease": False}
+            ),
+            stderr="",
+        )
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed):
+            remote = MODULE.remote_release("owner/repo", "1.2.3", False)
+
+        self.assertEqual(remote["state"], "unavailable")
+        self.assertIn("malformed", remote["reason"])
+
+    def test_complete_local_store_plans_missing_remote_assets_before_postconditions(
+        self,
+    ) -> None:
+        with (
+            tempfile.TemporaryDirectory() as directory,
+            mock.patch.object(
+                MODULE,
+                "retained_assets",
+                return_value=(list(MODULE.EXPECTED_ASSETS), []),
+            ),
+            mock.patch.object(MODULE, "dispatch_records", return_value=[]),
+            mock.patch.object(
+                MODULE,
+                "remote_release",
+                return_value={
+                    "assets": [],
+                    "missing_assets": list(MODULE.EXPECTED_ASSETS),
+                    "state": "published",
+                },
+            ),
+        ):
+            state = MODULE.inspect(
+                Path(directory) / "retained", "1.2.3", "owner/repo", False
+            )
+
+        self.assertIn("incomplete remote release", state["next_action"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -369,6 +369,54 @@ class ReleaseStateTests(unittest.TestCase):
         )
         self.assertEqual(action["name"], "complete")
 
+    def test_missing_retained_docs_route_to_documentation_recovery(self) -> None:
+        action = MODULE.plan_recovery(
+            [],
+            [],
+            ["k8s.tgz"],
+            {"missing_assets": [], "state": "published"},
+            {"formulae": {"state": "verified"}, "pages": {"state": "verified"}},
+        )
+
+        self.assertEqual(action["name"], "restore-documentation-artifacts")
+        self.assertNotIn("published release assets", action["summary"])
+        unpublished = MODULE.plan_recovery(
+            [],
+            [],
+            ["k8s.tgz"],
+            {"state": "absent"},
+            {"formulae": {"state": "deferred"}, "pages": {"state": "deferred"}},
+        )
+        self.assertEqual(unpublished["name"], "publish-retained-release")
+
+    def test_successful_linked_retry_supersedes_its_failed_lineage(self) -> None:
+        first = {
+            "request_id": "11111111-1111-1111-1111-111111111111",
+            "state": "failed",
+        }
+        second = {
+            "previous_request_id": first["request_id"],
+            "request_id": "22222222-2222-2222-2222-222222222222",
+            "state": "failed",
+        }
+        successful = {
+            "observed": {"conclusion": "success", "state": "completed"},
+            "previous_request_id": second["request_id"],
+            "request_id": "33333333-3333-3333-3333-333333333333",
+            "state": "dispatched",
+        }
+
+        unresolved = MODULE.unresolved_failed_dispatches([first, second, successful])
+        self.assertEqual(unresolved, [])
+        action = MODULE.plan_recovery(
+            [],
+            unresolved,
+            [],
+            {"missing_assets": [], "state": "published"},
+            {"formulae": {"state": "verified"}, "pages": {"state": "verified"}},
+        )
+        self.assertEqual(action["name"], "complete")
+
     def test_pure_plan_declares_authority_and_invalidated_descendants(self) -> None:
         action = MODULE.plan_recovery(
             [],

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -42,7 +42,7 @@ SPEC.loader.exec_module(WORKSPACE)
 class ReleaseWorkspaceTests(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory()
-        self.root = Path(self.temporary.name)
+        self.root = Path(self.temporary.name).resolve()
         self.remote_root = self.root / "remotes"
         self.remote_root.mkdir()
         self.build_root = self.root / "build"
@@ -2349,7 +2349,11 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         )
 
         self.assertNotEqual(completed.returncode, 0)
-        self.assertIn("escaped its build root", completed.stderr)
+        self.assertTrue(
+            "escaped its build root" in completed.stderr
+            or "release transaction root must be on /Volumes/SSD" in completed.stderr,
+            completed.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/Tools/release/test_retain_local_release_assets.py
+++ b/Tools/release/test_retain_local_release_assets.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("retain-local-release-assets.py")
+SPEC = importlib.util.spec_from_file_location("retain_release_assets", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class RetainReleaseAssetsTests(unittest.TestCase):
+    def test_retained_asset_survives_transient_cleanup_and_is_discoverable(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            transient = root / "external/download/container.tar.gz"
+            transient.parent.mkdir(parents=True)
+            transient.write_bytes(b"archive")
+            retained = root / "local"
+            MODULE.retain(retained, "1.2.3", [transient])
+            shutil.rmtree(transient.parent.parent)
+
+            restored = MODULE.retained_path(retained, "1.2.3", transient.name)
+            self.assertEqual(restored.read_bytes(), b"archive")
+            self.assertTrue(str(restored).startswith(str(retained.resolve())))
+
+    def test_same_stable_name_cannot_be_replaced_with_new_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            asset = root / "asset.tar.gz"
+            asset.write_bytes(b"one")
+            retained = root / "retained"
+            MODULE.retain(retained, "1.2.3", [asset])
+            asset.write_bytes(b"two")
+            with self.assertRaisesRegex(MODULE.RetentionError, "conflicts"):
+                MODULE.retain(retained, "1.2.3", [asset])
+            objects = list((retained / "release/artifacts/objects/sha256").glob("*/*/*"))
+            self.assertEqual(len(objects), 1)
+
+    def test_manifest_cannot_redirect_lookup_outside_retained_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            asset = root / "asset.tar.gz"
+            asset.write_bytes(b"archive")
+            retained = root / "retained"
+            MODULE.retain(retained, "1.2.3", [asset])
+            manifest_path = MODULE.manifest_path(retained, "1.2.3")
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            manifest["assets"][asset.name]["path"] = str(asset)
+            manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+            with self.assertRaisesRegex(MODULE.RetentionError, "invalid"):
+                MODULE.retained_path(retained, "1.2.3", asset.name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/test_retain_local_release_assets.py
+++ b/Tools/release/test_retain_local_release_assets.py
@@ -23,6 +23,7 @@ import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 SCRIPT = Path(__file__).with_name("retain-local-release-assets.py")
@@ -35,7 +36,7 @@ SPEC.loader.exec_module(MODULE)
 class RetainReleaseAssetsTests(unittest.TestCase):
     def test_retained_asset_survives_transient_cleanup_and_is_discoverable(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             transient = root / "external/download/container.tar.gz"
             transient.parent.mkdir(parents=True)
             transient.write_bytes(b"archive")
@@ -49,7 +50,7 @@ class RetainReleaseAssetsTests(unittest.TestCase):
 
     def test_same_stable_name_cannot_be_replaced_with_new_bytes(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             asset = root / "asset.tar.gz"
             asset.write_bytes(b"one")
             retained = root / "retained"
@@ -62,7 +63,7 @@ class RetainReleaseAssetsTests(unittest.TestCase):
 
     def test_manifest_cannot_redirect_lookup_outside_retained_artifacts(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
+            root = Path(directory).resolve()
             asset = root / "asset.tar.gz"
             asset.write_bytes(b"archive")
             retained = root / "retained"
@@ -74,6 +75,45 @@ class RetainReleaseAssetsTests(unittest.TestCase):
 
             with self.assertRaisesRegex(MODULE.RetentionError, "invalid"):
                 MODULE.retained_path(retained, "1.2.3", asset.name)
+
+    def test_exact_candidate_repairs_missing_retained_object(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            asset = root / "asset.tar.gz"
+            asset.write_bytes(b"archive")
+            retained = root / "retained"
+            MODULE.retain(retained, "1.2.3", [asset])
+            retained_path = MODULE.retained_path(retained, "1.2.3", asset.name)
+            retained_path.unlink()
+
+            MODULE.retain(retained, "1.2.3", [asset])
+
+            self.assertEqual(
+                MODULE.retained_path(retained, "1.2.3", asset.name).read_bytes(),
+                b"archive",
+            )
+
+    def test_manifest_records_bytes_installed_by_single_promotion(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory).resolve()
+            asset = root / "asset.tar.gz"
+            asset.write_bytes(b"first")
+            retained = root / "retained"
+            original_promote = MODULE.STACK_ARTIFACT.promote
+
+            def mutate_then_promote(source: Path, destination: Path, name: str) -> Path:
+                source.write_bytes(b"second")
+                return original_promote(source, destination, name)
+
+            with mock.patch.object(
+                MODULE.STACK_ARTIFACT, "promote", side_effect=mutate_then_promote
+            ):
+                MODULE.retain(retained, "1.2.3", [asset])
+
+            self.assertEqual(
+                MODULE.retained_path(retained, "1.2.3", asset.name).read_bytes(),
+                b"second",
+            )
 
 
 if __name__ == "__main__":

--- a/Tools/release/test_verify_homebrew_formula_pair.py
+++ b/Tools/release/test_verify_homebrew_formula_pair.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify-homebrew-formula-pair.py")
+SPEC = importlib.util.spec_from_file_location("verify_formula_pair", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class FormulaPairTests(unittest.TestCase):
+    def test_verifies_the_complete_stable_pair(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose.rb"
+            runtime = root / "container.rb"
+            compose.write_text(
+                '  url "https://example.test/compose.tgz"\n'
+                f'  sha256 "{"a" * 64}"\n'
+                '  depends_on "stephenlclarke/tap/container"\n',
+                encoding="utf-8",
+            )
+            runtime.write_text(
+                '  url "https://example.test/runtime.tgz"\n'
+                f'  sha256 "{"b" * 64}"\n'
+                '  plugin = opt/container-compose/libexec/container-plugins/compose\n',
+                encoding="utf-8",
+            )
+            MODULE.verify(
+                compose,
+                runtime,
+                "https://example.test/compose.tgz",
+                "https://example.test/runtime.tgz",
+                "a" * 64,
+                "b" * 64,
+            )
+
+            compose.write_text(compose.read_text() + '  version "1.2.3"\n')
+            with self.assertRaisesRegex(MODULE.FormulaError, "derive its version"):
+                MODULE.verify(
+                    compose,
+                    runtime,
+                    "https://example.test/compose.tgz",
+                    "https://example.test/runtime.tgz",
+                    "a" * 64,
+                    "b" * 64,
+                )
+
+    def test_rejects_duplicate_fields_and_missing_registration(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            compose = root / "container-compose.rb"
+            runtime = root / "container.rb"
+            compose.write_text(
+                '  url "https://example.test/compose.tgz"\n'
+                '  url "https://example.test/other.tgz"\n'
+                f'  sha256 "{"a" * 64}"\n'
+                '  depends_on "stephenlclarke/tap/container"\n',
+                encoding="utf-8",
+            )
+            runtime.write_text(
+                '  url "https://example.test/runtime.tgz"\n'
+                f'  sha256 "{"b" * 64}"\n',
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(MODULE.FormulaError, "exactly one url"):
+                MODULE.verify(
+                    compose,
+                    runtime,
+                    "https://example.test/compose.tgz",
+                    "https://example.test/runtime.tgz",
+                    "a" * 64,
+                    "b" * 64,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/test_verify_stable_authority_bundle.py
+++ b/Tools/release/test_verify_stable_authority_bundle.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import io
+import json
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("verify-stable-authority-bundle.py")
+SPEC = importlib.util.spec_from_file_location("verify_stable_authority_bundle", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class VerifyStableAuthorityBundleTests(unittest.TestCase):
+    def fixture(self, root: Path) -> tuple[Path, argparse.Namespace]:
+        values = {
+            "candidate_sha": "a" * 40,
+            "builder_ref": "b" * 40,
+            "containerization_ref": "c" * 40,
+            "container_ref": "d" * 40,
+            "init_image_sha256": "e" * 64,
+        }
+        output_name = "hosted-output.log"
+        output = b"verified\n"
+        fingerprint = "immutable inputs"
+        checkpoint = {
+            "schema": 4,
+            "stage": "hosted-sibling-stack",
+            "status": 0,
+            "digest": "f" * 64,
+            "fingerprint": fingerprint,
+            "fingerprint_before": "same",
+            "fingerprint_after": "same",
+            "duration_seconds": 1.25,
+            "output_file": output_name,
+            "output_sha256": hashlib.sha256(output).hexdigest(),
+        }
+        checkpoint_bytes = (json.dumps(checkpoint, sort_keys=True) + "\n").encode()
+        components = {
+            "container-builder-shim": values["builder_ref"],
+            "containerization": values["containerization_ref"],
+            "container": values["container_ref"],
+            "homebrew-tap": "1" * 40,
+        }
+        package_inputs = {
+            "candidateSha": values["candidate_sha"],
+            "components": components,
+            "guestInitImageSha256": values["init_image_sha256"],
+        }
+        receipt = {
+            "schema": 2,
+            "result": "success",
+            "releaseTag": "1.2.3",
+            **package_inputs,
+            "packageInputsSha256": hashlib.sha256(
+                json.dumps(
+                    package_inputs, sort_keys=True, separators=(",", ":")
+                ).encode()
+            ).hexdigest(),
+            "buildEvidence": {
+                "checkpointSha256": hashlib.sha256(checkpoint_bytes).hexdigest(),
+                "durationSeconds": checkpoint["duration_seconds"],
+                "fingerprintSha256": hashlib.sha256(fingerprint.encode()).hexdigest(),
+                "outputFile": output_name,
+                "outputSha256": hashlib.sha256(output).hexdigest(),
+                "stage": "hosted-sibling-stack",
+            },
+        }
+        receipt_bytes = (json.dumps(receipt, sort_keys=True) + "\n").encode()
+        archive = root / "stable-release-authority.tar.gz"
+        with tarfile.open(archive, "w:gz") as bundle:
+            for name, payload in {
+                "stable-release-authority.json": receipt_bytes,
+                "hosted-sibling-stack.success.json": checkpoint_bytes,
+                output_name: output,
+            }.items():
+                member = tarfile.TarInfo(f"./{name}")
+                member.size = len(payload)
+                bundle.addfile(member, io.BytesIO(payload))
+        return archive, argparse.Namespace(
+            archive=archive,
+            release_tag="1.2.3",
+            receipt_sha256=hashlib.sha256(receipt_bytes).hexdigest(),
+            **values,
+        )
+
+    def test_verified_bundle_binds_every_release_input(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive, options = self.fixture(Path(directory))
+            receipt_digest, homebrew_ref = MODULE.verify_bundle(options)
+            self.assertEqual(receipt_digest, options.receipt_sha256)
+            self.assertEqual(homebrew_ref, "1" * 40)
+
+            options.container_ref = "2" * 40
+            with self.assertRaisesRegex(MODULE.AuthorityBundleError, "container"):
+                MODULE.verify_bundle(options)
+
+    def test_bundle_rejects_path_traversal(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            archive, options = self.fixture(Path(directory))
+            with tarfile.open(archive, "w:gz") as bundle:
+                payload = b"unsafe"
+                member = tarfile.TarInfo("../receipt.json")
+                member.size = len(payload)
+                bundle.addfile(member, io.BytesIO(payload))
+            with self.assertRaisesRegex(MODULE.AuthorityBundleError, "unsafe"):
+                MODULE.verify_bundle(options)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/verify-homebrew-formula-pair.py
+++ b/Tools/release/verify-homebrew-formula-pair.py
@@ -58,10 +58,27 @@ def verify(
     compose_sha: str,
     runtime_sha: str,
 ) -> None:
+    verify_texts(
+        regular_text(compose_path),
+        regular_text(runtime_path),
+        compose_url,
+        runtime_url,
+        compose_sha,
+        runtime_sha,
+    )
+
+
+def verify_texts(
+    compose: str,
+    runtime: str,
+    compose_url: str,
+    runtime_url: str,
+    compose_sha: str,
+    runtime_sha: str,
+) -> None:
+    """Verify formula bodies already obtained from an authenticated source."""
     if SHA256.fullmatch(compose_sha) is None or SHA256.fullmatch(runtime_sha) is None:
         raise FormulaError("expected formula digests must be lowercase SHA-256 values")
-    compose = regular_text(compose_path)
-    runtime = regular_text(runtime_path)
     if one_field(compose, "url", "compose formula") != compose_url:
         raise FormulaError("compose formula URL does not match the stable asset")
     if one_field(runtime, "url", "runtime formula") != runtime_url:

--- a/Tools/release/verify-homebrew-formula-pair.py
+++ b/Tools/release/verify-homebrew-formula-pair.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify the complete stable Homebrew formula-pair publication contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+SHA256 = re.compile(r"[0-9a-f]{64}")
+FIELD = {
+    "sha256": re.compile(r'^  sha256 "([^"]*)"$', re.MULTILINE),
+    "url": re.compile(r'^  url "([^"]*)"$', re.MULTILINE),
+    "version": re.compile(r'^  version "([^"]*)"$', re.MULTILINE),
+}
+
+
+class FormulaError(RuntimeError):
+    """A formula pair does not describe the expected stable closure."""
+
+
+def regular_text(path: Path) -> str:
+    if not path.is_absolute() or path.is_symlink() or not path.is_file():
+        raise FormulaError(f"formula must be an absolute regular file: {path}")
+    return path.read_text(encoding="utf-8")
+
+
+def one_field(text: str, name: str, label: str) -> str:
+    matches = FIELD[name].findall(text)
+    if len(matches) != 1:
+        raise FormulaError(f"{label} must contain exactly one {name}")
+    return matches[0]
+
+
+def verify(
+    compose_path: Path,
+    runtime_path: Path,
+    compose_url: str,
+    runtime_url: str,
+    compose_sha: str,
+    runtime_sha: str,
+) -> None:
+    if SHA256.fullmatch(compose_sha) is None or SHA256.fullmatch(runtime_sha) is None:
+        raise FormulaError("expected formula digests must be lowercase SHA-256 values")
+    compose = regular_text(compose_path)
+    runtime = regular_text(runtime_path)
+    if one_field(compose, "url", "compose formula") != compose_url:
+        raise FormulaError("compose formula URL does not match the stable asset")
+    if one_field(runtime, "url", "runtime formula") != runtime_url:
+        raise FormulaError("runtime formula URL does not match the stable asset")
+    if one_field(compose, "sha256", "compose formula") != compose_sha:
+        raise FormulaError("compose formula digest does not match the stable asset")
+    if one_field(runtime, "sha256", "runtime formula") != runtime_sha:
+        raise FormulaError("runtime formula digest does not match the stable asset")
+    if FIELD["version"].findall(compose):
+        raise FormulaError("stable compose formula must derive its version from its URL")
+    if 'depends_on "stephenlclarke/tap/container"' not in compose:
+        raise FormulaError("stable compose formula is missing its runtime dependency")
+    if "opt/container-compose/libexec/container-plugins/compose" not in runtime:
+        raise FormulaError("stable runtime formula does not register the compose plugin")
+
+
+def main(arguments: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--compose-formula", required=True, type=Path)
+    parser.add_argument("--runtime-formula", required=True, type=Path)
+    parser.add_argument("--compose-url", required=True)
+    parser.add_argument("--runtime-url", required=True)
+    parser.add_argument("--compose-sha256", required=True)
+    parser.add_argument("--runtime-sha256", required=True)
+    options = parser.parse_args(arguments)
+    try:
+        verify(
+            options.compose_formula,
+            options.runtime_formula,
+            options.compose_url,
+            options.runtime_url,
+            options.compose_sha256,
+            options.runtime_sha256,
+        )
+    except (FormulaError, OSError, UnicodeError) as error:
+        print(f"verify-homebrew-formula-pair: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Tools/release/verify-stable-authority-bundle.py
+++ b/Tools/release/verify-stable-authority-bundle.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify a published stable-authority archive without extracting it."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import sys
+import tarfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+
+OBJECT_ID = re.compile(r"[0-9a-f]{40}")
+DIGEST = re.compile(r"[0-9a-f]{64}")
+SEMVER = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
+MAX_FILE_SIZE = 64 * 1024 * 1024
+MAX_ARCHIVE_SIZE = 128 * 1024 * 1024
+
+
+class AuthorityBundleError(RuntimeError):
+    """The authority archive does not prove its claimed candidate."""
+
+
+def digest_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def require_digest(value: object, label: str) -> str:
+    if not isinstance(value, str) or not DIGEST.fullmatch(value):
+        raise AuthorityBundleError(f"invalid {label}")
+    return value
+
+
+def read_bundle(path: Path) -> dict[str, bytes]:
+    if not path.is_absolute() or path.is_symlink() or not path.is_file():
+        raise AuthorityBundleError(f"authority bundle is indirect or missing: {path}")
+    files: dict[str, bytes] = {}
+    total = 0
+    with tarfile.open(path, "r:gz") as archive:
+        for member in archive.getmembers():
+            name = str(PurePosixPath(member.name))
+            while name.startswith("./"):
+                name = name[2:]
+            if member.isdir() and name in {"", "."}:
+                continue
+            if (
+                not member.isfile()
+                or not name
+                or PurePosixPath(name).name != name
+                or member.size < 0
+                or member.size > MAX_FILE_SIZE
+                or name in files
+            ):
+                raise AuthorityBundleError(f"unsafe authority bundle member: {member.name}")
+            stream = archive.extractfile(member)
+            if stream is None:
+                raise AuthorityBundleError(f"unreadable authority bundle member: {name}")
+            payload = stream.read(MAX_FILE_SIZE + 1)
+            total += len(payload)
+            if len(payload) != member.size or total > MAX_ARCHIVE_SIZE:
+                raise AuthorityBundleError("authority bundle exceeds its safe size")
+            files[name] = payload
+    return files
+
+
+def read_json(files: dict[str, bytes], name: str) -> dict[str, Any]:
+    try:
+        value = json.loads(files[name])
+    except (KeyError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise AuthorityBundleError(f"invalid authority bundle JSON: {name}") from error
+    if not isinstance(value, dict):
+        raise AuthorityBundleError(f"authority bundle JSON is not an object: {name}")
+    return value
+
+
+def verify_bundle(options: argparse.Namespace) -> tuple[str, str]:
+    expected_objects = {
+        "candidateSha": options.candidate_sha,
+        "containerBuilderShim": options.builder_ref,
+        "containerization": options.containerization_ref,
+        "container": options.container_ref,
+    }
+    if not SEMVER.fullmatch(options.release_tag):
+        raise AuthorityBundleError("invalid stable release tag")
+    for label, value in expected_objects.items():
+        if not OBJECT_ID.fullmatch(value):
+            raise AuthorityBundleError(f"invalid expected {label}")
+    require_digest(options.init_image_sha256, "expected guest image digest")
+
+    files = read_bundle(options.archive)
+    receipt_name = "stable-release-authority.json"
+    receipt = read_json(files, receipt_name)
+    receipt_digest = digest_bytes(files[receipt_name])
+    if options.receipt_sha256 and receipt_digest != options.receipt_sha256:
+        raise AuthorityBundleError("authority receipt digest does not match its check")
+    if receipt.get("schema") != 2 or receipt.get("result") != "success":
+        raise AuthorityBundleError("authority receipt did not pass")
+    if receipt.get("releaseTag") != options.release_tag:
+        raise AuthorityBundleError("authority receipt release tag changed")
+    if receipt.get("candidateSha") != options.candidate_sha:
+        raise AuthorityBundleError("authority receipt candidateSha changed")
+    if receipt.get("guestInitImageSha256") != options.init_image_sha256:
+        raise AuthorityBundleError("authority receipt guest image digest changed")
+    components = receipt.get("components")
+    if not isinstance(components, dict) or set(components) != {
+        "container-builder-shim",
+        "containerization",
+        "container",
+        "homebrew-tap",
+    }:
+        raise AuthorityBundleError("authority receipt components are invalid")
+    expected_components = {
+        "container-builder-shim": options.builder_ref,
+        "containerization": options.containerization_ref,
+        "container": options.container_ref,
+    }
+    for name, value in expected_components.items():
+        if components.get(name) != value:
+            raise AuthorityBundleError(f"authority receipt component changed: {name}")
+    homebrew_ref = components.get("homebrew-tap")
+    if not isinstance(homebrew_ref, str) or not OBJECT_ID.fullmatch(homebrew_ref):
+        raise AuthorityBundleError("authority receipt Homebrew snapshot is invalid")
+
+    package_inputs = {
+        "candidateSha": options.candidate_sha,
+        "components": components,
+        "guestInitImageSha256": options.init_image_sha256,
+    }
+    package_digest = digest_bytes(
+        json.dumps(package_inputs, sort_keys=True, separators=(",", ":")).encode()
+    )
+    if receipt.get("packageInputsSha256") != package_digest:
+        raise AuthorityBundleError("authority package-input digest changed")
+
+    evidence = receipt.get("buildEvidence")
+    if not isinstance(evidence, dict) or evidence.get("stage") != "hosted-sibling-stack":
+        raise AuthorityBundleError("authority build evidence is invalid")
+    checkpoint_name = "hosted-sibling-stack.success.json"
+    checkpoint = read_json(files, checkpoint_name)
+    if digest_bytes(files[checkpoint_name]) != evidence.get("checkpointSha256"):
+        raise AuthorityBundleError("authority checkpoint digest changed")
+    if (
+        checkpoint.get("schema") != 4
+        or checkpoint.get("stage") != "hosted-sibling-stack"
+        or checkpoint.get("status") != 0
+        or checkpoint.get("fingerprint_before") != checkpoint.get("fingerprint_after")
+    ):
+        raise AuthorityBundleError("authority checkpoint did not pass unchanged inputs")
+    require_digest(checkpoint.get("digest"), "checkpoint digest")
+    output_name = checkpoint.get("output_file")
+    if not isinstance(output_name, str) or PurePosixPath(output_name).name != output_name:
+        raise AuthorityBundleError("authority checkpoint output name is unsafe")
+    output = files.get(output_name)
+    if output is None or set(files) != {receipt_name, checkpoint_name, output_name}:
+        raise AuthorityBundleError("authority bundle file closure changed")
+    output_digest = digest_bytes(output)
+    if (
+        checkpoint.get("output_sha256") != output_digest
+        or evidence.get("outputFile") != output_name
+        or evidence.get("outputSha256") != output_digest
+    ):
+        raise AuthorityBundleError("authority checkpoint output changed")
+    duration = checkpoint.get("duration_seconds")
+    if (
+        isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration < 0
+        or evidence.get("durationSeconds") != duration
+    ):
+        raise AuthorityBundleError("authority checkpoint duration is invalid")
+    fingerprint = checkpoint.get("fingerprint")
+    if (
+        not isinstance(fingerprint, str)
+        or not fingerprint
+        or evidence.get("fingerprintSha256")
+        != digest_bytes(fingerprint.encode())
+    ):
+        raise AuthorityBundleError("authority checkpoint fingerprint changed")
+    return receipt_digest, homebrew_ref
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--archive", type=Path, required=True)
+    parser.add_argument("--release-tag", required=True)
+    parser.add_argument("--candidate-sha", required=True)
+    parser.add_argument("--builder-ref", required=True)
+    parser.add_argument("--containerization-ref", required=True)
+    parser.add_argument("--container-ref", required=True)
+    parser.add_argument("--init-image-sha256", required=True)
+    parser.add_argument("--receipt-sha256")
+    options = parser.parse_args()
+    try:
+        receipt_digest, homebrew_ref = verify_bundle(options)
+    except (AuthorityBundleError, OSError, tarfile.TarError) as error:
+        print(f"verify-stable-authority-bundle: {error}", file=sys.stderr)
+        return 2
+    print(f"{receipt_digest}\t{homebrew_ref}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture/recoverable-container-family-builds.md
+++ b/docs/architecture/recoverable-container-family-builds.md
@@ -38,11 +38,16 @@ flowchart LR
   compose --> bundle
 ```
 
-Generated state defaults to
-`/Volumes/SSD/github/.container-compose-build`. If that development volume is
-not mounted, the fallback is `.build/stack`. SwiftPM scratch directories, Go
-artifacts, pins, timing logs, and the final bundle all live below that managed
-state root rather than in source checkouts.
+Mutable work defaults to `/Volumes/SSD/cf/build`. Completed products, pins,
+timing logs and the final bundle are promoted into the internal
+`~/Library/Application Support/ContainerFamily/retained/build` store. There is
+no automatic fallback when the external volume is unavailable: retained
+outputs remain verifiable, while new builds fail before creating internal
+scratch. Both independently marked roots live outside source checkouts.
+The self-hosted release runner's `_work` link resolves to
+`/Volumes/SSD/cf/github-actions/container-compose-release-runner-work`, keeping
+Actions workspaces, downloaded actions, tools and runner temp data on the same
+external lifetime boundary.
 
 Every compiler command has a wall-clock deadline and complete process-session
 cleanup. Every full invocation records concurrency-safe JSONL timing evidence
@@ -59,7 +64,7 @@ A marker prevents the build from claiming an arbitrary state directory, and
 one `lockf` lock prevents concurrent writers. Each successful repository build
 atomically publishes a durable JSON pin containing:
 
-- canonical source path, exact commit, Git tree, and origin;
+- canonical build-time source path, exact commit, Git tree, and origin;
 - exact dependency-pin receipts;
 - artifact paths, modes, and SHA-256 digests;
 - successful native command, duration, and completion time; and
@@ -73,7 +78,9 @@ targets therefore do not invalidate native caches, while any stack recipe
 change automatically changes the contract. Tooling that enforces or records
 the contract is itself hashed into the build identity.
 
-Pins are flushed and atomically renamed only after success. Before reuse,
+Completed binaries are copied from external scratch into an immutable,
+content-addressed local object before their pins are written. Pins are flushed
+and atomically renamed only after success. Before reuse,
 `Tools/build/stack-pin.py` recursively verifies its own digest, clean source
 identity, dependencies, and artifacts. Source, dependency, artifact, toolchain,
 SDK, environment, or controller drift invalidates only the affected transitive
@@ -155,9 +162,18 @@ flowchart TD
 
 The hosted gate stores stage checkpoints below the immutable release-candidate
 commit. Each checkpoint records exact inputs, status, duration, output name,
-and output digest. A corrected retry starts at the first missing or invalid
-stage. The stable-release authority receipt binds component commits to the
-verified checkpoint and log.
+and output digest. Producer stages can additionally declare required product
+files; a missing, indirect, mode-changed, size-changed, or digest-changed
+product invalidates reuse even when the log remains. A corrected retry starts
+at the first missing or invalid stage. The stable-release authority receipt
+binds component commits to the verified checkpoint and log.
+
+Stable archives, checksum sidecars, authority bundles and verified DocC site
+archives are copied into the internal retained store before their transient
+download directories are removed. Workflow dispatch intent and the exact run
+ID are journalled there as well. Use `make release-status VERSION=X.Y.Z` or
+`make release-recovery-plan VERSION=X.Y.Z` to inspect that state without
+starting a build or changing GitHub, Homebrew, or Pages.
 
 ## Unattended Operation
 

--- a/docs/architecture/release-workflow-resilience-design.md
+++ b/docs/architecture/release-workflow-resilience-design.md
@@ -1079,6 +1079,8 @@ Decisions to confirm during implementation, not silently assume:
 
 ## Implementation status
 
+Follow-up review, 2026-09-10: the status below records the original implementation assessment, not a verified completion claim. The [follow-up review and design](release-workflow-resilience-followup-design-2026-09-10.md) reproduces remaining cleanup, relocation, retention, checkpoint, and dispatch defects and specifies their fixes. Its findings supersede the stronger recovery and storage-safety assertions below until the documented acceptance tests pass.
+
 The resilience implementation now establishes the required lifetime boundary:
 native scratch and release transactions use `/Volumes/SSD`, while completed
 binaries, pins, timing records, release assets, signed authority bundles, DocC

--- a/docs/architecture/release-workflow-resilience-design.md
+++ b/docs/architecture/release-workflow-resilience-design.md
@@ -1,0 +1,1144 @@
+# Build and release resilience: review and implementation design
+
+## Status and scope
+
+Design and local implementation record, 10 September 2026. The implementation
+is authorised by the user; publication and mutation of existing releases remain
+outside this document's authority.
+
+Reviewed checkout: `/Volumes/SSD/github/container-compose-release-0.14.3`.
+Reviewed head: `8861c73b9dad6933b54c56d796fbdd8f03df21c5`.
+Change baseline: `4c023f68fe8ac69460aa7d504e0ae4f01aec8b42`.
+The worktree was clean at the start of this review.
+
+Additional user requirement: everything worth retaining must live on the
+internal/local drive, separate from disposable data on `/Volumes/SSD`.
+Tidying external workspaces, branches and build attempts must preserve built
+artifacts and reusable evidence/caches and must not force unnecessary rebuilds.
+Section J makes this a mandatory storage contract, superseding the current
+single-root external-state default in the earlier build architecture document.
+
+The review covers all eleven files changed by the head commit and the
+surrounding Make, build-pin, checkpoint, CI selection, release authority,
+asset publication, Homebrew, documentation and test contracts. It is not a
+complete audit of Compose application features, all sibling repositories,
+live signing infrastructure or GitHub repository settings. Failure scenarios
+below are distinguished from reproduced failures and measured performance.
+
+The head improves guest-asset recovery, distinguishes package and tap-repair
+runs, preserves independently successful documentation jobs, and separates
+the gate's historical tap snapshot from the live publication destination.
+Those are useful changes. It does **not** yet provide end-to-end idempotent
+recovery: several paths mistake historical success for current completeness,
+and the release checkpoint layers still do not share the native build
+controller's artifact-verification contract. The earlier claim that all
+resilience issues were fixed was too strong.
+
+This design extends, rather than replaces,
+[Recoverable Container-family builds](https://github.com/stephenlclarke/container-compose/blob/8861c73b9dad6933b54c56d796fbdd8f03df21c5/docs/architecture/recoverable-container-family-builds.md).
+Make remains the execution graph; SwiftPM and Go remain the builders. No
+Nextflow revival or second build scheduler is proposed.
+
+## Executive findings
+
+P1 means resolve before relying on unattended release recovery. P2 means an
+important correctness, efficiency or operability follow-up. These are review
+priorities, not claims that every scenario has occurred in production.
+
+| ID | Priority | Finding | Origin |
+| --- | --- | --- | --- |
+| F01 | P1 | Runtime skips have no evidence baseline and can strand Current | Changed CI policy interacting with existing classifier |
+| F02 | P1 | Historical successful repair suppresses a currently needed repair | New reuse branch |
+| F03 | P1 | Missing stable binaries are routed to a publisher that refuses existing releases | New routing versus existing immutability contract |
+| F04 | P2 | Formula probe and final verifier disagree about correctness | New partial probe |
+| F05 | P1 | Dispatch lookup races main movement and masks API errors | Partly new matching logic; existing dispatch pattern |
+| F06 | P1 | Recovery still depends on local state and expiring Actions evidence | Existing dependency, not fixed by new reuse |
+| F07 | P1 | Release checkpoints verify logs/input stamps, not produced artifacts | Existing gap, not addressed in head |
+| F08 | P2 | DocC caches lack complete identity, integrity and invalid-cache recovery | New caching |
+| F09 | P2 | Different releases can race to overwrite the same Pages destination | Existing deployment gap |
+| F10 | P2 | Broad fingerprints and repeated Make invocations waste reusable work | Existing architecture gap |
+| F11 | P2 | Tests prove wiring more than recovery; workflow lint is not green | Incomplete validation of changes |
+| F12 | P2 | No unified read-only recovery/status plan or durable dispatch journal | Existing functional gap |
+| F13 | P1 | Current finalization deletes the release before replacement succeeds | Existing publication interruption window |
+| F14 | P1 | Retained outputs and transient scratch share the external drive and checkout identities | Existing layout conflicts with the new retention requirement |
+
+## Findings and evidence
+
+All source line numbers in this section refer to the reviewed head, not to a
+future implementation. Repository-relative paths identify source locations.
+
+### F01 — Unsafe runtime selection and a Current readiness dead end
+
+Evidence: `.github/workflows/ci.yml:45`, `:239`, `:768`, `:904`;
+`Tools/ci/classify-ci-changes.py:50`; `.github/workflows/prebuilt-binaries.yml:294`;
+`scripts/CONTAINER_STACK_RELEASE.sh:409`.
+
+Runtime validation is now selected only by the changed-file classifier, even
+on main. Main CI still cancels its previous run. Consider runtime commit A,
+followed by documentation-only B before A finishes: A can be cancelled, B
+skips runtime, and packaging explicitly skips runs with skipped runtime
+validation. There is no successful equivalent baseline lookup to recover the
+missing evidence. This scenario follows directly from the workflow conditions;
+it was not dispatched against GitHub during this review.
+
+The release controller also expects Current to identify exact main. Even
+when A was fully validated, a tools/docs-only B can leave Current at A and
+block that readiness check. Merely changing the readiness check to accept an
+ancestor would weaken authority without proving equivalence.
+
+Executable classifier probe confirmed that `Tools/release/stack-refs.json`
+and `Tools/build/stack-pin.py` select tools but not runtime. Not every change
+to those files needs every runtime test, but dependency pins and build recipes
+cannot be dismissed without a stage-input comparison.
+
+Required fix: typed stage fingerprints and an authenticated evidence resolver.
+Until that exists, restore conservative main runtime selection. A cancelled,
+missing or unreadable baseline must cause execution, not a successful skip.
+
+### F02 — A successful run is not an idempotency key for mutable outputs
+
+Evidence: `scripts/CONTAINER_STACK_RELEASE.sh:6302`, especially the completed
+success branch around `:6338`, and resume routing at `:6586`.
+
+Resume detects formula drift and selects tap repair. The dispatcher then finds
+an older successful repair for the same version/control SHA, skips dispatch,
+and calls the verifier. If the tap drifted after that success, verification
+fails and every retry follows the same path.
+
+Reproduced with the real dispatcher and isolated mocked external boundaries:
+the historical run was `123/completed/success`; current verification returned
+17. The function returned 17 without calling dispatch. Output was:
+
+```text
+container-compose stable tap repair workflow already passed for the exact release controls: 123
+CURRENT FORMULA STILL DRIFTED
+```
+
+Required fix: make current postconditions authoritative. Reuse historical
+evidence for immutable assets, but re-observe mutable destinations and execute
+the smallest needed repair. Repeated repair of an already-correct tap must
+produce zero commits; a newly drifted tap must not be blocked by past success.
+
+### F03 — Missing stable assets cannot be repaired by the package path
+
+Evidence: `scripts/CONTAINER_STACK_RELEASE.sh:6241`, `:6606`;
+`Tools/release/publish-github-release.sh:198`.
+
+The new binary-existence probe sends an existing stable release with a missing
+archive or checksum back to ordinary packaging. A past successful package run
+can suppress execution as in F02. If execution happens, the publisher rejects
+an existing immutable release. Recompiling would also not establish that the
+new signed archive is byte-identical to the original release artifact.
+
+Required fix: an explicit missing-asset recovery operation consuming retained,
+authenticated original bytes. Separate absent assets from conflicting assets,
+authentication failures, and a platform-enforced immutable release. Never
+delete/recreate a stable release or overwrite an existing conflicting asset.
+If exact original bytes no longer exist, report an unrecoverable artifact
+with a concrete restoration/new-version path, not an endless package retry.
+
+### F04 — Formula repair selection has a weaker contract than verification
+
+Evidence: `scripts/CONTAINER_STACK_RELEASE.sh:6258` versus `:6170`–`:6204`.
+
+The probe compares only two URLs and two SHA values. The final verifier also
+rejects an explicit Compose formula version and a missing dependency on the
+matched runtime formula. A formula with correct URLs/checksums but either
+defect is selected as healthy, then fails completion instead of being repaired.
+A missing formula API response is treated like an infrastructure error rather
+than a repairable absence. Both formulas are fetched separately from moving
+main, so the pair need not be one atomic tap snapshot.
+
+Required fix: one typed formula validator used by inspection, repair and final
+verification, evaluated at one exact tap commit. Include generated-template
+semantics, version policy, runtime dependency and any declared guest resources.
+Distinguish authenticated absence from permission/network/parse failure.
+
+### F05 — Dispatch correlation and control identity are not race-safe
+
+Evidence: `scripts/CONTAINER_STACK_RELEASE.sh:5741`, `:6334`, `:6364`, `:6420`;
+`.github/workflows/stable-release-gate.yml:80`.
+
+The controller reads main SHA C, dispatches with `--ref main`, then searches for
+a title at C. Main may advance to D before dispatch. The real run can start at
+D while the controller waits for a run at C. A queued gate also rejects a head
+that is no longer current main. Titles plus a 100-run history window are not
+durable dispatch identities. API lookup failures are swallowed with `|| true`,
+so lack of visibility can cause duplicate work.
+
+The current GitHub REST documentation describes a dispatch response containing
+the run ID and URLs; use that documented capability through an explicitly
+versioned adapter rather than relying on title search. The documented dispatch
+ref is a branch or tag, so do not assume a raw SHA is accepted.
+[GitHub workflow dispatch API](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event).
+
+Required fix: persist request identity before dispatch and run identity after
+acknowledgement, supply expected controls as an input, validate observed
+controls at job start, and reconcile ambiguous responses without blind retries.
+Preserve the reviewed-main control policy; do not bypass it using an arbitrary
+temporary branch. See the dispatch protocol below.
+
+### F06 — Successful gates and published releases are not durably recoverable
+
+Evidence: `scripts/CONTAINER_STACK_RELEASE.sh:4292`, `:5964`, `:6420`;
+`.github/workflows/prebuilt-binaries.yml:1159`;
+`.github/workflows/stable-release-gate.yml:512`.
+
+Gate reuse first needs the retained local guest digest, then accepts historical
+workflow success without validating that the receipt artifact still exists.
+Packaging independently rejects expired/missing Actions artifacts. Published
+recovery still requires a check-run and the referenced successful workflow;
+it does not authenticate from the durable published authority bundle alone.
+
+The new guest fallback works when the archive is already on the release and
+the local archive variable is unset. It cannot recover missing remote bytes
+after local loss. A stale explicitly configured local path also prevents the
+fallback. That last behavior is defensible fail-closed policy, but needs an
+actionable diagnostic distinguishing an explicit override from a persisted hint.
+
+Required fix: persist all original release outputs and signed evidence before
+public visibility. Treat Actions as transport/observation, not the sole
+long-term authority store. Artifact availability and digest must be part of
+gate reuse eligibility. Keep signed source, controls and guest identity checks.
+
+### F07 — Nested checkpoint success can survive missing build products
+
+Evidence: `Tools/ci/run-release-checkpoint.py:130`, `:330`, `:350`;
+`Tools/ci/run-stack-release-validation.sh:548`–`:585`.
+
+The outer checkpoint's `output_sha256` is the captured `.log` digest, not a
+manifest of binaries, coverage files, test reports or packages. Inner stages
+reuse a matching input stamp without an output manifest. Deleting a product
+while retaining the log/stamp does not itself invalidate success. Some downstream
+checks will fail closed, but can then fail repeatedly instead of regenerating
+the missing producer; other consumers must not infer product availability from
+these checkpoints.
+
+The native `Tools/build/stack-pin.py` contract already verifies exact artifacts
+and transitive dependencies. Preserve that stronger behavior and extend its
+principles to release/test receipts. A tests-only receipt need not retain every
+intermediate binary, but must explicitly declare its durable test evidence and
+must not advertise artifacts it no longer retains.
+
+Required fix: typed output manifests, explicit producer/consumer contracts,
+atomic receipts and transitive invalidation. Rename log fields to make their
+meaning unambiguous. Existing schema-4 receipts cannot silently become proof
+of artifact completeness.
+
+### F08 — DocC caching is opportunistic, not verified recovery
+
+Evidence: `.github/workflows/docs.yml:224`–`:243`, `:304`–`:319`.
+
+SwiftPM cache keys omit Xcode/Swift/SDK identity and use a broad site restore
+prefix. Final-site keys include the entire control SHA and release version,
+invalidating otherwise equivalent sibling docs, while omitting an explicit
+toolchain contract. A cache hit bypasses generation after checking only
+`index.html` and `theme-settings.json`; missing documentation payload can pass.
+Invalid exact caches have no rebuild path.
+
+The combined cache action normally saves after successful job completion. A
+failure after generation but before job completion can lose reusable output.
+Separate restore/save actions allow verified output to be saved earlier.
+[Actions cache documentation](https://github.com/actions/cache#usage).
+
+Required fix: separate dependency acceleration from verified site artifacts;
+key site reuse by exact semantic inputs and toolchain, verify a signed or
+trusted-producer-bound output manifest, explicitly persist each completed site,
+and rebuild invalid caches. Preserve fail-fast false for independent sites.
+
+### F09 — Per-version serialization does not protect a shared Pages site
+
+Evidence: `.github/workflows/docs.yml:31`, `:376` onward;
+`Tools/release/documentation-authority.py:87`.
+
+Different version groups can deploy to the same GitHub Pages destination.
+An older slow build can finish after a newer one. The before/after authority
+checks prove each release's pinned inputs, not that it remains the designated
+release for the destination. Historical docs workflow success also does not
+prove that those docs are still deployed now.
+
+Required fix: independent site builds, one serialized deployment boundary per
+destination, and an in-lock destination-selection check. Preserve immutable
+versioned site artifacts even when deployment is superseded. Keep the existing
+explicitly allowed pinned k8s prerelease authority; do not accidentally require
+all sibling documentation releases to be stable.
+
+### F10 — Work is still invalidated and invoked too broadly
+
+Evidence: `Makefile:250`, `:274`, `:726`; nested target loop in
+`Tools/ci/run-stack-release-validation.sh:590`.
+
+The release-level fingerprint includes all component trees, tap state, many
+tools and settings. Unrelated changes can invalidate expensive stages. Each
+nested Make target is invoked separately, so shared prerequisites may run
+again. Native incremental builds may reduce recompilation, but they do not
+eliminate repeated graph planning, prerequisites and test invocations.
+
+The existing five-repository build already has independent parallel roots and
+verified pins. Do not replace it with indiscriminate scratch-directory sharing.
+The historical timing record demonstrates a 5.747-second native no-op versus
+a 282.796-second cold build, not an end-to-end release speedup.
+[Retained timing evidence](https://github.com/stephenlclarke/container-compose/blob/8861c73b9dad6933b54c56d796fbdd8f03df21c5/docs/reviews/CONTAINER-FAMILY-BUILD-WORKFLOW-TIMINGS-2026-09-09.md).
+
+Required fix: stage-local contracts, reuse compatible products within one Make
+graph, and measure invocation counts. Investigate repeated Container DocC build
+planning with pinned sibling scripts before choosing a multi-target generation
+change. No percentage speedup is justified yet.
+
+### F11 — Validation misses the recovery contract and has a tooling mismatch
+
+Evidence: `Tools/ci/test_documentation_workflow.py:39`;
+`Tools/release/test_container_stack_release.py:9328` onward.
+
+Several new tests assert YAML strings or stub the actual inspectors/verifiers.
+They do not combine historical success with present drift, missing artifacts,
+expired evidence, ambiguous dispatch or invalid caches. During this review,
+13 classifier/documentation tests passed while the F02 reproduction failed as
+described above.
+
+Installed actionlint 1.7.12 rejected `queue` in all three changed workflows.
+This is not proof that GitHub rejects the syntax: GitHub now documents queued
+concurrency. It is an unresolved local validator compatibility gap. Queues are
+bounded, so queuing alone cannot promise that every request will execute.
+[GitHub concurrency controls](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
+
+Required fix: behavioral state-machine tests plus a pinned compatible workflow
+validation strategy. Retain structural policy checks as supplementary tests;
+do not equate their success with a working recovery path.
+
+### F12 — Recovery lacks a unified operator-facing plan
+
+Evidence: dispatch polling in `scripts/CONTAINER_STACK_RELEASE.sh:6385`;
+separate build status, checkpoint logs and workflow lookups across the tools.
+
+There is no single read-only command that explains the active release, what
+is reusable, why a stage invalidated, which run is queued, which output is
+missing, or whether resuming will mutate a release/tap/Pages. The repeated
+status questions in this task illustrate the usability gap, but are not a
+measurement of process liveness.
+
+Required fix: a shared inspection/plan model, durable event journal, phase
+timings and concise status output. Waiting is an explicit state, not failure;
+unknown external state must never be rendered as success or absence.
+
+### F13 — Current publication has a destructive interruption window
+
+Evidence: `Tools/release/publish-github-release.sh:212`–`:220`;
+`.github/workflows/prebuilt-binaries.yml:1850`–`:1930`.
+
+Current finalization deletes and recreates the release to refresh its
+`published_at` timestamp. A failure between deletion and creation leaves the
+release unavailable after the tap may already have moved. Staged local files
+are not an adequate machine-loss recovery guarantee. This predates the head
+commit and is distinct from stable-release immutability.
+
+Required fix: preserve the Current release object, upload uniquely named
+candidate assets first, and publish pointers through a resumable transaction.
+Use an explicit build timestamp in metadata instead of deleting the release
+for display freshness. If refreshing `published_at` is a hard product
+requirement, document the unavoidable availability tradeoff and provide durable
+restoration before retaining that behavior.
+
+### F14 — Storage lifetime and cleanup boundaries are not separated
+
+Evidence: `Makefile:207`–`:222`, `:554`–`:570`, `:677`–`:697`;
+`scripts/CONTAINER_STACK_RELEASE.sh:283`, `:3546`, `:3945`;
+`Tools/build/stack-pin.py:552` onward.
+
+`STACK_STATE_ROOT` currently defaults to
+`/Volumes/SSD/github/.container-compose-build`, with pins, timings, scratch and
+artifacts beneath it. Swift build pins point directly into the scratch binary
+directory rather than a separately retained product store. The release evidence
+root also doubles as build scratch. A host-restoration journal defaults to
+`/private/tmp`, although it can be essential after interruption. Native receipt
+verification couples source authority to a concrete checkout path.
+
+These defaults mean that deleting build scratch can delete the pinned binary;
+removing the external drive can make both retained artifacts and their evidence
+unavailable. A recreated worktree at another path can also defeat reuse even
+when its source commit is unchanged. That is directly contrary to the user's
+requested clean separation. Disk inspection confirms `/Users/sclarke` and
+`/Volumes/SSD` are on different filesystems on this host.
+
+Required fix: two independently marked roots, immutable promoted products and
+durable recovery state on the internal drive, disposable execution data on the
+external drive, and explicit source-versus-workspace identities. Do not simply
+move the existing mixed tree and call it separation. See section J.
+
+## Target contract and recovery invariants
+
+One observable contract governs the work:
+
+> An interrupted build or release resumes from the smallest missing or invalid
+> stage, preserves authenticated equivalent work, never substitutes new bytes
+> for an immutable published artifact, and reports its exact remaining work.
+
+The following invariants are mandatory:
+
+1. A run conclusion is observation, not proof of current destination state.
+2. A cache is acceleration, not release authority.
+3. Every reusable product has a content manifest and authenticated provenance.
+4. Every reusable test result names the exact tested artifacts, tests, policy
+   and relevant environment; coverage and sanitizer configurations are distinct.
+5. Mutable side effects are reconciled against current state under their own
+   serialization boundary. No global atomicity across GitHub, tap and Pages
+   is claimed.
+6. Authorization, source identity and execution-control identity remain
+   distinct. Narrow compatibility proofs never rewrite source provenance.
+7. Missing, invalid, conflicting and unknown are different states.
+8. Loss of both original artifacts and every authenticated replica is an
+   explicit recovery limit, not permission to fabricate equivalent bytes.
+9. Normal workspace/build/branch cleanup cannot delete retained artifacts,
+   evidence, journals or reusable cache snapshots. The internal store remains
+   usable for inspection and artifact consumption with `/Volumes/SSD` absent.
+
+## Architecture and interfaces
+
+### A. Extend the existing graph with typed receipts
+
+Add a reusable Python receipt/inspection module under `Tools/release/` and
+share low-level content-manifest validation with `Tools/build/stack-pin.py`.
+Do not change the native build-pin wire schema just to rename it. Make declares
+stage dependencies; the module verifies evidence and determines eligibility.
+
+Conceptual dependency graph:
+
+```mermaid
+flowchart TD
+  I[Resolve signed sources and reviewed controls] --> P[Fail-fast preflight]
+  P --> B[Verified native build pins]
+  B --> T[Tests, coverage and local runtime gates]
+  T --> A[Candidate-bound release authority]
+  A --> K[Package, sign and notarise once]
+  K --> S[Durably stage exact output closure]
+  S --> R[Publish or reconcile release]
+  R --> H[Reconcile atomic formula pair]
+  H --> D[Build or restore independent DocC sites]
+  D --> V[Select and deploy Pages destination]
+  V --> F[Verify final postconditions]
+```
+
+Keep full docs generation release-only and after the package/tap boundary for
+the first implementation, matching current policy. Do cheap source/toolchain
+and documentation-manifest preflight early. Overlapping full DocC with
+packaging is a later policy/performance decision, not a prerequisite for
+correct recovery.
+
+A release-stage receipt should have a new schema version with these fields:
+
+```json
+{
+  "schema": 5,
+  "stage": "compose-test",
+  "input_digest": "sha256:<canonical-stage-inputs>",
+  "contract_digest": "sha256:<stage-recipes-and-policy>",
+  "source_manifest_digest": "sha256:<exact-source-manifest>",
+  "dependencies": [{"stage": "compose-build", "receipt_digest": "sha256:<digest>"}],
+  "execution": {
+    "control_sha": "<full-commit>",
+    "toolchain_digest": "sha256:<digest>",
+    "environment_class": "macos-arm64-unit",
+    "run_id": "<optional-hosted-run-id>",
+    "attempt": 1
+  },
+  "outputs": [{
+    "role": "test-report",
+    "path": "reports/compose-tests.json",
+    "sha256": "<64-hex>",
+    "size": 1234,
+    "mode": "0644"
+  }],
+  "log": {"path": "logs/compose-test.log", "sha256": "<64-hex>"},
+  "status": "succeeded",
+  "completed_at": "<UTC-time>",
+  "duration_seconds": 12.3
+}
+```
+
+The JSON is illustrative, not a valid receipt to install. Define strict JSON
+schemas and canonical serialization in tests. Receipt digest covers the
+payload excluding its signature/digest envelope. A self-hash detects accidental
+corruption, not malicious replacement: hosted/published receipts also require
+a trusted producer identity or signature binding their exact digest.
+
+Reuse algorithm:
+
+1. Compute only the selected stage's declared inputs and dependency receipts.
+2. Load a supported receipt and validate schema, provenance and input digest.
+3. Verify required outputs are regular files under the managed root, with
+   expected size, mode and content digest. Reject escaping paths, unsafe
+   symlinks, duplicate archive entries and special files during restore.
+4. For tests, require the complete selected-test set and compatible environment
+   class. For VM/parity tests, include runtime/guest/oracle identities and
+   relevant host capabilities. Always rerun lifecycle cleanup/preflight that
+   is deliberately not checkpointable.
+5. Reuse if all conditions hold; otherwise report the precise invalidation and
+   schedule that producer plus affected consumers. Preserve independent roots.
+6. Publish outputs, flush them, then atomically publish the success receipt
+   with file and directory fsync. A crash must never expose success first.
+
+Verification receipts and product receipts have different output requirements.
+Rehydrating a byte-identical binary can preserve a compatible test receipt;
+rebuilding to a different binary invalidates dependent test evidence. A
+different host need not invalidate portable static evidence, but cannot inherit
+VM authority merely because its CPU architecture matches.
+
+### B. Separate build identity from policy and publication identity
+
+Use a small explicit stage-input inventory, with fail-closed handling of new
+unclassified inputs. It drives classifier tests and receipt fingerprints.
+
+| Identity | Includes | Must not automatically include |
+| --- | --- | --- |
+| Native build | Source closure, dependencies, compiler/SDK, target, flags, build recipes | Live tap head, docs deployment state |
+| Unit/coverage | Exact tested build, test selection, instrumentation, test harness, quality policy | Release queue position, unrelated formula edits |
+| Runtime/parity | Tested runtime/guest hashes, oracle, capabilities, isolation and runtime harness | Unrelated documentation controls |
+| DocC site | Source/dependency closure, DocC toolchain, flags, targets, hosting path, relevant scripts | Entire unrelated control commit |
+| Package | Input products, archive recipe, signing/notarization provenance, naming/version inputs | Current live tap commit |
+| Publication | Artifact manifest, release identity, lane, current destination snapshot, mutation policy | Compiler scratch paths |
+
+Record full source/control SHAs for audit even when semantic contract digests
+permit reuse. Do not remove host/path identity where tools are not relocatable.
+Separate scheduling deadlines from output identity: a prior result may satisfy
+a tighter maximum-duration policy only if its recorded duration satisfies it;
+runtime startup deadlines that affect tested behavior remain semantic inputs.
+
+### C. Main CI equivalence and Current behavior
+
+Initial safe change: restore the previous conservative main runtime condition
+while introducing an evidence resolver in shadow mode.
+
+For each new head H, the resolver computes build/test identities, finds a
+trusted successful baseline with matching identities, verifies its receipts
+and required retained outputs, and emits one of:
+
+- `execute`: changed identity, missing/invalid baseline or unsupported schema;
+- `reuse`: verified equivalent evidence with a named source run and digest;
+- `unknown`: transient authority failure; bounded retry or fail, never skip.
+
+Changed-file classification is only a fast hint. In particular, a short push
+diff is not proof that all earlier runtime changes were validated. An aggregate
+job must report `runtime-executed` or `runtime-evidence-reused`, not infer
+success from `skipped`. Packaging must consume that explicit contract.
+
+Keep exact Current-to-main readiness initially. A controls-only main commit can
+reuse compilation/tests but still needs a current-head publication envelope;
+do not relabel an artifact containing an older embedded commit/version as H.
+Separate source-version-sensitive assembly from expensive compatible compile
+work. If that separation cannot preserve provenance, build the affected product.
+Changing readiness to artifact-equivalent Current is a separate explicit
+policy change requiring revised soak and release-authority tests.
+
+Acceptance includes A runtime -> B docs while A is cancelled: B must acquire
+valid runtime evidence and a valid Current decision, never silently lose both.
+
+### D. Dispatch and recovery journal
+
+Proposed interfaces in `Tools/release/release-state.py`:
+
+```text
+inspect --version VERSION --format json|text
+plan --version VERSION --format json|text
+resume --version VERSION --expected-plan-digest DIGEST
+```
+
+Inspection/plan perform no remote mutations and start no builds. The existing
+shell entry point remains the user-facing compatibility wrapper. The planner
+is not another executor: it produces decisions consumed by existing Make and
+workflow operations.
+
+Persist an atomic transaction record below the new internal retained root
+specified in section J: source tag object/commit, release manifest digest, expected controls,
+stage contract, request UUID, mode, attempt, run ID, run attempt and timestamps.
+Replicate operation receipts with durable candidate evidence; a lost local
+journal must be reconstructible from trusted remote records.
+
+Dispatch protocol:
+
+1. Inspect current postconditions and outstanding exact requests first.
+2. Write `dispatch-intent` with a stable request UUID before sending anything.
+3. Dispatch through a versioned REST adapter, retaining the returned run ID.
+   Validate response structure; capability-test supported server/API behavior.
+4. Pass `request_id`, `expected_control_sha` and manifest digest to the workflow.
+   The first job records observed identity and rejects mismatches before costly
+   or mutating work. Request ID is correlation, not authentication.
+5. If the HTTP result is ambiguous, enter `dispatch-unknown`; reconcile using
+   the exact request ID and authenticated workflow identity. Do not dispatch
+   again solely because a title search or API query failed. For deployments
+   lacking run-ID responses, use paginated request-ID reconciliation, not the
+   newest 100 titles.
+6. Follow the acknowledged run, including a control-mismatch rejection. If
+   main advanced, replan under the existing reviewed-control policy; never wait
+   forever for the pre-dispatch SHA. Any permitted redispatch has a bounded
+   attempt count and its own recorded attempt ID.
+7. After success, verify required artifact receipts and current side effects.
+   A missing postcondition schedules repair, not reuse of the same stale run.
+
+Local locking avoids duplicate local controllers. Remote serialization plus
+an in-lock state recheck prevents duplicate mutations from different hosts.
+GitHub concurrency is not a distributed idempotency database: queued/cancelled
+requests remain in the journal until reconciled. Use bounded backoff with
+jitter and server retry hints for transient reads; do not retry authentication,
+signature, schema or artifact conflicts as transient faults.
+
+Failed-job reruns may be used only with the original exact controls and valid
+retained outputs. They are not a way to pick up workflow fixes; GitHub reruns
+retain the original SHA/ref and have a limited rerun window.
+[GitHub rerun behavior](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/re-run-workflows-and-jobs).
+
+### E. Publication as postcondition reconciliation
+
+Define a typed inspection result for each output:
+
+```text
+verified | absent | invalid | conflicting | unavailable | superseded
+```
+
+For every result include expected identity, observed identity, evidence origin
+and repairability. `unavailable` covers network/auth/unknown state and must
+never fall through to `absent`.
+
+| Observed state | Planned operation | Forbidden shortcut |
+| --- | --- | --- |
+| Everything currently verifies | No publication; verify final status | Rebuild because no recent workflow title matches |
+| Formula pair drift/absence, artifacts verify | Render and commit pair from one pinned tap snapshot | Repackage binaries |
+| Missing sidecar, original archive verifies | Recreate expected sidecar and upload if permitted | Change archive bytes |
+| Missing archive, authenticated original retained | Upload exact retained bytes if permitted | Re-sign or rebuild replacement under the same stable identity |
+| Existing asset digest conflicts | Stop with conflict details | Clobber or delete published asset |
+| Receipt transport expired, durable receipt valid | Restore authenticated evidence transport | Repeat expensive tests just to recreate a log |
+| No authentic authority or original bytes | Explicit blocked restoration/new-version plan | Treat release metadata or self-signed cache as authority |
+| Existing owned candidate draft | Verify transaction ownership and complete staged closure | Delete unknown drafts or publish unrelated contents |
+| Platform-enforced immutable release lacks asset | Report platform restriction and supported recovery path | Assume uploads are allowed |
+| Older maintenance release | Repair its immutable closure only | Move default stable formula pair or default Pages |
+
+Use a single asset download per inspection transaction, stored by verified
+digest in a bounded managed content store. Pass validated paths/manifests
+through guest publication and final verification rather than re-downloading
+the same guest archive in each function. Revalidate local integrity before use
+and remote asset identity around mutation; never trust filename alone.
+
+For new releases, stage complete binaries, guest archive, checksums, authority
+bundle and provenance in a transaction-owned draft before public visibility.
+Verify that staged bytes can be downloaded and authenticated independently of
+the local host. Only then finalize the release. Draft ownership and source tag
+object must be explicit; an arbitrary existing draft remains a conflict.
+
+A published authority bundle needs an independently verifiable signature or
+trusted attestation over the complete release manifest, not just a guest hash
+or an expiring check summary. Bind original source tag object, source commits,
+component pins, control SHA, stage receipts, exact asset digests, signer and
+notarization evidence. Avoid circular hashes: sign the payload manifest, then
+store its envelope alongside it. Preserve validation rules for existing schema-2
+stable authority; introduce a new schema only for this expanded contract.
+
+Finalized release assets are a remote durable copy; always retain an
+authenticated copy in the internal retained store for local disaster recovery.
+Platform immutability and replica retention must be checked during deployment
+of this design. No storage system can promise recovery after all copies are
+deleted. Older releases without a complete signed manifest require a strictly
+validated migration or explicit operator restoration, not invented authority.
+
+### F. Homebrew and Current mutation boundaries
+
+Homebrew inspection resolves one tap commit T and reads both formulas at T.
+Generate expected formula content using the existing pinned templates and
+verified release metadata. Share this semantic validator between the cheap
+probe and final verifier; do not execute untrusted downloaded Ruby to inspect it.
+
+Keep both formula files in one commit. Existing non-force push already prevents
+blind overwrites; add bounded conflict reconciliation: fetch new T, re-evaluate
+lane eligibility, render again and retry only if the new state remains valid.
+Preserve unrelated tap edits. A newer stable release supersedes an older
+default-lane repair; maintenance backfills may not roll the pair back.
+
+For Current, keep the existing release object. Stage immutable candidate-named
+assets and verify them before moving the Current tag, formula pair and visible
+metadata. Record each operation and re-observe freshness inside the publication
+lock. A restart completes only the still-eligible candidate; a stale candidate
+must not supersede a newer publication. Prefer roll-forward reconciliation;
+never blindly roll back another publisher's successful state.
+
+No cross-service atomic commit exists here. Readers may briefly observe a
+transition, but all referenced URLs must already resolve to complete verified
+artifacts. Keep prior referenced assets through a retention grace period. Use
+an explicit `built_at` value instead of recreating Current for a timestamp.
+
+### G. Documentation artifacts and deployment
+
+Two layers have separate contracts:
+
+1. Dependency/native acceleration: exact Xcode build, Swift, SDK, runner
+   architecture, lockfile, package identity and compilation configuration.
+   Broad fallback is allowed only for safe dependency downloads within the same
+   compatibility class. Do not restore mutable `.swiftpm` edit/config state as
+   authoritative dependency selection.
+2. Site artifact: exact source and dependency closure, documentation toolchain,
+   relevant scripts, target list, source-link base, static hosting path and flags.
+   Store a full file manifest plus required entry routes and module indexes.
+
+Pin/select Xcode explicitly and record its fingerprint before restore. Enforce
+locked resolution consistently across sibling generators where supported;
+verify source/lockfiles remain exact after generation. Any sibling script
+change must land there first and flow into the matched pins last.
+
+Restore a matching verified site artifact first, then use cache-assisted build
+on absence or invalidity. Treat a bad cache as an invalid candidate, not a
+terminal workflow failure: quarantine the restored directory, rebuild, persist
+the verified result as a new artifact, and avoid republishing under an immutable
+bad cache entry. Use an explicit cache generation/repair key with bounded
+retention rather than deleting broad cache collections.
+
+Persist each site immediately after validation, before aggregate assembly or
+deployment. Site artifacts remain independently reusable when another site
+fails. Artifact identity includes site digest; attempt-specific upload names
+avoid collisions during failed-job reruns. A signed release-level manifest
+maps logical site names to exact artifact digests.
+
+At the Pages boundary, use a destination-wide serialized deploy job and recheck
+the selected default release while holding that boundary. Proposed default
+policy: the latest eligible stable Compose release owns the root portal;
+maintenance rebuilds retain artifacts without moving it. Its pinned k8s
+release can remain a prerelease as allowed today. If product policy instead
+requires versioned published URLs, design explicit per-version routing before
+changing the root portal's meaning.
+
+Publish a deployment manifest containing release ID/tag object, site digests,
+deployment ID and expected route probes. Validate actual served routes and
+manifest after deployment with a bounded propagation allowance. Historical
+workflow success cannot substitute for this observation. A superseded build
+ends successfully as `artifact-ready/deployment-superseded`, not as a rollback.
+
+### H. Faster builds and tests without reducing coverage
+
+Preserve parallel native roots. Share scratch state only for compatible
+package/toolchain/configuration identities and never allow concurrent writers
+to the same native scratch directory. Coverage, sanitizers, debug and signed
+release builds are separate compatibility classes unless proved otherwise.
+
+Convert nested independent target invocations into Make producer/consumer
+targets backed by verified receipts. A component checkpoint should build the
+required test bundle once and run selected tests from it when the native tool
+supports that mode. CLI smoke tests consume a named verified binary instead of
+reinvoking the build prerequisite. Keep runtime lifecycle transitions outside
+reusable stamps and serialize VM/parity/signing resources unless isolation is
+proved.
+
+Before changing Container DocC generation, capture per-invocation command,
+target, duration, input identity and symbol-graph output at the pinned source.
+Test whether one multi-target invocation or shared symbol-graph extraction can
+produce the exact existing routes and public symbols. Require an output
+equivalence check; fewer log lines are not a performance proof.
+
+Profile the Python tool suites by test duration and subprocess count. Use fake
+clocks/API state for polling/retry policy tests, but retain real bounded process
+tests for signal propagation and process-tree cleanup. Partition long suites
+only across isolated fixtures; preserve coverage aggregation and the same test
+inventory. Do not paper over flaky behavior with more retries.
+
+### I. Status, telemetry and retention
+
+Proposed `make release-status VERSION=...` and `make release-plan VERSION=...`
+wrap the read-only model. Text output should answer:
+
+```text
+Release 0.x.y: recovering
+Source: <tag object / commit>  Controls: <commit>
+Verified: build, tests, signed assets, guest
+Needs repair: Homebrew pair (observed tap <sha>, dependency missing)
+Waiting: none
+Next mutation: one atomic tap commit; no builds or tests
+Last progress: <UTC>  Evidence: <local receipt / run URL>
+```
+
+Emit JSONL events for inspected, invalidated, restored, started, waiting,
+completed, failed, superseded and blocked states. Record queue time separately
+from execution; include cache hit/miss, bytes transferred and compiler/test
+invocation counts. Provide a bounded log tail while preserving full logs.
+
+Retention distinguishes disposable caches, resumable candidate outputs,
+published authority and artifacts still referenced by Current/tap/Pages.
+Retained-store garbage collection is mark-and-sweep from those live manifests, supports a
+read-only plan and grace period, and never deletes an active transaction or
+the last authenticated recovery copy. It requires a separate explicit operation
+and retention policy; ordinary tidying never invokes it. Implement GC
+separately from resume and transient cleanup.
+
+### J. Internal retention, external execution and safe tidying
+
+This section is a user requirement, not an optional optimization. Proposed
+defaults on this Mac are:
+
+```text
+/Users/sclarke/Library/Application Support/ContainerFamily/retained/
+  .container-family-retained-root
+  objects/sha256/                 immutable binaries, bundles and archives
+  manifests/                     product/dependency/output manifests
+  receipts/                      test, build, signing and release evidence
+  transactions/                  dispatch and host-restoration journals
+  releases/                      named references to retained object digests
+  docs/                          verified sites and deployment manifests
+  caches/                        reusable dependency/compiler cache snapshots
+  sources/                       retained source objects/bundles and lockfiles
+  reports/                       completed logs, profiles, timings and designs
+  locks/                         store publication and transaction locks
+  incoming/                      uncommitted durable-publication transactions
+
+/Volumes/SSD/cf/
+  .container-family-transient-root
+  workspaces/                    disposable clones and Git worktrees
+  builds/                        mutable SwiftPM/Go build-attempt directories
+  tmp/                           tool scratch, extraction and packaging attempts
+  downloads/                     incomplete/unverified transfer data
+  r/                             short runtime/socket/VM attempt directories
+  attempts/                      live logs and uncommitted test outputs
+```
+
+Use the actual user application-support directory on other Macs rather than
+hardcoding this username. Do not use the OS `Caches` or temporary directory for
+the only copy of anything required for recovery. Both roots are outside source
+worktrees and are neither ancestors nor descendants of one another. The
+retained root must resolve to the internal filesystem; `/Volumes/SSD` must be
+the expected mounted external volume, not an accidentally created mountpoint
+directory on the system disk.
+
+Proposed configuration:
+
+```text
+CONTAINER_FAMILY_RETAINED_ROOT=<internal application-support path>
+CONTAINER_FAMILY_TRANSIENT_ROOT=/Volumes/SSD/cf
+```
+
+Resolve these once in a shared path-policy module and pass explicit derived
+paths into Make and subprocesses. Deprecate the ambiguous `STACK_STATE_ROOT`;
+do not let it place both lifetimes together. Compatibility handling should
+diagnose an old mixed-root override and offer migration, not silently move or
+delete its contents.
+
+#### What is retained versus transient
+
+| Data | Internal retained location | External transient location |
+| --- | --- | --- |
+| Completed executable, dylib, app bundle, resource bundle, dSYM | Complete product closure in immutable objects | Active compiler/linker output only |
+| Signed/notarized tar/OCI/package and checksum | Original verified bytes plus provenance | Staging and verification scratch |
+| Build/test/coverage/authority receipts | Immutable receipts and necessary evidence | In-progress report generation |
+| DocC site and module manifests | Verified full site artifacts | Symbol-graph/build/assembly scratch |
+| SwiftPM/Go/dependency caches worth reusing | Verified compatible snapshots/download cache | Writable per-attempt materialization |
+| Git source identity and unmerged work worth keeping | Authenticated source objects and explicitly preserved work | Disposable checkouts and review worktrees |
+| Release/dispatch/host recovery state | Durable journals, including interrupted attempts | Disposable process-local state only |
+| Diagnostics needed to understand a failure | Retained completed/failure logs and useful profiles | Live streams and throwaway fixture outputs |
+| Temporary sockets, VM test disks and extracted test data | None by default | Owned attempt under the short external root |
+
+Successful native compiler state can save substantial incremental work and
+therefore belongs in the retained cache class, even though it is not release
+authority. Keep a verified snapshot on the internal drive and materialize a
+writable copy on SSD for active work. Measure transfer cost versus rebuild
+savings and deduplicate by compatible cache identity. Do not let ordinary
+`clean` erase the retained snapshot. A tool's path-sensitive cache may require
+stable materialization paths or a measured migration; do not remove path checks
+without proving compatibility.
+
+The complete runtime closure matters: copying only the top-level executable
+is insufficient if resources, libraries or helper programs still resolve into
+an external `.build` tree. Product manifests must enumerate those files,
+preserve required permissions/signatures/extended attributes, and verify that
+runtime dependencies do not escape to disposable storage. Never hard-link a
+retained object to writable build output or retain a symlink pointing to SSD.
+
+#### Atomic cross-volume promotion
+
+Promotion is copy-and-verify, not a cross-filesystem rename:
+
+1. Build in an explicitly owned external attempt directory.
+2. Enumerate the finished output closure and compute its expected manifest.
+3. Copy into a unique `incoming` transaction on the internal filesystem;
+   preserve required metadata and verify hashes, modes, bundle signatures and
+   closure. `incoming` is a narrowly scoped durable commit protocol, not a
+   general temporary build area. This small internal staging boundary is
+   required for atomic publication across disks.
+4. Flush local files, atomically rename within the internal store, then publish
+   the receipt/reference and fsync its directory. Consumers only follow
+   committed references. Resume or explicitly discard incomplete incoming
+   transactions; do not expose them as complete artifacts.
+5. Only after that commit may the external attempt be deleted. Disk-full,
+   disconnect or copy failure leaves the source attempt intact and reports
+   `retention-incomplete`; it must not claim a safely disposable successful build.
+
+Source provenance is content/repository identity, while checkout path is an
+execution detail. Extend build-pin verification with a retained-artifact mode
+that validates source objects/receipts without requiring a deleted checkout.
+The build-input mode still proves the requested live checkout is exact and
+clean before execution. Retain necessary Git objects through explicit retained
+refs/bundles independent of disposable branch names, without weakening signed
+source-tag authority or preserving every abandoned branch forever.
+
+#### Cleanup must not mean artifact deletion
+
+Provide separate commands with a shared, typed cleanup plan:
+
+- `clean`: remove only this owned inactive external build attempt.
+- `workspace-prune --dry-run`: list eligible external workspaces/worktrees;
+  execution requires their normal clean/merged/unique-work checks.
+- `transient-prune --dry-run`: list owned inactive external attempts with
+  committed retention or an explicit discard decision for failed scratch.
+- `retained-gc --dry-run`: separate inventory of retained candidates; deletion
+  requires explicit scope and policy, and is never called by any command above.
+
+Every destructive target is resolved and checked against its expected marker,
+owner, device/volume identity, canonical parent and live lease. Reject symlink
+escapes, mount changes, broad roots, active attempts and any target reaching the
+retained store. Use filesystem-safe traversal that cannot follow a replaced
+symlink during cleanup. Never use a repository-wide recursive deletion as a
+substitute for `git worktree remove`, and never delete a branch with unique
+unpreserved work. Branch deletion is independent of artifact retention: no
+artifact directory is keyed solely by a branch name.
+
+Existing `make clean`, clean-related scripts, worktree cleanup, `git clean`
+wrappers, `TMPDIR` use, language caches, DocC scratch, CodeQL state and test
+fixture roots all need an audit. Tool-managed transient paths must resolve to
+SSD. Durable cache/evidence roots must remain internal even when external
+workspace configuration changes. Use `PYTHONDONTWRITEBYTECODE` or an explicitly
+external bytecode cache where relevant; do not scatter generated state into
+retained source/control checkouts.
+
+#### Platform constraints are explicit, never silent fallbacks
+
+If SSD is absent, allow internal status, artifact verification and use of an
+already-retained product, but fail preflight before new transient work. Do not
+silently fall back to `.build`, `/private/tmp` or an internal workspace.
+
+The current release code intentionally stages runtime input locally because
+launchd-managed services can be denied removable-volume access
+(`scripts/CONTAINER_STACK_RELEASE.sh:3910`). Retained executable/guest inputs
+will now be local naturally. Writable runtime data and sockets should use the
+short external root, but must be validated against macOS access rules and
+Unix socket path limits on the actual host. If a required service cannot use
+external writable state, report that incompatibility and obtain an explicit
+exception; do not silently violate the storage requirement. OS-owned launchd,
+Keychain or system service metadata is not relocatable application scratch and
+must be disclosed as such, not moved by this controller.
+
+GitHub-hosted runners do not have this Mac's physical drives. Their execution
+is transient, while every required hosted artifact/receipt must be imported and
+verified into the internal local store before a locally managed transaction is
+marked retention-complete or its workspace is pruned. Remote release/artifact
+storage is an additional replica, not a replacement for the requested local
+copy. Apply the two-root policy directly to local/self-hosted MBP execution.
+
+#### Non-destructive migration
+
+Inventory legacy mixed roots read-only. Copy valid products, full closures,
+receipts, logs, journals, required source objects and useful caches to the local
+store first. Verify old and new copies independently, write new location-aware
+manifests, and retain legacy provenance rather than editing a signed receipt.
+Prove a consumer works from retained local bytes before offering old external
+copies for cleanup. Do not clean external source workspaces while they contain
+the only copy of this review/design or uncommitted work. Keep an interrupted
+migration journal so copying can resume without restarting completed objects.
+
+Storage acceptance tests must include disconnecting SSD after promotion,
+pruning every disposable workspace/branch/build attempt, recreating an exact
+source workspace at a different path, and verifying zero unnecessary native
+build/test invocations. Test internal disk-full during promotion, retained-root
+symlinks, replaced mountpoints, source/retained path overlap, concurrent cleanup,
+metadata/signature preservation and incomplete local imports of hosted output.
+
+## Implementation sequence and ownership boundaries
+
+These work packages are one coherent contract, not a requirement for repeated
+full builds, PRs or releases after each row.
+
+| Package | Main files/components | Deliverable and dependencies |
+| --- | --- | --- |
+| WP0: storage lifetime boundary | Make roots, build-pin promotion, release evidence/journals, cleanup helpers | Internal retained store and external attempts; non-destructive migration and cleanup proof; prerequisite to enabling broader cleanup/reuse |
+| WP1: regression and safe CI selection | CI classifier/workflow; release helper tests | Reproduce F01–F06; conservative main policy; no dependency |
+| WP2: inspection and dispatch identity | Release-state module, shell wrapper, three workflows | Typed inspection, run-ID adapter, journal, mutable postconditions; follows WP1 |
+| WP3: durable receipts and authority | Checkpoint runner, nested validator, stable authority, build-pin shared utilities | Output manifests, schema migration, durable authority; may develop alongside WP2 but integrate before reuse expansion |
+| WP4: recoverable publication | Publisher, package workflow, formula renderer/validator | Draft staging, exact-byte asset recovery, atomic pair reconciliation, non-deleting Current; depends on WP2/WP3 |
+| WP5: verified documentation | Docs workflow, authority module, pinned sibling generators | Toolchain keys, verified per-site artifacts, deployment serialization and probes; depends on WP3/WP4 |
+| WP6: precise reuse and speed | Make graph, classifier/evidence resolver, build/test harnesses | Shadow then enforced equivalence; measured removal of repeated work; depends on WP3 |
+| WP7: operational closure | Status CLI, timing summaries, docs, validator setup | Operator commands, fault matrix, final exact-head review; integrates all packages |
+
+Implementation should concentrate Python logic in small modules rather than
+adding another large block of state-machine logic to the release shell script.
+Keep shell at process/environment boundaries. Reuse existing publication and
+authority validators before creating parallel implementations.
+
+## Acceptance and fault-injection matrix
+
+Use the real planner, receipt validator and shell adapters with a stateful fake
+GitHub/tap/artifact boundary. Count actual requested builds/tests/uploads/
+dispatches. Do not mock the decision being tested.
+
+| Scenario | Required result |
+| --- | --- |
+| Unchanged completed release, local checkout recreated | Zero compile/test/sign/dispatch/upload; verify retained evidence and current destinations |
+| Prior successful tap repair followed by drift | Exactly one needed repair; zero package builds; second resume no-op |
+| Correct formula URLs/SHA but bad version/dependency | Classified repairable and repaired by same validator used at completion |
+| Missing formula versus 403/timeout/malformed response | Absence repairable only when authenticated; unknown errors cause no mutation |
+| Published binary or checksum removed | Restore exact authenticated bytes if permitted; otherwise precise blocked state |
+| Conflicting published archive digest | Fail closed; zero overwrite/delete/re-sign |
+| Local guest missing; remote original present | Restore once and verify source-qualified OCI/digest; no guest rebuild |
+| Every original guest copy missing | Explicit unrecoverable artifact; no automatic substitute |
+| Successful gate but Actions artifact expired | Use durable authenticated receipt or regenerate only invalid evidence; never stale-success loop |
+| Main changes before dispatch or during queue | Follow acknowledged run, reject wrong controls before work, bounded replan |
+| Dispatch response lost; run actually created | Reconcile exact request ID; no blind duplicate mutation |
+| More than 100 intervening runs | Persisted run/request lookup still works |
+| Two hosts resume same release | In-lock reinspection; at most one effective mutation per required postcondition |
+| A runtime commit cancelled by B docs-only commit | B executes or proves equivalent runtime evidence; Current decision remains valid |
+| Dependency pin/build recipe/toolchain changes | Relevant stages invalidate even if directory classifier originally said tools-only |
+| Build artifact deleted but log/stamp intact | Producer restored/rebuilt; no false product readiness |
+| Crash before/after receipt atomic rename | No partial success; completed unaffected stages reused |
+| Same sources, changed instrumentation/runtime authority | Relevant tests rerun; incompatible coverage/parity never reused |
+| DocC cache has entry HTML but missing module payload | Reject, rebuild only that site, preserve other sites |
+| Site succeeds; sibling/upload/deployment fails | Successful site survives retry without generation |
+| Older and newer docs finish out of order | Only eligible destination owner deploys; no old-root overwrite |
+| Maintenance backfill | No default formula or Pages rollback |
+| Current failure after each individual remote write | Prior release stays available; resume rolls forward only eligible candidate |
+| SIGTERM/deadline during native/VM work | Owned process tree cleaned; no foreign service killed; no success receipt |
+| Queue overflow/cancellation/API outage | Journal reports actionable waiting/failure; no silent completion |
+| Cache path traversal/symlink or forged receipt | Rejected before extraction/execution/publication |
+| External workspaces, branches and build attempts pruned | Internal artifacts/receipts/caches untouched; retained binaries still usable |
+| SSD unmounted after successful artifact promotion | Local status/verification/retained product works; new transient work fails preflight |
+| Internal disk fills midway through promotion | No committed receipt; external source retained; resume copies only missing data |
+| Exact checkout recreated at another path | Retained artifact verification independent of old checkout; path-sensitive native cache reuse proved or explicitly invalidated |
+| Cleanup races an active build/import or mount replacement | Refuse cleanup; no crossing roots or deleting last retained copy |
+
+Validation cadence:
+
+1. Run the new deterministic regression cases while implementing each affected
+   contract, with small compatible fixture bundles.
+2. Run component tooling suites once at a coherent checkpoint. Use one final
+   full review-to-clean loop; changes after that review invalidate it.
+3. Run `make check`, build self-tests and authority/receipt contract suites for
+   the final implementation head, not after every documentation edit.
+4. Run one matched-stack integration/parity checkpoint for any changed runtime
+   authority/build semantics, retaining exact tested artifact identities.
+5. Validate actual hosted queue/dispatch/artifact/Pages behavior in an explicitly
+   authorised non-production rehearsal; mocks cannot prove platform behavior.
+6. Do not dispatch or rebuild an existing production release merely to test the
+   controller. Signing, publication and destructive drills require their normal
+   authorised release boundary.
+
+## Performance experiment and success criteria
+
+Measure cold, warm no-op, one-component change, one failed independent stage,
+machine restart with retained artifacts, and docs-only retry. Keep source pins,
+toolchain, host load and configuration equivalent; report medians and spread
+from repeated comparable samples, not a single elapsed run.
+
+Primary acceptance is deterministic work counts:
+
+- Unchanged resume: zero native build/test/signing invocations.
+- Formula-only repair: zero builds/tests and at most one effective tap commit.
+- One invalid DocC site: exactly one site generation, zero sibling regeneration.
+- One changed producer: only affected transitive consumers rebuild/retest.
+- One inspection: at most one payload download per required digest, absent
+  network retry or deliberate remote mutation verification.
+- Read-only status: no builds, downloads of large archives or external writes;
+  expose verification freshness when using prior local observations.
+
+Provisional latency targets, to validate rather than promise: retain native
+warm verification in roughly the existing single-digit-second range; make
+local-only status sub-second for a small manifest; bound remote status by
+explicit API deadlines. Set release/DocC speedup targets only after equivalent
+baseline traces exist. Queue time, service propagation and unavailable runners
+must be reported separately from controller performance.
+
+## Migration, rollback and remaining decisions
+
+Existing stable source tags and artifacts remain untouched. Read old receipts
+for diagnostics and explicitly supported legacy authority checks, but do not
+upgrade input/log stamps into artifact proof. Native build pins continue to
+work. New release-stage receipts use a separate schema/key namespace, and old
+DocC caches may accelerate dependency fetching only after compatibility checks.
+
+The storage migration in section J precedes external cleanup. The old
+single-root `STACK_STATE_ROOT` arrangement is not an acceptable final state
+under the user's requirement. Retained data must be verified on the internal
+disk before an old external copy becomes eligible for removal.
+
+Deploy the inspector first in read-only/shadow mode and compare its decisions
+with current behavior. Enable postcondition-driven repairs before enabling
+broader cross-head evidence reuse. Keep conservative main runtime execution as
+the fallback throughout rollout. A rollback disables new reuse and runs the
+required work; it must not reintroduce stable overwrites or Current deletion.
+
+Decisions to confirm during implementation, not silently assume:
+
+- Whether root Pages means latest stable only or supports selectable versioned
+  sites; this design defaults to latest stable with retained version artifacts.
+- Repository/platform immutability settings, draft permissions, trusted signing
+  identities and the retention owner for the second recovery replica.
+- A compatible pinned actionlint release/build or a narrowly scoped documented
+  schema adapter with separate queue validation. Do not globally suppress YAML
+  errors or downgrade queue behavior merely to make an old validator pass.
+- Which test/build environments are genuinely reusable across hosts; default
+  to rerunning environment-sensitive evidence when equivalence is not proved.
+- Whether `published_at` freshness is a hard Current requirement; the proposed
+  reliable default uses explicit build metadata instead.
+
+## Implementation status
+
+The resilience implementation now establishes the required lifetime boundary:
+native scratch and release transactions use `/Volumes/SSD`, while completed
+binaries, pins, timing records, release assets, signed authority bundles, DocC
+sites, dispatch journals and recovery evidence use the internal retained root.
+Artifact promotion is content-addressed and atomic; cleanup is marker-protected,
+allowlisted, symlink-safe, and cannot select the retained root. Exact checkout
+relocation no longer invalidates an otherwise matching retained product.
+The live self-hosted runner work tree was migrated to `/Volumes/SSD`, eight
+verified legacy 0.14.3 source bundles were retained on the internal disk, and
+six clean retired release workspaces were isolated in an external cleanup
+quarantine after their recovery objects were verified reachable.
+
+The P1 recovery paths now execute runtime validation conservatively on `main`,
+reject stale-success reuse for a newly required tap repair, restore missing
+stable members only from exact retained/published bytes, and preserve the
+Current release object during finalization. Dispatch writes intent before the
+request, requires an exact returned run ID, and records ambiguous responses as
+`dispatch-unknown` rather than retrying blindly. The three dispatched workflows
+bind the request UUID and expected control SHA.
+
+The cheap stable formula probe and final package verifier now call the same
+typed formula-pair validator, so URL, checksum, derived-version, dependency and
+plugin-registration rules cannot drift between repair selection and the final
+postcondition.
+
+Stable recovery retains and validates the authority archive against the signed
+source/guest authority, exact component refs, hosted receipt digest, checkpoint
+and output. When check history is unavailable it requires the durable GitHub
+artifact attestation. Release checkpoints can declare product files; reuse then
+requires each product's path, mode, size and digest in addition to the durable
+log and exact inputs.
+
+DocC reuse includes toolchain and semantic source inputs, verifies a complete
+site manifest, rebuilds an invalid cache, and retains each successful site
+archive locally. Pages deployment is destination-serialized and rechecks the
+latest stable owner after acquiring that boundary. The local actionlint adapter
+validates the supported queued-concurrency extension separately and runs pinned
+actionlint over all remaining workflow structure.
+
+Both published and historical benchmark workflows now put downloads, prepared
+distributions, worktrees, fixtures and compiler scratch on `/Volumes/SSD`, but
+write evidence, provenance and prepared-distribution manifests to the internal
+retained root before transient cleanup. Historical fixture archives and exact
+`cctl` builds are verified and reused from retained caches. Docker applications
+remain permitted only in the explicitly isolated parity/benchmark oracle lane;
+normal build, release and shipped-product paths do not acquire a Docker
+application dependency. Benchmark execution remains guarded by the quiet-host
+preflight.
+
+Operators can use `make release-status VERSION=X.Y.Z` and
+`make release-recovery-plan VERSION=X.Y.Z` for a read-only view of retained
+assets, remote release state, acknowledged/unknown dispatches and the next safe
+action. These commands never build, dispatch, upload, or mutate a release.
+
+Focused deterministic fault tests cover artifact relocation and cleanup,
+missing/conflicting release bytes, durable authority validation, ambiguous
+dispatch, invalid DocC archives/caches, superseded Pages deployment policy,
+product-deleted checkpoint invalidation and non-deleting Current finalization.
+No production workflow, release, tap commit or Pages deployment was started.
+Performance timings and real runtime/parity validation remain deliberately
+deferred until the Mac is quiet and the coordinated Container/Compose changes
+have reached immutable commits; historical timings are not presented as proof
+for this implementation.

--- a/docs/architecture/release-workflow-resilience-followup-design-2026-09-10.md
+++ b/docs/architecture/release-workflow-resilience-followup-design-2026-09-10.md
@@ -21,8 +21,12 @@ input indexes, output-manifest dependency identity, complete Compose package
 materialization, output-aware validation checkpoints, atomic logical dispatch
 claims and request-ID reconciliation, retained gate/package authority, resumable
 exact-byte stable drafts, context-bound independently retained DocC sites, and
-bounded typed release observation. Normal validation fingerprints no longer
-execute Docker applications; Docker remains confined to explicit oracle lanes.
+bounded typed release observation. Recovery inspection now proves the latest
+stable formula bodies against the retained archive URLs and digests, and binds
+the active Pages deployment to a successful exact-version Documentation run;
+superseded versions are classified explicitly. Normal validation fingerprints
+no longer execute Docker applications; Docker remains confined to explicit
+oracle lanes.
 
 For local/self-hosted work, build workspaces, compiler temporary directories,
 downloads, and runner work are required to resolve beneath `/Volumes/SSD`.

--- a/docs/architecture/release-workflow-resilience-followup-design-2026-09-10.md
+++ b/docs/architecture/release-workflow-resilience-followup-design-2026-09-10.md
@@ -1,0 +1,425 @@
+# Follow-up review and implementation design: recoverable Container-family builds
+
+Date: 2026-09-10. Status: implemented on `release-workflow-resilience`; quiet-machine performance measurements remain deliberately deferred.
+
+Reviewed checkout: `/Volumes/SSD/github/container-compose-release-0.14.3`, branch `release-workflow-resilience`, HEAD `acb46f59ac958136f4dae391e7fade5ff72129a7`. Review covers the changes in `8861c73b` and `acb46f59`, their callers, build/cleanup paths, release publication, DocC, checkpointing, and recovery inspection. Product version remains **0.14.3**.
+
+## Decision
+
+Do not yet treat the previous resilience implementation as fully recoverable, cleanup-safe, or sufficient to eliminate redundant work. The content-addressed store, atomic records, exact-byte checks, shared formula validator, and non-deleting Current finalization are useful foundations. Several guarantees, however, stop at a helper API rather than holding across the complete workflow.
+
+This review identifies twelve findings: eight P1 correctness/recovery issues and four P2 recovery/efficiency issues. Eight isolated probe scenarios produced direct evidence; other findings are traced through callers and consumers. No native build, runtime/parity test, benchmark, production dispatch, release mutation, tap update, or Pages deployment was performed.
+
+The previous document's implementation-status assertions about symlink-safe cleanup, complete checkout relocation, dispatch reconciliation, independent DocC retention, and universal storage separation were stronger than the implementation supported. This review supersedes those assertions, not the historical record of what was changed.
+
+## Implementation record
+
+The follow-up implementation closes R01–R12 through the shared storage
+initializer, descriptor-relative cleanup, no-follow content acquisition,
+repairable retained objects, source-independent product receipts, immutable
+input indexes, output-manifest dependency identity, complete Compose package
+materialization, output-aware validation checkpoints, atomic logical dispatch
+claims and request-ID reconciliation, retained gate/package authority, resumable
+exact-byte stable drafts, context-bound independently retained DocC sites, and
+bounded typed release observation. Normal validation fingerprints no longer
+execute Docker applications; Docker remains confined to explicit oracle lanes.
+
+For local/self-hosted work, build workspaces, compiler temporary directories,
+downloads, and runner work are required to resolve beneath `/Volumes/SSD`.
+Retained products, manifests, journals, locks, authority and publication inputs
+are required to remain on the internal disk. GitHub-hosted workers are the
+documented remote exception: their outputs do not become locally recoverable
+authority until imported into the internal retained store.
+
+The native stack's `container` receipt is validation evidence for the Container
+CLI product, not a claim that one executable is the complete installed runtime.
+The complete signed Container runtime archive and sidecar are retained by the
+stable package closure; its helpers, resources, service images and manifests
+remain governed by Container's own packaging manifest. Building those service
+images is not added to the normal Compose stack path because it would invoke a
+Docker application, contrary to this programme's boundary.
+
+No elapsed-time speedup is claimed here. Deterministic work-count regressions
+prove reuse without running a benchmark on a busy machine; the quiet-machine
+protocol below remains the required follow-up before publishing timing results.
+
+## Requirements and boundaries
+
+- Keep disposable checkouts, worktrees, compiler scratch, temporary archives, downloads, runner work, and runtime fixtures on the external `/Volumes/SSD`.
+- Keep everything required for recovery on the internal disk: complete usable products, signed distribution archives, source-recovery objects, immutable dependency locks, success/failure evidence, publication authority, manifests, journals, and deliberately retained acceleration caches.
+- Workspace and branch cleanup must never select retained objects. Removing the SSD must not prevent local verification of already retained products.
+- Do not rebuild or rerun tests merely to recover packaging, publication, a formula, or a documentation deployment when exact valid inputs and results exist.
+- Keep existing OSS Docker Go libraries. Normal native/static/release-control paths must not invoke Docker applications. An explicitly selected parity/benchmark oracle is a separate lane.
+- Performance comparisons require an agreed quiet-machine window. Work-count assertions can be tested now without timing a build.
+- Production recovery drills remain separately authorized operations; this implementation used local fixtures only.
+
+## Prioritized findings
+
+P1 means fix before relying on the claimed recovery/cleanup guarantee. P2 means a remaining functional or efficiency gap to address in the same follow-up programme.
+
+| ID | Priority | Finding | Evidence |
+| --- | --- | --- | --- |
+| R01 | P1 | Cleanup can escape after a directory-to-symlink replacement | Deterministic fault injection |
+| R02 | P1 | Storage policy is not enforced throughout the path and command tree | Promotion escape reproduced; root/environment callers traced |
+| R03 | P1 | Dependent retained receipts still require old source locations | Relocation failure reproduced |
+| R04 | P1 | Native retained pins are not complete runnable/packageable products | Build and package consumers traced |
+| R05 | P1 | Production checkpoints can reuse success after products are deleted | Wrapper failure reproduced; production wiring traced |
+| R06 | P1 | Dispatch journals do not prevent ambiguous duplicate requests | Two POSTs/two UUIDs reproduced with a fake remote |
+| R07 | P1 | Publication recovery still has a retention/authority handoff gap | Workflow and controller paths traced |
+| R08 | P1 | Exact retained-object repair fails; import can commit an inconsistent digest | Both failures reproduced |
+| R09 | P2 | DocC recovery couples sites and lacks durable source-context binding | Retention, cache, manifest, and retry paths traced |
+| R10 | P2 | Broad/repeated fingerprints invalidate unrelated work and probe Docker | Make and validation fingerprint paths traced |
+| R11 | P2 | Single mutable pin slots and separate producer builds limit reuse | Receipt identity, pin paths, and build graph traced |
+| R12 | P2 | Recovery plans omit important remote state and have unbounded reads | Incomplete/malformed remote fixtures plus code trace |
+
+### R01: cleanup safety does not survive path replacement
+
+Location: `Tools/build/stack-transient-clean.py:50`; wrapper lock at `Makefile:522`.
+
+`remove_tree` checks a pathname with `lstat`, then scans the same pathname. Replacing that directory with a symlink between those operations makes the scan and child unlink operations follow the replacement. The probe deleted a sentinel outside the selected tree, then returned `NotADirectoryError`. Reporting failure after deletion is not containment.
+
+The Make wrapper's cooperative lock helps only when every writer uses that exact lock. The cleanup CLI itself takes no lock, and the lock location changes with the transient root. Static symlink fixtures do not cover this race.
+
+Required result: cleanup must remain contained under concurrent rename/replacement and must not depend solely on all other processes behaving correctly. An unexpected device, link, ownership change, or active lease must stop deletion before it reaches unrelated data.
+
+### R02: separate default roots are not an enforced lifetime policy
+
+Locations: `Makefile:419`, `Makefile:238`, `Tools/build/stack-artifact.py:87`, `Tools/build/stack-artifact.py:99`, `scripts/CONTAINER_STACK_RELEASE.sh:270`, `.github/workflows/docs.yml:218`.
+
+The Make initializer checks that two roots have different device IDs, not that transient storage is on the approved SSD and retained storage is internal. It creates/marks roots before completing overlap/device checks. Managed children may resolve beneath either root instead of their assigned lifetime root. Direct-leaf symlink checks do not validate ancestors.
+
+The promoter follows an existing `objects` directory symlink. The probe successfully returned an object path whose resolved location was outside its purported retained root. With both incoming and object directories redirected, the default separation is not a sufficient safeguard. The probe demonstrates path escape on one fixture filesystem, not a cross-volume crash test.
+
+Native stack recipes set Swift scratch paths but do not centrally set `TMPDIR`/`GOTMPDIR`; therefore they cannot guarantee where subprocess temporaries land. The release transaction sets `TMPDIR` later, but that does not cover standalone native commands. DocC generation also still selects a hosted macOS runner; no technical exception to the local-MBP policy was established by this review.
+
+Required result: validate the volume and the full managed path chain before writes; route every entry point through one storage/environment contract. An absent SSD must fail without creating a replacement `/Volumes/SSD` tree on the internal disk.
+
+### R03: source-independent verification and recursive relocation are missing
+
+Locations: `Tools/build/stack-pin.py:610`, `Tools/build/stack-pin.py:659`, `Tools/build/stack-pin.py:678`, `Tools/build/stack-pin.py:773`.
+
+A caller can supply a replacement checkout for the top receipt. Recursive dependencies still use each receipt's recorded source path. Bundle creation and verification also call the source-dependent verifier without a repository-location map.
+
+The probe moved a clean parent and dependency without changing their Git contents. Explicitly verifying the relocated leaf succeeded. Verifying the relocated parent failed because its dependency lookup used the removed location. Verifying retained bytes without a checkout also failed. This contradicts the intended cleanup and SSD-offline recovery contract.
+
+Required result: separate artifact/receipt verification from verification of a newly supplied source checkout. Recursive dependencies must be resolved by immutable identity, not absolute historical paths.
+
+### R04: the retained native stack is not a deployable closure
+
+Locations: `Makefile:555` through `Makefile:726`, `Makefile:2377`, `Sources/ComposeCore/ComposeNormalizer.swift:235`.
+
+Native stages promote individual executables, including only `compose` for Compose. The packaging target instead needs a specific layout containing the Go normalizer, configuration, icon, build metadata, and the Compose executable from `.build/<configuration>`. It does not consume the retained pin as a package input.
+
+The normalizer locator uses an explicit override, installed resources, or a source-checkout Go fallback. A retained standalone Compose executable cannot rely on that fallback after the checkout is removed. The existing stack graph does not build/retain the normalizer as part of this closure. Likewise, a single Container CLI is not by itself proof of a complete installed runtime; its distribution manifest must define the required helpers and resources.
+
+Required result: retain a verified installation/package closure with logical member names and relative layout, not a collection of convenient executable probes. Packaging must consume that closure without rebuilding or depending on source-tree paths.
+
+### R05: output-aware checkpoint support is unused by production callers
+
+Locations: `Tools/ci/run-release-checkpoint.py:53`, `Tools/ci/run-release-checkpoint.py:397`, `Tools/ci/run-stack-release-validation.sh:548`, `Tools/ci/run-stack-release-validation.sh:590`.
+
+The new `--required-output` option is used in its tests but not by production Make/workflow/controller callers. The sibling validator independently maintains input-only `.sha256` success stamps. It checkpoints producer targets such as build, docs, dSYM, and coverage as well as pure checks.
+
+The probe ran a producer through the wrapper using the current output-free calling convention, deleted its product, then retried. The wrapper returned success and reported reuse while the product remained absent. This does not mean all check-only stamps are invalid; it means producer reuse lacks the postcondition it needs.
+
+Required result: make output/evidence declarations mandatory for each producer stage and wire the same evaluator through the sibling validator. Logs cannot substitute for generated products or reusable test evidence.
+
+### R06: a durable intent is not yet a reconciled operation
+
+Locations: `scripts/CONTAINER_STACK_RELEASE.sh:6080`, `scripts/CONTAINER_STACK_RELEASE.sh:6125`, `Tools/release/release-dispatch-journal.py:63`, workflow `run-name` declarations at line 18.
+
+Every dispatch call generates a new UUID and writes a new intent. No dispatch/resume path first searches the journal for an unresolved operation. Workflow run names omit the UUID; historical reuse searches only the latest 100 runs by title/control SHA. Journals also omit operation mode such as tap repair from their durable identity.
+
+The fake remote accepted the first conceptual request but returned a timeout. A second invocation made another POST with a different UUID. The store then contained both `dispatch-unknown` and `dispatched` records. The inspector's warning is not enforced by the executor.
+
+The API version/response field is not a finding: GitHub's 2026-03-10 dispatch contract documents a successful response with `workflow_run_id`. Keep that exact-run binding; add recovery when the response is lost. [GitHub workflow dispatch API](https://docs.github.com/en/rest/actions/workflows?apiVersion=2026-03-10#create-a-workflow-dispatch-event).
+
+Required result: reconcile a stable logical operation before any new POST. Unknown does not mean failed or absent, and exhausting a run-list page is not proof that no run exists.
+
+### R07: durable retention is not a prerequisite for publication
+
+Locations: `.github/workflows/prebuilt-binaries.yml:1165`, `.github/workflows/prebuilt-binaries.yml:1713`, `scripts/CONTAINER_STACK_RELEASE.sh:6542`, `scripts/CONTAINER_STACK_RELEASE.sh:6932`, `Tools/release/publish-github-release.sh:137`, `Tools/release/publish-github-release.sh:199`.
+
+The package workflow produces assets in runner temporary storage and publishes them without importing them into the internal retained store. The controller retains downloaded package assets later during verification. A manually dispatched workflow does not necessarily execute that controller step. Therefore the guarantee currently depends on an after-publication controller handoff.
+
+The stable gate reuse path accepts a successful run without proving that its required output closure remains available. Fresh packaging requires a non-expired Actions artifact and downloads it. A successful old gate plus an expired authority artifact can thus be repeatedly selected while packaging remains unable to proceed. The published-authority fallback helps already published releases, not every pre-publication recovery state.
+
+The stable publisher also rejects any existing release record without distinguishing a resumable matching draft from a published immutable release. GitHub CLI's documented asset-create sequence uses draft, upload, then publish; this review does not claim that `gh release create` necessarily exposes partial public assets. The gap is the repository's inability to reconcile a matching intermediate draft and the missing local durability barrier. [GitHub CLI release creation implementation](https://github.com/cli/cli/blob/trunk/pkg/cmd/release/create/create.go).
+
+Required result: durably retain and authenticate gate authority and the complete package before publication. Make draft recovery explicit and exact-byte-only. Preserve stable immutability and the existing non-deleting Current behavior.
+
+### R08: object acquisition needs repair and single-pass identity
+
+Locations: `Tools/release/retain-local-release-assets.py:98`, `Tools/release/retain-local-release-assets.py:117`, `Tools/build/stack-artifact.py:127`.
+
+When a manifest record exists with the right digest but its object is missing/corrupt, `retain` verifies the broken object and fails instead of restoring it from the exact candidate. The first probe removed only a fixture object and supplied its unchanged source bytes; repair failed.
+
+The importer also hashes a candidate, then asks the promoter to independently read/hash it again, but records the first digest. The second probe changed the candidate between those reads. Retention returned success with a manifest that immediately failed verification. This is a deterministic race injection, not an assertion that a production candidate was observed changing.
+
+Required result: record the identity of the bytes actually installed; distinguish an immutable logical asset identity from the repairable physical copy storing those bytes. A conflicting digest must still stop the operation.
+
+### R09: DocC retains neither independent recovery progress nor source context
+
+Locations: `scripts/CONTAINER_STACK_RELEASE.sh:6974`, `scripts/CONTAINER_STACK_RELEASE.sh:7025`, `.github/workflows/docs.yml:289`, `.github/workflows/docs.yml:396`, `Tools/ci/doc-site-manifest.py:90`.
+
+The controller returns early only when all four local site archives exist, otherwise downloads all four and imports them together after workflow success. A successful site in an otherwise failed workflow is not independently retained by this path. A previously successful run with expired archives and missing local copies is selected again; recovery retries its unavailable download instead of planning only missing site generation.
+
+The manifest proves file-list/content consistency but carries no repository, source SHA, site identity, hosting base path, toolchain, or generator contract. The hosted cache key supplies some context, but the retained archive verifier does not bind those semantics. Stable local names are only version plus site. A valid, self-consistent archive is not proof that it belongs to the requested site/source.
+
+Required result: retain each successful site under an exact semantic context before assembling Pages. Rebuild only missing/invalid sites; retry deployment independently from generation.
+
+### R10: stage keys are overbroad and fingerprint acquisition is repeated
+
+Locations: `Makefile:238`, `Makefile:255`, `Tools/ci/run-stack-release-validation.sh:300`, `Tools/ci/run-stack-release-validation.sh:417`.
+
+Swift and Go contracts hash broad shared Make sections. The recursive `$(shell ...)` variables are evaluated at multiple references. The sibling validator puts a shared environment/tool catalogue in every stage's fingerprint and rechecks broad identities at stage boundaries. Independent Make invocations also prevent a single Make traversal from sharing common prerequisites.
+
+The shared catalogue explicitly executes `docker buildx version` and `docker compose version`, including when computing non-oracle validation fingerprints. Failures are tolerated, so this is not proof Docker is a required installed dependency; it is still an unnecessary Docker-application invocation in a normal path.
+
+Required result: declare each stage's semantic input closure and relevant tools. Acquire an immutable observation once per run, then cheaply detect relevant mutation at boundaries. Do not weaken runtime/parity evidence merely to increase reuse.
+
+### R11: retained lookup and build graph do not fully support cross-attempt reuse
+
+Locations: `Makefile:227`, `Makefile:546`, `Tools/build/stack-pin.py:174`, `Tools/build/stack-pin.py:755`.
+
+Pins use one mutable slot per repository/configuration. Building source A, then B, replaces the lookup for A even if A's object bytes remain retained. There is no input-key index to find the old receipt. Receipt hashes also include source location, completion time, and duration; dependencies key on those whole receipt hashes. Reissuing equivalent evidence can therefore invalidate consumers even when product semantics/bytes are unchanged.
+
+The native stages use separate SwiftPM scratch roots. Downstream stages receive source package paths and receipt checks, not reusable binary library products. The graph orders and records builds, but must not be described as sharing compiled dependencies across those separate invocations. Actual compiler duplication was not measured.
+
+Required result: separate semantic build identity, immutable output identity, and attempt evidence; retain multiple indexed results. Plan shared compatible build/test prerequisites once. Do not attempt unsafe cross-toolchain or arbitrary Swift module-cache sharing.
+
+### R12: the inspector does not yet compute a complete recovery plan
+
+Locations: `Tools/release/release-state.py:115`, `Tools/release/release-state.py:154`, `Tools/release/release-state.py:216`.
+
+The next action is selected mainly from local missing assets and unresolved requests. It does not reconcile expected versus actual remote asset members/digests, does not verify formula/Pages state, and does not make failed acknowledged runs into explicit stage failure states. Both remote subprocess paths lack a timeout.
+
+With all local assets present and a remote release reporting no assets, the probe recommended formula/Pages verification rather than restoring the missing remote members. A remote response with `assets: null` raised an uncaught `TypeError`. The tool also reloads the same local manifest for each member and deeply hashes payloads during ordinary status.
+
+Required result: a bounded, typed observer must feed the same pure planner used by resume. Unknown/unavailable observations must remain distinct from absent, valid, and conflicting state.
+
+## Target design
+
+### A. One storage and lease contract
+
+Extend the existing tools with a small shared Python storage module; do not create another independent cleanup/import framework. It should own path validation, root-role checks, object access, lock ordering, and atomic record replacement.
+
+| Data class | Canonical location | Cleanup policy |
+| --- | --- | --- |
+| Active source/worktrees and build attempts | External SSD managed roots | Disposable only after source/evidence closure is retained |
+| Compiler scratch, temporary files, downloads, test/runtime fixtures | External per-attempt directories | Lease-protected; recoverable quarantine before deletion |
+| Complete product objects and signed package archives | Internal retained object store | Never included in transient cleanup |
+| Source bundles/mirrors, locks, provenance, receipts, test logs, DocC sites | Internal retained namespaces | Explicit retention owner and reachability policy |
+| Reusable compiler/module/download acceleration cache | Internal, explicitly retained and toolchain-keyed | Separate opt-in cache GC; never claimed as authoritative evidence |
+| Writer leases, journals, release state, cleanup manifests | Internal retained control namespace | Survive SSD disappearance and process restart |
+
+Configuration records approved retained volume identity, SSD volume identity, canonical roots, roles, and schema. Validate mounts using macOS mount/disk metadata and device identities; a different device ID alone is insufficient. Reject symlink/reparse-like ancestors, overlap, root aliases, wrong device, special files, and unmarked non-empty targets before creating children. Recheck at mutation boundaries. Existing marker text is supporting ownership evidence, not authorization to delete arbitrary paths.
+
+Export scoped `TMPDIR`, `TMP`, `TEMP`, `GOTMPDIR`, Swift scratch, runtime roots, and runner working directories from one launcher. Do not repurpose `HOME` or `CODEX_HOME`. Distinguish retained acceleration caches from disposable compiler scratch. Scope enforcement to build/test/release processes; unrelated macOS application temporaries are not under this workflow's control.
+
+Put locks under the retained control namespace, keyed by store/operation identity, not a configurable transient path. Fixed acquisition order: store mutation coordination, logical operation, then object/manifest lock. Use OS-held locks for live ownership and records with PID/start identity for diagnosis; do not treat a stale PID file as ownership. Independent objects/stages may proceed concurrently when their declared resources do not conflict.
+
+Cleanup protocol:
+
+1. Validate the mounted SSD, marker, target allowlist, active leases, and retained closure.
+2. Write a retained plan with exact target identity, owner, reason, device/inode, and retention preconditions.
+3. Acquire the shared cleanup/build lease and revalidate identities.
+4. Rename each eligible disposable tree into a same-volume managed quarantine, retaining the rename result.
+5. Delete using directory descriptors and no-follow relative operations, or a platform primitive whose symlink-attack resistance is checked at startup. A pathname `lstat` followed by pathname recursion is not sufficient.
+6. Stop on mount/identity change; report partial completion precisely. Leave retained data untouched.
+
+The deletion primitive itself must resist the R01 injected replacement even if a writer ignores the cooperative lease. Quarantine is recoverable until explicitly purged; distinguish disposal from irreversible purge in operator output.
+
+### B. Identity model: inputs, outputs, evidence, locations
+
+Keep these concepts separate:
+
+- `input_key`: hash of schema, product/stage, source identities, dependency input/output contracts, configuration, architecture/SDK/toolchain, relevant environment, and the producing recipe contract.
+- `output_manifest_digest`: hash of canonical logical members, file digests, size, executable mode, layout, and required package/signature metadata.
+- `attempt_id`: unique execution record with start/end, duration, logs, exit state, host, and observed resource conditions.
+- Source/build paths: optional diagnostic locators; never required to verify retained content.
+- `authority`: independently verified provenance/approval binding. A self-hashed JSON file supplies integrity, not authenticity.
+
+Store immutable receipts by identity and index `product/configuration/input_key` to valid output manifests. Keep optional `latest` pointers for convenience only. Preserve historical indexes until explicit reachability GC says they are unowned. A receipt repair or location change must not alter downstream semantic identity.
+
+Provide separate operations:
+
+- `verify-retained`: verify retained closure and provenance without a checkout or SSD.
+- `match-source`: compare a supplied clean checkout to its expected source identity.
+- `materialize`: produce a transient runnable/package layout from retained objects.
+- `plan-build`: reuse an exact retained product or select missing producers.
+- `verify-stack`: resolve dependency manifests recursively by digest with cycle, duplicate, and schema checks.
+
+Record source bundle reachability before deleting a unique workspace or branch. Retaining a branch name is unnecessary if the exact source objects and metadata remain reachable; deleting the only reachable source representation is not authorized merely because binaries exist.
+
+### C. Complete product closure and repairable acquisition
+
+Define manifests from actual install/package consumers. Compose's minimum closure includes its executable, normalizer executable, `config.toml`, icon, and exact build metadata. Container and supporting products must enumerate required helpers, configuration, resources, guest/image references, and symbols if those are retained deliverables. Do not claim an arbitrary CLI subset is a full runtime.
+
+Retain final signed distribution archives byte-for-byte. For an unpacked runnable product, preserve its required relative layout and validated metadata. Sign a derived staging copy, never mutate a shared immutable unsigned object. Cross-attempt signature/archive identity may differ even for equivalent source; once bound to a stable release, exact published bytes are the authority.
+
+Acquisition protocol:
+
+1. Lock the logical asset/manifest mutation and validate the expected digest/provenance, if one exists.
+2. Open a regular source without following links; copy/hash one stream into an internal incoming object.
+3. Record the digest, size, and normalized intended mode of the actual copied bytes. Reject a changing candidate when its before/after identity fails the import contract.
+4. Compare against expected authority; install with no-clobber semantics and verify any concurrent winner.
+5. Flush data and required directory/record updates before committing the manifest pointer.
+6. If an existing logical member has matching identity but missing bytes, reinstall the exact object. If corrupt bytes occupy its immutable path, quarantine under an exclusive repair lock, install the expected bytes, verify, and record repair evidence.
+7. A different digest for the same stable logical member is a conflict, never a clobber or implicit rebuild.
+
+Successful import must imply that immediate verification succeeds. Disk full, permission failure, process death, or an unmounted source must leave either the old valid manifest or a recoverable pending import, never a success pointing at inconsistent bytes.
+
+### D. Output-aware execution graph
+
+Use a shared stage declaration consumed by Make, the checkpoint wrapper, and sibling validation. Extend existing orchestration incrementally; avoid a wholesale rewrite of the release controller.
+
+Each stage declares ID, relevant inputs, dependencies, products/evidence, validator, side effects, resource class, and retry policy. Separate pure checks from producers and publication operations.
+
+A stage is reusable only when input identity matches, its required output/evidence closure verifies, and its environment-sensitive policy permits reuse. Missing materialized scratch with valid retained output calls `materialize`, not `build`. Missing/corrupt evidence reruns only the stage whose proof is unavailable. A downstream consumer cannot manufacture success from a producer's surviving log.
+
+Generate one build/test plan per coherent input snapshot. Merge identical prerequisites. Recheck relevant immutable heads/tool identities before a stage and before recording success; if another task changes a dependency, invalidate that dependent subgraph, not unrelated results.
+
+Do not unconditionally memoize mutable observations across attempts. Cache immutable content by digest; use inexpensive metadata only to decide whether deeper identity validation is required. Full verification remains available before publication/cleanup. Restrict Docker fingerprints and invocations to explicit oracle stages.
+
+### E. Dispatch and publication reconciliation
+
+Logical operation identity is a hash of repository, workflow, workflow control SHA, candidate/release identity, full normalized inputs, and mode (package, tap repair, gate, docs, and so on). Reuse a retained operation record across controller restarts.
+
+Dispatch states: `planned -> intent -> acknowledged -> observing -> verified`, with explicit `unknown`, `failed`, `cancelled`, and `conflict` branches. A new attempt is not automatically a new logical operation.
+
+Before dispatch, lock and reconcile the operation. If acknowledged, inspect that exact run. If unknown, search paginated/time-bounded observations using the recorded request ID and validate repository, workflow, event, control SHA, and candidate. Put the request ID in the run name and an early machine-readable acknowledgement. Retain the remote run binding when it becomes known.
+
+A bounded search that cannot prove acceptance or absence leaves the operation unknown and blocks another expensive dispatch. Do not promise exactly-once delivery from client journaling alone. Add an entry-point idempotency guard where duplicate deliveries could reach side effects. Genuine failure can create an explicit new attempt linked to the prior one; lost responses cannot.
+
+GitHub concurrency controls schedule contention but are not the durable operation journal or business postcondition. Continue verifying actual candidate ownership and outputs. [GitHub concurrency documentation](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency).
+
+Publication sequence:
+
+1. Verify and retain gate authority, supporting logs, source identities, and guest/image closure as soon as the gate produces them.
+2. Build/sign/package only missing product nodes; verify and retain the complete release manifest locally.
+3. Record `retained-complete` before allowing remote publication, regardless of whether initiation was manual, scheduled, or controller-driven.
+4. Create or reconcile a matching draft by exact tag/candidate/manifest identity. Upload only absent exact members; conflicting bytes stop.
+5. Re-read the remote draft and required asset bindings; publish only when complete. A lost response triggers observation, not recreation.
+6. Reconcile the formula pair and Pages separately with candidate-bound postconditions.
+7. Retain final remote identities and evidence; then permit transient cleanup.
+
+Already published stable assets remain immutable. If platform settings forbid adding a missing member, surface a precise blocker rather than weakening that policy. Do not delete/recreate Current; preserve the existing availability-safe behavior. A complete retained gate can be reused after hosted expiration only when its authenticated authority is sufficient under the release policy. Missing authority is not license to trust a local checksum or silently rebuild a different stable artifact.
+
+### F. Independent DocC generation and deployment
+
+Introduce a context-bearing site manifest with site, repository/source SHA, documentation dependency refs, toolchain/generator contract, hosting base path, complete member digests, and output-manifest digest. Verify expected context at every cache restore, local import, assembly, and deployment boundary.
+
+Retain each site's successful archive immediately, independent of sibling outcome. Keep a source/toolchain input-key index and a release-to-site-manifest mapping. Preserve the exact first accepted archive; if regeneration is needed, normalize archive ordering/metadata where safe and distinguish semantic site identity from gzip byte identity.
+
+Plan site generation, Pages assembly, and deployment as separate nodes. An expired hosted archive first falls back to internal retained bytes. If those bytes are genuinely missing and documentation regeneration is authorized, schedule only that site at its pinned source context. Do not repeatedly select the same expired run as an executable recovery plan.
+
+Keep destination serialization and latest-stable ownership rechecks. An old release may retain its docs without being allowed to overwrite the current Pages destination. Run DocC generation on the local self-hosted Mac by default; keep only unavoidable GitHub Pages service operations hosted, with a documented exception for any required hosted compute.
+
+### G. One bounded observer and pure recovery planner
+
+Represent observations as typed states: absent, valid, incomplete, conflicting, unknown, unavailable, running, failed, and stale. Include evidence source, identity, verification depth, and observation time.
+
+Read local manifests once per snapshot. Ordinary status may use previous integrity observations but must label their age/depth; `--verify` performs bounded deep checks. Never present cached integrity as fresh cryptographic verification.
+
+Use bounded API calls and pagination; catch malformed top-level/member shapes. Permission/transport errors are not absence. Query candidate-bound remote asset inventory/digests, exact workflow runs, formula pair, and Pages deployment ownership where the requested plan requires them.
+
+The pure planner takes observations and produces action records with prerequisites, reason, side effects, required authority, and invalidated descendants. The executor consumes this plan only under the normal execute boundary and revalidates before mutations. Inspection itself performs no build, dispatch, upload, cleanup, or large archive download.
+
+## Implementation sequence
+
+Keep one active vertical contract at a time. Each implementation commit should include its affected regression tests and concise operator documentation. Do not dispatch releases as an incidental validation step.
+
+| Slice | End-to-end contract | Primary changes | Findings |
+| --- | --- | --- | --- |
+| 1 | Storage safety and exact object repair | Shared storage/lease utilities; promoter/importer; cleaner; Make entry points | R01, R02, R08 |
+| 2 | Checkout-independent usable product recovery | Receipt schema/index; full product manifests; materialization; package consumers | R03, R04, R11 |
+| 3 | Correct minimal stage reuse | Stage declarations; output-aware wrapper/sibling validator; scoped fingerprints | R05, R10 |
+| 4 | Interruption-safe release transaction | Operation journal/reconciler; gate retention; package durability barrier; draft handling; observer/planner | R06, R07, R12 |
+| 5 | Independent documentation recovery | Context manifest; per-site retention; local generation; assembly/deploy plan | R09 |
+| 6 | Integrated migration and fault rehearsal | Import/report tooling; recovery fixture; coherent checkpoint validation | All |
+
+Do not begin cross-stage performance tuning before storage and identity correctness are established. In Slice 2, preserve standalone developer targets while making their consumers use explicit retained products; avoid a flag day across all sibling repositories.
+
+## Acceptance and fault-injection matrix
+
+Tests must assert work counts and terminal state, not merely exit success or the presence of an error string.
+
+| Scenario | Required outcome |
+| --- | --- |
+| SSD absent at command start | Build/cleanup fails before scratch creation; internal retained verification still works |
+| Wrong-device or nested/ancestor-symlink root | No marker claiming, promotion, or deletion outside approved roots |
+| Directory replaced during cleanup | Outside sentinel survives; operation stops or safely cleans only the opened target |
+| Two workspaces share a retained store | No manifest lost update, pin overwrite race, or duplicate build for the same locked input |
+| Source checkouts moved or removed | Retained dependency closure verifies; exact product materializes without historical paths |
+| Compose source removed | Retained layout supports version/config smoke test without Go source fallback or Docker |
+| Retained object missing/corrupt; exact copy available | Repair succeeds without build/sign/test; different bytes remain a conflict |
+| Candidate changes during import | No success manifest contains a digest different from installed bytes |
+| Kill/disk-full at each promotion/manifest boundary | Old valid state or explicit recoverable pending state; never false success |
+| Producer scratch removed after checkpoint | Restore from retained product or rerun only missing producer; consumer sees valid output |
+| Run A, B, then A again | Find A's valid indexed product; no unnecessary A rebuild |
+| Response lost after accepted dispatch | Reconcile same operation/run; zero blind second POSTs |
+| Controller dies after gate, signing, or upload | Resume from authenticated retained closure; zero repeated valid builds/tests/signing |
+| Matching partial draft | Upload only missing exact members; published stable bytes never replaced |
+| Hosted gate or site artifact expires | Use valid retained authority/site; otherwise explicit missing-node plan or authority blocker |
+| One of four DocC sites fails | Retain three successes; retry only the failed site; deploy without regenerating valid sites |
+| Self-consistent site from wrong source/base path | Reject despite valid file hashes |
+| Remote unavailable/malformed/incomplete | Bounded typed observation and correct action/blocker, not false absence/completion |
+| Unrelated tool/formatting change | Only stages whose declared inputs changed invalidate |
+| Oracle disabled | Zero Docker application invocations, including version probes |
+
+Use subprocess counters, deterministic filesystem hooks, and a stateful fake GitHub service for ordinary development. Add a non-production platform rehearsal only with authorization; local fakes do not prove GitHub queue timing, permissions, draft/immutability configuration, attestation availability, or Pages deployment behavior.
+
+Aim for at least 90% focused line coverage of materially changed Python/controller boundaries, with meaningful branch/fault assertions and explicit exceptions. Do not manufacture coverage by testing only serialization or implementation strings.
+
+## Performance design and quiet-machine protocol
+
+No speedup or benchmark timing is claimed by this review. First enforce deterministic budgets:
+
+- Warm unchanged resume: zero native builds, tests, signing operations, and new dispatches for already verified operations.
+- Deleted materialization with retained closure: zero compilation; copy/verify only.
+- Formula-only recovery: zero build/test/sign; at most one effective conflict-checked formula commit.
+- One invalid site: one site generation, zero sibling generation.
+- A single producer change: rebuild/retest only its justified transitive closure.
+- Repeated status: one local manifest parse per snapshot; no implicit payload downloads.
+- One run observation: avoid repeated full tool-catalog hashing for independent stages with the same immutable observation.
+
+Then coordinate a quiet-machine window with the other task. Record exact source/toolchain/product identities, active runners/builds/VMs, host load/thermal context, cache state, and the agreed noise threshold. Acquire an exclusive performance lease; do not stop another task or user process without authorization. Recheck noise during samples and reject contaminated comparisons.
+
+Compare cold, warm, one-component-change, failed-stage resume, source-relocation recovery, and docs-only retry using matched inputs. Report medians/spread and separate queue time, compilation, hashing, copying, signing, testing, and publication latency. Set numerical speedup targets only after a credible baseline; do not use the durations of these review probes as performance evidence.
+
+## Migration, rollout, and rollback
+
+1. Inventory current retained objects, old pin slots, release/source bundles, and SSD attempts without deletion. Record owner, identity, recovery role, and terminal condition.
+2. Preserve old receipts read-only. Import verified objects into new manifests/indexes; do not infer missing output closure or authenticity from legacy success stamps.
+3. Mark incomplete legacy products as diagnostic/partial, not runnable or publication-ready. Locate exact missing members from authenticated existing sources before considering a rebuild.
+4. Run the new planner in read-only shadow mode, compare decisions against fixture expectations, and enable storage safety before enabling broader reuse.
+5. Perform a relocation/disposal drill on dedicated fixtures. Any real cleanup requires verified internal retained closure and the normal explicit scope.
+6. At the integrated immutable checkpoint, run affected focused suites, shell/YAML/Markdown/static checks, then one justified broad validation. Re-run broad gates only when evidence inputs change.
+7. Keep rollback able to disable new reuse while preserving retained objects and stable immutability. Never roll back by deleting retained state or reinstating unsafe cleanup.
+8. Correct the prior implementation-status claims and build/operator help when fixes actually meet the matrix.
+
+The internal drive is the requested authoritative retained location, not a complete disaster-recovery strategy for internal-disk loss. A second authenticated replica is an optional operational decision; do not silently create new remote storage, upload artifacts, or delete the only internal copy.
+
+## Coordination and integration inputs
+
+The other task reported the following pending product work. These are coordination inputs, not claims that the PRs are merged or independently verified here:
+
+- Compose PR 632, `fcccb9fd`: stock profile/lock, Engine Unix client, and CI lane.
+- Engine API PR 41, `276a7cfd`.
+- Container PR 257, `ccf99d73`.
+- Devcontainer PR 75, `373f4ce`.
+
+No product files or branches from that work were changed during this review. Before implementing product closure or stage identities, obtain the agreed immutable integration heads and include the selected stock/enhanced profile in the relevant contract. Do not reuse runtime evidence across different profiles merely because the Compose source version is 0.14.3.
+
+## Evidence and review limitations
+
+Retained local probe harness: `/Users/sclarke/Documents/ContainerFamily/designs/review-evidence/resilience-followup-probes-2026-09-10.py`.
+
+Retained raw observations: `/Users/sclarke/Documents/ContainerFamily/designs/review-evidence/resilience-followup-probes-2026-09-10.json`.
+
+The harness exercises real Python helpers and the real dispatch shell function, using temporary Git repositories and files under `/Volumes/SSD/cf/build/tmp`. Remote calls are replaced with a narrow fake. It records eight scenario groups covering recursive relocation, promotion escape, exact-object repair, changing-candidate import, cleanup replacement, missing-output checkpoint reuse, ambiguous dispatch retry, and incomplete/malformed release status. Fixture trees were removed by the harness; retained evidence remains internal.
+
+During initial harness setup, the shell library's configured-root variable overrode the test's first environment choice, creating two fake dispatch journal records in the default retained store. No network call occurred. Those exact records were identified by UUID and moved, recoverably, to the review-evidence directory. The harness was corrected to use `CONTAINER_FAMILY_RETAINED_ROOT` and assert the resolved root before dispatching; subsequent probes were isolated.
+
+These results are new fault evidence, not a rerun of the prior full test suite. No full Swift/Go product or API-compatibility audit was attempted; the scope is the build/release/recovery changes and their actual product consumers. Runtime correctness, benchmark speedups, cross-volume power-loss durability, live GitHub behavior, and pending product PR integration remain validation obligations for implementation, not verified outcomes of this design.

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -160,11 +160,41 @@ reused and the first missing or stale stage continues from its native build
 cache. The hosted release gate uses candidate-keyed stage checkpoints and
 durable logs under the same principle. Never repair a success receipt by hand.
 
-Each full stack invocation writes a unique JSONL file below
-`$(STACK_STATE_ROOT)/timings`. It records the end-to-end duration plus each
+Each full stack invocation writes a unique JSONL file below the internal
+`$(STACK_RETAINED_ROOT)/timings` directory. Mutable compiler scratch lives
+under `$(STACK_TRANSIENT_ROOT)` on `/Volumes/SSD`; completed products, pins and
+timings are promoted to the local retained root before success is published.
+Cleaning an external workspace or scratch tree therefore leaves verified
+artifacts reusable. The timing log records the end-to-end duration plus each
 native compiler and bin-path operation, including failures. Compare a clean
 run, the immediate no-op rerun, and a fail-once recovery using these durable
 records rather than terminal timestamps.
+
+Stable packages, their checksum sidecars, the signed release-authority bundle,
+and each verified DocC site archive are likewise promoted into
+`~/Library/Application Support/ContainerFamily/retained`. Release workspaces,
+downloads, native build attempts, and disposable recovery directories remain
+under `/Volumes/SSD`. Inspect an existing semantic release without changing it
+using `make release-status VERSION=X.Y.Z`, or print its read-only recovery
+decision using `make release-recovery-plan VERSION=X.Y.Z`. An unknown dispatch
+is reported by request ID and must be reconciled; it is never treated as an
+absent run or permission to dispatch again.
+
+The self-hosted release runner's `_work` link must also resolve to the external
+volume so Actions checkouts, action caches, tool downloads, and `RUNNER_TEMP`
+cannot silently consume internal retained storage. On the release Mac it points
+to `/Volumes/SSD/cf/github-actions/container-compose-release-runner-work`.
+Verify both the resolved path and filesystem device after runner maintenance;
+the workflows' retained roots must continue to resolve to the internal volume.
+
+Published and historical benchmark attempts follow the same lifetime split:
+downloads, reconstructed distributions, fixtures, worktrees and compiler
+scratch are transient on `/Volumes/SSD`, while evidence, provenance and the
+small distribution manifests remain on the internal retained root after
+cleanup. Historical fixture and `cctl` caches are digest/receipt verified before
+reuse. Docker applications are confined to the explicitly comparative
+benchmark oracle and are not dependencies of normal builds, releases or the
+shipped product. Run timing lanes only after their quiet-host preflight passes.
 
 Every stage has a wall-clock deadline and terminates its complete process
 session, including descendant process groups, when that deadline expires. A
@@ -456,6 +486,8 @@ From clean `~/github/container-compose`, `~/github/container-builder-shim`,
 make release-plan
 make release-version
 make release-plan VERSION_SELECTOR=--+ # reviewed maintenance plan
+make release-status VERSION=0.14.3
+make release-recovery-plan VERSION=0.14.3
 ```
 
 ### Promote The Current Build
@@ -464,9 +496,11 @@ Do not copy, rename, or edit the mutable GitHub **Current build** prerelease.
 It is an installable view of green `main`, not a stable release candidate asset.
 Promotion always rebuilds the exact tagged source into immutable stable assets,
 which is what keeps the semantic version, runtime pin, checksums, Homebrew
-formulae, and release notes deterministic. The current prerelease is recreated
-by its workflow after the matching Homebrew formulae update, so its GitHub
-published time always identifies the build users are viewing.
+formulae, and release notes deterministic. Current finalization preserves the
+existing GitHub release object, uploads the complete replacement closure, then
+edits its metadata after the matching Homebrew formulae update. A failed refresh
+therefore leaves the prior Current release available; freshness is carried by
+explicit build metadata rather than destructive recreation for `published_at`.
 
 `make release-version` reports the latest reachable semantic tag, selected
 bump, and next version. `make release-plan` includes that decision. After the
@@ -505,7 +539,7 @@ behind Apple upstream, requires `kern.hv_support=1`, bootstraps the matched
 stack tools, fetches the required `containerization` integration kernel when it
 is absent, and runs the full local `make release-gate` inside one fresh,
 marker-protected, uniquely namespaced runtime lifecycle. Nested runtime targets
-reuse that owner without stopping it. Local runtime and parity checkpoints under the release evidence directory may be reused after an interrupted retry, subject to the legacy checkpoint limitations described above. An unpublished
+reuse that owner without stopping it. Local runtime and parity checkpoints under the internal retained release-evidence directory may be reused after an interrupted retry only when their exact inputs, durable log, and every declared product digest still verify. An unpublished
 helper-generated candidate commit is likewise retained rather than recommitted with a new identity after its signature, exact subject, ancestry, and changed files pass the fail-closed recovery policy. The hosted gate then runs the checkpointed sibling proof from its immutable release-control checkout against the immutable source, runtime, and tap checkouts before package publication. The helper waits up to three hours for
 that hosted gate, which exceeds its 120-minute workflow timeout; set
 `CONTAINER_STACK_STABLE_GATE_WAIT_SECONDS` only when an operator needs a
@@ -619,7 +653,7 @@ listed warm-image lifecycle and logging fixtures; `develop.watch` sync,
 build-context transfer, and other missing lanes remain in the
 [performance backlog](../project/BACKLOG.md#comparable-or-better-performance).
 
-Released DocC sites are built independently with fail-fast disabled. Each job restores its source-specific SwiftPM cache and an exact site cache keyed by the release controls, semantic release, site, and immutable source ref. A successful site is therefore retained when a sibling site fails, and an exact retry archives the verified cached output instead of rebuilding it. Pages assembly and authority checks remain the final release operation.
+Released DocC sites are built independently with fail-fast disabled. Each job restores its source-specific SwiftPM cache and an exact site cache keyed by the toolchain contract, site, immutable source ref, lockfile, and relevant generation controls. A complete content manifest is verified before reuse; an invalid cache is discarded and only that site is rebuilt. The controller downloads and verifies all four successful site archives into the internal retained store before hosted artifacts can expire. Pages assembly remains separate, serialized for the single destination, and rechecks that the release is still latest after acquiring the deployment boundary so an older build cannot overwrite a newer portal.
 
 The standalone local comparator remains available for focused performance
 development:

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -397,7 +397,7 @@ their live engines. The release helper no longer accepts
 
 There are two package lanes, with no manual asset copying:
 
-- Every successful CI run that originates from a push to `main` refreshes the explicit `current` tag and a newly published mutable GitHub prerelease named **Current build**, plus the opt-in `container-current` / `container-compose-current` Homebrew pair. A commit superseded before promotion is skipped so the subsequent successful run publishes the newest `main` head.
+- Every successful runtime-affecting CI run that originates from a push to `main` refreshes the explicit `current` tag and a newly published mutable GitHub prerelease named **Current build**, plus the opt-in `container-current` / `container-compose-current` Homebrew pair. Documentation, workflow-control, and other changes classified outside runtime validation do not rebuild or republish the unchanged product. A commit superseded before promotion is skipped so the subsequent successful runtime run publishes the newest eligible `main` head.
 - A semantic release is an immutable `x.y.z` tag and becomes Homebrew's default `container` / `container-compose` pair.
 
 `current` is deliberately an unsigned, movable pointer; signing it would make
@@ -535,7 +535,9 @@ publishes the immutable stable assets and atomically updates both stable
 Homebrew formulae. Do not create a semantic tag, copy a prerelease asset, or
 edit either stable formula by hand.
 
-If a hosted gate fails before the semantic GitHub release is created, correct the release automation on `main` and rerun the same explicit version, for example `make release VERSION_SELECTOR=X.Y.Z`. The helper reuses only the latest existing GitHub-verified signed source tag, reruns the gates and package workflow, and refuses to change a tag or overwrite an existing semantic release. The package job checks out and verifies the workflow commit's immutable release-control tools before it stages notes or publishes assets, while compiling package content only from the signed source tag. A stable retry can therefore repair release automation on `main` without retagging or changing the release payload. If the semantic GitHub release is published but its stable Homebrew formula pair is absent or incomplete, the same command dispatches formula-only recovery. It validates the existing immutable Compose and runtime assets and updates only the paired stable formulae; it never rebuilds a package, changes a signed tag, or replaces release assets.
+If a hosted gate fails before the semantic GitHub release is created, correct the release automation on `main` and rerun the same explicit version, for example `make release VERSION_SELECTOR=X.Y.Z`. The helper reuses a successful gate or package run only when its semantic tag, operation mode, and immutable release-control SHA all match; an active matching run is joined instead of duplicated. Failed or superseded controls dispatch a new run without changing the signed source tag. The package job checks out and verifies the workflow commit's immutable release-control tools before it stages notes or publishes assets, while compiling package content only from the signed source tag. If the semantic GitHub release is already published, the helper first verifies its package, signed guest image, and Homebrew pair. A complete release skips packaging entirely; missing formulae dispatch formula-only recovery, while missing binary assets dispatch package recovery. Published guest-image recovery downloads and validates the immutable release asset when the original local archive is no longer present.
+
+Stable gate, package, and documentation concurrency groups retain a full pending queue rather than replacing an earlier pending release. Candidate-bound gate receipts verify the immutable Homebrew snapshot recorded by the gate; later tap movement is handled only by the serial, conflict-checked formula publication transaction and does not invalidate compiled release evidence.
 
 After the tag is published, the one mutable `current` prerelease continues to
 follow later green `main` commits. Homebrew users without `-current` always use
@@ -616,6 +618,8 @@ not compile a product or delay a release. The report is evidence only for its
 listed warm-image lifecycle and logging fixtures; `develop.watch` sync,
 build-context transfer, and other missing lanes remain in the
 [performance backlog](../project/BACKLOG.md#comparable-or-better-performance).
+
+Released DocC sites are built independently with fail-fast disabled. Each job restores its source-specific SwiftPM cache and an exact site cache keyed by the release controls, semantic release, site, and immutable source ref. A successful site is therefore retained when a sibling site fails, and an exact retry archives the verified cached output instead of rebuilding it. Pages assembly and authority checks remain the final release operation.
 
 The standalone local comparator remains available for focused performance
 development:

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -5740,38 +5740,45 @@ github_cli() {
 
 # Return the newest workflow-dispatch package run for one stable semantic tag.
 latest_compose_package_dispatch_run() {
-  local version="$1" title
-  title="Prebuilt Binaries · ${version}"
+  local version="$1" repair_tap="$2" control_sha="$3" title mode
+  if [[ "${repair_tap}" == "true" ]]; then
+    mode=tap-repair
+  else
+    mode=package
+  fi
+  title="Prebuilt Binaries · ${version} · ${mode}"
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow "Prebuilt Binaries" \
     --event workflow_dispatch \
     --limit 100 \
-    --json databaseId,displayTitle \
-    --jq "map(select(.displayTitle == \"${title}\")) | .[0].databaseId // \"\""
+    --json databaseId,displayTitle,headSha,status,conclusion \
+    --jq "map(select(.displayTitle == \"${title}\" and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
 latest_stable_release_gate_dispatch_run() {
+  local version="$1" control_sha="$2" title
+  title="Stable Release Gate · ${version}"
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow stable-release-gate.yml \
     --event workflow_dispatch \
-    --limit 1 \
-    --json databaseId \
-    --jq '.[0].databaseId // ""'
+    --limit 100 \
+    --json databaseId,displayTitle,headSha,status,conclusion \
+    --jq "map(select(.displayTitle == \"${title}\" and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
 # Return the newest run for one immutable stable documentation manifest.
 latest_stable_documentation_dispatch() {
-  local version="$1" title
+  local version="$1" control_sha="$2" title
   title="Documentation · ${version}"
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow Documentation \
     --event workflow_dispatch \
     --limit 100 \
-    --json databaseId,displayTitle,status,conclusion \
-    --jq "map(select(.displayTitle == \"${title}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
+    --json databaseId,displayTitle,headSha,status,conclusion \
+    --jq "map(select(.displayTitle == \"${title}\" and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
 # Resolve the newest published (draft-free) container-k8s release tag and its
@@ -5960,9 +5967,9 @@ publish_stable_init_image_asset() {
   repo="$(github_repo "${COMPOSE_REPO}")"
   archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
   asset="container-vminit-arm64.oci.tar"
-  if [[ "${archive}" != /* || ! -f "${archive}" ]]; then
-    printf 'stable guest publication requires the absolute retained release-gate archive via CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE: %s\n' \
-      "${archive:-unset}" >&2
+  if [[ -n "${archive}" && ( "${archive}" != /* || ! -f "${archive}" ) ]]; then
+    printf 'stable guest publication received an invalid retained release-gate archive: %s\n' \
+      "${archive}" >&2
     return 2
   fi
   if [[ ! "${expected_digest}" =~ ^[0-9a-f]{64}$ ]]; then
@@ -5979,10 +5986,19 @@ publish_stable_init_image_asset() {
   containerization_repository="${authority[0]}"
   containerization_reference="${authority[1]}"
   tmp="$(mktemp -d)"
-  if cp "${archive}" "${tmp}/${asset}"; then
+  if [[ -n "${archive}" ]]; then
+    if cp "${archive}" "${tmp}/${asset}"; then
+      status=0
+    else
+      status=$?
+    fi
+  elif github_cli release download "${version}" \
+    --repo "${repo}" --pattern "${asset}" --dir "${tmp}" --clobber; then
     status=0
   else
     status=$?
+    printf 'stable guest publication could not recover %s from the published release; provide the absolute gate archive via CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE\n' \
+      "${asset}" >&2
   fi
   if (( status == 0 )); then
     if "${OCI_IMAGE_LAYOUT_VALIDATOR}" "${tmp}/${asset}" \
@@ -6207,9 +6223,84 @@ verify_compose_stable_package() {
     "${version}" "${asset_sha}" "${runtime_asset_sha}" "${init_asset_sha}"
 }
 
+# Complete local publication work after an exact stable package workflow passes.
+complete_compose_stable_workflow() {
+  local version="$1" promote_default_lane="$2" stable_formula_identities_before="$3"
+  local authority_record authority_object authority_init_digest
+  authority_record="$(ensure_published_stable_recovery_authority "${version}")"
+  IFS=$'\t' read -r authority_object authority_init_digest <<<"${authority_record}"
+  publish_stable_init_image_asset "${version}" "${authority_init_digest}"
+  verify_compose_stable_package \
+    "${version}" "${promote_default_lane}" \
+    "${stable_formula_identities_before}" "${authority_init_digest}"
+  require_stable_init_image_authority_unchanged \
+    "${version}" "${authority_object}" "${authority_init_digest}"
+}
+
+# Return success when stable binary assets exist and only tap repair can remain.
+stable_binary_assets_are_published() {
+  local version="$1" repo asset_names required_asset
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  asset_names="$(
+    github_cli release view "${version}" --repo "${repo}" --json assets \
+      --jq '.assets[].name'
+  )" || return 2
+  for required_asset in \
+    container-compose-plugin-release-arm64.tar.gz \
+    container-compose-plugin-release-arm64.tar.gz.sha256 \
+    container-release-arm64.tar.gz \
+    container-release-arm64.tar.gz.sha256; do
+    grep -Fxq "${required_asset}" <<<"${asset_names}" || return 1
+  done
+}
+
+# Distinguish formula-only recovery from asset or authority failures cheaply.
+stable_formula_pair_matches_release() {
+  local version="$1" repo tmp compose_asset runtime_asset compose_sha runtime_sha
+  local compose_formula runtime_formula compose_url runtime_url compose_formula_sha runtime_formula_sha
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  compose_asset=container-compose-plugin-release-arm64.tar.gz
+  runtime_asset=container-release-arm64.tar.gz
+  tmp="$(mktemp -d)"
+  if ! github_cli release download "${version}" --repo "${repo}" \
+    --pattern "${compose_asset}.sha256" \
+    --pattern "${runtime_asset}.sha256" --dir "${tmp}"; then
+    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+    return 2
+  fi
+  compose_sha="$(awk '{print $1}' "${tmp}/${compose_asset}.sha256")"
+  runtime_sha="$(awk '{print $1}' "${tmp}/${runtime_asset}.sha256")"
+  if [[ ! "${compose_sha}" =~ ^[0-9a-f]{64}$ || \
+    ! "${runtime_sha}" =~ ^[0-9a-f]{64}$ ]]; then
+    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+    return 2
+  fi
+  if ! compose_formula="$(
+    github_cli api repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose.rb \
+      --jq '.content' | base64 --decode
+  )" || ! runtime_formula="$(
+    github_cli api repos/stephenlclarke/homebrew-tap/contents/Formula/container.rb \
+      --jq '.content' | base64 --decode
+  )"; then
+    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+    return 2
+  fi
+  find "${tmp}" -depth -delete >/dev/null 2>&1 || return 2
+  compose_url="$(sed -n 's/^  url "\(.*\)"/\1/p' <<<"${compose_formula}" | head -n 1)"
+  runtime_url="$(sed -n 's/^  url "\(.*\)"/\1/p' <<<"${runtime_formula}" | head -n 1)"
+  compose_formula_sha="$(sed -n 's/^  sha256 "\(.*\)"/\1/p' <<<"${compose_formula}" | head -n 1)"
+  runtime_formula_sha="$(sed -n 's/^  sha256 "\(.*\)"/\1/p' <<<"${runtime_formula}" | head -n 1)"
+  [[ "${compose_url}" == \
+    "https://github.com/${repo}/releases/download/${version}/${compose_asset}" && \
+    "${runtime_url}" == \
+    "https://github.com/${repo}/releases/download/${version}/${runtime_asset}" && \
+    "${compose_formula_sha}" == "${compose_sha}" && \
+    "${runtime_formula_sha}" == "${runtime_sha}" ]]
+}
+
 # Dispatch and verify one stable package workflow mode for a semantic tag.
 dispatch_compose_stable_workflow() {
-  local version="$1" mode="$2" repair_tap="$3" previous_run run_id deadline now label promote_default_lane authority_record authority_object authority_init_digest stable_formula_identities_before=""
+  local version="$1" mode="$2" repair_tap="$3" details previous_run run_id status conclusion deadline now label promote_default_lane stable_formula_identities_before="" control_sha
   print_header "dispatch container-compose ${version} ${mode}"
 
   if [[ "${repair_tap}" == "true" ]]; then
@@ -6240,7 +6331,28 @@ dispatch_compose_stable_workflow() {
       "${version}" >&2
     exit 1
   fi
-  previous_run="$(latest_compose_package_dispatch_run "${version}" || true)"
+  control_sha="$(remote_main_commit "${COMPOSE_REPO}")"
+  details="$(latest_compose_package_dispatch_run \
+    "${version}" "${repair_tap}" "${control_sha}" || true)"
+  IFS=$'\t' read -r previous_run status conclusion <<<"${details}"
+  if [[ -n "${previous_run}" && "${status}" == "completed" && \
+    "${conclusion}" == "success" ]]; then
+    printf '%s already passed for the exact release controls: %s\n' \
+      "${label}" "${previous_run}"
+    complete_compose_stable_workflow \
+      "${version}" "${promote_default_lane}" \
+      "${stable_formula_identities_before}"
+    return 0
+  fi
+  if [[ -n "${previous_run}" && "${status}" != "completed" ]]; then
+    printf '%s is already running for the exact release controls: %s\n' \
+      "${label}" "${previous_run}"
+    wait_for_github_run_success "${previous_run}" "${label}"
+    complete_compose_stable_workflow \
+      "${version}" "${promote_default_lane}" \
+      "${stable_formula_identities_before}"
+    return 0
+  fi
   if [[ "${repair_tap}" == "true" ]]; then
     run github_cli workflow run prebuilt-binaries.yml \
       --repo "$(github_repo "${COMPOSE_REPO}")" \
@@ -6256,18 +6368,15 @@ dispatch_compose_stable_workflow() {
 
   deadline=$((SECONDS + COMPOSE_PACKAGE_WAIT_SECONDS))
   while true; do
-    run_id="$(latest_compose_package_dispatch_run "${version}" || true)"
+    details="$(latest_compose_package_dispatch_run \
+      "${version}" "${repair_tap}" "${control_sha}" || true)"
+    IFS=$'\t' read -r run_id status conclusion <<<"${details}"
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
       printf '%s started: %s\n' "${label}" "${run_id}"
       wait_for_github_run_success "${run_id}" "${label}"
-      authority_record="$(ensure_published_stable_recovery_authority "${version}")"
-      IFS=$'\t' read -r authority_object authority_init_digest <<<"${authority_record}"
-      publish_stable_init_image_asset "${version}" "${authority_init_digest}"
-      verify_compose_stable_package \
+      complete_compose_stable_workflow \
         "${version}" "${promote_default_lane}" \
-        "${stable_formula_identities_before}" "${authority_init_digest}"
-      require_stable_init_image_authority_unchanged \
-        "${version}" "${authority_object}" "${authority_init_digest}"
+        "${stable_formula_identities_before}"
       return 0
     fi
 
@@ -6296,7 +6405,7 @@ dispatch_compose_stable_tap_repair() {
 }
 
 dispatch_stable_release_gate() {
-  local version="$1" previous_run run_id deadline now init_image_digest
+  local version="$1" details previous_run run_id status conclusion deadline now init_image_digest control_sha
   print_header "dispatch hosted stable release gate for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -6311,7 +6420,24 @@ dispatch_stable_release_gate() {
   need_command gh
   init_image_digest="$(retained_stable_init_image_gate_digest "${version}")"
   ensure_stable_init_image_authority_tag "${version}" "${init_image_digest}"
-  previous_run="$(latest_stable_release_gate_dispatch_run || true)"
+  control_sha="$(remote_main_commit "${COMPOSE_REPO}")"
+  details="$(latest_stable_release_gate_dispatch_run \
+    "${version}" "${control_sha}" || true)"
+  IFS=$'\t' read -r previous_run status conclusion <<<"${details}"
+  if [[ -n "${previous_run}" && "${status}" == "completed" && \
+    "${conclusion}" == "success" ]]; then
+    printf 'hosted stable release gate already passed for the exact release controls: %s\n' \
+      "${previous_run}"
+    return 0
+  fi
+  if [[ -n "${previous_run}" && "${status}" != "completed" ]]; then
+    printf 'hosted stable release gate is already running for the exact release controls: %s\n' \
+      "${previous_run}"
+    wait_for_github_run_success \
+      "${previous_run}" "hosted stable release gate" \
+      "${STABLE_RELEASE_GATE_WAIT_SECONDS}"
+    return 0
+  fi
   run github_cli workflow run stable-release-gate.yml \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --ref main \
@@ -6319,7 +6445,9 @@ dispatch_stable_release_gate() {
 
   deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))
   while true; do
-    run_id="$(latest_stable_release_gate_dispatch_run || true)"
+    details="$(latest_stable_release_gate_dispatch_run \
+      "${version}" "${control_sha}" || true)"
+    IFS=$'\t' read -r run_id status conclusion <<<"${details}"
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
       printf 'stable release gate started: %s\n' "${run_id}"
       wait_for_github_run_success \
@@ -6344,7 +6472,7 @@ dispatch_stable_release_gate() {
 # recovery checkpoint; every retry reads the same refs from the immutable
 # stable source tag.
 dispatch_stable_documentation() {
-  local version="$1" details previous_run run_id status conclusion deadline now
+  local version="$1" details previous_run run_id status conclusion deadline now control_sha
   print_header "publish released documentation for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -6356,7 +6484,8 @@ dispatch_stable_documentation() {
   fi
 
   need_command gh
-  details="$(latest_stable_documentation_dispatch "${version}")"
+  control_sha="$(remote_main_commit "${COMPOSE_REPO}")"
+  details="$(latest_stable_documentation_dispatch "${version}" "${control_sha}")"
   IFS=$'\t' read -r previous_run status conclusion <<<"${details}"
   if [[ -n "${previous_run}" && "${status}" == "completed" && \
     "${conclusion}" == "success" ]]; then
@@ -6380,7 +6509,8 @@ dispatch_stable_documentation() {
 
   deadline=$((SECONDS + DOCUMENTATION_WAIT_SECONDS))
   while true; do
-    details="$(latest_stable_documentation_dispatch "${version}")"
+    details="$(latest_stable_documentation_dispatch \
+      "${version}" "${control_sha}")"
     IFS=$'\t' read -r run_id status conclusion <<<"${details}"
     if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
       printf 'stable documentation started: %s\n' "${run_id}"
@@ -6449,7 +6579,7 @@ tag_stable_version() {
 
 # Resume the latest signed tag without mutating its stable source identity.
 resume_stable_release() {
-  local version="$1" promote_default_lane stable_formula_identities_before
+  local version="$1" promote_default_lane stable_formula_identities_before recovery_status
   local authority_record authority_object authority_init_digest
   print_header "resume stable release ${version}"
   verify_github_stable_tag_signature "${version}"
@@ -6457,9 +6587,26 @@ resume_stable_release() {
     promote_default_lane="$(stable_version_promotes_default_lane "${version}")"
     if [[ "${promote_default_lane}" == "true" ]]; then
       ensure_latest_stable_retry "${version}"
-      dispatch_compose_stable_tap_repair "${version}"
+      if stable_binary_assets_are_published "${version}"; then
+        if stable_formula_pair_matches_release "${version}"; then
+          complete_compose_stable_workflow "${version}" "true" ""
+          printf 'stable package, guest image, and formula pair already verify; no package workflow required\n'
+        else
+          recovery_status=$?
+          if (( recovery_status != 1 )); then
+            return "${recovery_status}"
+          fi
+          dispatch_compose_stable_tap_repair "${version}"
+        fi
+      else
+        recovery_status=$?
+        if (( recovery_status != 1 )); then
+          return "${recovery_status}"
+        fi
+        dispatch_compose_stable_package "${version}"
+      fi
       dispatch_stable_documentation "${version}"
-      print_stable_release_point "${version}" "formula-only recovery from immutable release assets"
+      print_stable_release_point "${version}" "verified recovery from immutable release assets"
     else
       authority_record="$(ensure_published_stable_recovery_authority "${version}")"
       IFS=$'\t' read -r authority_object authority_init_digest <<<"${authority_record}"

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -25,6 +25,11 @@ readonly HOMEBREW_PREFLIGHT_TOOL="${SELF_DIRECTORY}/../Tools/release/homebrew-pr
 readonly OCI_IMAGE_LAYOUT_VALIDATOR="${SELF_DIRECTORY}/../Tools/release/validate-oci-image-layout.py"
 readonly RELEASE_COMMAND_DEADLINE_RUNNER="${SELF_DIRECTORY}/../Tools/ci/run-command-with-deadline.py"
 readonly RELEASE_HOST_STATE_TOOL="${SELF_DIRECTORY}/../Tools/release/release-host-state.py"
+readonly RELEASE_DISPATCH_JOURNAL_TOOL="${SELF_DIRECTORY}/../Tools/release/release-dispatch-journal.py"
+readonly RELEASE_ASSET_RETENTION_TOOL="${SELF_DIRECTORY}/../Tools/release/retain-local-release-assets.py"
+readonly FORMULA_PAIR_VALIDATOR="${CONTAINER_STACK_FORMULA_PAIR_VALIDATOR:-${SELF_DIRECTORY}/../Tools/release/verify-homebrew-formula-pair.py}"
+readonly STABLE_AUTHORITY_BUNDLE_VERIFIER="${SELF_DIRECTORY}/../Tools/release/verify-stable-authority-bundle.py"
+readonly DOC_SITE_MANIFEST_TOOL="${SELF_DIRECTORY}/../Tools/ci/doc-site-manifest.py"
 readonly RELEASE_WORKSPACE_TOOL="${SELF_DIRECTORY}/../Tools/release/release-workspace.py"
 readonly STABLE_RELEASE_LANE_CLASSIFIER="${SELF_DIRECTORY}/../Tools/release/stable-release-default-lane.py"
 # shellcheck disable=SC1091
@@ -180,9 +185,14 @@ Environment:
       live but definitively unready service.
 
   CONTAINER_STACK_RELEASE_HOST_STATE_ROOT
-      Override the private, marker-protected local restoration journal used by
-      focused tests. Production defaults to /private/tmp and records every
-      launch agent before the release controller can suspend or stop it.
+      Override the marker-protected durable restoration journal. Production
+      stores it below the internal retained root so external cleanup cannot
+      erase interrupted host-restoration state.
+
+  CONTAINER_FAMILY_RETAINED_ROOT
+      Override the internal root for retained artifacts, evidence, caches, and
+      recovery journals. Production defaults below ~/Library/Application
+      Support/ContainerFamily/retained. It must not be on /Volumes/SSD.
 
   CONTAINER_STACK_RELEASE_DEVCONTAINER_CLI
   CONTAINER_STACK_RELEASE_CURL
@@ -257,6 +267,7 @@ parse_arguments() {
 
 ROOT="${CONTAINER_STACK_RELEASE_ROOT:-${HOME}/github}"
 RELEASE_BUILD_ROOT="${CONTAINER_STACK_RELEASE_BUILD_ROOT:-/Volumes/SSD/github/container-compose-release-transactions}"
+RELEASE_RETAINED_ROOT="${CONTAINER_FAMILY_RETAINED_ROOT:-${HOME}/Library/Application Support/ContainerFamily/retained}"
 COMPOSE_REPO="container-compose"
 CONTAINER_REPO="container"
 COMPOSE_PACKAGE_WAIT_SECONDS="${CONTAINER_STACK_COMPOSE_PACKAGE_WAIT_SECONDS:-3600}"
@@ -280,7 +291,7 @@ RELEASE_RESTORE_WAIT_ATTEMPTS="${CONTAINER_STACK_RELEASE_RESTORE_WAIT_ATTEMPTS:-
 RELEASE_RESTORE_TIMEOUT_SECONDS="${CONTAINER_STACK_RELEASE_RESTORE_TIMEOUT_SECONDS:-60}"
 RELEASE_RESTORE_POLL_SECONDS="${CONTAINER_STACK_RELEASE_RESTORE_POLL_SECONDS:-1}"
 RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS="${CONTAINER_STACK_RELEASE_RESTORE_RESTART_GRACE_ATTEMPTS:-10}"
-RELEASE_HOST_STATE_ROOT="${CONTAINER_STACK_RELEASE_HOST_STATE_ROOT:-/private/tmp/container-compose-release-host-state-$(id -u)}"
+RELEASE_HOST_STATE_ROOT="${CONTAINER_STACK_RELEASE_HOST_STATE_ROOT:-${RELEASE_RETAINED_ROOT}/release/host-state}"
 RELEASE_DEVCONTAINER_CLI="${CONTAINER_STACK_RELEASE_DEVCONTAINER_CLI:-$(command -v devcontainer || true)}"
 RELEASE_CURL="${CONTAINER_STACK_RELEASE_CURL:-/usr/bin/curl}"
 RELEASE_GITHUB_CLI="${CONTAINER_STACK_RELEASE_GITHUB_CLI:-$(command -v gh || true)}"
@@ -295,7 +306,7 @@ RELEASE_CONTROLLER_RESTART_REQUIRED=0
 RELEASE_BOOTSTRAP_HEAD=""
 CURRENT_INIT_IMAGE_AUTHORITY_ROOT=""
 CURRENT_INIT_IMAGE_AUTHORITY_RELEASED=0
-RELEASE_INIT_AUTHORITY_CACHE_ROOT="${CONTAINER_STACK_RELEASE_INIT_AUTHORITY_CACHE_ROOT:-$({ getconf DARWIN_USER_CACHE_DIR 2>/dev/null || printf '/private/tmp/'; })container-compose-release-authorities}"
+RELEASE_INIT_AUTHORITY_CACHE_ROOT="${CONTAINER_STACK_RELEASE_INIT_AUTHORITY_CACHE_ROOT:-${RELEASE_RETAINED_ROOT}/release/authorities}"
 readonly STABLE_CURRENT_SOAK_SECONDS=604800
 HOMEBREW_TAP_REPO="${ROOT}/homebrew-tap"
 REPOS=(
@@ -304,6 +315,180 @@ REPOS=(
   "container"
   "container-compose"
 )
+
+# Return whether an unmarked retained release root is empty or contains only
+# the independently marked build store created by `make stack-state-init`.
+retained_release_root_is_claimable() {
+  local retained_root="$1" child_marker
+  if [[ ! -d "${retained_root}" ]] || \
+    [[ -z "$(find "${retained_root}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    return 0
+  fi
+  if [[ -f "${retained_root}/.container-family-retained-root" ]] && \
+    [[ ! -L "${retained_root}/.container-family-retained-root" ]]; then
+    return 0
+  fi
+  child_marker="${retained_root}/build/.container-family-retained-root"
+  [[ -d "${retained_root}/build" && ! -L "${retained_root}/build" ]] && \
+    [[ -f "${child_marker}" && ! -L "${child_marker}" ]] && \
+    [[ "$(<"${child_marker}")" == "container-compose retained build v2" ]] && \
+    [[ -z "$(find "${retained_root}" -mindepth 1 -maxdepth 1 ! -name build -print -quit)" ]]
+}
+
+# Return whether a release transaction root is empty, currently marked, or
+# carries the exact legacy ownership marker used by the same controller.
+transient_release_root_is_claimable() {
+  local transient_root="$1" legacy_marker
+  if [[ ! -d "${transient_root}" ]] || \
+    [[ -z "$(find "${transient_root}" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+    return 0
+  fi
+  if [[ -f "${transient_root}/.container-family-transient-root" ]] && \
+    [[ ! -L "${transient_root}/.container-family-transient-root" ]]; then
+    return 0
+  fi
+  legacy_marker="${transient_root}/.container-compose-release-root.json"
+  [[ -f "${legacy_marker}" && ! -L "${legacy_marker}" ]] || return 1
+  python3 - "${legacy_marker}" <<'PY'
+import json
+import pathlib
+import sys
+
+try:
+    value = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+except (OSError, UnicodeError, json.JSONDecodeError):
+    raise SystemExit(1)
+raise SystemExit(0 if value == {"owner": "container-compose", "schemaVersion": 1} else 1)
+PY
+}
+
+# Initialize and verify the separate retained and transient release stores.
+initialize_release_storage() {
+  local retained_parent retained_root transient_root transient_parent retained_device transient_device
+  local marker_specification marker_path marker_value
+  retained_root="${RELEASE_RETAINED_ROOT}"
+  case "${retained_root}" in
+    /*) ;;
+    *) printf 'retained release root must be absolute: %s\n' "${retained_root}" >&2; return 2 ;;
+  esac
+  case "${retained_root}/" in
+    /Volumes/SSD/*)
+      printf 'retained release root must be on the internal drive, not /Volumes/SSD: %s\n' \
+        "${retained_root}" >&2
+      return 2
+      ;;
+  esac
+  case "${RELEASE_BUILD_ROOT}/" in
+    /Volumes/SSD/*) ;;
+    *)
+      printf 'release transaction root must be on /Volumes/SSD: %s\n' \
+        "${RELEASE_BUILD_ROOT}" >&2
+      return 2
+      ;;
+  esac
+  if [[ ! -d /Volumes/SSD ]] || \
+    [[ "$(/usr/bin/stat -f %d /Volumes/SSD)" == "$(/usr/bin/stat -f %d /)" ]]; then
+    printf 'external /Volumes/SSD filesystem is unavailable; refusing new release work\n' >&2
+    return 2
+  fi
+  retained_parent="$(dirname "${retained_root}")"
+  mkdir -p "${retained_parent}"
+  [[ ! -L "${retained_root}" ]] || {
+    printf 'retained release root must not be a symbolic link: %s\n' \
+      "${retained_root}" >&2
+    return 2
+  }
+  if ! retained_release_root_is_claimable "${retained_root}"; then
+    printf 'refusing to claim non-empty unmarked retained release root: %s\n' \
+      "${retained_root}" >&2
+    return 2
+  fi
+  mkdir -p "${retained_root}"
+  retained_root="$(cd "${retained_root}" && pwd -P)"
+  case "${retained_root}/" in
+    /Volumes/SSD/*)
+      printf 'retained release root resolves onto /Volumes/SSD: %s\n' \
+        "${retained_root}" >&2
+      return 2
+      ;;
+  esac
+  retained_device="$(/usr/bin/stat -f %d "${retained_root}")"
+  transient_parent="$(dirname "${RELEASE_BUILD_ROOT}")"
+  mkdir -p "${transient_parent}"
+  [[ ! -L "${RELEASE_BUILD_ROOT}" ]] || {
+    printf 'release transaction root must not be a symbolic link: %s\n' \
+      "${RELEASE_BUILD_ROOT}" >&2
+    return 2
+  }
+  if ! transient_release_root_is_claimable "${RELEASE_BUILD_ROOT}"; then
+    printf 'refusing to claim non-empty unmarked release transaction root: %s\n' \
+      "${RELEASE_BUILD_ROOT}" >&2
+    return 2
+  fi
+  mkdir -p "${RELEASE_BUILD_ROOT}"
+  transient_root="$(cd "${RELEASE_BUILD_ROOT}" && pwd -P)"
+  case "${transient_root}/" in
+    /Volumes/SSD/*) ;;
+    *)
+      printf 'release transaction root resolves outside /Volumes/SSD: %s\n' \
+        "${transient_root}" >&2
+      return 2
+      ;;
+  esac
+  transient_device="$(/usr/bin/stat -f %d "${transient_root}")"
+  if [[ "${retained_device}" == "${transient_device}" ]]; then
+    printf 'retained release data and transient transactions must use separate filesystems\n' >&2
+    return 2
+  fi
+  for marker_specification in \
+    "${retained_root}/.container-family-retained-root|container-compose retained build v2" \
+    "${transient_root}/.container-family-transient-root|container-compose transient build v2"; do
+    marker_path="${marker_specification%%|*}"
+    marker_value="${marker_specification#*|}"
+    if [[ -L "${marker_path}" ]]; then
+      printf 'release storage marker must not be a symbolic link: %s\n' \
+        "${marker_path}" >&2
+      return 2
+    fi
+    if [[ -e "${marker_path}" ]]; then
+      if [[ ! -f "${marker_path}" ]] || \
+        [[ "$(<"${marker_path}")" != "${marker_value}" ]]; then
+        printf 'release storage marker is invalid: %s\n' "${marker_path}" >&2
+        return 2
+      fi
+    else
+      printf '%s\n' "${marker_value}" >"${marker_path}"
+    fi
+  done
+  RELEASE_RETAINED_ROOT="${retained_root}"
+  RELEASE_BUILD_ROOT="${transient_root}"
+  RELEASE_HOST_STATE_ROOT="${CONTAINER_STACK_RELEASE_HOST_STATE_ROOT:-${RELEASE_RETAINED_ROOT}/release/host-state}"
+  RELEASE_INIT_AUTHORITY_CACHE_ROOT="${CONTAINER_STACK_RELEASE_INIT_AUTHORITY_CACHE_ROOT:-${RELEASE_RETAINED_ROOT}/release/authorities}"
+}
+
+# Create disposable release data only beneath the external transaction root.
+release_transient_directory() {
+  local label="$1" temporary_root
+  if [[ ! "${label}" =~ ^[a-z0-9-]+$ ]]; then
+    printf 'invalid release temporary-directory label: %s\n' "${label}" >&2
+    return 2
+  fi
+  temporary_root="${RELEASE_BUILD_ROOT}/tmp"
+  mkdir -p "${temporary_root}"
+  mktemp -d "${temporary_root}/${label}.XXXXXX"
+}
+
+# Create a disposable release file only beneath the external transaction root.
+release_transient_file() {
+  local label="$1" temporary_root
+  if [[ ! "${label}" =~ ^[a-z0-9-]+$ ]]; then
+    printf 'invalid release temporary-file label: %s\n' "${label}" >&2
+    return 2
+  fi
+  temporary_root="${RELEASE_BUILD_ROOT}/tmp"
+  mkdir -p "${temporary_root}"
+  mktemp "${temporary_root}/${label}.XXXXXX"
+}
 
 # Map local checkout names to their stephenlclarke-owned GitHub repositories.
 github_repo() {
@@ -780,9 +965,7 @@ compute_release_candidate_refresh_tree() {
 
   authority_paths=$'docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json\ndocs/upstream/FORK-COMMIT-CLASSIFICATIONS.md'
 
-  index_root="$(
-    mktemp -d "${TMPDIR:-/tmp}/container-compose-refresh-index.XXXXXX"
-  )" || {
+  index_root="$(release_transient_directory refresh-index)" || {
     RELEASE_CANDIDATE_REFRESH_ERROR="could not create an isolated refresh index"
     return 1
   }
@@ -1855,7 +2038,7 @@ require_release_hawkeye_cli() {
 stage_container_runtime_candidate() {
   local container_path="$1" evidence_root="$2"
   local container_head artifact_parent artifact_root build_root archive archive_digest
-  local marker marker_value candidate_parent signing_identity expected_marker
+  local marker marker_value candidate_parent signing_identity expected_marker promotion_root
 
   signing_identity="${CONTAINER_RUNTIME_CODESIGN_IDENTITY:-}"
   if [[ ! "${signing_identity}" =~ ^[0-9A-Fa-f]{40}$ ]]; then
@@ -1892,7 +2075,8 @@ stage_container_runtime_candidate() {
       return 1
     fi
   else
-    build_root="$(mktemp -d "${artifact_parent}/.build-${container_head}.XXXXXX")"
+    build_root="$(release_transient_directory runtime-candidate-build)"
+    promotion_root=""
     # shellcheck disable=SC2329
     cleanup_unpublished_runtime_candidate_build() {
       local trapped_status="${1:-$?}"
@@ -1900,12 +2084,24 @@ stage_container_runtime_candidate() {
       trap '' HUP INT QUIT TERM
       if [[ -n "${build_root:-}" && -d "${build_root}" ]]; then
         case "${build_root}" in
-          "${artifact_parent}/.build-${container_head}."*)
+          "${RELEASE_BUILD_ROOT}/tmp/runtime-candidate-build."*)
             find "${build_root}" -depth -delete
             ;;
           *)
-            printf 'refusing to remove a runtime candidate build outside its evidence root: %s\n' \
+            printf 'refusing to remove a runtime candidate build outside its transaction root: %s\n' \
               "${build_root}" >&2
+            return 1
+            ;;
+        esac
+      fi
+      if [[ -n "${promotion_root:-}" && -d "${promotion_root}" ]]; then
+        case "${promotion_root}" in
+          "${artifact_parent}/.promote-${container_head}."*)
+            find "${promotion_root}" -depth -delete
+            ;;
+          *)
+            printf 'refusing to remove runtime candidate promotion outside its retained root: %s\n' \
+              "${promotion_root}" >&2
             return 1
             ;;
         esac
@@ -1933,9 +2129,15 @@ stage_container_runtime_candidate() {
       cleanup_unpublished_runtime_candidate_build 1 || true
       return 1
     fi
+    promotion_root="$(mktemp -d \
+      "${artifact_parent}/.promote-${container_head}.XXXXXX")"
+    cp "${archive}" "${archive}.sha256" "${promotion_root}/"
     printf '%s\n' "${expected_marker}" \
-      >"${build_root}/.container-compose-runtime-candidate-artifact"
-    mv "${build_root}" "${artifact_root}"
+      >"${promotion_root}/.container-compose-runtime-candidate-artifact"
+    chmod -R a-w "${promotion_root}"
+    mv "${promotion_root}" "${artifact_root}"
+    promotion_root=""
+    find "${build_root}" -depth -delete
     build_root=""
     trap - EXIT HUP INT QUIT TERM
     archive="${artifact_root}/container-homebrew-release-arm64.tar.gz"
@@ -3570,7 +3772,7 @@ stable_init_image_gate_evidence_path() {
   fi
   path="$(repo_path "${COMPOSE_REPO}")"
   evidence_root="$(resolve_release_evidence_root "${path}" \
-    "${PARITY_EVIDENCE_DIR:-.build/release-evidence}")"
+    "${PARITY_EVIDENCE_DIR:-${RELEASE_RETAINED_ROOT}/release/evidence}")"
   authority_root="${evidence_root}/stable-init-image-authority"
   if [[ -L "${authority_root}" ]]; then
     printf 'stable init-image authority directory must not be a symlink: %s\n' \
@@ -3816,7 +4018,7 @@ PY
   fi
 
   evidence_root="$(resolve_release_evidence_root "${path}" \
-    "${PARITY_EVIDENCE_DIR:-.build/release-evidence}")"
+    "${PARITY_EVIDENCE_DIR:-${RELEASE_RETAINED_ROOT}/release/evidence}")"
   container_binary=""
   runtime_parent=""
   runtime_app_root=""
@@ -4289,10 +4491,46 @@ ensure_stable_retry_source_authority() {
 # immutable signed tag and its successful candidate-bound hosted gate. A
 # movable release branch must not make later recovery of immutable assets
 # time-dependent.
+stable_stack_component_refs() {
+  local version="$1" path
+  path="$(repo_path "${COMPOSE_REPO}")"
+  python3 - "${path}" "${version}" <<'PY'
+import json
+import re
+import subprocess
+import sys
+
+repository, version = sys.argv[1:]
+manifest = json.loads(
+    subprocess.run(
+        ["git", "-C", repository, "show", f"{version}:Tools/release/stack-refs.json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+)
+components = manifest["components"]
+for name in ("container-builder-shim", "containerization", "container"):
+    component = components[name]
+    reference = component["ref"]
+    if component["repository"] != f"stephenlclarke/{name}" or re.fullmatch(
+        r"[0-9a-f]{40}", reference
+    ) is None:
+        raise SystemExit(f"invalid stable {name} authority")
+    print(reference)
+PY
+}
+
+# Authenticate recovery of an already-published stable release against the
+# immutable signed tag, candidate-bound hosted gate, and its retained receipt.
 ensure_published_stable_recovery_authority() {
   local version="$1" path repo tag_sha authority_name authority_filter authority_record
   local authority_run_id authority_summary authority_conclusion authority_init_digest
   local signed_authority_record signed_authority_object signed_authority_init_digest
+  local authority_receipt_sha authority_asset authority_archive authority_sidecar
+  local authority_archive_sha authority_sidecar_sha tmp status cleanup_status
+  local component_ref component_refs=() builder_ref containerization_ref container_ref
+  local verifier_receipt_args=() hosted_check_available=0
   path="$(repo_path "${COMPOSE_REPO}")"
   repo="$(github_repo "${COMPOSE_REPO}")"
   tag_sha="$(git -C "${path}" rev-list -n 1 "refs/tags/${version}")"
@@ -4315,37 +4553,137 @@ ensure_published_stable_recovery_authority() {
   authority_filter+=' | select((.external_id // "") | test("^[0-9]+$"))'
   authority_filter+=' | select((.output.summary // "") | test("Guest init image SHA-256: [0-9a-f]{64}[.]"))'
   authority_filter+=' | [.external_id, .output.summary] | @tsv'
-  authority_record="$(
+  if authority_record="$(
     github_cli api --paginate \
       "repos/${repo}/commits/${tag_sha}/check-runs?per_page=100" \
       --jq "${authority_filter}" |
       tail -n 1
-  )"
-  IFS=$'\t' read -r authority_run_id authority_summary <<<"${authority_record}"
-  if [[ ! "${authority_run_id}" =~ ^[0-9]+$ ]]; then
-    printf 'refusing published recovery without candidate-bound Stable Release Authority %s\n' \
-      "${authority_name}" >&2
-    return 1
-  fi
-  if [[ "${authority_summary}" =~ Guest\ init\ image\ SHA-256:\ ([0-9a-f]{64})[.] ]]; then
-    authority_init_digest="${BASH_REMATCH[1]}"
+  )"; then
+    :
   else
-    printf 'refusing published recovery without a candidate-bound guest init-image digest\n' >&2
-    return 1
+    printf 'could not inspect candidate-bound Stable Release Authority checks for %s\n' \
+      "${version}" >&2
+    return 2
+  fi
+  IFS=$'\t' read -r authority_run_id authority_summary <<<"${authority_record}"
+  authority_init_digest="${signed_authority_init_digest}"
+  authority_receipt_sha=""
+  if [[ "${authority_run_id}" =~ ^[0-9]+$ ]]; then
+    hosted_check_available=1
+    if [[ "${authority_summary}" =~ Guest\ init\ image\ SHA-256:\ ([0-9a-f]{64})[.] ]]; then
+      authority_init_digest="${BASH_REMATCH[1]}"
+    else
+      printf 'refusing published recovery without a candidate-bound guest init-image digest\n' >&2
+      return 1
+    fi
+    if [[ "${authority_summary}" =~ Authority\ receipt\ SHA-256:\ ([0-9a-f]{64})[.] ]]; then
+      authority_receipt_sha="${BASH_REMATCH[1]}"
+      verifier_receipt_args=(--receipt-sha256 "${authority_receipt_sha}")
+    else
+      printf 'refusing published recovery without a candidate-bound authority receipt digest\n' >&2
+      return 1
+    fi
+    authority_conclusion="$(
+      github_cli run view "${authority_run_id}" --repo "${repo}" \
+        --json workflowName,event,status,conclusion \
+        --jq 'select(.workflowName == "Stable Release Gate" and .event == "workflow_dispatch" and .status == "completed" and .conclusion == "success") | .conclusion'
+    )"
+    if [[ "${authority_conclusion}" != "success" ]]; then
+      printf 'refusing published recovery without a successful Stable Release Gate authority\n' >&2
+      return 1
+    fi
+  else
+    printf 'candidate-bound check history is unavailable for %s; requiring durable artifact attestation\n' \
+      "${authority_name}"
   fi
   if [[ "${authority_init_digest}" != "${signed_authority_init_digest}" ]]; then
     printf 'refusing published recovery because hosted authority records %s instead of signed init-image digest %s\n' \
       "${authority_init_digest}" "${signed_authority_init_digest}" >&2
     return 1
   fi
-  authority_conclusion="$(
-    github_cli run view "${authority_run_id}" --repo "${repo}" \
-      --json workflowName,event,status,conclusion \
-      --jq 'select(.workflowName == "Stable Release Gate" and .event == "workflow_dispatch" and .status == "completed" and .conclusion == "success") | .conclusion'
-  )"
-  if [[ "${authority_conclusion}" != "success" ]]; then
-    printf 'refusing published recovery without a successful Stable Release Gate authority\n' >&2
+  while IFS= read -r component_ref; do
+    component_refs+=("${component_ref}")
+  done < <(stable_stack_component_refs "${version}")
+  if ((${#component_refs[@]} != 3)); then
+    printf 'stable tag %s has no complete component authority\n' "${version}" >&2
     return 1
+  fi
+  builder_ref="${component_refs[0]}"
+  containerization_ref="${component_refs[1]}"
+  container_ref="${component_refs[2]}"
+  authority_asset=stable-release-authority.tar.gz
+  authority_archive=""
+  if authority_archive="$(
+    python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
+      --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+      --name "${authority_asset}" 2>/dev/null
+  )"; then
+    :
+  else
+    authority_archive=""
+  fi
+  tmp="$(release_transient_directory stable-authority)"
+  status=0
+  if [[ -z "${authority_archive}" ]]; then
+    if github_cli release download "${version}" --repo "${repo}" \
+      --pattern "${authority_asset}" --pattern "${authority_asset}.sha256" \
+      --dir "${tmp}"; then
+      authority_archive="${tmp}/${authority_asset}"
+      authority_sidecar="${tmp}/${authority_asset}.sha256"
+      authority_archive_sha="$(shasum -a 256 "${authority_archive}" | awk '{print $1}')"
+      authority_sidecar_sha="$(awk '{print $1}' "${authority_sidecar}")"
+      if [[ ! "${authority_archive_sha}" =~ ^[0-9a-f]{64}$ || \
+        "${authority_archive_sha}" != "${authority_sidecar_sha}" ]]; then
+        printf 'published stable authority archive checksum is invalid for %s\n' \
+          "${version}" >&2
+        status=1
+      fi
+    else
+      status=$?
+    fi
+  fi
+  if (( status == 0 && hosted_check_available == 0 )); then
+    if github_cli attestation verify "${authority_archive}" --repo "${repo}"; then
+      status=0
+    else
+      status=$?
+      printf 'refusing published recovery without hosted check history or a valid durable authority attestation\n' >&2
+    fi
+  fi
+  if (( status == 0 )); then
+    if python3 "${STABLE_AUTHORITY_BUNDLE_VERIFIER}" \
+      --archive "${authority_archive}" \
+      --release-tag "${version}" \
+      --candidate-sha "${tag_sha}" \
+      --builder-ref "${builder_ref}" \
+      --containerization-ref "${containerization_ref}" \
+      --container-ref "${container_ref}" \
+      --init-image-sha256 "${authority_init_digest}" \
+      "${verifier_receipt_args[@]}" >/dev/null; then
+      status=0
+    else
+      status=$?
+    fi
+  fi
+  if (( status == 0 )) && [[ -n "${authority_sidecar:-}" ]]; then
+    if python3 "${RELEASE_ASSET_RETENTION_TOOL}" retain \
+      --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+      --asset "${authority_archive}" --asset "${authority_sidecar}"; then
+      status=0
+    else
+      status=$?
+    fi
+  fi
+  if find "${tmp}" -depth -delete; then
+    cleanup_status=0
+  else
+    cleanup_status=$?
+  fi
+  if (( status != 0 )); then
+    return "${status}"
+  fi
+  if (( cleanup_status != 0 )); then
+    return "${cleanup_status}"
   fi
   printf '%s\t%s\n' "${signed_authority_object}" "${authority_init_digest}"
 }
@@ -4613,7 +4951,7 @@ unedit_release_dependency() {
 
   if [[ -f "${path}/Package.resolved" ]]; then
     had_resolved=1
-    backup="$(mktemp "${TMPDIR:-/tmp}/container-compose-package-resolved.XXXXXX")"
+    backup="$(release_transient_file package-resolved)"
     cp "${path}/Package.resolved" "${backup}"
   fi
 
@@ -4721,7 +5059,7 @@ resolve_release_dependency_pins() {
     return 0
   fi
 
-  backup="$(mktemp "${TMPDIR:-/tmp}/container-compose-package-resolved.XXXXXX")"
+  backup="$(release_transient_file package-resolved)"
   cp "${path}/Package.resolved" "${backup}"
   if ! run swift package --package-path "${path}" resolve; then
     cp "${backup}" "${path}/Package.resolved"
@@ -5781,6 +6119,68 @@ latest_stable_documentation_dispatch() {
     --jq "map(select(.displayTitle == \"${title}\" and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
+# Dispatch a workflow through the API that returns its exact run ID. The
+# expected control SHA is also an input, so a moving main branch fails before
+# expensive or mutating work instead of leaving title-based polling ambiguous.
+dispatch_github_workflow_run() {
+  local workflow="$1" version="$2" control_sha="$3" repair_tap="${4:-}"
+  local repo request_id run_id dispatch_status
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  run_id=""
+  request_id="$(/usr/bin/uuidgen | tr '[:upper:]' '[:lower:]')"
+  python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" intent \
+    --root "${RELEASE_RETAINED_ROOT}" \
+    --request-id "${request_id}" \
+    --workflow "${workflow}" \
+    --version "${version}" \
+    --control-sha "${control_sha}" >/dev/null
+  if [[ -n "${repair_tap}" ]]; then
+    if run_id="$(
+      github_cli api --method POST \
+        -H 'X-GitHub-Api-Version: 2026-03-10' \
+        "repos/${repo}/actions/workflows/${workflow}/dispatches" \
+        -f ref=main \
+        -f "inputs[ref]=${version}" \
+        -f "inputs[expected_control_sha]=${control_sha}" \
+        -f "inputs[request_id]=${request_id}" \
+        -F "inputs[repair_tap]=${repair_tap}" \
+        --jq '.workflow_run_id'
+    )"; then
+      dispatch_status=0
+    else
+      dispatch_status=$?
+    fi
+  else
+    if run_id="$(
+      github_cli api --method POST \
+        -H 'X-GitHub-Api-Version: 2026-03-10' \
+        "repos/${repo}/actions/workflows/${workflow}/dispatches" \
+        -f ref=main \
+        -f "inputs[ref]=${version}" \
+        -f "inputs[expected_control_sha]=${control_sha}" \
+        -f "inputs[request_id]=${request_id}" \
+        --jq '.workflow_run_id'
+    )"; then
+      dispatch_status=0
+    else
+      dispatch_status=$?
+    fi
+  fi
+  if (( dispatch_status != 0 )) || [[ ! "${run_id}" =~ ^[0-9]+$ ]]; then
+    python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" unknown \
+      --root "${RELEASE_RETAINED_ROOT}" \
+      --request-id "${request_id}" >/dev/null
+    printf 'workflow dispatch result is unknown for %s (request %s); reconcile this request before retrying\n' \
+      "${workflow}" "${request_id}" >&2
+    return 75
+  fi
+  python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" ack \
+    --root "${RELEASE_RETAINED_ROOT}" \
+    --request-id "${request_id}" \
+    --run-id "${run_id}" >/dev/null
+  printf '%s\n' "${run_id}"
+}
+
 # Resolve the newest published (draft-free) container-k8s release tag and its
 # exact Git object. The pair is committed into the stable source candidate,
 # so documentation recovery never relies on retained workflow history.
@@ -5897,7 +6297,7 @@ publish_stable_asset_pair() {
     github_cli release view "${version}" --repo "${repo}" --json assets \
       --jq '.assets[].name'
   )"
-  remote_tmp="$(mktemp -d)"
+  remote_tmp="$(release_transient_directory published-assets)"
   if grep -Fxq "${asset}" <<<"${asset_names}"; then
     github_cli release download "${version}" --repo "${repo}" \
       --pattern "${asset}" --dir "${remote_tmp}"
@@ -5968,7 +6368,7 @@ publish_stable_init_image_asset() {
   archive="${CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE:-}"
   asset="container-vminit-arm64.oci.tar"
   if [[ -n "${archive}" && ( "${archive}" != /* || ! -f "${archive}" ) ]]; then
-    printf 'stable guest publication received an invalid retained release-gate archive: %s\n' \
+    printf 'stable guest publication received an invalid explicit release-gate archive: %s; unset CONTAINER_RUNTIME_INIT_IMAGE_ARCHIVE to recover the exact published copy\n' \
       "${archive}" >&2
     return 2
   fi
@@ -5985,7 +6385,7 @@ publish_stable_init_image_asset() {
   fi
   containerization_repository="${authority[0]}"
   containerization_reference="${authority[1]}"
-  tmp="$(mktemp -d)"
+  tmp="$(release_transient_directory stable-init-asset)"
   if [[ -n "${archive}" ]]; then
     if cp "${archive}" "${tmp}/${asset}"; then
       status=0
@@ -6041,7 +6441,7 @@ publish_stable_init_image_asset() {
 # Verify the stable release assets and Homebrew formula agree.
 verify_compose_stable_package() {
   local version="$1" promote_default_lane="${2:-true}" stable_formula_identities_before="${3:-}" expected_init_digest="$4"
-  local repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text formula_url formula_version formula_sha runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text container_formula_url container_formula_sha signature_verifier init_asset init_asset_sha init_checksum_sha stable_formula_identities_after
+  local repo asset expected_url tmp asset_names asset_sha checksum_sha formula_text runtime_asset runtime_url runtime_asset_sha runtime_checksum_sha runtime_formula_text signature_verifier init_asset init_asset_sha init_checksum_sha highlights_asset quality_asset stable_formula_identities_after tap_ref
   local authority=() containerization_repository containerization_reference
   repo="$(github_repo "${COMPOSE_REPO}")"
   asset="container-compose-plugin-release-arm64.tar.gz"
@@ -6053,7 +6453,7 @@ verify_compose_stable_package() {
     return 0
   fi
 
-  tmp="$(mktemp -d)"
+  tmp="$(release_transient_directory stable-package)"
   asset_names="$(
     github_cli release view "${version}" \
       --repo "${repo}" \
@@ -6088,6 +6488,15 @@ verify_compose_stable_package() {
     printf 'release %s is missing asset %s.sha256\n' "${version}" "${init_asset}" >&2
     exit 1
   fi
+  highlights_asset=release-highlights.json
+  quality_asset=quality-snapshot.svg
+  for required_asset in "${highlights_asset}" "${quality_asset}"; do
+    if ! grep -Fxq "${required_asset}" <<<"${asset_names}"; then
+      printf 'release %s is missing retained evidence asset %s\n' \
+        "${version}" "${required_asset}" >&2
+      exit 1
+    fi
+  done
 
   github_cli release download "${version}" \
     --repo "${repo}" \
@@ -6097,6 +6506,8 @@ verify_compose_stable_package() {
     --pattern "${runtime_asset}.sha256" \
     --pattern "${init_asset}" \
     --pattern "${init_asset}.sha256" \
+    --pattern "${highlights_asset}" \
+    --pattern "${quality_asset}" \
     --dir "${tmp}"
   asset_sha="$(shasum -a 256 "${tmp}/${asset}" | awk '{print $1}')"
   checksum_sha="$(awk '{print $1}' "${tmp}/${asset}.sha256")"
@@ -6150,7 +6561,12 @@ verify_compose_stable_package() {
   fi
   "${signature_verifier}" "${tmp}/${asset}"
   "${signature_verifier}" "${tmp}/${runtime_asset}"
-  rm -rf "${tmp}"
+  python3 "${RELEASE_ASSET_RETENTION_TOOL}" retain \
+    --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+    --asset "${tmp}/${asset}" --asset "${tmp}/${asset}.sha256" \
+    --asset "${tmp}/${runtime_asset}" --asset "${tmp}/${runtime_asset}.sha256" \
+    --asset "${tmp}/${init_asset}" --asset "${tmp}/${init_asset}.sha256" \
+    --asset "${tmp}/${highlights_asset}" --asset "${tmp}/${quality_asset}"
 
   if [[ "${promote_default_lane}" != "true" ]]; then
     if [[ -z "${stable_formula_identities_before}" ]]; then
@@ -6165,59 +6581,39 @@ verify_compose_stable_package() {
     fi
     printf 'stable stack %s maintenance backfill verified without moving stable Homebrew formulae %s: %s + %s + %s\n' \
       "${version}" "${stable_formula_identities_after}" "${asset_sha}" "${runtime_asset_sha}" "${init_asset_sha}"
+    rm -rf "${tmp}"
     return 0
   fi
 
+  tap_ref="$(
+    git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git \
+      refs/heads/main | awk '{print $1}' | tail -n 1
+  )"
+  if [[ ! "${tap_ref}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'could not resolve an immutable Homebrew tap snapshot\n' >&2
+    exit 1
+  fi
   formula_text="$(
-    github_cli api \
+    github_cli api --method GET \
       repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose.rb \
+      -f "ref=${tap_ref}" \
       --jq '.content' | base64 --decode
   )"
-  formula_url="$(sed -n 's/^  url "\(.*\)"/\1/p' <<<"${formula_text}" | head -n 1)"
-  formula_version="$(sed -n 's/^  version "\(.*\)"/\1/p' <<<"${formula_text}" | head -n 1)"
-  formula_sha="$(sed -n 's/^  sha256 "\(.*\)"/\1/p' <<<"${formula_text}" | head -n 1)"
-
-  if [[ "${formula_url}" != "${expected_url}" ]]; then
-    printf 'Homebrew formula URL mismatch: expected %s, got %s\n' "${expected_url}" "${formula_url}" >&2
-    exit 1
-  fi
-  if [[ -n "${formula_version}" ]]; then
-    printf 'stable Homebrew formula must derive version %s from its release URL; found explicit version %s\n' \
-      "${version}" "${formula_version}" >&2
-    exit 1
-  fi
-  if [[ "${formula_sha}" != "${asset_sha}" ]]; then
-    printf 'Homebrew formula SHA mismatch: expected %s, got %s\n' "${asset_sha}" "${formula_sha}" >&2
-    exit 1
-  fi
-
-  if ! grep -Fq 'depends_on "stephenlclarke/tap/container"' <<<"${formula_text}"; then
-    printf 'stable compose formula does not depend on stephenlclarke/tap/container\n' >&2
-    exit 1
-  fi
-
   runtime_url="https://github.com/${repo}/releases/download/${version}/${runtime_asset}"
   runtime_formula_text="$(
-    github_cli api \
+    github_cli api --method GET \
       repos/stephenlclarke/homebrew-tap/contents/Formula/container.rb \
+      -f "ref=${tap_ref}" \
       --jq '.content' | base64 --decode
   )"
-  container_formula_url="$(sed -n 's/^  url "\(.*\)"/\1/p' <<<"${runtime_formula_text}" | head -n 1)"
-  container_formula_sha="$(sed -n 's/^  sha256 "\(.*\)"/\1/p' <<<"${runtime_formula_text}" | head -n 1)"
-  if [[ "${container_formula_url}" != "${runtime_url}" ]]; then
-    printf 'stable container formula URL mismatch: expected %s, got %s\n' \
-      "${runtime_url}" "${container_formula_url}" >&2
-    exit 1
-  fi
-  if [[ "${container_formula_sha}" != "${runtime_asset_sha}" ]]; then
-    printf 'stable container formula SHA mismatch: expected %s, got %s\n' \
-      "${runtime_asset_sha}" "${container_formula_sha}" >&2
-    exit 1
-  fi
-  if ! grep -Fq 'opt/container-compose/libexec/container-plugins/compose' <<<"${runtime_formula_text}"; then
-    printf 'stable container formula does not register the stable compose plugin\n' >&2
-    exit 1
-  fi
+  printf '%s\n' "${formula_text}" >"${tmp}/container-compose.rb"
+  printf '%s\n' "${runtime_formula_text}" >"${tmp}/container.rb"
+  python3 "${FORMULA_PAIR_VALIDATOR}" \
+    --compose-formula "${tmp}/container-compose.rb" \
+    --runtime-formula "${tmp}/container.rb" \
+    --compose-url "${expected_url}" --runtime-url "${runtime_url}" \
+    --compose-sha256 "${asset_sha}" --runtime-sha256 "${runtime_asset_sha}"
+  rm -rf "${tmp}"
 
   printf 'stable stack %s package closure verified: %s + %s + %s\n' \
     "${version}" "${asset_sha}" "${runtime_asset_sha}" "${init_asset_sha}"
@@ -6249,19 +6645,154 @@ stable_binary_assets_are_published() {
     container-compose-plugin-release-arm64.tar.gz \
     container-compose-plugin-release-arm64.tar.gz.sha256 \
     container-release-arm64.tar.gz \
-    container-release-arm64.tar.gz.sha256; do
+    container-release-arm64.tar.gz.sha256 \
+    release-highlights.json \
+    quality-snapshot.svg; do
     grep -Fxq "${required_asset}" <<<"${asset_names}" || return 1
   done
 }
 
+# Recover missing immutable members from locally retained bytes or from the
+# exact published archive. Stable identities are never repaired by rebuilding.
+recover_published_stable_binary_assets() {
+  local version="$1" repo asset_names asset asset_path tmp digest status cleanup_status
+  local required_assets=(
+    container-compose-plugin-release-arm64.tar.gz
+    container-release-arm64.tar.gz
+  )
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  if ! asset_names="$(
+    github_cli release view "${version}" --repo "${repo}" --json assets \
+      --jq '.assets[].name'
+  )"; then
+    printf 'could not inspect immutable stable release assets for %s\n' \
+      "${version}" >&2
+    return 2
+  fi
+  for asset in "${required_assets[@]}"; do
+    if grep -Fxq "${asset}" <<<"${asset_names}" && \
+      grep -Fxq "${asset}.sha256" <<<"${asset_names}"; then
+      continue
+    fi
+    asset_path=""
+    if asset_path="$(
+      python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
+        --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+        --name "${asset}" 2>/dev/null
+    )"; then
+      :
+    else
+      asset_path=""
+    fi
+    tmp="$(release_transient_directory stable-recovery)"
+    status=0
+    if [[ -z "${asset_path}" ]]; then
+      if grep -Fxq "${asset}" <<<"${asset_names}"; then
+        if github_cli release download "${version}" --repo "${repo}" \
+          --pattern "${asset}" --dir "${tmp}"; then
+          asset_path="${tmp}/${asset}"
+        else
+          status=$?
+        fi
+      else
+        printf 'stable release %s is missing original archive %s and no exact retained copy is available; ordinary packaging cannot repair an immutable release\n' \
+          "${version}" "${asset}" >&2
+        status=2
+      fi
+    fi
+    if (( status == 0 )) && \
+      digest="$(shasum -a 256 "${asset_path}" | awk '{print $1}')" && \
+      [[ "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+      printf '%s  %s\n' "${digest}" "${asset}" >"${tmp}/${asset}.sha256"
+      if publish_stable_asset_pair \
+        "${version}" "${repo}" "${asset_path}" \
+        "${tmp}/${asset}.sha256" "${asset}" "${digest}"; then
+        if python3 "${RELEASE_ASSET_RETENTION_TOOL}" retain \
+          --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+          --asset "${asset_path}" --asset "${tmp}/${asset}.sha256"; then
+          status=0
+        else
+          status=$?
+        fi
+      else
+        status=$?
+      fi
+    elif (( status == 0 )); then
+      status=2
+    fi
+    if find "${tmp}" -depth -delete; then
+      cleanup_status=0
+    else
+      cleanup_status=$?
+    fi
+    if (( status != 0 )); then
+      return "${status}"
+    fi
+    if (( cleanup_status != 0 )); then
+      return "${cleanup_status}"
+    fi
+  done
+  for asset in release-highlights.json quality-snapshot.svg; do
+    if grep -Fxq "${asset}" <<<"${asset_names}"; then
+      continue
+    fi
+    if ! asset_path="$(
+      python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
+        --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+        --name "${asset}" 2>/dev/null
+    )"; then
+      printf 'stable release %s is missing original evidence asset %s and no exact retained copy is available\n' \
+        "${version}" "${asset}" >&2
+      return 2
+    fi
+    if github_cli release upload "${version}" --repo "${repo}" "${asset_path}"; then
+      continue
+    else
+      status=$?
+    fi
+    tmp="$(release_transient_directory stable-evidence-recovery)"
+    if github_cli release download "${version}" --repo "${repo}" \
+      --pattern "${asset}" --dir "${tmp}" && \
+      cmp -s "${asset_path}" "${tmp}/${asset}"; then
+      find "${tmp}" -depth -delete || return 2
+      continue
+    fi
+    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+    return "${status}"
+  done
+}
+
+# Read one formula at a pinned tap commit and distinguish absence from an API
+# failure so recovery never turns an outage into a blind repair dispatch.
+github_formula_at_ref() {
+  local formula="$1" tap_ref="$2" encoded
+  if encoded="$(
+    github_cli api --method GET \
+      "repos/stephenlclarke/homebrew-tap/contents/Formula/${formula}.rb" \
+      -f "ref=${tap_ref}" --jq '.content' 2>&1
+  )"; then
+    if ! base64 --decode <<<"${encoded}"; then
+      printf 'Homebrew formula content is not valid base64: %s.rb\n' \
+        "${formula}" >&2
+      return 2
+    fi
+    return 0
+  fi
+  if [[ "${encoded}" == *"HTTP 404"* || "${encoded}" == *"Not Found (HTTP 404)"* ]]; then
+    return 1
+  fi
+  printf '%s\n' "${encoded}" >&2
+  return 2
+}
+
 # Distinguish formula-only recovery from asset or authority failures cheaply.
 stable_formula_pair_matches_release() {
-  local version="$1" repo tmp compose_asset runtime_asset compose_sha runtime_sha
-  local compose_formula runtime_formula compose_url runtime_url compose_formula_sha runtime_formula_sha
+  local version="$1" repo tmp compose_asset runtime_asset compose_sha runtime_sha tap_ref status
+  local compose_formula runtime_formula compose_url runtime_url
   repo="$(github_repo "${COMPOSE_REPO}")"
   compose_asset=container-compose-plugin-release-arm64.tar.gz
   runtime_asset=container-release-arm64.tar.gz
-  tmp="$(mktemp -d)"
+  tmp="$(release_transient_directory stable-formula-probe)"
   if ! github_cli release download "${version}" --repo "${repo}" \
     --pattern "${compose_asset}.sha256" \
     --pattern "${runtime_asset}.sha256" --dir "${tmp}"; then
@@ -6275,32 +6806,48 @@ stable_formula_pair_matches_release() {
     find "${tmp}" -depth -delete >/dev/null 2>&1 || true
     return 2
   fi
-  if ! compose_formula="$(
-    github_cli api repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose.rb \
-      --jq '.content' | base64 --decode
-  )" || ! runtime_formula="$(
-    github_cli api repos/stephenlclarke/homebrew-tap/contents/Formula/container.rb \
-      --jq '.content' | base64 --decode
-  )"; then
+  tap_ref="$(
+    git ls-remote --heads https://github.com/stephenlclarke/homebrew-tap.git \
+      refs/heads/main | awk '{print $1}' | tail -n 1
+  )"
+  if [[ ! "${tap_ref}" =~ ^[0-9a-f]{40}$ ]]; then
     find "${tmp}" -depth -delete >/dev/null 2>&1 || true
     return 2
   fi
+  if compose_formula="$(github_formula_at_ref container-compose "${tap_ref}")"; then
+    :
+  else
+    status=$?
+    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+    return "${status}"
+  fi
+  if runtime_formula="$(github_formula_at_ref container "${tap_ref}")"; then
+    :
+  else
+    status=$?
+    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+    return "${status}"
+  fi
+  printf '%s\n' "${compose_formula}" >"${tmp}/container-compose.rb"
+  printf '%s\n' "${runtime_formula}" >"${tmp}/container.rb"
+  compose_url="https://github.com/${repo}/releases/download/${version}/${compose_asset}"
+  runtime_url="https://github.com/${repo}/releases/download/${version}/${runtime_asset}"
+  if python3 "${FORMULA_PAIR_VALIDATOR}" \
+    --compose-formula "${tmp}/container-compose.rb" \
+    --runtime-formula "${tmp}/container.rb" \
+    --compose-url "${compose_url}" --runtime-url "${runtime_url}" \
+    --compose-sha256 "${compose_sha}" --runtime-sha256 "${runtime_sha}"; then
+    status=0
+  else
+    status=1
+  fi
   find "${tmp}" -depth -delete >/dev/null 2>&1 || return 2
-  compose_url="$(sed -n 's/^  url "\(.*\)"/\1/p' <<<"${compose_formula}" | head -n 1)"
-  runtime_url="$(sed -n 's/^  url "\(.*\)"/\1/p' <<<"${runtime_formula}" | head -n 1)"
-  compose_formula_sha="$(sed -n 's/^  sha256 "\(.*\)"/\1/p' <<<"${compose_formula}" | head -n 1)"
-  runtime_formula_sha="$(sed -n 's/^  sha256 "\(.*\)"/\1/p' <<<"${runtime_formula}" | head -n 1)"
-  [[ "${compose_url}" == \
-    "https://github.com/${repo}/releases/download/${version}/${compose_asset}" && \
-    "${runtime_url}" == \
-    "https://github.com/${repo}/releases/download/${version}/${runtime_asset}" && \
-    "${compose_formula_sha}" == "${compose_sha}" && \
-    "${runtime_formula_sha}" == "${runtime_sha}" ]]
+  return "${status}"
 }
 
 # Dispatch and verify one stable package workflow mode for a semantic tag.
 dispatch_compose_stable_workflow() {
-  local version="$1" mode="$2" repair_tap="$3" details previous_run run_id status conclusion deadline now label promote_default_lane stable_formula_identities_before="" control_sha
+  local version="$1" mode="$2" repair_tap="$3" details previous_run run_id status conclusion label promote_default_lane stable_formula_identities_before="" control_sha
   print_header "dispatch container-compose ${version} ${mode}"
 
   if [[ "${repair_tap}" == "true" ]]; then
@@ -6332,10 +6879,14 @@ dispatch_compose_stable_workflow() {
     exit 1
   fi
   control_sha="$(remote_main_commit "${COMPOSE_REPO}")"
-  details="$(latest_compose_package_dispatch_run \
-    "${version}" "${repair_tap}" "${control_sha}" || true)"
+  if ! details="$(latest_compose_package_dispatch_run \
+    "${version}" "${repair_tap}" "${control_sha}")"; then
+    printf 'could not inspect existing %s runs; refusing a blind duplicate dispatch\n' \
+      "${label}" >&2
+    return 2
+  fi
   IFS=$'\t' read -r previous_run status conclusion <<<"${details}"
-  if [[ -n "${previous_run}" && "${status}" == "completed" && \
+  if [[ "${repair_tap}" != "true" && -n "${previous_run}" && "${status}" == "completed" && \
     "${conclusion}" == "success" ]]; then
     printf '%s already passed for the exact release controls: %s\n' \
       "${label}" "${previous_run}"
@@ -6353,43 +6904,13 @@ dispatch_compose_stable_workflow() {
       "${stable_formula_identities_before}"
     return 0
   fi
-  if [[ "${repair_tap}" == "true" ]]; then
-    run github_cli workflow run prebuilt-binaries.yml \
-      --repo "$(github_repo "${COMPOSE_REPO}")" \
-      --ref main \
-      -f "ref=${version}" \
-      -f "repair_tap=true"
-  else
-    run github_cli workflow run prebuilt-binaries.yml \
-      --repo "$(github_repo "${COMPOSE_REPO}")" \
-      --ref main \
-      -f "ref=${version}"
-  fi
-
-  deadline=$((SECONDS + COMPOSE_PACKAGE_WAIT_SECONDS))
-  while true; do
-    details="$(latest_compose_package_dispatch_run \
-      "${version}" "${repair_tap}" "${control_sha}" || true)"
-    IFS=$'\t' read -r run_id status conclusion <<<"${details}"
-    if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
-      printf '%s started: %s\n' "${label}" "${run_id}"
-      wait_for_github_run_success "${run_id}" "${label}"
-      complete_compose_stable_workflow \
-        "${version}" "${promote_default_lane}" \
-        "${stable_formula_identities_before}"
-      return 0
-    fi
-
-    now="${SECONDS}"
-    if (( now >= deadline )); then
-      printf 'timed out waiting for %s dispatch for %s\n' "${label}" "${version}" >&2
-      exit 1
-    fi
-
-    printf 'waiting for %s dispatch for %s; next check in %ss\n' \
-      "${label}" "${version}" "${COMPOSE_PACKAGE_POLL_SECONDS}"
-    sleep "${COMPOSE_PACKAGE_POLL_SECONDS}"
-  done
+  run_id="$(dispatch_github_workflow_run \
+    prebuilt-binaries.yml "${version}" "${control_sha}" "${repair_tap}")"
+  printf '%s started: %s\n' "${label}" "${run_id}"
+  wait_for_github_run_success "${run_id}" "${label}"
+  complete_compose_stable_workflow \
+    "${version}" "${promote_default_lane}" \
+    "${stable_formula_identities_before}"
 }
 
 # Dispatch and wait for a new stable package publication.
@@ -6405,7 +6926,7 @@ dispatch_compose_stable_tap_repair() {
 }
 
 dispatch_stable_release_gate() {
-  local version="$1" details previous_run run_id status conclusion deadline now init_image_digest control_sha
+  local version="$1" details previous_run run_id status conclusion init_image_digest control_sha
   print_header "dispatch hosted stable release gate for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -6421,8 +6942,11 @@ dispatch_stable_release_gate() {
   init_image_digest="$(retained_stable_init_image_gate_digest "${version}")"
   ensure_stable_init_image_authority_tag "${version}" "${init_image_digest}"
   control_sha="$(remote_main_commit "${COMPOSE_REPO}")"
-  details="$(latest_stable_release_gate_dispatch_run \
-    "${version}" "${control_sha}" || true)"
+  if ! details="$(latest_stable_release_gate_dispatch_run \
+    "${version}" "${control_sha}")"; then
+    printf 'could not inspect existing stable gate runs; refusing a blind duplicate dispatch\n' >&2
+    return 2
+  fi
   IFS=$'\t' read -r previous_run status conclusion <<<"${details}"
   if [[ -n "${previous_run}" && "${status}" == "completed" && \
     "${conclusion}" == "success" ]]; then
@@ -6438,41 +6962,68 @@ dispatch_stable_release_gate() {
       "${STABLE_RELEASE_GATE_WAIT_SECONDS}"
     return 0
   fi
-  run github_cli workflow run stable-release-gate.yml \
-    --repo "$(github_repo "${COMPOSE_REPO}")" \
-    --ref main \
-    -f "ref=${version}"
-
-  deadline=$((SECONDS + STABLE_RELEASE_GATE_WAIT_SECONDS))
-  while true; do
-    details="$(latest_stable_release_gate_dispatch_run \
-      "${version}" "${control_sha}" || true)"
-    IFS=$'\t' read -r run_id status conclusion <<<"${details}"
-    if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
-      printf 'stable release gate started: %s\n' "${run_id}"
-      wait_for_github_run_success \
-        "${run_id}" "hosted stable release gate" "${STABLE_RELEASE_GATE_WAIT_SECONDS}"
-      return 0
-    fi
-
-    now="${SECONDS}"
-    if (( now >= deadline )); then
-      printf 'timed out waiting for stable release gate dispatch for %s\n' "${version}" >&2
-      exit 1
-    fi
-
-    printf 'waiting for stable release gate dispatch for %s; next check in %ss\n' \
-      "${version}" "${COMPOSE_PACKAGE_POLL_SECONDS}"
-    sleep "${COMPOSE_PACKAGE_POLL_SECONDS}"
-  done
+  run_id="$(dispatch_github_workflow_run \
+    stable-release-gate.yml "${version}" "${control_sha}")"
+  printf 'stable release gate started: %s\n' "${run_id}"
+  wait_for_github_run_success \
+    "${run_id}" "hosted stable release gate" "${STABLE_RELEASE_GATE_WAIT_SECONDS}"
 }
 
-# Build and publish DocC only after the stable package, Homebrew pair, and all
-# earlier release gates have succeeded. A successful exact-input run is the
-# recovery checkpoint; every retry reads the same refs from the immutable
-# stable source tag.
+# Retain all four verified DocC site archives locally before a hosted run can
+# age out. A complete local set avoids downloading or rebuilding on retries.
+retain_stable_documentation_artifacts() {
+  local version="$1" run_id="$2" site retained_path tmp candidate count
+  local candidates=() complete=1
+  for site in compose container containerization k8s; do
+    if retained_path="$(
+      python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
+        --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+        --name "${site}.tgz" 2>/dev/null
+    )"; then
+      python3 "${DOC_SITE_MANIFEST_TOOL}" verify-archive "${retained_path}"
+    else
+      complete=0
+    fi
+  done
+  if (( complete == 1 )); then
+    printf 'stable documentation artifacts already retained locally: %s\n' \
+      "${version}"
+    return 0
+  fi
+
+  tmp="$(release_transient_directory stable-documentation)"
+  if ! github_cli run download "${run_id}" \
+    --repo "$(github_repo "${COMPOSE_REPO}")" \
+    --pattern "api-docs-${version}-*" --dir "${tmp}"; then
+    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+    return 1
+  fi
+  for site in compose container containerization k8s; do
+    candidate=""
+    count=0
+    while IFS= read -r matched; do
+      [[ -n "${matched}" ]] || continue
+      candidate="${matched}"
+      ((count += 1))
+    done < <(find "${tmp}" -type f -name "${site}.tgz" -print)
+    if (( count != 1 )); then
+      printf 'documentation run %s produced %s copies of %s.tgz\n' \
+        "${run_id}" "${count}" "${site}" >&2
+      find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+      return 1
+    fi
+    python3 "${DOC_SITE_MANIFEST_TOOL}" verify-archive "${candidate}"
+    candidates+=(--asset "${candidate}")
+  done
+  python3 "${RELEASE_ASSET_RETENTION_TOOL}" retain \
+    --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+    "${candidates[@]}"
+  find "${tmp}" -depth -delete
+}
+
+# Dispatch or reuse the exact documentation workflow for a stable release.
 dispatch_stable_documentation() {
-  local version="$1" details previous_run run_id status conclusion deadline now control_sha
+  local version="$1" details previous_run status conclusion control_sha run_id
   print_header "publish released documentation for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -6491,6 +7042,7 @@ dispatch_stable_documentation() {
     "${conclusion}" == "success" ]]; then
     printf 'stable documentation already passed for the exact released inputs: %s (run %s)\n' \
       "${version}" "${previous_run}"
+    retain_stable_documentation_artifacts "${version}" "${previous_run}"
     return 0
   fi
   if [[ -n "${previous_run}" && "${status}" != "completed" ]]; then
@@ -6499,38 +7051,16 @@ dispatch_stable_documentation() {
     wait_for_github_run_success \
       "${previous_run}" "stable documentation and Pages deployment" \
       "${DOCUMENTATION_WAIT_SECONDS}"
+    retain_stable_documentation_artifacts "${version}" "${previous_run}"
     return 0
   fi
 
-  run github_cli workflow run docs.yml \
-    --repo "$(github_repo "${COMPOSE_REPO}")" \
-    --ref main \
-    -f "ref=${version}"
-
-  deadline=$((SECONDS + DOCUMENTATION_WAIT_SECONDS))
-  while true; do
-    details="$(latest_stable_documentation_dispatch \
-      "${version}" "${control_sha}")"
-    IFS=$'\t' read -r run_id status conclusion <<<"${details}"
-    if [[ -n "${run_id}" && "${run_id}" != "${previous_run}" ]]; then
-      printf 'stable documentation started: %s\n' "${run_id}"
-      wait_for_github_run_success \
-        "${run_id}" "stable documentation and Pages deployment" \
-        "${DOCUMENTATION_WAIT_SECONDS}"
-      return 0
-    fi
-
-    now="${SECONDS}"
-    if (( now >= deadline )); then
-      printf 'timed out waiting for stable documentation dispatch for %s\n' \
-        "${version}" >&2
-      exit 1
-    fi
-
-    printf 'waiting for stable documentation dispatch for %s; next check in %ss\n' \
-      "${version}" "${COMPOSE_PACKAGE_POLL_SECONDS}"
-    sleep "${COMPOSE_PACKAGE_POLL_SECONDS}"
-  done
+  run_id="$(dispatch_github_workflow_run docs.yml "${version}" "${control_sha}")"
+  printf 'stable documentation started: %s\n' "${run_id}"
+  wait_for_github_run_success \
+    "${run_id}" "stable documentation and Pages deployment" \
+    "${DOCUMENTATION_WAIT_SECONDS}"
+  retain_stable_documentation_artifacts "${version}" "${run_id}"
 }
 
 # Print the verified boundary for a stable release or its formula-only recovery.
@@ -6603,7 +7133,8 @@ resume_stable_release() {
         if (( recovery_status != 1 )); then
           return "${recovery_status}"
         fi
-        dispatch_compose_stable_package "${version}"
+        recover_published_stable_binary_assets "${version}"
+        complete_compose_stable_workflow "${version}" "true" ""
       fi
       dispatch_stable_documentation "${version}"
       print_stable_release_point "${version}" "verified recovery from immutable release assets"
@@ -6847,7 +7378,7 @@ require_release_bootstrap_authority() {
 # created by the release workspace controller. A failed child is retained for
 # the next invocation; only a completely successful publication is removed.
 run_isolated_release() {
-  local workspace bootstrap child child_pid status claim_status
+  local workspace bootstrap child child_pid status claim_status release_tmp
   if [[ "${EXECUTE}" != "1" ]]; then
     python3 "${RELEASE_WORKSPACE_TOOL}" plan
     printf 'would materialize and retain an exact isolated release workspace for %s\n' \
@@ -6863,7 +7394,12 @@ run_isolated_release() {
     printf 'isolated release controller is missing or unsafe: %s\n' "${child}" >&2
     return 1
   fi
+  release_tmp="${RELEASE_BUILD_ROOT}/tmp"
+  mkdir -p "${release_tmp}"
   status=0
+  TMPDIR="${release_tmp}" \
+  TMP="${release_tmp}" \
+  TEMP="${release_tmp}" \
   CONTAINER_STACK_RELEASE_ROOT="${workspace}" \
   CONTAINER_STACK_RELEASE_BUILD_ROOT="${RELEASE_BUILD_ROOT}" \
   CONTAINER_STACK_RELEASE_WORKSPACE_ACTIVE=1 \
@@ -6898,6 +7434,9 @@ main() {
     release)
       trap cleanup_current_init_image_authority EXIT
       ensure_compose_promotion_mode
+      if [[ "${EXECUTE}" == "1" && "${CONTAINER_STACK_RELEASE_LIBRARY:-0}" != "1" ]]; then
+        initialize_release_storage
+      fi
       if [[ "${CONTAINER_STACK_RELEASE_LIBRARY:-0}" == "1" ]]; then
         recover_release_host_state_on_startup
         release_current_stack

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -6084,56 +6084,110 @@ latest_compose_package_dispatch_run() {
   else
     mode=package
   fi
-  title="Prebuilt Binaries · ${version} · ${mode}"
+  title="Prebuilt Binaries · ${version} · ${mode} · "
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow "Prebuilt Binaries" \
     --event workflow_dispatch \
     --limit 100 \
     --json databaseId,displayTitle,headSha,status,conclusion \
-    --jq "map(select(.displayTitle == \"${title}\" and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
+    --jq "map(select((.displayTitle | startswith(\"${title}\")) and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
 latest_stable_release_gate_dispatch_run() {
   local version="$1" control_sha="$2" title
-  title="Stable Release Gate · ${version}"
+  title="Stable Release Gate · ${version} · "
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow stable-release-gate.yml \
     --event workflow_dispatch \
     --limit 100 \
     --json databaseId,displayTitle,headSha,status,conclusion \
-    --jq "map(select(.displayTitle == \"${title}\" and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
+    --jq "map(select((.displayTitle | startswith(\"${title}\")) and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
 # Return the newest run for one immutable stable documentation manifest.
 latest_stable_documentation_dispatch() {
   local version="$1" control_sha="$2" title
-  title="Documentation · ${version}"
+  title="Documentation · ${version} · "
   github_cli run list \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
     --workflow Documentation \
     --event workflow_dispatch \
     --limit 100 \
     --json databaseId,displayTitle,headSha,status,conclusion \
-    --jq "map(select(.displayTitle == \"${title}\" and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
+    --jq "map(select((.displayTitle | startswith(\"${title}\")) and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
 # Dispatch a workflow through the API that returns its exact run ID. The
 # expected control SHA is also an input, so a moving main branch fails before
 # expensive or mutating work instead of leaving title-based polling ambiguous.
+reconcile_github_dispatch_request() {
+  local workflow="$1" request_id="$2" control_sha="$3" repo
+  repo="$(github_repo "${COMPOSE_REPO}")"
+  github_cli api --paginate --slurp \
+    "repos/${repo}/actions/workflows/${workflow}/runs?event=workflow_dispatch&per_page=100" \
+    | jq -r --arg request_id "${request_id}" --arg control_sha "${control_sha}" '
+      [.[][] | select(
+        .event == "workflow_dispatch" and
+        .head_sha == $control_sha and
+        (.display_title | type == "string") and
+        (.display_title | endswith($request_id))
+      ) | .id] | unique | if length == 1 then .[0] else empty end
+    '
+}
+
 dispatch_github_workflow_run() {
-  local workflow="$1" version="$2" control_sha="$3" repair_tap="${4:-}"
-  local repo request_id run_id dispatch_status
+  local workflow="$1" version="$2" control_sha="$3" repair_tap="${4:-}" mode_override="${5:-}"
+  local repo request_id proposed_request_id run_id dispatch_status mode existing existing_state existing_run run_details run_status run_conclusion
   repo="$(github_repo "${COMPOSE_REPO}")"
   run_id=""
-  request_id="$(/usr/bin/uuidgen | tr '[:upper:]' '[:lower:]')"
-  python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" intent \
-    --root "${RELEASE_RETAINED_ROOT}" \
-    --request-id "${request_id}" \
-    --workflow "${workflow}" \
-    --version "${version}" \
-    --control-sha "${control_sha}" >/dev/null
+  if [[ -n "${mode_override}" ]]; then
+    mode="${mode_override}"
+  elif [[ "${workflow}" == prebuilt-binaries.yml ]]; then
+    mode="package"
+    [[ "${repair_tap}" == true ]] && mode="tap-repair"
+  else
+    mode="${workflow%.yml}"
+  fi
+  proposed_request_id="$(/usr/bin/uuidgen | tr '[:upper:]' '[:lower:]')"
+  existing="$(python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" claim \
+    --root "${RELEASE_RETAINED_ROOT}" --request-id "${proposed_request_id}" \
+    --workflow "${workflow}" --version "${version}" \
+    --control-sha "${control_sha}" --mode "${mode}")"
+  request_id="$(jq -r '.request_id' <<<"${existing}")"
+  existing_state="$(jq -r '.state // empty' <<<"${existing}")"
+  existing_run="$(jq -r '.run_id // empty' <<<"${existing}")"
+  if [[ "${existing_state}" == dispatch-unknown ]]; then
+    existing_run="$(reconcile_github_dispatch_request \
+      "${workflow}" "${request_id}" "${control_sha}" 2>/dev/null || true)"
+    if [[ "${existing_run}" =~ ^[0-9]+$ ]]; then
+      python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" ack \
+        --root "${RELEASE_RETAINED_ROOT}" --request-id "${request_id}" \
+        --run-id "${existing_run}" >/dev/null
+      printf '%s\n' "${existing_run}"
+      return 0
+    fi
+  fi
+  if [[ ( "${existing_state}" == dispatch-intent && "${request_id}" != "${proposed_request_id}" ) || "${existing_state}" == dispatch-unknown ]]; then
+    printf 'workflow dispatch result is unresolved for %s (request %s); refusing a duplicate request\n' \
+      "${workflow}" "${request_id}" >&2
+    return 75
+  fi
+  if [[ "${existing_state}" == dispatched && "${existing_run}" =~ ^[0-9]+$ ]]; then
+    run_details="$(github_cli run view "${existing_run}" --repo "${repo}" \
+      --json status,conclusion --jq '[.status, (.conclusion // "")] | @tsv' \
+      2>/dev/null || true)"
+    IFS=$'\t' read -r run_status run_conclusion <<<"${run_details}"
+    if [[ "${run_status}" == completed && "${run_conclusion}" != success ]]; then
+      python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" fail \
+        --root "${RELEASE_RETAINED_ROOT}" --request-id "${request_id}" >/dev/null
+      dispatch_github_workflow_run "${workflow}" "${version}" "${control_sha}" "${repair_tap}" "${mode_override}"
+      return
+    fi
+    printf '%s\n' "${existing_run}"
+    return 0
+  fi
   if [[ -n "${repair_tap}" ]]; then
     if run_id="$(
       github_cli api --method POST \
@@ -6179,6 +6233,73 @@ dispatch_github_workflow_run() {
     --request-id "${request_id}" \
     --run-id "${run_id}" >/dev/null
   printf '%s\n' "${run_id}"
+}
+
+# Retain and authenticate a successful gate's complete authority before its
+# hosted artifact can expire. The package workflow may consume this exact copy.
+retain_stable_gate_authority() {
+  local version="$1" run_id="$2" init_digest="$3"
+  local archive sidecar tmp receipt bundle tag_sha receipt_sha status retained
+  local refs=()
+  archive=""
+  retained=0
+  if archive="$(python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
+    --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+    --name stable-release-authority.tar.gz 2>/dev/null)"; then
+    sidecar="$(python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
+      --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+      --name stable-release-authority.tar.gz.sha256)"
+    retained=1
+  fi
+  tmp="$(release_transient_directory stable-gate-authority)"
+  status=0
+  if (( retained == 1 )); then
+    [[ "$(awk 'NR == 1 { print $1 }' "${sidecar}")" == \
+      "$(shasum -a 256 "${archive}" | awk '{ print $1 }')" ]] || {
+      printf 'retained stable authority checksum does not match its archive\n' >&2
+      return 2
+    }
+    bundle="${tmp}/retained"
+    mkdir -p "${bundle}"
+    /usr/bin/tar -xzf "${archive}" -C "${bundle}"
+  else
+    if github_cli run download "${run_id}" \
+      --repo "$(github_repo "${COMPOSE_REPO}")" \
+      --pattern "stable-release-authority-${version}-*" --dir "${tmp}"; then
+      status=0
+    else
+      status=$?
+    fi
+  fi
+  receipt="$(find "${tmp}" -type f -name stable-release-authority.json -print -quit)"
+  if (( status == 0 )) && [[ -n "${receipt}" ]]; then
+    bundle="$(dirname "${receipt}")"
+    if (( retained == 0 )); then
+      archive="${tmp}/stable-release-authority.tar.gz"
+      sidecar="${archive}.sha256"
+      /usr/bin/tar -C "${bundle}" -czf "${archive}" .
+    fi
+    receipt_sha="$(shasum -a 256 "${receipt}" | awk '{print $1}')"
+    tag_sha="$(git -C "$(repo_path "${COMPOSE_REPO}")" rev-list -n 1 "refs/tags/${version}")"
+    while IFS= read -r value; do refs+=("${value}"); done < <(stable_stack_component_refs "${version}")
+    if ((${#refs[@]} != 3)) || ! python3 "${STABLE_AUTHORITY_BUNDLE_VERIFIER}" \
+      --archive "${archive}" --release-tag "${version}" \
+      --candidate-sha "${tag_sha}" --builder-ref "${refs[0]:-}" \
+      --containerization-ref "${refs[1]:-}" --container-ref "${refs[2]:-}" \
+      --init-image-sha256 "${init_digest}" --receipt-sha256 "${receipt_sha}"; then
+      status=2
+    elif (( retained == 0 )); then
+      python3 "${SELF_DIRECTORY}/../Tools/release/write-sha256-sidecar.py" "${archive}"
+      python3 "${RELEASE_ASSET_RETENTION_TOOL}" retain \
+        --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+        --asset "${archive}" --asset "${sidecar}" || status=$?
+    fi
+  elif (( status == 0 )); then
+    printf 'stable gate %s did not provide its authority receipt\n' "${run_id}" >&2
+    status=2
+  fi
+  find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+  return "${status}"
 }
 
 # Resolve the newest published (draft-free) container-k8s release tag and its
@@ -6952,6 +7073,7 @@ dispatch_stable_release_gate() {
     "${conclusion}" == "success" ]]; then
     printf 'hosted stable release gate already passed for the exact release controls: %s\n' \
       "${previous_run}"
+    retain_stable_gate_authority "${version}" "${previous_run}" "${init_image_digest}"
     return 0
   fi
   if [[ -n "${previous_run}" && "${status}" != "completed" ]]; then
@@ -6960,6 +7082,7 @@ dispatch_stable_release_gate() {
     wait_for_github_run_success \
       "${previous_run}" "hosted stable release gate" \
       "${STABLE_RELEASE_GATE_WAIT_SECONDS}"
+    retain_stable_gate_authority "${version}" "${previous_run}" "${init_image_digest}"
     return 0
   fi
   run_id="$(dispatch_github_workflow_run \
@@ -6967,20 +7090,48 @@ dispatch_stable_release_gate() {
   printf 'stable release gate started: %s\n' "${run_id}"
   wait_for_github_run_success \
     "${run_id}" "hosted stable release gate" "${STABLE_RELEASE_GATE_WAIT_SECONDS}"
+  retain_stable_gate_authority "${version}" "${run_id}" "${init_image_digest}"
 }
 
 # Retain all four verified DocC site archives locally before a hosted run can
 # age out. A complete local set avoids downloading or rebuilding on retries.
+stable_documentation_source_ref() {
+  local version="$1" site="$2" refs=()
+  case "${site}" in
+    compose)
+      git -C "$(repo_path "${COMPOSE_REPO}")" rev-list -n 1 "refs/tags/${version}"
+      ;;
+    containerization|container)
+      while IFS= read -r value; do refs+=("${value}"); done < <(
+        stable_stack_component_refs "${version}"
+      )
+      if [[ "${site}" == containerization ]]; then printf '%s\n' "${refs[1]:-}"
+      else printf '%s\n' "${refs[2]:-}"
+      fi
+      ;;
+    k8s)
+      jq -er '.sites.k8s.ref' \
+        "$(repo_path "${COMPOSE_REPO}")/Tools/release/documentation-refs.json"
+      ;;
+    *) return 2 ;;
+  esac
+}
+
 retain_stable_documentation_artifacts() {
-  local version="$1" run_id="$2" site retained_path tmp candidate count
-  local candidates=() complete=1
+  local version="$1" run_id="$2" site retained_path tmp site_tmp candidate count source_ref base_path
+  local complete=1
   for site in compose container containerization k8s; do
+    source_ref="$(stable_documentation_source_ref "${version}" "${site}")"
+    base_path="container-compose/${site}"
+    [[ "${site}" == compose ]] && base_path=container-compose
     if retained_path="$(
       python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
         --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
         --name "${site}.tgz" 2>/dev/null
     )"; then
-      python3 "${DOC_SITE_MANIFEST_TOOL}" verify-archive "${retained_path}"
+      python3 "${DOC_SITE_MANIFEST_TOOL}" verify-archive "${retained_path}" \
+        --site "${site}" --source-ref "${source_ref}" \
+        --hosting-base-path "${base_path}"
     else
       complete=0
     fi
@@ -6992,32 +7143,43 @@ retain_stable_documentation_artifacts() {
   fi
 
   tmp="$(release_transient_directory stable-documentation)"
-  if ! github_cli run download "${run_id}" \
-    --repo "$(github_repo "${COMPOSE_REPO}")" \
-    --pattern "api-docs-${version}-*" --dir "${tmp}"; then
-    find "${tmp}" -depth -delete >/dev/null 2>&1 || true
-    return 1
-  fi
   for site in compose container containerization k8s; do
+    source_ref="$(stable_documentation_source_ref "${version}" "${site}")"
+    base_path="container-compose/${site}"
+    [[ "${site}" == compose ]] && base_path=container-compose
+    if python3 "${RELEASE_ASSET_RETENTION_TOOL}" path \
+      --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+      --name "${site}.tgz" >/dev/null 2>&1; then
+      continue
+    fi
+    site_tmp="${tmp}/${site}"
+    mkdir -p "${site_tmp}"
+    if ! github_cli run download "${run_id}" \
+      --repo "$(github_repo "${COMPOSE_REPO}")" \
+      --pattern "api-docs-${version}-${site}-*" --dir "${site_tmp}"; then
+      find "${tmp}" -depth -delete >/dev/null 2>&1 || true
+      return 1
+    fi
     candidate=""
     count=0
     while IFS= read -r matched; do
       [[ -n "${matched}" ]] || continue
       candidate="${matched}"
       ((count += 1))
-    done < <(find "${tmp}" -type f -name "${site}.tgz" -print)
+    done < <(find "${site_tmp}" -type f -name "${site}.tgz" -print)
     if (( count != 1 )); then
       printf 'documentation run %s produced %s copies of %s.tgz\n' \
         "${run_id}" "${count}" "${site}" >&2
       find "${tmp}" -depth -delete >/dev/null 2>&1 || true
       return 1
     fi
-    python3 "${DOC_SITE_MANIFEST_TOOL}" verify-archive "${candidate}"
-    candidates+=(--asset "${candidate}")
+    python3 "${DOC_SITE_MANIFEST_TOOL}" verify-archive "${candidate}" \
+      --site "${site}" --source-ref "${source_ref}" \
+      --hosting-base-path "${base_path}"
+    python3 "${RELEASE_ASSET_RETENTION_TOOL}" retain \
+      --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
+      --asset "${candidate}"
   done
-  python3 "${RELEASE_ASSET_RETENTION_TOOL}" retain \
-    --root "${RELEASE_RETAINED_ROOT}" --version "${version}" \
-    "${candidates[@]}"
   find "${tmp}" -depth -delete
 }
 
@@ -7042,24 +7204,43 @@ dispatch_stable_documentation() {
     "${conclusion}" == "success" ]]; then
     printf 'stable documentation already passed for the exact released inputs: %s (run %s)\n' \
       "${version}" "${previous_run}"
-    retain_stable_documentation_artifacts "${version}" "${previous_run}"
+    if retain_stable_documentation_artifacts "${version}" "${previous_run}"; then
+      return 0
+    fi
+    printf 'documentation artifacts for run %s are unavailable; dispatching exact-input regeneration (valid site caches remain reusable)\n' \
+      "${previous_run}" >&2
+    run_id="$(dispatch_github_workflow_run docs.yml "${version}" \
+      "${control_sha}" "" "docs-regenerate-${previous_run}")"
+    if ! wait_for_github_run_success \
+      "${run_id}" "stable documentation and Pages deployment" \
+      "${DOCUMENTATION_WAIT_SECONDS}"; then
+      retain_stable_documentation_artifacts "${version}" "${run_id}" || true
+      return 1
+    fi
+    retain_stable_documentation_artifacts "${version}" "${run_id}"
     return 0
   fi
   if [[ -n "${previous_run}" && "${status}" != "completed" ]]; then
     printf 'stable documentation is already running for the exact released inputs: %s\n' \
       "${previous_run}"
-    wait_for_github_run_success \
+    if ! wait_for_github_run_success \
       "${previous_run}" "stable documentation and Pages deployment" \
-      "${DOCUMENTATION_WAIT_SECONDS}"
+      "${DOCUMENTATION_WAIT_SECONDS}"; then
+      retain_stable_documentation_artifacts "${version}" "${previous_run}" || true
+      return 1
+    fi
     retain_stable_documentation_artifacts "${version}" "${previous_run}"
     return 0
   fi
 
   run_id="$(dispatch_github_workflow_run docs.yml "${version}" "${control_sha}")"
   printf 'stable documentation started: %s\n' "${run_id}"
-  wait_for_github_run_success \
+  if ! wait_for_github_run_success \
     "${run_id}" "stable documentation and Pages deployment" \
-    "${DOCUMENTATION_WAIT_SECONDS}"
+    "${DOCUMENTATION_WAIT_SECONDS}"; then
+    retain_stable_documentation_artifacts "${version}" "${run_id}" || true
+    return 1
+  fi
   retain_stable_documentation_artifacts "${version}" "${run_id}"
 }
 

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -7110,8 +7110,9 @@ stable_documentation_source_ref() {
       fi
       ;;
     k8s)
-      jq -er '.sites.k8s.ref' \
-        "$(repo_path "${COMPOSE_REPO}")/Tools/release/documentation-refs.json"
+      git -C "$(repo_path "${COMPOSE_REPO}")" show \
+        "refs/tags/${version}:Tools/release/documentation-refs.json" \
+        | jq -er '.sites.k8s.ref'
       ;;
     *) return 2 ;;
   esac

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -4690,7 +4690,7 @@ ensure_published_stable_recovery_authority() {
 
 # Refuse to retry a semantic tag once GitHub has made it a published release.
 ensure_stable_release_is_unpublished() {
-  local version="$1" output status
+  local version="$1" output status is_draft is_prerelease
   if [[ "${EXECUTE}" != "1" ]]; then
     printf 'would verify that stable release %s is unpublished\n' "${version}"
     return 0
@@ -4699,7 +4699,12 @@ ensure_stable_release_is_unpublished() {
   need_command gh
   if output="$(github_cli release view "${version}" \
     --repo "$(github_repo "${COMPOSE_REPO}")" \
-    --json id 2>&1)"; then
+    --json isDraft,isPrerelease \
+    --jq '[.isDraft, .isPrerelease] | @tsv' 2>&1)"; then
+    IFS=$'\t' read -r is_draft is_prerelease <<<"${output}"
+    if [[ "${is_draft}" == "true" && "${is_prerelease}" == "false" ]]; then
+      return 0
+    fi
     printf 'stable release %s already exists and is immutable\n' "${version}" >&2
     exit 1
   else
@@ -4732,6 +4737,9 @@ stable_release_is_published() {
     IFS=$'\t' read -r is_draft is_prerelease <<<"${output}"
     if [[ "${is_draft}" == "false" && "${is_prerelease}" == "false" ]]; then
       return 0
+    fi
+    if [[ "${is_draft}" == "true" ]]; then
+      return 1
     fi
     printf 'stable release %s exists but is not published and immutable (draft=%s, prerelease=%s)\n' \
       "${version}" "${is_draft:-missing}" "${is_prerelease:-missing}" >&2


### PR DESCRIPTION
## Summary

- separate disposable SSD workspaces, compiler scratch, and downloads from complete retained products and release authority on the internal disk
- make build receipts checkout-independent, output-aware, content-addressed, repairable, and reusable without repeating valid builds or tests
- make dispatch, packaging, publication, Homebrew, DocC, cleanup, and recovery planning interruption-safe and idempotent
- retain the complete PR #634 package closure, including both Docker-free Linux volume initializers, across checkpoints, receipts, materialization, verification, and archive creation
- quarantine incompatible interrupted SwiftPM editable workspaces without deleting their recovery evidence

## Validation

- `make release-tools-test`: 562 tests passed
- `make ci-tools-test`: 320 CI tests and 46 stack tests passed
- `make go-test go-build`: all Go packages passed; both Linux release binaries passed executable and static ELF checks
- `make swift-test-direct`: 1,416 tests passed across 64 suites; 1,390 executed and 26 live-runtime cases intentionally skipped
- `make actions-lint check-licenses`
- focused recovery integration: 22 tests passed
- `git diff --check`

No Container runtime, Docker/Colima application, parity smoke, benchmark, workflow dispatch, release, or merge operation was used for this validation.