### PR TITLE
chore(deps): pin validated container stack

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "45ee9ab4c98fc1c9faf10c4fc37ad453377bfc5b9d1c008ddf5258574d108667",
+  "originHash" : "4e4975b0b53e0a5e3b131d4e28ec872d93bff348bb19be947135d18289627e84",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "d049e1d8dfa7b5bc839a9742a2b84c3a8569571f"
+        "revision" : "46bc879296fe78debe51133e81eecfa64455be86"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "bd8130fea851f6ee264f00fc684e2543a7d2faa3"
+        "revision" : "333c5a9986fb8fd6bc17328b4b355fe97764f794"
       }
     },
     {
@@ -253,9 +253,9 @@
     {
       "identity" : "swift-nio-ssl",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/stephenlclarke/swift-nio-ssl.git",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "3e13ce5f6dd5b7e89fff9ab55ab7caed39fe7285"
+        "revision" : "322f3c2a4a21df31c84ca416bf65ee5e9059e440"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let containerDependency: Package.Dependency = {
     return enhancedRuntime
         ? .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "d049e1d8dfa7b5bc839a9742a2b84c3a8569571f",
+            revision: "46bc879296fe78debe51133e81eecfa64455be86",
         )
         : .package(url: "https://github.com/apple/container.git", exact: "1.4.1")
 }()
@@ -54,15 +54,15 @@ let containerizationDependency: Package.Dependency = {
     return enhancedRuntime
         ? .package(
             url: "https://github.com/stephenlclarke/containerization.git",
-            revision: "bd8130fea851f6ee264f00fc684e2543a7d2faa3",
+            revision: "333c5a9986fb8fd6bc17328b4b355fe97764f794",
         )
         : .package(url: "https://github.com/apple/containerization.git", exact: "0.45.0")
 }()
 
 let runtimeOnlyDependencies: [Package.Dependency] = enhancedRuntime
     ? [.package(
-        url: "https://github.com/stephenlclarke/swift-nio-ssl.git",
-        revision: "3e13ce5f6dd5b7e89fff9ab55ab7caed39fe7285",
+        url: "https://github.com/apple/swift-nio-ssl.git",
+        revision: "322f3c2a4a21df31c84ca416bf65ee5e9059e440",
     )]
     : []
 

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "d049e1d8dfa7b5bc839a9742a2b84c3a8569571f",
+      "ref": "46bc879296fe78debe51133e81eecfa64455be86",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "bd8130fea851f6ee264f00fc684e2543a7d2faa3",
+      "ref": "333c5a9986fb8fd6bc17328b4b355fe97764f794",
       "repository": "stephenlclarke/containerization"
     }
   },


### PR DESCRIPTION
## Summary

- pin container and containerization to their reviewed fork main commits
- use the canonical Apple swift-nio-ssl identity and exact reviewed revision
- align the release stack manifest with the same immutable authorities

## Motivation

Current publication correctly fails fast while Compose records older lower-stack revisions. This atomic integration lets the automatic Current package workflow publish the validated stack before the authorized 0.15.0 promotion.

## Validation

- warning-free enhanced swift package resolve
- warning-free enhanced dependency graph inspection
- make source-checks with the exact container 46bc879296fe78debe51133e81eecfa64455be86 checkout
- git diff --check

## Compatibility

Stock Apple runtime dependencies are unchanged. Enhanced builds advance only to the already reviewed container and containerization main commits.

## Release note

None.