### PR TITLE
fix(runtime): scope volume initializer root explicitly

### DIFF
--- a/Sources/ComposeEngineRuntime/EngineVolumeInitializationSupport.swift
+++ b/Sources/ComposeEngineRuntime/EngineVolumeInitializationSupport.swift
@@ -161,16 +161,27 @@ enum EngineVolumeInitializerBuildContext {
         helperName: String = "compose-volume-initializer-linux-arm64",
         helperPath: String
     ) async throws -> Data {
-        let dockerfile = Data("""
-        FROM \(sourceImage)
-        COPY --chmod=0755 \(helperName) \(helperPath)
-        USER 0:0
-        ENTRYPOINT [\"\(helperPath)\"]
-        """.utf8)
+        let dockerfile = dockerfile(
+            sourceImage: sourceImage,
+            helperName: helperName,
+            helperPath: helperPath
+        )
         return ustar([
             Entry(name: "Dockerfile", mode: 0o644, contents: dockerfile),
             Entry(name: helperName, mode: 0o755, contents: helper),
         ])
+    }
+
+    private static func dockerfile(
+        sourceImage: String,
+        helperName: String,
+        helperPath: String
+    ) -> Data {
+        Data("""
+        FROM \(sourceImage)
+        COPY --chmod=0755 \(helperName) \(helperPath)
+        ENTRYPOINT [\"\(helperPath)\"]
+        """.utf8)
     }
 
     /// Apple's Engine build endpoint accepts a portable ustar context. Building
@@ -257,11 +268,14 @@ enum EngineVolumeInitializerBuildContext {
         helperPath: String
     ) -> String {
         let platformIdentity = platform ?? "<default>"
+        let recipe = dockerfile(
+            sourceImage: sourceDigest,
+            helperName: helperName,
+            helperPath: helperPath
+        )
         let digest = fnv1aHex([
-            Data(sourceDigest.utf8), Data([0]),
             Data(platformIdentity.utf8), Data([0]),
-            Data(helperName.utf8), Data([0]),
-            Data(helperPath.utf8), Data([0]),
+            recipe, Data([0]),
             helper,
         ])
         return "devcontainer-volume-initializer:\(digest)"

--- a/Tests/ComposeEngineRuntimeTests/ComposeEngineRuntimeTests.swift
+++ b/Tests/ComposeEngineRuntimeTests/ComposeEngineRuntimeTests.swift
@@ -154,12 +154,26 @@ struct ComposeEngineRuntimeTests {
             helperName: "compose-volume-initializer-linux-amd64",
             helperPath: "/.compose-volume-initializer"
         )
-
         #expect(arm != amd)
         #expect(arm != selectedDefault)
         #expect(arm != changedHelper)
         #expect(arm != changedPath)
         #expect(arm != changedName)
+    }
+
+    @Test
+    func `volume initializer cache invalidates legacy recipe blind tags`() {
+        let helper = Data([0, 1, 2])
+        let current = EngineVolumeInitializerBuildContext.cacheTag(
+            sourceDigest: "example/image@sha256:digest",
+            platform: "linux/arm64",
+            helper: helper, helperPath: "/.compose-volume-initializer"
+        )
+        let legacyRecipe = Data(("example/image@sha256:digest\0linux/arm64\0" +
+                "compose-volume-initializer-linux-arm64\0/.compose-volume-initializer\0").utf8)
+        let legacyDigest = EngineVolumeInitializerBuildContext.fnv1aHex([legacyRecipe, helper])
+
+        #expect(current != "devcontainer-volume-initializer:\(legacyDigest)")
     }
 
     @Test
@@ -618,6 +632,7 @@ struct ComposeEngineRuntimeTests {
             #expect(build.target.contains("platform=linux/arm64"))
             #expect(build.body.containsText("FROM example/image@sha256:digest"))
             #expect(!build.body.containsText("FROM example/image:latest"))
+            #expect(!build.body.containsText("USER 0"))
             #expect(
                 build.body.containsText(
                     #"ENTRYPOINT ["\#(helperPath)"]"#

--- a/Tools/compose-normalizer/cmd/volume-initializer/Dockerfile.integration
+++ b/Tools/compose-normalizer/cmd/volume-initializer/Dockerfile.integration
@@ -4,5 +4,4 @@
 ARG SOURCE_IMAGE
 FROM ${SOURCE_IMAGE}
 COPY --chmod=0755 compose-volume-initializer-linux-arm64 /.compose-volume-initializer
-USER 0:0
 ENTRYPOINT ["/.compose-volume-initializer"]


### PR DESCRIPTION
## Summary

- remove the root default from generated and integration-only volume-initializer images
- retain the narrowly scoped explicit root user on the one initializer container create request
- hash the exact generated build recipe into the cache tag so old root-default images cannot be reused
- assert the build context cannot silently regain a root default or legacy recipe-blind cache key

## Motivation

Exact-main CI for `ba32ec3c602d44489a2f1e930fdf415a2e9233fc` passed source checks, tool tests, coverage, Stock Apple Runtime, and the built CLI smoke, but SonarCloud correctly failed `docker:S6471` because the helper image declared `USER 0:0`. The runtime already sets `User: 0` explicitly for the privileged copy-up operation, so the image-wide default was redundant and unnecessarily broad.

## Validation

- `make source-checks`
- `CONTAINER_COMPOSE_BUILD_PROFILE=stock swift test --filter ComposeEngineRuntimeTests` (24 tests)
- `git diff --check`

No local live runtime, Docker parity, or benchmark was run.