### PR TITLE
fix(release): resume interrupted publication

### DIFF
--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -211,7 +211,7 @@ create_release() {
 create_stable_draft() {
   "${GH}" release create "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
     --title "${RELEASE_TITLE}" --notes-file "${RELEASE_NOTES_FILE}" \
-    --verify-tag "${release_flags[@]}" --draft
+    --target "${PUBLISH_SHA}" --verify-tag "${release_flags[@]}" --draft
 }
 
 validate_stable_draft_asset_names() {
@@ -239,8 +239,89 @@ validate_stable_draft_asset_names() {
   fi
 }
 
+# Verify GitHub's final asset inventory and server-computed digests immediately
+# before making an immutable stable release public.
+validate_stable_draft_asset_digests() {
+  local remote_assets="$1" asset name expected_digest remote_digest count
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    count="$(awk -F '\t' -v name="${name}" '$1 == name { count += 1 } END { print count + 0 }' \
+      <<<"${remote_assets}")"
+    if (( count != 1 )); then
+      printf 'stable draft final inventory changed for asset: %s\n' "${name}" >&2
+      return 1
+    fi
+    remote_digest="$(awk -F '\t' -v name="${name}" '$1 == name { print $2 }' \
+      <<<"${remote_assets}")"
+    expected_digest="sha256:$(shasum -a 256 "${asset}" | awk '{print $1}')"
+    if [[ "${remote_digest}" != "${expected_digest}" ]]; then
+      printf 'stable draft final digest changed for asset: %s\n' "${name}" >&2
+      return 1
+    fi
+  done
+}
+
+# GitHub does not support conditional PATCH requests for the release update
+# endpoint. The workflow's repository-wide concurrency group is therefore the
+# exclusive writer for supported publication and recovery runs. Verify the
+# server's immutable post-publication snapshot so a privileged out-of-band
+# mutation or a lost publish response can never be reported as success.
+verify_published_stable_release() {
+  local expected_names="$1"
+  local snapshot remote_assets remote_names latest_tag remote_tag_sha
+  local field actual expected
+  snapshot="$("${GH}" release view "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" \
+    --json isDraft,isImmutable,isPrerelease,tagName,targetCommitish,name,body,assets)"
+
+  while IFS=$'\t' read -r field actual expected; do
+    if [[ "${actual}" != "${expected}" ]]; then
+      printf 'published stable release %s mismatch: expected %s, got %s\n' \
+        "${field}" "${expected}" "${actual}" >&2
+      return 1
+    fi
+  done < <(
+    jq -r --arg tag "${RELEASE_TAG}" --arg target "${PUBLISH_SHA}" \
+      --arg name "${RELEASE_TITLE}" --rawfile body "${RELEASE_NOTES_FILE}" \
+      --argjson prerelease "${RELEASE_PRERELEASE}" \
+      '["draft state", .isDraft, false], ["immutability", .isImmutable, true], ["prerelease state", .isPrerelease, $prerelease], ["tag", .tagName, $tag], ["target", .targetCommitish, $target], ["title", .name, $name], ["notes", .body, $body] | @tsv' \
+      <<<"${snapshot}"
+  )
+
+  remote_assets="$(jq -r '.assets[] | [.name, (.digest // "")] | @tsv' \
+    <<<"${snapshot}")"
+  remote_names="$(cut -f 1 <<<"${remote_assets}")"
+  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" true
+  validate_stable_draft_asset_digests "${remote_assets}"
+
+  latest_tag="$("${GH}" api "repos/${RELEASE_REPOSITORY}/releases/latest" \
+    --jq '.tag_name')"
+  if [[ "${RELEASE_LATEST}" == "true" && "${latest_tag}" != "${RELEASE_TAG}" ]]; then
+    printf 'published stable release is not latest: expected %s, got %s\n' \
+      "${RELEASE_TAG}" "${latest_tag}" >&2
+    return 1
+  fi
+  if [[ "${RELEASE_LATEST}" != "true" && "${latest_tag}" == "${RELEASE_TAG}" ]]; then
+    printf 'published stable release unexpectedly became latest: %s\n' \
+      "${RELEASE_TAG}" >&2
+    return 1
+  fi
+
+  remote_tag_sha="$(
+    "${GIT}" ls-remote --tags "https://github.com/${RELEASE_REPOSITORY}.git" \
+      "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" |
+      awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+  )"
+  if [[ "${remote_tag_sha}" != "${PUBLISH_SHA}" ]]; then
+    printf 'published stable tag target mismatch: expected %s, got %s\n' \
+      "${PUBLISH_SHA}" "${remote_tag_sha:-missing}" >&2
+    return 1
+  fi
+}
+
 reconcile_stable_draft() {
-  local temporary verification remote_names expected_names asset name downloaded
+  local temporary verification final_snapshot remote_names remote_assets
+  local expected_names asset name downloaded
   local missing_assets=()
   if [[ "$("${GIT}" rev-list -n 1 "refs/tags/${RELEASE_TAG}")" != "${PUBLISH_SHA}" ]]; then
     printf 'stable draft tag no longer resolves to the requested candidate: %s\n' \
@@ -301,9 +382,23 @@ reconcile_stable_draft() {
       return 1
     fi
   done
+  final_snapshot="$("${GH}" release view "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" --json isDraft,assets)"
+  if [[ "$(jq -r '.isDraft' <<<"${final_snapshot}")" != true ]]; then
+    printf 'stable release is no longer a draft before publication: %s\n' \
+      "${RELEASE_TAG}" >&2
+    return 1
+  fi
+  remote_assets="$(jq -r '.assets[] | [.name, (.digest // "")] | @tsv' \
+    <<<"${final_snapshot}")"
+  remote_names="$(cut -f 1 <<<"${remote_assets}")"
+  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" true
+  validate_stable_draft_asset_digests "${remote_assets}"
   "${GH}" release edit "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
-    --title "${RELEASE_TITLE}" --notes-file "${RELEASE_NOTES_FILE}" \
+    --target "${PUBLISH_SHA}" --title "${RELEASE_TITLE}" \
+    --notes-file "${RELEASE_NOTES_FILE}" \
     --draft=false --prerelease="${RELEASE_PRERELEASE}" "${release_flags[@]}"
+  verify_published_stable_release "${expected_names}"
 }
 
 if [[ "${published_release_state}" == "draft" ]]; then
@@ -317,9 +412,18 @@ fi
 
 if [[ "${published_release_state}" == "exists" ]]; then
   if [[ "${RELEASE_MUTABLE}" != "true" ]]; then
-    printf 'release %s already exists; published releases are immutable\n' \
-      "${RELEASE_TAG}" >&2
-    exit 1
+    expected_names=""
+    for asset in "${release_assets[@]}"; do
+      name="$(basename "${asset}")"
+      if grep -Fqx -- "${name}" <<<"${expected_names}"; then
+        printf 'stable release candidate contains a duplicate asset name: %s\n' \
+          "${name}" >&2
+        exit 1
+      fi
+      expected_names+="${name}"$'\n'
+    done
+    verify_published_stable_release "${expected_names}"
+    exit 0
   fi
 
   if [[ "${RELEASE_PHASE}" == "stage" ]]; then

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -215,7 +215,7 @@ create_stable_draft() {
 }
 
 reconcile_stable_draft() {
-  local temporary remote_names asset name downloaded
+  local temporary remote_names expected_names asset name downloaded count
   if [[ "$("${GIT}" rev-list -n 1 "refs/tags/${RELEASE_TAG}")" != "${PUBLISH_SHA}" ]]; then
     printf 'stable draft tag no longer resolves to the requested candidate: %s\n' \
       "${RELEASE_TAG}" >&2
@@ -223,6 +223,28 @@ reconcile_stable_draft() {
   fi
   remote_names="$("${GH}" release view "${RELEASE_TAG}" \
     --repo "${RELEASE_REPOSITORY}" --json assets --jq '.assets[].name')"
+  expected_names=""
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    if grep -Fqx -- "${name}" <<<"${expected_names}"; then
+      printf 'stable draft candidate contains a duplicate asset name: %s\n' \
+        "${name}" >&2
+      return 1
+    fi
+    expected_names+="${name}"$'\n'
+  done
+  while IFS= read -r name; do
+    [[ -n "${name}" ]] || continue
+    if ! grep -Fqx -- "${name}" <<<"${expected_names}"; then
+      printf 'stable draft contains an unexpected asset: %s\n' "${name}" >&2
+      return 1
+    fi
+    count="$(grep -Fxc -- "${name}" <<<"${remote_names}" || true)"
+    if (( count != 1 )); then
+      printf 'stable draft contains a duplicate asset name: %s\n' "${name}" >&2
+      return 1
+    fi
+  done <<<"${remote_names}"
   temporary="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/stable-draft-assets.XXXXXX")"
   trap 'find "${temporary}" -depth -delete >/dev/null 2>&1 || true' RETURN
   for asset in "${release_assets[@]}"; do

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -216,6 +216,7 @@ create_stable_draft() {
 
 reconcile_stable_draft() {
   local temporary remote_names expected_names asset name downloaded count
+  local missing_assets=()
   if [[ "$("${GIT}" rev-list -n 1 "refs/tags/${RELEASE_TAG}")" != "${PUBLISH_SHA}" ]]; then
     printf 'stable draft tag no longer resolves to the requested candidate: %s\n' \
       "${RELEASE_TAG}" >&2
@@ -261,9 +262,12 @@ reconcile_stable_draft() {
         return 1
       fi
     else
-      "${GH}" release upload "${RELEASE_TAG}" "${asset}" \
-        --repo "${RELEASE_REPOSITORY}"
+      missing_assets+=("${asset}")
     fi
+  done
+  for asset in "${missing_assets[@]}"; do
+    "${GH}" release upload "${RELEASE_TAG}" "${asset}" \
+      --repo "${RELEASE_REPOSITORY}"
   done
   "${GH}" release edit "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
     --title "${RELEASE_TITLE}" --notes-file "${RELEASE_NOTES_FILE}" \

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -266,7 +266,8 @@ reconcile_stable_draft() {
     fi
   done
   "${GH}" release edit "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
-    --draft=false "${release_flags[@]}"
+    --title "${RELEASE_TITLE}" --notes-file "${RELEASE_NOTES_FILE}" \
+    --draft=false --prerelease="${RELEASE_PRERELEASE}" "${release_flags[@]}"
 }
 
 if [[ "${published_release_state}" == "draft" ]]; then

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -214,8 +214,33 @@ create_stable_draft() {
     --verify-tag "${release_flags[@]}" --draft
 }
 
+validate_stable_draft_asset_names() {
+  local remote_names="$1" expected_names="$2" require_complete="$3" name count
+  while IFS= read -r name; do
+    [[ -n "${name}" ]] || continue
+    if ! grep -Fqx -- "${name}" <<<"${expected_names}"; then
+      printf 'stable draft contains an unexpected asset: %s\n' "${name}" >&2
+      return 1
+    fi
+    count="$(grep -Fxc -- "${name}" <<<"${remote_names}" || true)"
+    if (( count != 1 )); then
+      printf 'stable draft contains a duplicate asset name: %s\n' "${name}" >&2
+      return 1
+    fi
+  done <<<"${remote_names}"
+  if [[ "${require_complete}" == "true" ]]; then
+    while IFS= read -r name; do
+      [[ -n "${name}" ]] || continue
+      if ! grep -Fqx -- "${name}" <<<"${remote_names}"; then
+        printf 'stable draft is missing an uploaded asset: %s\n' "${name}" >&2
+        return 1
+      fi
+    done <<<"${expected_names}"
+  fi
+}
+
 reconcile_stable_draft() {
-  local temporary remote_names expected_names asset name downloaded count
+  local temporary verification remote_names expected_names asset name downloaded
   local missing_assets=()
   if [[ "$("${GIT}" rev-list -n 1 "refs/tags/${RELEASE_TAG}")" != "${PUBLISH_SHA}" ]]; then
     printf 'stable draft tag no longer resolves to the requested candidate: %s\n' \
@@ -234,20 +259,10 @@ reconcile_stable_draft() {
     fi
     expected_names+="${name}"$'\n'
   done
-  while IFS= read -r name; do
-    [[ -n "${name}" ]] || continue
-    if ! grep -Fqx -- "${name}" <<<"${expected_names}"; then
-      printf 'stable draft contains an unexpected asset: %s\n' "${name}" >&2
-      return 1
-    fi
-    count="$(grep -Fxc -- "${name}" <<<"${remote_names}" || true)"
-    if (( count != 1 )); then
-      printf 'stable draft contains a duplicate asset name: %s\n' "${name}" >&2
-      return 1
-    fi
-  done <<<"${remote_names}"
+  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" false
   temporary="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/stable-draft-assets.XXXXXX")"
-  trap 'find "${temporary}" -depth -delete >/dev/null 2>&1 || true' RETURN
+  verification=""
+  trap 'find "${temporary}" -depth -delete >/dev/null 2>&1 || true; if [[ -n "${verification:-}" ]]; then find "${verification}" -depth -delete >/dev/null 2>&1 || true; fi' RETURN
   for asset in "${release_assets[@]}"; do
     name="$(basename "${asset}")"
     if grep -Fqx "${name}" <<<"${remote_names}"; then
@@ -268,6 +283,23 @@ reconcile_stable_draft() {
   for asset in "${missing_assets[@]}"; do
     "${GH}" release upload "${RELEASE_TAG}" "${asset}" \
       --repo "${RELEASE_REPOSITORY}"
+  done
+  remote_names="$("${GH}" release view "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" --json assets --jq '.assets[].name')"
+  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" true
+  verification="$(mktemp -d \
+    "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/stable-draft-final.XXXXXX")"
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    "${GH}" release download "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
+      --pattern "${name}" --dir "${verification}"
+    downloaded="${verification}/${name}"
+    if [[ ! -f "${downloaded}" ]] || \
+      [[ "$(shasum -a 256 "${downloaded}" | awk '{print $1}')" != \
+        "$(shasum -a 256 "${asset}" | awk '{print $1}')" ]]; then
+      printf 'stable draft asset changed before publication: %s\n' "${name}" >&2
+      return 1
+    fi
   done
   "${GH}" release edit "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
     --title "${RELEASE_TITLE}" --notes-file "${RELEASE_NOTES_FILE}" \

--- a/Tools/release/release-dispatch-journal.py
+++ b/Tools/release/release-dispatch-journal.py
@@ -96,7 +96,11 @@ def validate_record(value: object, request_id: str) -> dict[str, object]:
 
 
 def matching_records(
-    root: Path, workflow: str, version: str, control_sha: str, mode: str
+    root: Path,
+    workflow: str,
+    version: str,
+    control_sha: str,
+    mode: str | None,
 ) -> list[dict[str, object]]:
     directory = root / "release/dispatches"
     matches: list[dict[str, object]] = []
@@ -111,7 +115,7 @@ def matching_records(
                 record.get("workflow") == workflow
                 and record.get("version") == version
                 and record.get("control_sha") == control_sha
-                and record.get("mode", "") == mode
+                and (mode is None or record.get("mode", "") == mode)
             ):
                 matches.append(record)
     matches.sort(key=lambda value: str(value.get("created_at", "")), reverse=True)
@@ -140,7 +144,10 @@ def intent_value(options: argparse.Namespace) -> dict[str, object]:
 
 def main(arguments: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("action", choices=("intent", "unknown", "ack", "fail", "find", "claim"))
+    parser.add_argument(
+        "action",
+        choices=("intent", "unknown", "ack", "fail", "find", "find-run", "claim"),
+    )
     parser.add_argument("--root", type=Path, required=True)
     parser.add_argument("--request-id")
     parser.add_argument("--workflow")
@@ -150,18 +157,31 @@ def main(arguments: list[str] | None = None) -> int:
     parser.add_argument("--mode", default="")
     options = parser.parse_args(arguments)
     try:
-        if options.action in {"find", "claim"}:
+        if options.action in {"find", "find-run", "claim"}:
             if (
                 not options.workflow
                 or VERSION_PATTERN.fullmatch(options.version or "") is None
                 or not re.fullmatch(r"[0-9a-f]{40}", options.control_sha or "")
             ):
                 raise JournalError("dispatch lookup is missing workflow/version/control")
-            if options.action == "find":
+            if options.action in {"find", "find-run"}:
                 matches = matching_records(
-                    options.root, options.workflow, options.version,
-                    options.control_sha, options.mode,
+                    options.root,
+                    options.workflow,
+                    options.version,
+                    options.control_sha,
+                    options.mode if options.action == "find" else None,
                 )
+                if options.action == "find-run":
+                    if not re.fullmatch(r"[0-9]+", options.run_id or ""):
+                        raise JournalError("find-run requires a valid --run-id")
+                    matches = [
+                        record
+                        for record in matches
+                        if record.get("run_id") == options.run_id
+                    ]
+                    if len(matches) > 1:
+                        raise JournalError("workflow run matches multiple dispatch records")
                 print(json.dumps(matches[0] if matches else {}, sort_keys=True))
                 return 0
             if not options.request_id:

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -703,7 +703,12 @@ def plan_recovery(
     postconditions: dict[str, Any],
 ) -> dict[str, Any]:
     """Return a pure, single-next-step recovery plan from typed observations."""
-    missing_release_assets = sorted(set(missing) & set(EXPECTED_RELEASE_ASSETS))
+    expected_release_assets = (
+        EXPECTED_DRAFT_ASSETS
+        if remote.get("state") == "draft"
+        else EXPECTED_RELEASE_ASSETS
+    )
+    missing_release_assets = sorted(set(missing) & set(expected_release_assets))
     missing_documentation = sorted(
         set(missing) & set(EXPECTED_DOCUMENTATION_ASSETS)
     )

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -218,6 +218,12 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
         for asset in assets
         if isinstance(asset, dict) and isinstance(asset.get("name"), str)
     )
+    if release.get("draft") is False and release.get("prerelease") is False:
+        release_state = "published"
+    elif release.get("draft") is True and release.get("prerelease") is False:
+        release_state = "draft"
+    else:
+        release_state = "invalid"
     result = {
         "assets": names,
         "asset_digests": {
@@ -230,9 +236,7 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
         "draft": release.get("draft"),
         "id": release.get("id"),
         "prerelease": release.get("prerelease"),
-        "state": "published"
-        if release.get("draft") is False and release.get("prerelease") is False
-        else "invalid",
+        "state": release_state,
     }
     result["missing_assets"] = sorted(set(EXPECTED_RELEASE_ASSETS) - set(names))
     return result
@@ -706,6 +710,15 @@ def plan_recovery(
             prerequisites=["retained manifest", "remote release identity and digests"],
             side_effects=[],
             authority="release maintainer decision",
+            invalidates=["formulae", "pages"],
+        )
+    if remote.get("state") == "draft" and not missing_release_assets:
+        return recovery_action(
+            "resume-stable-draft",
+            "reconcile and publish the existing stable release draft",
+            prerequisites=["retained-complete manifest", "matching stable draft"],
+            side_effects=["upload missing assets", "publish stable release"],
+            authority="retained publication authority",
             invalidates=["formulae", "pages"],
         )
     if (

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -226,7 +226,7 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
     )
     if release.get("draft") is False and release.get("prerelease") is False:
         release_state = "published"
-    elif release.get("draft") is True and release.get("prerelease") is False:
+    elif release.get("draft") is True:
         release_state = "draft"
     else:
         release_state = "invalid"

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -45,18 +45,20 @@ FORMULA = importlib.util.module_from_spec(FORMULA_SPEC)
 FORMULA_SPEC.loader.exec_module(FORMULA)
 SEMVER = re.compile(r"[0-9]+[.][0-9]+[.][0-9]+")
 REQUEST_ID = re.compile(r"[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}")
-EXPECTED_RELEASE_ASSETS = (
+EXPECTED_DRAFT_ASSETS = (
     "container-compose-plugin-release-arm64.tar.gz",
     "container-compose-plugin-release-arm64.tar.gz.sha256",
     "container-release-arm64.tar.gz",
     "container-release-arm64.tar.gz.sha256",
-    "container-vminit-arm64.oci.tar",
-    "container-vminit-arm64.oci.tar.sha256",
     "stable-release-authority.tar.gz",
     "stable-release-authority.tar.gz.sha256",
     "release-highlights.json",
     "quality-snapshot.svg",
 )
+EXPECTED_RELEASE_ASSETS = EXPECTED_DRAFT_ASSETS[:4] + (
+    "container-vminit-arm64.oci.tar",
+    "container-vminit-arm64.oci.tar.sha256",
+) + EXPECTED_DRAFT_ASSETS[4:]
 EXPECTED_DOCUMENTATION_ASSETS = (
     "compose.tgz",
     "container.tgz",
@@ -244,7 +246,10 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
         "prerelease": release.get("prerelease"),
         "state": release_state,
     }
-    result["missing_assets"] = sorted(set(EXPECTED_RELEASE_ASSETS) - set(names))
+    expected = (
+        EXPECTED_DRAFT_ASSETS if release_state == "draft" else EXPECTED_RELEASE_ASSETS
+    )
+    result["missing_assets"] = sorted(set(expected) - set(names))
     return result
 
 
@@ -265,7 +270,12 @@ def reconcile_remote_digests(
         )
         return result
     duplicates = sorted({name for name in names if names.count(name) > 1})
-    unexpected = sorted(set(names) - set(EXPECTED_RELEASE_ASSETS))
+    expected = (
+        EXPECTED_DRAFT_ASSETS
+        if remote.get("state") == "draft"
+        else EXPECTED_RELEASE_ASSETS
+    )
+    unexpected = sorted(set(names) - set(expected))
     result["duplicate_assets"] = duplicates
     result["unexpected_assets"] = unexpected
     if duplicates or unexpected:

--- a/Tools/release/release-state.py
+++ b/Tools/release/release-state.py
@@ -213,10 +213,16 @@ def remote_release(repo: str, version: str, offline: bool) -> dict[str, Any]:
     assets = release.get("assets", [])
     if not isinstance(assets, list):
         return {"reason": "GitHub returned malformed release assets", "state": "unavailable"}
+    if not all(
+        isinstance(asset, dict)
+        and isinstance(asset.get("name"), str)
+        and bool(asset["name"])
+        for asset in assets
+    ):
+        return {"reason": "GitHub returned malformed release assets", "state": "unavailable"}
     names = sorted(
         asset["name"]
         for asset in assets
-        if isinstance(asset, dict) and isinstance(asset.get("name"), str)
     )
     if release.get("draft") is False and release.get("prerelease") is False:
         release_state = "published"
@@ -247,7 +253,26 @@ def reconcile_remote_digests(
 ) -> dict[str, Any]:
     """Bind API-provided remote asset digests to the retained manifest."""
     result = dict(remote)
-    if remote.get("state") != "published" or manifest is None:
+    if remote.get("state") not in {"draft", "published"} or manifest is None:
+        return result
+    names = remote.get("assets")
+    if not isinstance(names, list) or not all(
+        isinstance(name, str) and name for name in names
+    ):
+        result.update(
+            reason="remote release asset inventory is malformed",
+            state="unavailable",
+        )
+        return result
+    duplicates = sorted({name for name in names if names.count(name) > 1})
+    unexpected = sorted(set(names) - set(EXPECTED_RELEASE_ASSETS))
+    result["duplicate_assets"] = duplicates
+    result["unexpected_assets"] = unexpected
+    if duplicates or unexpected:
+        result.update(
+            reason="remote release asset inventory conflicts with retained closure",
+            state="conflicting",
+        )
         return result
     observed = remote.get("asset_digests")
     if not isinstance(observed, dict):
@@ -258,9 +283,10 @@ def reconcile_remote_digests(
         return result
     conflicts: dict[str, dict[str, str]] = {}
     unavailable: list[str] = []
-    for name in EXPECTED_RELEASE_ASSETS:
+    for name in names:
         record = manifest["assets"].get(name)
         if not isinstance(record, dict) or not isinstance(record.get("sha256"), str):
+            unavailable.append(name)
             continue
         digest = observed.get(name)
         if digest is None:
@@ -277,7 +303,7 @@ def reconcile_remote_digests(
             reason="remote release asset digests conflict with retained bytes",
             state="conflicting",
         )
-    elif unavailable and not result.get("missing_assets"):
+    elif unavailable:
         result.update(
             reason="remote release asset digests are unavailable",
             state="unavailable",

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2549,6 +2549,39 @@ github_cli() {{
         self.assertIn("wait 812 stable documentation and Pages deployment", active.stdout)
         self.assertIn("retained 0.15.0 812", active.stdout)
 
+    def test_failed_docc_regeneration_retries_the_same_logical_lineage(self) -> None:
+        retried = self.run_release_function(
+            Path("/tmp/unused-release-root"),
+            "dispatch_stable_documentation 0.15.0",
+            shell_setup="\n".join(
+                [
+                    (
+                        "latest_stable_documentation_dispatch() { "
+                        "printf '913\\tcompleted\\tfailure\\n'; }"
+                    ),
+                    "remote_main_commit() { printf '%s\\n' control; }",
+                    (
+                        "documentation_dispatch_mode_for_run() { "
+                        "printf '%s\\n' docs-regenerate-731; }"
+                    ),
+                    (
+                        "dispatch_github_workflow_run() { "
+                        "printf 'dispatch:%s:%s\\n' \"$1\" \"$5\" >&2; "
+                        "printf '%s\\n' 914; }"
+                    ),
+                    "wait_for_github_run_success() { :; }",
+                    (
+                        "retain_stable_documentation_artifacts() { "
+                        "printf 'retained %s %s\\n' \"$1\" \"$2\"; }"
+                    ),
+                ]
+            ),
+        )
+
+        self.assertEqual(retried.returncode, 0, retried.stderr)
+        self.assertIn("dispatch:docs.yml:docs-regenerate-731", retried.stderr)
+        self.assertIn("retained 0.15.0 914", retried.stdout)
+
     def test_release_helper_writes_the_published_k8s_documentation_authority(
         self,
     ) -> None:

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -2582,6 +2582,47 @@ github_cli() {{
         self.assertIn("dispatch:docs.yml:docs-regenerate-731", retried.stderr)
         self.assertIn("retained 0.15.0 914", retried.stdout)
 
+    def test_unjournaled_failed_docc_run_starts_a_new_logical_lineage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            retried = self.run_release_function(
+                Path(directory),
+                "documentation_dispatch_mode_for_run 0.15.0 "
+                f"{'a' * 40} 913",
+            )
+
+        self.assertEqual(retried.returncode, 0, retried.stderr)
+        self.assertEqual(retried.stdout.strip(), "docs-regenerate-913")
+
+    def test_legacy_mode_less_docc_run_starts_a_new_logical_lineage(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            request_id = "11111111-1111-1111-1111-111111111111"
+            dispatches = root / "retained" / "release" / "dispatches"
+            dispatches.mkdir(parents=True)
+            (dispatches / f"{request_id}.json").write_text(
+                json.dumps(
+                    {
+                        "control_sha": "a" * 40,
+                        "created_at": "2026-09-11T00:00:00+00:00",
+                        "request_id": request_id,
+                        "run_id": "913",
+                        "schema": 1,
+                        "state": "failed",
+                        "version": "0.15.0",
+                        "workflow": "docs.yml",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            retried = self.run_release_function(
+                root,
+                "documentation_dispatch_mode_for_run 0.15.0 "
+                f"{'a' * 40} 913",
+            )
+
+        self.assertEqual(retried.returncode, 0, retried.stderr)
+        self.assertEqual(retried.stdout.strip(), "docs-regenerate-913")
+
     def test_release_helper_writes_the_published_k8s_documentation_authority(
         self,
     ) -> None:

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -37,7 +37,7 @@ if [[ "$1" == "api" ]]; then
       exit 0
       ;;
     draft)
-      printf '{"draft":true}\n'
+      printf '{"draft":true,"name":"Foreign title","body":"foreign notes","prerelease":true}\n'
       exit 0
       ;;
     missing)
@@ -156,7 +156,7 @@ run_publisher tag missing "${stable_create_calls}"
 grep -Fqx "release create 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --verify-tag --latest --draft" "${stable_create_calls}"
 grep -Fqx "release upload 1.2.3 ${asset} --repo stephenlclarke/container-compose" "${stable_create_calls}"
 grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-compose" "${stable_create_calls}"
-grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --draft=false --latest" "${stable_create_calls}"
+grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --draft=false --prerelease=false --latest" "${stable_create_calls}"
 if grep -Eq 'clobber|release delete' "${stable_create_calls}"; then
   printf 'stable publication attempted to replace immutable state\n' >&2
   exit 1
@@ -166,7 +166,7 @@ stable_draft_calls="${temporary_directory}/stable-draft.calls"
 run_publisher tag draft "${stable_draft_calls}"
 grep -Fqx "release upload 1.2.3 ${asset} --repo stephenlclarke/container-compose" "${stable_draft_calls}"
 grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-compose" "${stable_draft_calls}"
-grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --draft=false --latest" "${stable_draft_calls}"
+grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --draft=false --prerelease=false --latest" "${stable_draft_calls}"
 if grep -Eq 'release create|clobber|release delete' "${stable_draft_calls}"; then
   printf 'stable draft recovery recreated or clobbered release state\n' >&2
   exit 1

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -54,7 +54,16 @@ if [[ "$1" == "api" ]]; then
 fi
 
 if [[ "$1" == "release" && "$2" == "view" ]]; then
-  printf '%s' "${MOCK_REMOTE_ASSETS:-}"
+  view_count=0
+  if [[ -f "${MOCK_VIEW_COUNT_FILE}" ]]; then
+    view_count="$(<"${MOCK_VIEW_COUNT_FILE}")"
+  fi
+  view_count=$((view_count + 1))
+  printf '%s\n' "${view_count}" > "${MOCK_VIEW_COUNT_FILE}"
+  if (( view_count == 2 )) && [[ -n "${MOCK_RACE_ASSET:-}" ]]; then
+    printf '%s\n' "${MOCK_RACE_ASSET}" >> "${MOCK_REMOTE_STATE}"
+  fi
+  cat "${MOCK_REMOTE_STATE}"
   exit 0
 fi
 
@@ -76,6 +85,10 @@ if [[ "$1" == "release" && "$2" == "download" ]]; then
   done
   printf '%s' "${MOCK_DOWNLOAD_CONTENT:-}" > "${directory}/${pattern}"
   exit 0
+fi
+
+if [[ "$1" == "release" && "$2" == "upload" ]]; then
+  basename "$4" >> "${MOCK_REMOTE_STATE}"
 fi
 
 printf '%s\n' "$*" >> "${MOCK_GH_CALLS}"
@@ -116,6 +129,8 @@ run_publisher() {
     release_prerelease="false"
     release_mutable="false"
   fi
+  printf '%s' "${6:-}" > "${3}.remote"
+  printf '0\n' > "${3}.views"
 
   GH="${temporary_directory}/bin/gh" \
     GIT="${temporary_directory}/bin/git" \
@@ -136,6 +151,9 @@ run_publisher() {
     MOCK_RELEASE_STATE="$2" \
     MOCK_REMOTE_ASSETS="${6:-}" \
     MOCK_DOWNLOAD_CONTENT="${7:-}" \
+    MOCK_RACE_ASSET="${8:-}" \
+    MOCK_REMOTE_STATE="${3}.remote" \
+    MOCK_VIEW_COUNT_FILE="${3}.views" \
     MOCK_GH_CALLS="$3" \
     MOCK_GIT_CALLS="${3}.git" \
     "${publisher}"
@@ -205,6 +223,18 @@ fi
 if [[ -e "${stable_draft_late_mismatch_calls}" ]] && \
   grep -Eq 'release (upload|edit|create|delete)' "${stable_draft_late_mismatch_calls}"; then
   printf 'stable draft recovery mutated before validating every existing asset\n' >&2
+  exit 1
+fi
+
+stable_draft_race_calls="${temporary_directory}/stable-draft-race.calls"
+if run_publisher tag draft "${stable_draft_race_calls}" "" publish \
+  "" "" 'foreign-after-upload.tar.gz'; then
+  printf 'stable draft recovery published after a concurrent inventory change\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'release upload' "${stable_draft_race_calls}" || \
+  grep -Fq 'release edit' "${stable_draft_race_calls}"; then
+  printf 'stable draft recovery did not block publication after the inventory race\n' >&2
   exit 1
 fi
 

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -196,6 +196,18 @@ if [[ -e "${stable_draft_mismatch_calls}" ]] && \
   exit 1
 fi
 
+stable_draft_late_mismatch_calls="${temporary_directory}/stable-draft-late-mismatch.calls"
+if run_publisher tag draft "${stable_draft_late_mismatch_calls}" "" publish \
+  "$(basename "${checksum}")" 'conflicting bytes'; then
+  printf 'stable draft recovery accepted a later mismatched asset\n' >&2
+  exit 1
+fi
+if [[ -e "${stable_draft_late_mismatch_calls}" ]] && \
+  grep -Eq 'release (upload|edit|create|delete)' "${stable_draft_late_mismatch_calls}"; then
+  printf 'stable draft recovery mutated before validating every existing asset\n' >&2
+  exit 1
+fi
+
 stable_unavailable_calls="${temporary_directory}/stable-unavailable.calls"
 if run_publisher tag unavailable "${stable_unavailable_calls}"; then
   printf 'stable publication unexpectedly ignored a release lookup failure\n' >&2

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -32,6 +32,10 @@ if [[ "$1" == "api" ]]; then
     printf 'release lookup must preserve the response body\n' >&2
     exit 64
   fi
+  if [[ "$2" == */releases/latest ]]; then
+    printf '%s\n' "${MOCK_LATEST_TAG:-1.2.3}"
+    exit 0
+  fi
   case "${MOCK_RELEASE_STATE}" in
     exists)
       exit 0
@@ -63,7 +67,37 @@ if [[ "$1" == "release" && "$2" == "view" ]]; then
   if (( view_count == 2 )) && [[ -n "${MOCK_RACE_ASSET:-}" ]]; then
     printf '%s\n' "${MOCK_RACE_ASSET}" >> "${MOCK_REMOTE_STATE}"
   fi
-  cat "${MOCK_REMOTE_STATE}"
+  if (( view_count == 4 )) && [[ -n "${MOCK_POST_PUBLISH_RACE_ASSET:-}" ]]; then
+    printf '%s\n' "${MOCK_POST_PUBLISH_RACE_ASSET}" >> "${MOCK_REMOTE_STATE}"
+  fi
+  if [[ " $* " == *"isDraft"* ]]; then
+    digest="$(printf '%s' "${MOCK_DOWNLOAD_CONTENT:-}" | shasum -a 256 | awk '{print $1}')"
+    if [[ "${MOCK_RELEASE_STATE}" == "exists" ]] || (( view_count >= 4 )); then
+      draft=false
+    else
+      draft="${MOCK_FINAL_DRAFT_STATE:-true}"
+    fi
+    printf '{"isDraft":%s,"isImmutable":%s,"isPrerelease":false,"tagName":"1.2.3","targetCommitish":"0123456789012345678901234567890123456789","name":"%s","body":"%s","assets":[' \
+      "${draft}" "${MOCK_PUBLISHED_IMMUTABLE:-true}" \
+      "${MOCK_PUBLISHED_NAME:-1.2.3}" "${MOCK_PUBLISHED_BODY:-}"
+    separator=""
+    while IFS= read -r name; do
+      [[ -n "${name}" ]] || continue
+      if [[ -n "${MOCK_FINAL_DIGEST_MISMATCH:-}" && \
+        "${name}" == "${MOCK_FINAL_DIGEST_MISMATCH}" ]]; then
+        asset_digest="$(printf '%064d' 0)"
+      else
+        asset_digest="${digest}"
+      fi
+      printf '%s' "${separator}"
+      jq -cn --arg name "${name}" --arg digest "sha256:${asset_digest}" \
+        '{name: $name, digest: $digest}'
+      separator=,
+    done < "${MOCK_REMOTE_STATE}"
+    printf ']}\n'
+  else
+    cat "${MOCK_REMOTE_STATE}"
+  fi
   exit 0
 fi
 
@@ -102,6 +136,10 @@ set -Eeuo pipefail
 printf '%s\n' "$*" >> "${MOCK_GIT_CALLS}"
 if [[ "$1" == rev-list ]]; then
   printf '0123456789012345678901234567890123456789\n'
+fi
+if [[ "$1" == ls-remote ]]; then
+  printf '%s\trefs/tags/1.2.3\n' \
+    "${MOCK_REMOTE_TAG_SHA:-0123456789012345678901234567890123456789}"
 fi
 EOF
 chmod +x "${temporary_directory}/bin/git"
@@ -152,6 +190,14 @@ run_publisher() {
     MOCK_REMOTE_ASSETS="${6:-}" \
     MOCK_DOWNLOAD_CONTENT="${7:-}" \
     MOCK_RACE_ASSET="${8:-}" \
+    MOCK_FINAL_DIGEST_MISMATCH="${9:-}" \
+    MOCK_FINAL_DRAFT_STATE="${10:-true}" \
+    MOCK_POST_PUBLISH_RACE_ASSET="${11:-}" \
+    MOCK_PUBLISHED_IMMUTABLE="${12:-true}" \
+    MOCK_PUBLISHED_NAME="${13:-1.2.3}" \
+    MOCK_PUBLISHED_BODY="${14:-}" \
+    MOCK_LATEST_TAG="${15:-1.2.3}" \
+    MOCK_REMOTE_TAG_SHA="${16:-0123456789012345678901234567890123456789}" \
     MOCK_REMOTE_STATE="${3}.remote" \
     MOCK_VIEW_COUNT_FILE="${3}.views" \
     MOCK_GH_CALLS="$3" \
@@ -169,12 +215,21 @@ if [[ -e "${stable_existing_calls}" ]]; then
   exit 1
 fi
 
+stable_existing_exact_calls="${temporary_directory}/stable-existing-exact.calls"
+run_publisher tag exists "${stable_existing_exact_calls}" "" publish \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n'
+if [[ -e "${stable_existing_exact_calls}" ]] && \
+  grep -Eq 'release (upload|edit|create|delete)' "${stable_existing_exact_calls}"; then
+  printf 'exact published stable recovery performed a mutation\n' >&2
+  exit 1
+fi
+
 stable_create_calls="${temporary_directory}/stable-create.calls"
 run_publisher tag missing "${stable_create_calls}"
-grep -Fqx "release create 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --verify-tag --latest --draft" "${stable_create_calls}"
+grep -Fqx "release create 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --target 0123456789012345678901234567890123456789 --verify-tag --latest --draft" "${stable_create_calls}"
 grep -Fqx "release upload 1.2.3 ${asset} --repo stephenlclarke/container-compose" "${stable_create_calls}"
 grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-compose" "${stable_create_calls}"
-grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --draft=false --prerelease=false --latest" "${stable_create_calls}"
+grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --title 1.2.3 --notes-file ${notes} --draft=false --prerelease=false --latest" "${stable_create_calls}"
 if grep -Eq 'clobber|release delete' "${stable_create_calls}"; then
   printf 'stable publication attempted to replace immutable state\n' >&2
   exit 1
@@ -184,7 +239,7 @@ stable_draft_calls="${temporary_directory}/stable-draft.calls"
 run_publisher tag draft "${stable_draft_calls}"
 grep -Fqx "release upload 1.2.3 ${asset} --repo stephenlclarke/container-compose" "${stable_draft_calls}"
 grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-compose" "${stable_draft_calls}"
-grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --draft=false --prerelease=false --latest" "${stable_draft_calls}"
+grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --title 1.2.3 --notes-file ${notes} --draft=false --prerelease=false --latest" "${stable_draft_calls}"
 if grep -Eq 'release create|clobber|release delete' "${stable_draft_calls}"; then
   printf 'stable draft recovery recreated or clobbered release state\n' >&2
   exit 1
@@ -235,6 +290,77 @@ fi
 if ! grep -Fq 'release upload' "${stable_draft_race_calls}" || \
   grep -Fq 'release edit' "${stable_draft_race_calls}"; then
   printf 'stable draft recovery did not block publication after the inventory race\n' >&2
+  exit 1
+fi
+
+stable_draft_digest_race_calls="${temporary_directory}/stable-draft-digest-race.calls"
+if run_publisher tag draft "${stable_draft_digest_race_calls}" "" publish \
+  "" "" "" "$(basename "${asset}")"; then
+  printf 'stable draft recovery published after a concurrent digest change\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'release upload' "${stable_draft_digest_race_calls}" || \
+  grep -Fq 'release edit' "${stable_draft_digest_race_calls}"; then
+  printf 'stable draft recovery did not block publication after the digest race\n' >&2
+  exit 1
+fi
+
+stable_draft_published_race_calls="${temporary_directory}/stable-draft-published-race.calls"
+if run_publisher tag draft "${stable_draft_published_race_calls}" "" publish \
+  "" "" "" "" false; then
+  printf 'stable draft recovery edited a concurrently published release\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'release upload' "${stable_draft_published_race_calls}" || \
+  grep -Fq 'release edit' "${stable_draft_published_race_calls}"; then
+  printf 'stable draft recovery did not stop after concurrent publication\n' >&2
+  exit 1
+fi
+
+stable_post_publish_race_calls="${temporary_directory}/stable-post-publish-race.calls"
+if run_publisher tag draft "${stable_post_publish_race_calls}" "" publish \
+  "" "" "" "" true 'foreign-after-publication.tar.gz'; then
+  printf 'stable publication accepted a changed immutable snapshot\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'release edit' "${stable_post_publish_race_calls}"; then
+  printf 'stable publication did not exercise post-publication verification\n' >&2
+  exit 1
+fi
+
+stable_mutable_publication_calls="${temporary_directory}/stable-mutable-publication.calls"
+if run_publisher tag draft "${stable_mutable_publication_calls}" "" publish \
+  "" "" "" "" true "" false; then
+  printf 'stable publication accepted a mutable published release\n' >&2
+  exit 1
+fi
+
+stable_metadata_drift_calls="${temporary_directory}/stable-metadata-drift.calls"
+if run_publisher tag exists "${stable_metadata_drift_calls}" "" publish \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n' \
+  "" "" "" true "" true 'Foreign title'; then
+  printf 'stable recovery accepted changed release metadata\n' >&2
+  exit 1
+fi
+
+stable_latest_drift_calls="${temporary_directory}/stable-latest-drift.calls"
+if run_publisher tag exists "${stable_latest_drift_calls}" "" publish \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n' \
+  "" "" "" true "" true 1.2.3 "" 1.2.2; then
+  printf 'stable recovery accepted a changed latest-release pointer\n' >&2
+  exit 1
+fi
+
+stable_tag_drift_calls="${temporary_directory}/stable-tag-drift.calls"
+if run_publisher tag exists "${stable_tag_drift_calls}" "" publish \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n' \
+  "" "" "" true "" true 1.2.3 "" 1.2.3 \
+  1111111111111111111111111111111111111111; then
+  printf 'stable recovery accepted a retargeted published tag\n' >&2
+  exit 1
+fi
+if ! grep -Fq 'release edit' "${stable_mutable_publication_calls}"; then
+  printf 'stable immutable verification did not run after publication\n' >&2
   exit 1
 fi
 

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -53,6 +53,31 @@ if [[ "$1" == "api" ]]; then
   exit 2
 fi
 
+if [[ "$1" == "release" && "$2" == "view" ]]; then
+  printf '%s' "${MOCK_REMOTE_ASSETS:-}"
+  exit 0
+fi
+
+if [[ "$1" == "release" && "$2" == "download" ]]; then
+  while (( $# > 0 )); do
+    case "$1" in
+      --pattern)
+        pattern="$2"
+        shift 2
+        ;;
+      --dir)
+        directory="$2"
+        shift 2
+        ;;
+      *)
+        shift
+        ;;
+    esac
+  done
+  printf '%s' "${MOCK_DOWNLOAD_CONTENT:-}" > "${directory}/${pattern}"
+  exit 0
+fi
+
 printf '%s\n' "$*" >> "${MOCK_GH_CALLS}"
 EOF
 chmod +x "${temporary_directory}/bin/gh"
@@ -109,6 +134,8 @@ run_publisher() {
     RELEASE_RETAINED_COMPLETE_MANIFEST="${retained_manifest}" \
     RELEASE_EXTRA_ASSETS_FILE="${4:-}" \
     MOCK_RELEASE_STATE="$2" \
+    MOCK_REMOTE_ASSETS="${6:-}" \
+    MOCK_DOWNLOAD_CONTENT="${7:-}" \
     MOCK_GH_CALLS="$3" \
     MOCK_GIT_CALLS="${3}.git" \
     "${publisher}"
@@ -142,6 +169,30 @@ grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-comp
 grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --draft=false --latest" "${stable_draft_calls}"
 if grep -Eq 'release create|clobber|release delete' "${stable_draft_calls}"; then
   printf 'stable draft recovery recreated or clobbered release state\n' >&2
+  exit 1
+fi
+
+stable_draft_unexpected_calls="${temporary_directory}/stable-draft-unexpected.calls"
+if run_publisher tag draft "${stable_draft_unexpected_calls}" "" publish \
+  $'foreign.tar.gz\n'; then
+  printf 'stable draft recovery accepted an unexpected asset\n' >&2
+  exit 1
+fi
+if [[ -e "${stable_draft_unexpected_calls}" ]] && \
+  grep -Eq 'release (upload|edit|create|delete)' "${stable_draft_unexpected_calls}"; then
+  printf 'stable draft recovery mutated a draft with an unexpected asset\n' >&2
+  exit 1
+fi
+
+stable_draft_mismatch_calls="${temporary_directory}/stable-draft-mismatch.calls"
+if run_publisher tag draft "${stable_draft_mismatch_calls}" "" publish \
+  "$(basename "${asset}")" 'conflicting bytes'; then
+  printf 'stable draft recovery accepted a mismatched asset\n' >&2
+  exit 1
+fi
+if [[ -e "${stable_draft_mismatch_calls}" ]] && \
+  grep -Eq 'release (upload|edit|create|delete)' "${stable_draft_mismatch_calls}"; then
+  printf 'stable draft recovery mutated a draft with a mismatched asset\n' >&2
   exit 1
 fi
 

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -174,7 +174,7 @@ fi
 
 stable_draft_unexpected_calls="${temporary_directory}/stable-draft-unexpected.calls"
 if run_publisher tag draft "${stable_draft_unexpected_calls}" "" publish \
-  $'foreign.tar.gz\n'; then
+  $'container-vminit-arm64.oci.tar\ncontainer-vminit-arm64.oci.tar.sha256\n'; then
   printf 'stable draft recovery accepted an unexpected asset\n' >&2
   exit 1
 fi

--- a/Tools/release/test_release_dispatch_journal.py
+++ b/Tools/release/test_release_dispatch_journal.py
@@ -153,6 +153,40 @@ class ReleaseDispatchJournalTests(unittest.TestCase):
         self.assertEqual(result, 0)
         self.assertEqual(json.loads(output.getvalue())["request_id"], self.request)
 
+    def test_find_run_recovers_the_original_logical_mode(self) -> None:
+        common = [
+            "--workflow",
+            "docs.yml",
+            "--version",
+            "0.15.0",
+            "--control-sha",
+            "a" * 40,
+            "--mode",
+            "docs-regenerate-731",
+        ]
+        self.assertEqual(self.invoke("intent", *common), 0)
+        self.assertEqual(self.invoke("ack", "--run-id", "987"), 0)
+        output = StringIO()
+        with redirect_stdout(output):
+            result = MODULE.main(
+                [
+                    "find-run",
+                    "--root",
+                    str(self.root),
+                    "--workflow",
+                    "docs.yml",
+                    "--version",
+                    "0.15.0",
+                    "--control-sha",
+                    "a" * 40,
+                    "--run-id",
+                    "987",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        self.assertEqual(json.loads(output.getvalue())["mode"], "docs-regenerate-731")
+
     def test_claim_reuses_one_logical_operation(self) -> None:
         arguments = [
             "claim", "--root", str(self.root), "--workflow", "docs.yml",

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -220,6 +220,29 @@ class ReleaseStateTests(unittest.TestCase):
         self.assertEqual(observed["state"], "conflicting")
         self.assertEqual(observed["unexpected_assets"], ["foreign.tar.gz"])
 
+    def test_draft_rejects_postpublication_init_asset_pair(self) -> None:
+        names = [
+            "container-vminit-arm64.oci.tar",
+            "container-vminit-arm64.oci.tar.sha256",
+        ]
+        assets = {
+            asset: {"sha256": "a" * 64}
+            for asset in MODULE.EXPECTED_RETAINED_ASSETS
+        }
+        remote = {
+            "asset_digests": {
+                name: "sha256:" + str(assets[name]["sha256"]) for name in names
+            },
+            "assets": names,
+            "missing_assets": list(MODULE.EXPECTED_DRAFT_ASSETS),
+            "state": "draft",
+        }
+
+        observed = MODULE.reconcile_remote_digests(remote, {"assets": assets})
+
+        self.assertEqual(observed["state"], "conflicting")
+        self.assertEqual(observed["unexpected_assets"], sorted(names))
+
     def test_draft_with_mismatched_asset_digest_is_a_conflict(self) -> None:
         name = MODULE.EXPECTED_RELEASE_ASSETS[0]
         assets = {

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -147,6 +147,29 @@ class ReleaseStateTests(unittest.TestCase):
         self.assertEqual(remote["state"], "unavailable")
         self.assertIn("malformed", remote["reason"])
 
+    def test_nonprerelease_draft_is_planned_as_resumable(self) -> None:
+        completed = self.completed(
+            {
+                "assets": [],
+                "draft": True,
+                "id": 123,
+                "prerelease": False,
+            }
+        )
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed):
+            remote = MODULE.remote_release("owner/repo", "1.2.3", False)
+
+        self.assertEqual(remote["state"], "draft")
+        action = MODULE.plan_recovery(
+            [],
+            [],
+            [],
+            remote,
+            {"formulae": {"state": "deferred"}, "pages": {"state": "deferred"}},
+        )
+        self.assertEqual(action["name"], "resume-stable-draft")
+        self.assertIn("publish", action["summary"])
+
     def test_complete_local_store_plans_missing_remote_assets_before_postconditions(
         self,
     ) -> None:

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -168,7 +168,10 @@ class ReleaseStateTests(unittest.TestCase):
         action = MODULE.plan_recovery(
             [],
             [],
-            [],
+            [
+                "container-vminit-arm64.oci.tar",
+                "container-vminit-arm64.oci.tar.sha256",
+            ],
             remote,
             {"formulae": {"state": "deferred"}, "pages": {"state": "deferred"}},
         )

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -159,6 +159,11 @@ class ReleaseStateTests(unittest.TestCase):
         with mock.patch.object(MODULE.subprocess, "run", return_value=completed):
             remote = MODULE.remote_release("owner/repo", "1.2.3", False)
 
+        assets = {
+            asset: {"sha256": "a" * 64}
+            for asset in MODULE.EXPECTED_RETAINED_ASSETS
+        }
+        remote = MODULE.reconcile_remote_digests(remote, {"assets": assets})
         self.assertEqual(remote["state"], "draft")
         action = MODULE.plan_recovery(
             [],
@@ -169,6 +174,41 @@ class ReleaseStateTests(unittest.TestCase):
         )
         self.assertEqual(action["name"], "resume-stable-draft")
         self.assertIn("publish", action["summary"])
+
+    def test_draft_with_unexpected_asset_is_a_conflict(self) -> None:
+        assets = {
+            asset: {"sha256": "a" * 64}
+            for asset in MODULE.EXPECTED_RETAINED_ASSETS
+        }
+        remote = {
+            "asset_digests": {"foreign.tar.gz": "sha256:" + "a" * 64},
+            "assets": ["foreign.tar.gz"],
+            "missing_assets": list(MODULE.EXPECTED_RELEASE_ASSETS),
+            "state": "draft",
+        }
+
+        observed = MODULE.reconcile_remote_digests(remote, {"assets": assets})
+
+        self.assertEqual(observed["state"], "conflicting")
+        self.assertEqual(observed["unexpected_assets"], ["foreign.tar.gz"])
+
+    def test_draft_with_mismatched_asset_digest_is_a_conflict(self) -> None:
+        name = MODULE.EXPECTED_RELEASE_ASSETS[0]
+        assets = {
+            asset: {"sha256": "a" * 64}
+            for asset in MODULE.EXPECTED_RETAINED_ASSETS
+        }
+        remote = {
+            "asset_digests": {name: "sha256:" + "b" * 64},
+            "assets": [name],
+            "missing_assets": sorted(set(MODULE.EXPECTED_RELEASE_ASSETS) - {name}),
+            "state": "draft",
+        }
+
+        observed = MODULE.reconcile_remote_digests(remote, {"assets": assets})
+
+        self.assertEqual(observed["state"], "conflicting")
+        self.assertIn(name, observed["digest_conflicts"])
 
     def test_complete_local_store_plans_missing_remote_assets_before_postconditions(
         self,
@@ -338,7 +378,7 @@ class ReleaseStateTests(unittest.TestCase):
         }
 
         observed = MODULE.reconcile_remote_digests(
-            remote, {"assets": assets}
+            {**remote, "assets": [name]}, {"assets": assets}
         )
 
         self.assertEqual(observed["state"], "conflicting")
@@ -352,7 +392,12 @@ class ReleaseStateTests(unittest.TestCase):
         }
 
         observed = MODULE.reconcile_remote_digests(
-            {"asset_digests": {}, "missing_assets": [], "state": "published"},
+            {
+                "asset_digests": {},
+                "assets": list(MODULE.EXPECTED_RELEASE_ASSETS),
+                "missing_assets": [],
+                "state": "published",
+            },
             {"assets": assets},
         )
 

--- a/Tools/release/test_release_state.py
+++ b/Tools/release/test_release_state.py
@@ -175,6 +175,34 @@ class ReleaseStateTests(unittest.TestCase):
         self.assertEqual(action["name"], "resume-stable-draft")
         self.assertIn("publish", action["summary"])
 
+    def test_stale_prerelease_draft_is_planned_as_resumable(self) -> None:
+        completed = self.completed(
+            {
+                "assets": [],
+                "draft": True,
+                "id": 123,
+                "prerelease": True,
+            }
+        )
+        with mock.patch.object(MODULE.subprocess, "run", return_value=completed):
+            remote = MODULE.remote_release("owner/repo", "1.2.3", False)
+
+        assets = {
+            asset: {"sha256": "a" * 64}
+            for asset in MODULE.EXPECTED_RETAINED_ASSETS
+        }
+        remote = MODULE.reconcile_remote_digests(remote, {"assets": assets})
+        action = MODULE.plan_recovery(
+            [],
+            [],
+            [],
+            remote,
+            {"formulae": {"state": "deferred"}, "pages": {"state": "deferred"}},
+        )
+
+        self.assertEqual(remote["state"], "draft")
+        self.assertEqual(action["name"], "resume-stable-draft")
+
     def test_draft_with_unexpected_asset_is_a_conflict(self) -> None:
         assets = {
             asset: {"sha256": "a" * 64}

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -6134,7 +6134,15 @@ documentation_dispatch_mode_for_run() {
     --root "${RELEASE_RETAINED_ROOT}" --workflow docs.yml \
     --version "${version}" --control-sha "${control_sha}" \
     --run-id "${run_id}")"
+  if jq -e 'length == 0' <<<"${record}" >/dev/null; then
+    printf 'docs-regenerate-%s\n' "${run_id}"
+    return 0
+  fi
   mode="$(jq -r '.mode // empty' <<<"${record}")"
+  if [[ -z "${mode}" ]]; then
+    printf 'docs-regenerate-%s\n' "${run_id}"
+    return 0
+  fi
   if [[ "${mode}" != docs && ! "${mode}" =~ ^docs-regenerate-[1-9][0-9]*$ ]]; then
     printf 'documentation run %s has no safe retained dispatch mode\n' \
       "${run_id}" >&2

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -6127,6 +6127,22 @@ latest_stable_documentation_dispatch() {
     --jq "map(select((.displayTitle | startswith(\"${title}\")) and .headSha == \"${control_sha}\")) | .[0] | [(.databaseId // \"\"), (.status // \"\"), (.conclusion // \"\")] | @tsv"
 }
 
+# Recover the logical dispatch mode for one acknowledged documentation run.
+documentation_dispatch_mode_for_run() {
+  local version="$1" control_sha="$2" run_id="$3" record mode
+  record="$(python3 "${RELEASE_DISPATCH_JOURNAL_TOOL}" find-run \
+    --root "${RELEASE_RETAINED_ROOT}" --workflow docs.yml \
+    --version "${version}" --control-sha "${control_sha}" \
+    --run-id "${run_id}")"
+  mode="$(jq -r '.mode // empty' <<<"${record}")"
+  if [[ "${mode}" != docs && ! "${mode}" =~ ^docs-regenerate-[1-9][0-9]*$ ]]; then
+    printf 'documentation run %s has no safe retained dispatch mode\n' \
+      "${run_id}" >&2
+    return 2
+  fi
+  printf '%s\n' "${mode}"
+}
+
 # Dispatch a workflow through the API that returns its exact run ID. The
 # expected control SHA is also an input, so a moving main branch fails before
 # expensive or mutating work instead of leaving title-based polling ambiguous.
@@ -7194,7 +7210,7 @@ retain_stable_documentation_artifacts() {
 
 # Dispatch or reuse the exact documentation workflow for a stable release.
 dispatch_stable_documentation() {
-  local version="$1" details previous_run status conclusion control_sha run_id
+  local version="$1" details previous_run status conclusion control_sha run_id retry_mode
   print_header "publish released documentation for ${version}"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -7242,7 +7258,13 @@ dispatch_stable_documentation() {
     return 0
   fi
 
-  run_id="$(dispatch_github_workflow_run docs.yml "${version}" "${control_sha}")"
+  retry_mode=docs
+  if [[ -n "${previous_run}" && "${status}" == "completed" ]]; then
+    retry_mode="$(documentation_dispatch_mode_for_run \
+      "${version}" "${control_sha}" "${previous_run}")"
+  fi
+  run_id="$(dispatch_github_workflow_run docs.yml "${version}" \
+    "${control_sha}" "" "${retry_mode}")"
   printf 'stable documentation started: %s\n' "${run_id}"
   if ! wait_for_github_run_success \
     "${run_id}" "stable documentation and Pages deployment" \


### PR DESCRIPTION
## Summary

Follow-up to #635 addressing the post-merge exact-head review findings and subsequent draft-recovery findings.

- recover failed documentation regeneration within its retained logical dispatch lineage, including schema-1 journals without an explicit mode
- treat stable-tag drafts, including stale prerelease metadata, as recoverable only after exact retained inventory and digest reconciliation
- define distinct pre-publication draft and completed-release asset contracts so post-publication vminit assets do not force rebuilds during draft recovery
- reject unexpected, duplicate, unverifiable, or mismatched draft assets
- validate all existing members before upload, then re-read and reverify complete membership and bytes immediately before publication
- serialize supported publishers, publish the exact target, and verify the authoritative immutable post-publication identity, metadata, asset, and direct/peeled remote-tag snapshot
- make an exact already-published immutable snapshot an idempotent success, closing lost-response recovery without mutating retained artifacts
- restore authoritative stable title, notes, prerelease=false, and latest policy before publication
- add regressions for lineage, draft contracts, unsafe contents, stale metadata, late conflicts, pre/post-publication races, immutable enforcement, and published recovery

GitHub does not expose conditional PATCH preconditions for Update Release. The static workflow concurrency group is the exclusive-writer contract for supported automation; a privileged out-of-band draft mutation is detected by the authoritative post-publication snapshot and cannot be reported as success.

## Validation

At exact signed head `c0372c7cccec88981a0d0a5c0e19c3e58d3929c7`:

- focused release-state and publisher regressions pass
- the publisher shell suite passes its draft-contract, stale-metadata, late-conflict/no-mutation, pre/post-publication race, immutable-state, and exact published-recovery fixtures
- Bash syntax and ShellCheck pass for changed shell entry points
- Python compilation and diff checks pass
- `make release-tools-test` passes 577 tests in 703.341s, plus the publisher shell suite, using a short mounted APFS temporary volume whose backing sparse image was on `/Volumes/SSD`; the volume and image were removed after the gate
- exact-head hosted Source Checks have passed; the remaining hosted exact-head checks are required before merge

No local runtime, Docker application, benchmark, release, or merge action was performed by this pull request validation.

