### PR TITLE
fix(release): publish immutable Current builds

### DIFF
--- a/.github/workflows/current-demo.yml
+++ b/.github/workflows/current-demo.yml
@@ -31,9 +31,8 @@ permissions:
 
 concurrency:
   group: container-compose-current-demo
-  # A replacement is a delete-upload transaction against one immutable
-  # release ID. Let the running transaction reach its recovery path; a queued
-  # newer run will supersede the finished recording after freshness checks.
+  # Let one self-hosted recording finish before a newer exact-Current request
+  # starts so the runner never performs duplicate nested-virtualization work.
   cancel-in-progress: false
 
 jobs:
@@ -45,6 +44,7 @@ jobs:
     outputs:
       publish: ${{ steps.resolve.outputs.publish }}
       sha: ${{ steps.resolve.outputs.sha }}
+      tag: ${{ steps.resolve.outputs.tag }}
     steps:
       - name: Resolve exact Current release
         id: resolve
@@ -70,20 +70,21 @@ jobs:
             exit 1
           fi
 
+          current_tag="current-${source_sha}"
           current_tag_sha="$(
-            git ls-remote --tags "${remote}" refs/tags/current 'refs/tags/current^{}' \
-              | awk '$2 == "refs/tags/current^{}" { print $1; found = 1 } END { if (!found) print "" }' \
+            git ls-remote --tags "${remote}" "refs/tags/${current_tag}" "refs/tags/${current_tag}^{}" \
+              | awk -v peeled="refs/tags/${current_tag}^{}" '$2 == peeled { print $1; found = 1 } END { if (!found) print "" }' \
               | tail -n 1
           )"
           if [[ -z "${current_tag_sha}" ]]; then
             current_tag_sha="$(
-              git ls-remote --tags --refs "${remote}" refs/tags/current \
+              git ls-remote --tags --refs "${remote}" "refs/tags/${current_tag}" \
                 | awk '{ print $1 }' \
                 | tail -n 1
             )"
           fi
           release_target="$(
-            gh release view current --repo "${GITHUB_REPOSITORY}" \
+            gh release view "${current_tag}" --repo "${GITHUB_REPOSITORY}" \
               --json targetCommitish --jq .targetCommitish
           )"
 
@@ -100,6 +101,7 @@ jobs:
           {
             printf 'publish=%s\n' "${publish}"
             printf 'sha=%s\n' "${source_sha}"
+            printf 'tag=%s\n' "${current_tag}"
           } >> "${GITHUB_OUTPUT}"
 
   record:
@@ -113,7 +115,7 @@ jobs:
     timeout-minutes: 50
     permissions:
       attestations: read
-      contents: write
+      contents: read
     steps:
       - name: Checkout exact Current source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -148,6 +150,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PUBLISH_SHA: ${{ needs.resolve-current.outputs.sha }}
+          CURRENT_RELEASE_TAG: ${{ needs.resolve-current.outputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -158,7 +161,7 @@ jobs:
           download_root="${RUNNER_TEMP}/container-compose-current-demo-downloads"
           rm -rf -- "${download_root}"
           mkdir -p "${download_root}"
-          gh release download current \
+          gh release download "${CURRENT_RELEASE_TAG}" \
             --repo "${GITHUB_REPOSITORY}" \
             --dir "${download_root}" \
             --pattern "${plugin_asset}" \
@@ -328,235 +331,13 @@ jobs:
           test -s "${demo_output}"
           printf 'DEMO_OUTPUT=%s\n' "${demo_output}" >> "${GITHUB_ENV}"
 
-      - name: Verify source and release are still current
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PUBLISH_SHA: ${{ needs.resolve-current.outputs.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          remote="https://github.com/${GITHUB_REPOSITORY}.git"
-          main_sha="$(git ls-remote --heads "${remote}" refs/heads/main | awk '{ print $1 }' | tail -n 1)"
-          current_tag_sha="$(
-            git ls-remote --tags "${remote}" refs/tags/current 'refs/tags/current^{}' \
-              | awk '$2 == "refs/tags/current^{}" { print $1; found = 1 } END { if (!found) print "" }' \
-              | tail -n 1
-          )"
-          if [[ -z "${current_tag_sha}" ]]; then
-            current_tag_sha="$(git ls-remote --tags --refs "${remote}" refs/tags/current | awk '{ print $1 }' | tail -n 1)"
-          fi
-          release_target="$(
-            gh release view current --repo "${GITHUB_REPOSITORY}" \
-              --json targetCommitish --jq .targetCommitish
-          )"
-          if ! [[ "${PUBLISH_SHA}" == "${main_sha}" &&
-                  "${PUBLISH_SHA}" == "${current_tag_sha}" &&
-                  "${PUBLISH_SHA}" == "${release_target}" ]]; then
-            printf 'Current moved while the demo was recording; leaving its existing asset unchanged.\n'
-            printf 'PUBLISH_DEMO=false\n' >> "${GITHUB_ENV}"
-            exit 0
-          fi
-          printf 'PUBLISH_DEMO=true\n' >> "${GITHUB_ENV}"
-
-      - name: Publish exact Current demo
-        if: env.PUBLISH_DEMO == 'true'
-        env:
-          DEMO_ASSET: container-compose-demo-current.gif
-          GH_TOKEN: ${{ github.token }}
-          PUBLISH_SHA: ${{ needs.resolve-current.outputs.sha }}
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          CURRENT_RELEASE_ID=""
-
-          current_release_matches() {
-            local remote="https://github.com/${GITHUB_REPOSITORY}.git"
-            local main_sha
-            local current_tag_sha
-            local release_fields
-            local release_id
-            local release_target
-            local release_upload_url
-            local checkout_sha
-            local tracked_status
-            local expected_upload_url
-            checkout_sha="$(git rev-parse HEAD)" || return 1
-            tracked_status="$(git status --porcelain --untracked-files=no)" || return 1
-            main_sha="$(
-              git ls-remote --heads "${remote}" refs/heads/main \
-                | awk '{ print $1 }' \
-                | tail -n 1
-            )" || return 1
-            current_tag_sha="$(
-              git ls-remote --tags "${remote}" refs/tags/current 'refs/tags/current^{}' \
-                | awk '$2 == "refs/tags/current^{}" { print $1; found = 1 } END { if (!found) print "" }' \
-                | tail -n 1
-            )" || return 1
-            if [[ -z "${current_tag_sha}" ]]; then
-              current_tag_sha="$(
-                git ls-remote --tags --refs "${remote}" refs/tags/current \
-                  | awk '{ print $1 }' \
-                  | tail -n 1
-              )" || return 1
-            fi
-            release_fields="$(
-              gh release view current --repo "${GITHUB_REPOSITORY}" \
-                --json databaseId,targetCommitish,uploadUrl \
-                --jq '[.targetCommitish, (.databaseId | tostring), .uploadUrl] | @tsv'
-            )" || return 1
-            IFS=$'\t' read -r release_target release_id release_upload_url \
-              <<< "${release_fields}"
-            expected_upload_url="https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets"
-            if [[ ! "${release_id}" =~ ^[0-9]+$ ||
-                  "${release_upload_url}" != "${expected_upload_url}"'{?name,label}' ]]; then
-              return 1
-            fi
-            [[ "${PUBLISH_SHA}" == "${main_sha}" &&
-               "${PUBLISH_SHA}" == "${current_tag_sha}" &&
-               "${PUBLISH_SHA}" == "${release_target}" &&
-               "${PUBLISH_SHA}" == "${checkout_sha}" &&
-               -z "${tracked_status}" ]] || return 1
-            CURRENT_RELEASE_ID="${release_id}"
-          }
-
-          release_asset_id() {
-            local release_id="$1"
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?per_page=100" \
-              --jq ".[] | select(.name == \"${DEMO_ASSET}\") | .id" \
-              | tail -n 1
-          }
-
-          download_release_asset() {
-            local asset_id="$1"
-            local output="$2"
-            gh api -H 'Accept: application/octet-stream' \
-              "repos/${GITHUB_REPOSITORY}/releases/assets/${asset_id}" > "${output}"
-          }
-
-          upload_release_asset() {
-            local release_id="$1"
-            local input="$2"
-            gh api --method POST \
-              -H 'Content-Type: image/gif' \
-              --input "${input}" \
-              "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${release_id}/assets?name=${DEMO_ASSET}" \
-              --silent
-          }
-
-          replace_release_asset() {
-            local release_id="$1"
-            local input="$2"
-            local existing_asset_id
-            existing_asset_id="$(release_asset_id "${release_id}")" || return 1
-            if [[ -n "${existing_asset_id}" ]]; then
-              gh api --method DELETE \
-                "repos/${GITHUB_REPOSITORY}/releases/assets/${existing_asset_id}" \
-                --silent || return 1
-            fi
-            upload_release_asset "${release_id}" "${input}"
-          }
-
-          if ! current_release_matches; then
-            printf 'Current moved before demo publication; leaving its existing asset unchanged.\n'
-            exit 0
-          fi
-          publication_release_id="${CURRENT_RELEASE_ID}"
-
-          prior_demo_dir="${RUNNER_TEMP}/container-compose-prior-current-demo"
-          recovery_demo_dir="${RUNNER_TEMP}/container-compose-recovery-current-demo"
-          rm -rf -- "${prior_demo_dir}" "${recovery_demo_dir}"
-          mkdir -p "${prior_demo_dir}" "${recovery_demo_dir}"
-          prior_asset_id="$(release_asset_id "${publication_release_id}")"
-          prior_demo="${prior_demo_dir}/${DEMO_ASSET}"
-          if [[ -n "${prior_asset_id}" ]]; then
-            download_release_asset "${prior_asset_id}" "${prior_demo}"
-            test -s "${prior_demo}"
-          fi
-
-          if ! current_release_matches ||
-             [[ "${CURRENT_RELEASE_ID}" != "${publication_release_id}" ]]; then
-            printf 'Current moved immediately before demo upload; leaving its existing asset unchanged.\n'
-            exit 0
-          fi
-
-          set +e
-          replace_release_asset "${publication_release_id}" "${DEMO_OUTPUT}"
-          upload_status=$?
-          set -e
-          if ((upload_status == 0)); then
-            if ! current_release_matches ||
-               [[ "${CURRENT_RELEASE_ID}" != "${publication_release_id}" ]]; then
-              printf 'Current moved after demo upload; refusing to accept a stale publication.\n' >&2
-              exit 75
-            fi
-            published_asset_id="$(release_asset_id "${publication_release_id}")"
-            published_demo="${recovery_demo_dir}/${DEMO_ASSET}"
-            if [[ -n "${published_asset_id}" ]] &&
-              download_release_asset "${published_asset_id}" "${published_demo}"; then
-              published_sha256="$(shasum -a 256 \
-                "${published_demo}" | awk '{ print $1 }')"
-              candidate_sha256="$(shasum -a 256 "${DEMO_OUTPUT}" | awk '{ print $1 }')"
-              if [[ "${published_sha256}" == "${candidate_sha256}" ]]; then
-                printf 'Current demo output verified against release %s.\n' \
-                  "${publication_release_id}"
-                exit 0
-              fi
-            fi
-            printf 'Current demo upload returned success without the exact published output.\n' >&2
-            upload_status=1
-          fi
-
-          if [[ ! -s "${prior_demo}" ]]; then
-            printf 'Current demo upload failed and no prior asset is available to restore.\n' >&2
-            exit "${upload_status}"
-          fi
-
-          if ! current_release_matches ||
-             [[ "${CURRENT_RELEASE_ID}" != "${publication_release_id}" ]]; then
-            printf 'Current moved after the failed demo upload; refusing to modify the newer release.\n' >&2
-            exit "${upload_status}"
-          fi
-
-          published_asset_id="$(release_asset_id "${publication_release_id}")"
-          if [[ -n "${published_asset_id}" ]]; then
-            published_demo="${recovery_demo_dir}/${DEMO_ASSET}"
-            if download_release_asset "${published_asset_id}" "${published_demo}"; then
-              published_sha256="$(shasum -a 256 \
-                "${published_demo}" | awk '{ print $1 }')"
-              candidate_sha256="$(shasum -a 256 "${DEMO_OUTPUT}" | awk '{ print $1 }')"
-              prior_sha256="$(shasum -a 256 "${prior_demo}" | awk '{ print $1 }')"
-              if [[ "${published_sha256}" == "${candidate_sha256}" ]]; then
-                printf 'Current demo upload completed despite the client failure.\n'
-                exit 0
-              fi
-              if [[ "${published_sha256}" == "${prior_sha256}" ]]; then
-                printf 'Current demo upload failed; the prior asset remains intact.\n' >&2
-                exit "${upload_status}"
-              fi
-            fi
-          fi
-
-          restored=false
-          for attempt in 1 2 3; do
-            if ! current_release_matches ||
-               [[ "${CURRENT_RELEASE_ID}" != "${publication_release_id}" ]]; then
-              printf 'Current moved during demo recovery; refusing to modify the newer release.\n' >&2
-              exit "${upload_status}"
-            fi
-            if replace_release_asset "${publication_release_id}" "${prior_demo}"; then
-              restored=true
-              break
-            fi
-            sleep "$((attempt * 5))"
-          done
-          if [[ "${restored}" != true ]]; then
-            printf 'Current demo upload failed and the prior asset could not be restored.\n' >&2
-            exit 1
-          fi
-          printf 'Current demo upload failed; restored the prior asset.\n' >&2
-          exit "${upload_status}"
+      - name: Retain exact Current demo workflow artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: current-demo-${{ needs.resolve-current.outputs.sha }}
+          path: ${{ env.DEMO_OUTPUT }}
+          if-no-files-found: error
+          retention-days: 90
 
       - name: Save bounded demo diagnostics
         if: failure()

--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -386,38 +386,143 @@ jobs:
                     printf 'Skipping current package because stable candidate %s owns exact main %s.\n' \
                       "${stable_candidate_tag}" "${WORKFLOW_RUN_HEAD_SHA}"
                   else
+                    current_tag="current-${WORKFLOW_RUN_HEAD_SHA}"
                     current_tag_sha="$(
-                      git ls-remote --tags "${remote}" 'refs/tags/current' 'refs/tags/current^{}' \
-                        | awk '$2 == "refs/tags/current^{}" { print $1; found = 1 } END { if (!found) print "" }' \
+                      git ls-remote --tags "${remote}" "refs/tags/${current_tag}" "refs/tags/${current_tag}^{}" \
+                        | awk -v peeled="refs/tags/${current_tag}^{}" '$2 == peeled { print $1; found = 1 } END { if (!found) print "" }' \
                         | tail -n 1
                     )"
                     if [[ -z "${current_tag_sha}" ]]; then
                       current_tag_sha="$(
-                        git ls-remote --tags --refs "${remote}" 'refs/tags/current' \
+                        git ls-remote --tags --refs "${remote}" "refs/tags/${current_tag}" \
                           | awk '{ print $1 }' \
                           | tail -n 1
                       )"
                     fi
-                    current_release_exists="false"
+                    current_release_complete="false"
                     if [[ "${current_tag_sha}" == "${WORKFLOW_RUN_HEAD_SHA}" ]]; then
                       set +e
                       current_release_output="$(
-                        gh api --silent "repos/${GITHUB_REPOSITORY}/releases/tags/current" 2>&1
+                        gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${current_tag}" 2>&1
                       )"
                       current_release_status=$?
                       set -e
                       if (( current_release_status == 0 )); then
-                        current_release_exists="true"
+                        short_sha="${WORKFLOW_RUN_HEAD_SHA:0:12}"
+                        expected_current_assets="$(
+                          printf '%s\n' \
+                            "container-compose-plugin-current-${short_sha}-arm64.tar.gz" \
+                            "container-compose-plugin-current-${short_sha}-arm64.tar.gz.sha256" \
+                            "container-current-${short_sha}-arm64.tar.gz" \
+                            "container-current-${short_sha}-arm64.tar.gz.sha256" \
+                            "container-vminit-current-${short_sha}-arm64.oci.tar" \
+                            "container-vminit-current-${short_sha}-arm64.oci.tar.sha256" \
+                            "release-highlights-current-${short_sha}.json" \
+                            "quality-snapshot-current.svg" \
+                            | sort
+                        )"
+                        actual_current_assets="$(
+                          jq -r '.assets[].name' <<<"${current_release_output}" | sort
+                        )"
+                        if [[ "$(jq -r '.draft' <<<"${current_release_output}")" == "false" &&
+                              "$(jq -r '.immutable' <<<"${current_release_output}")" == "true" &&
+                              "$(jq -r '.prerelease' <<<"${current_release_output}")" == "true" &&
+                              "$(jq -r '.tag_name' <<<"${current_release_output}")" == "${current_tag}" &&
+                              "$(jq -r '.target_commitish' <<<"${current_release_output}")" == "${WORKFLOW_RUN_HEAD_SHA}" &&
+                              "${actual_current_assets}" == "${expected_current_assets}" ]]; then
+                          current_release_complete="true"
+                        elif [[ "$(jq -r '.draft' <<<"${current_release_output}")" != "true" ]]; then
+                          printf 'published immutable Current release %s has an invalid closure; refusing an unrecoverable overwrite\n' \
+                            "${current_tag}" >&2
+                          exit 1
+                        fi
                       elif [[ "${current_release_output}" != *"HTTP 404"* ]]; then
                         printf 'could not determine whether the current release exists:\n%s\n' \
                           "${current_release_output}" >&2
                         exit 1
                       fi
                     fi
-                    if [[ "${current_tag_sha}" == "${WORKFLOW_RUN_HEAD_SHA}" && "${current_release_exists}" == "true" ]]; then
-                      printf 'Skipping current package because current already points at %s.\n' \
-                        "${WORKFLOW_RUN_HEAD_SHA}"
+                    current_tap_complete="false"
+                    current_success_authority="false"
+                    current_formula_run_number=""
+                    if [[ "${current_release_complete}" == "true" ]]; then
+                      current_tap_complete="true"
+                      for formula in container-current container-compose-current; do
+                        if [[ "${formula}" == "container-current" ]]; then
+                          formula_asset="container-current-${short_sha}-arm64.tar.gz"
+                        else
+                          formula_asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"
+                        fi
+                        formula_digest="$(
+                          jq -r --arg name "${formula_asset}" \
+                            '.assets[] | select(.name == $name) | .digest // ""' \
+                            <<<"${current_release_output}"
+                        )"
+                        formula_body="$(
+                          github_authority_query "${formula} formula" \
+                            api -H 'Accept: application/vnd.github.raw+json' \
+                            "repos/stephenlclarke/homebrew-tap/contents/Formula/${formula}.rb?ref=main"
+                        )"
+                        formula_url="$(
+                          sed -nE 's/^  url "([^"]+)"[[:space:]]*$/\1/p' \
+                            <<<"${formula_body}"
+                        )"
+                        formula_sha256="$(
+                          sed -nE 's/^  sha256 "([0-9a-f]{64})"[[:space:]]*$/\1/p' \
+                            <<<"${formula_body}"
+                        )"
+                        formula_version="$(
+                          sed -nE 's/^  version "([^"]+)"[[:space:]]*$/\1/p' \
+                            <<<"${formula_body}"
+                        )"
+                        expected_formula_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${current_tag}/${formula_asset}"
+                        if [[ "${formula_url}" != "${expected_formula_url}" ]] ||
+                          [[ ! "${formula_digest}" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+                          [[ "${formula_sha256}" != "${formula_digest#sha256:}" ]] ||
+                          [[ ! "${formula_version}" =~ ^current\.([1-9][0-9]*)\.${short_sha}$ ]]; then
+                          current_tap_complete="false"
+                        elif [[ -z "${current_formula_run_number}" ]]; then
+                          current_formula_run_number="${BASH_REMATCH[1]}"
+                        elif [[ "${current_formula_run_number}" != "${BASH_REMATCH[1]}" ]]; then
+                          current_tap_complete="false"
+                        fi
+                      done
+                    fi
+                    if [[ "${current_release_complete}" == "true" && "${current_tap_complete}" == "true" ]]; then
+                      successful_current_runs="$(
+                        github_authority_query "successful exact Current package run" \
+                          api \
+                          "repos/${GITHUB_REPOSITORY}/actions/workflows/prebuilt-binaries.yml/runs?head_sha=${WORKFLOW_RUN_HEAD_SHA}&status=success&per_page=100"
+                      )"
+                      if jq -e --arg sha "${WORKFLOW_RUN_HEAD_SHA}" \
+                        --argjson run_number "${current_formula_run_number}" \
+                        '[.workflow_runs[] | select(
+                          .run_number == $run_number and
+                          .head_sha == $sha and
+                          .status == "completed" and
+                          .conclusion == "success"
+                        )] | length > 0' \
+                        <<<"${successful_current_runs}" >/dev/null; then
+                        current_success_authority="true"
+                      fi
+                    fi
+                    if [[ "${current_release_complete}" == "true" &&
+                          "${current_tap_complete}" == "true" &&
+                          "${current_success_authority}" == "true" ]]; then
+                      printf 'Skipping current package because immutable release %s already owns %s.\n' \
+                        "${current_tag}" "${WORKFLOW_RUN_HEAD_SHA}"
                     else
+                      if [[ "${current_release_complete}" == "true" &&
+                            "${current_tap_complete}" == "true" ]]; then
+                        printf 'Resuming Current transaction because no successful exact-commit package run proves %s.\n' \
+                          "${current_tag}"
+                      elif [[ "${current_release_complete}" == "true" ]]; then
+                        printf 'Resuming Current transaction because the Homebrew pair does not select %s.\n' \
+                          "${current_tag}"
+                      elif [[ "${current_tag_sha}" == "${WORKFLOW_RUN_HEAD_SHA}" ]]; then
+                        printf 'Resuming incomplete Current release transaction for %s.\n' \
+                          "${current_tag}"
+                      fi
                       ref_type="branch"
                       ref_name="${WORKFLOW_RUN_HEAD_BRANCH}"
                       checkout_ref="${WORKFLOW_RUN_HEAD_SHA}"
@@ -662,10 +767,15 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          preflight_flags=()
+          if [[ "${{ needs.resolve-publish-context.outputs.ref_type }}" == "branch" ]]; then
+            preflight_flags+=(--allow-legacy-current-pair)
+          fi
           python3 release-tools/Tools/release/homebrew-preflight.py \
             --tap homebrew-tap \
             --compose-repository container-compose \
-            --container-repository container
+            --container-repository container \
+            "${preflight_flags[@]}"
           [[ "$(git -C container-compose rev-parse HEAD)" == \
             "${{ needs.resolve-publish-context.outputs.sha }}" ]]
           [[ "$(git -C release-tools rev-parse HEAD)" == "${{ github.sha }}" ]]
@@ -872,17 +982,16 @@ jobs:
           short_sha="${PUBLISH_SHA:0:12}"
           case "${PUBLISH_REF_TYPE}:${PUBLISH_REF_NAME}" in
             branch:main)
-              # `current` is deliberately the sole mutable prerelease pointer.
-              # Semver tags remain immutable stable release identities.
-              release_tag="current"
+              # Current releases are immutable and content-addressed just like
+              # stable releases. Homebrew selects the active exact-SHA tag.
+              release_tag="current-${PUBLISH_SHA}"
               release_title="Current build"
               release_label="current build"
               release_latest="false"
               release_prerelease="true"
               update_tap="true"
-              # A commit-identified asset keeps the old formula pair valid
-              # while the candidate is staged. The current tag moves only
-              # after both matching formulae point at this immutable asset.
+              # Commit-identified assets and release tags keep the old formula
+              # pair valid until both matching formulae select this release.
               asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"
               highlights_asset="release-highlights-current-${short_sha}.json"
               quality_snapshot_asset="quality-snapshot-current.svg"
@@ -1840,7 +1949,7 @@ jobs:
             --repo "${GITHUB_REPOSITORY}"
             --commit "${PUBLISH_SHA}"
             --release-kind "${quality_release_kind}"
-            --badge-snapshot-id "${PUBLISH_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+            --badge-snapshot-id "${PUBLISH_SHA}"
             --verify-static-badges
           )
           if [[ "${quality_release_kind}" == "stable" ]]; then
@@ -2003,25 +2112,6 @@ jobs:
             fi
           done
 
-          # Finalizing Current edits the mutable release in place. Carry the
-          # last successful, non-authoritative demo through the idempotent asset
-          # upload so a failed asynchronous recording never removes it.
-          retained_demo="${RUNNER_TEMP}/container-compose-demo-current.gif"
-          demo_asset_present="$(
-            gh release view "${RELEASE_TAG}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --json assets \
-              --jq '[.assets[].name == "container-compose-demo-current.gif"] | any'
-          )"
-          if [[ "${demo_asset_present}" == "true" ]]; then
-            gh release download "${RELEASE_TAG}" \
-              --repo "${GITHUB_REPOSITORY}" \
-              --pattern "container-compose-demo-current.gif" \
-              --dir "${RUNNER_TEMP}" \
-              --clobber
-            printf '%s\n' "${retained_demo}" >> "${extra_assets}"
-          fi
-
           RELEASE_REPOSITORY="${GITHUB_REPOSITORY}" \
             RELEASE_TAG="${RELEASE_TAG}" \
             RELEASE_TITLE="${RELEASE_TITLE}" \
@@ -2076,9 +2166,6 @@ jobs:
               --current-asset "${CURRENT_INIT_ASSET}.sha256" \
               --current-asset "${HIGHLIGHTS_ASSET}" \
               --current-asset "${QUALITY_SNAPSHOT_ASSET}"
-              # The separately generated demo is non-authoritative, but retain
-              # the last good recording until its recoverable workflow replaces it.
-              --current-asset "container-compose-demo-current.gif"
             )
           fi
           python3 ../release-tools/Tools/release/retain-release-assets.py \

--- a/.github/workflows/scheduled-stable-release.yml
+++ b/.github/workflows/scheduled-stable-release.yml
@@ -35,6 +35,7 @@ on:
           - "+--"
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -120,12 +121,32 @@ jobs:
           }
 
           main_sha="$(git ls-remote --heads "${remote}" refs/heads/main | awk '{ print $1 }' | tail -n 1)"
-          current_sha="$(resolve_tag_sha current)"
-          current_release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/current")"
-          current_is_prerelease="$(jq -r '.prerelease' <<<"${current_release}")"
+          current_tag="current-${main_sha}"
+          current_sha="$(resolve_tag_sha "${current_tag}")"
+          current_release="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${current_tag}")"
+          current_runs="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/prebuilt-binaries.yml/runs?head_sha=${main_sha}&status=success&per_page=100"
+          )"
+          container_formula="$(
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              'repos/stephenlclarke/homebrew-tap/contents/Formula/container-current.rb?ref=main'
+          )"
+          compose_formula="$(
+            gh api -H 'Accept: application/vnd.github.raw+json' \
+              'repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose-current.rb?ref=main'
+          )"
           current_built_at="$(
-            jq -r '[.assets[] | select(.name | test("^container-compose-plugin-current-[0-9a-f]{12}-arm64[.]tar[.]gz$")) | .updated_at] | max // empty' \
-              <<<"${current_release}"
+            jq -n \
+              --argjson release "${current_release}" \
+              --argjson runs "${current_runs}" \
+              --arg container_formula "${container_formula}" \
+              --arg compose_formula "${compose_formula}" \
+              '{release: $release, runs: $runs, container_formula: $container_formula, compose_formula: $compose_formula}' \
+              | python3 Tools/release/verify-current-release-readiness.py \
+                  --repository "${GITHUB_REPOSITORY}" \
+                  --tag "${current_tag}" \
+                  --sha "${main_sha}"
           )"
           latest_stable_tag="$(
             git ls-remote --tags --refs "${remote}" \
@@ -142,8 +163,8 @@ jobs:
             printf 'could not resolve main or current tag SHA\n' >&2
             exit 1
           fi
-          if [[ "${current_is_prerelease}" != "true" || -z "${current_built_at}" ]]; then
-            printf 'current must be a prerelease with a published current package asset\n' >&2
+          if [[ -z "${current_built_at}" ]]; then
+            printf 'current must have a complete immutable release and package authority\n' >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,16 @@ falls back to Docker, Docker Compose, or Colima. The enhanced release profile
 remains the default for the independently installed Compose plugin. See the
 [installation guide](docs/guides/INSTALL.md#build-the-stock-apple-engine-adapter).
 
-## 0.14.2 Current candidate
+## Current candidate
 
-[`0.14.1`](https://github.com/stephenlclarke/container-compose/releases/tag/0.14.1)
-is the current stable macOS arm64 release. The rolling
-[`current`](https://github.com/stephenlclarke/container-compose/releases/tag/current)
-prerelease carries the reviewed 0.14.2 candidate with its matched Container
-stack. It is not an immutable 0.14.2 release until the hosted Stable Release
-Gate, including the supported Docker Compose parity suite, succeeds and
-publishes that version.
+The [latest stable release](https://github.com/stephenlclarke/container-compose/releases/latest)
+is the default macOS arm64 lane. The [Current release feed](https://github.com/stephenlclarke/container-compose/releases)
+contains immutable `current-<full-sha>` prereleases; the two Current Homebrew
+formulae atomically select the newest validated matched Container stack. A
+Current build becomes a semantic release only after the hosted Stable Release
+Gate, including the supported Docker Compose parity suite, succeeds.
 
-The 0.14.2 maintenance candidate retains stopped containers and their log
+The active maintenance candidate retains stopped containers and their log
 histories after foreground `up --abort-on-container-exit`,
 `--abort-on-container-failure`, and `--exit-code-from` completion. Its matched
 runtime also recovers interrupted prepared cleanup, preserves short-lived VM
@@ -125,8 +124,8 @@ The supported release line includes:
 - versioned runtime-capability negotiation plus stricter staging, containment,
   redaction, cancellation, and bounded-resource controls.
 
-The candidate notes and exact dependency revisions are on the
-[Current build page](https://github.com/stephenlclarke/container-compose/releases/tag/current).
+Candidate notes and exact dependency revisions are on the selected
+[`current-<full-sha>` release](https://github.com/stephenlclarke/container-compose/releases).
 [STATUS.md](docs/project/STATUS.md) describes the functionality and explicit limitations
 in the stable baseline and current candidate. Planned compatibility work is kept separately in
 [BACKLOG.md](docs/project/BACKLOG.md) and its linked GitHub issues.
@@ -169,7 +168,7 @@ supported commands include a `Limitations` line that names the remaining gap.
 Use `--ansi never` for plain output. Unsupported runtime behavior fails before
 side effects with an explicit `unsupported compose feature` message.
 
-For the 0.14.2 candidate, the generated help classifies 40 commands as green and six as
+For the current candidate, the generated help classifies 40 commands as green and six as
 orange (`attach`, `events`, `exec`, `logs`, `run`, and `up`); no command is
 red. It classifies 262 documented long options as green and only
 `exec --privileged` as orange; no documented long option is red. Orange command
@@ -194,7 +193,7 @@ become implicit exceptions.
 >
 > The complete maintained 62-target Docker Compose comparison suite passed in one uninterrupted 1,152.03-second run against Docker Compose 5.3.1 and Docker Engine 29.2.1 on a Mac17,9 running macOS 26.5.2. Its three-sample warm-image bridge comparator measured `up` at 0.153s for Docker Compose and 1.228s for container-compose (8.01×), while `down` measured 10.178s and 5.916s respectively (0.58×). Named-network service discovery, aliases, one-off aliases, recreate behavior, and source-scoped links all passed their live Docker oracles. Exact revisions, timing tables, fingerprints, and interpretation are retained in the [macOS Compose parity and performance review](docs/reviews/MACOS-COMPOSE-PARITY-AND-PERFORMANCE-REVIEW-2026-07-30.md).
 >
-> This retained run predates the current 0.14.2 candidate and is not a claim that the project goal is complete. Its lifecycle matrix covers warm-image 1/10/50-service detached startup and teardown, but its 31 July one-repetition debug diagnostic was slower than Docker at 10 and 50 services and is not release-grade evidence. That run did not include the later logging performance lanes; cold-resource collection, `develop.watch` sync, and build-context transfer remain open, and every partial surface in the current ledger remains open.
+> This retained run predates the current candidate and is not a claim that the project goal is complete. Its lifecycle matrix covers warm-image 1/10/50-service detached startup and teardown, but its 31 July one-repetition debug diagnostic was slower than Docker at 10 and 50 services and is not release-grade evidence. That run did not include the later logging performance lanes; cold-resource collection, `develop.watch` sync, and build-context transfer remain open, and every partial surface in the current ledger remains open.
 
 <!-- Separate GitHub callouts. -->
 
@@ -211,9 +210,9 @@ Use `container system version` to see the running `container` runtime source, br
 
 ## See It Work
 
-![Terminal recording: starting, inspecting, reusing, and tearing down the monitoring stack](https://github.com/stephenlclarke/container-compose/releases/download/current/container-compose-demo-current.gif)
+![Representative terminal recording: starting, inspecting, reusing, and tearing down the monitoring stack](https://github.com/stephenlclarke/container-compose/releases/download/current/container-compose-demo-current.gif)
 
-The recording is a complete matched-runtime execution of the portable nginx and Alertmanager service slice in the real [`examples/monitoring-stack/docker-compose.yaml`](examples/monitoring-stack/docker-compose.yaml). It visibly types `container system start`, confirms the running service, starts that two-service slice, shows `stats --no-stream` and `ps`, queries nginx `/healthz` and Alertmanager readiness from their running services, writes and reads data in the named `nginx_cache` volume across a retained-volume shutdown, and finally removes the project with `down --volumes --remove-orphans`. The focused slice keeps the recorded startup deterministic while the full macOS-safe monitoring stack remains covered by the Docker Compose v2 parity suite. Each displayed result is the live output of the command that was just typed; the tape has no transcript replay or marker helper. A separate recoverable Current Demo workflow records the session on the hardware-virtualization-capable runner after the signed Current packages and Homebrew formulae are available. Recording failure cannot block package, attestation, release, or tap publication, and an exact-SHA freshness check prevents a delayed recording from replacing a newer Current asset.
+The archived representative recording is a complete matched-runtime execution of the portable nginx and Alertmanager service slice in the real [`examples/monitoring-stack/docker-compose.yaml`](examples/monitoring-stack/docker-compose.yaml). It visibly types `container system start`, confirms the running service, starts that two-service slice, shows `stats --no-stream` and `ps`, queries nginx `/healthz` and Alertmanager readiness from their running services, writes and reads data in the named `nginx_cache` volume across a retained-volume shutdown, and finally removes the project with `down --volumes --remove-orphans`. The focused slice keeps the recorded startup deterministic while the full macOS-safe monitoring stack remains covered by the Docker Compose v2 parity suite. Each displayed result is the live output of the command that was just typed; the tape has no transcript replay or marker helper. A separate Current Demo workflow records exact-SHA sessions on the hardware-virtualization-capable runner after the signed Current packages and Homebrew formulae are available, retaining each result as a bounded workflow artifact. Recording failure cannot block package, attestation, release, or tap publication, and the workflow never mutates an immutable release.
 
 ## Install And Project Map
 
@@ -251,7 +250,7 @@ When installed correctly, `container help` lists `compose` under `PLUGINS`.
 - [DESIGN.md](docs/project/DESIGN.md): understand the Swift/Go boundary and runtime adapter ownership.
 - [STATUS.md](docs/project/STATUS.md): understand the functionality and explicit limitations in the current stable release and candidate.
 - [BACKLOG.md](docs/project/BACKLOG.md): understand the remaining parity contracts and follow their live GitHub issues.
-- [Runtime capability contract](docs/architecture/runtime-capabilities.md): see the versioned matched-runtime requirements negotiated by 0.14.2 before side effects.
+- [Runtime capability contract](docs/architecture/runtime-capabilities.md): see the matched-runtime requirements negotiated before side effects.
 - [Docker logging-driver design](docs/architecture/docker-logging-driver-semantics-design.md): review the released logging architecture, retained evidence, and remaining provider and certification gaps.
 - [Container-family parity architecture](docs/architecture/coherent-container-family-parity-design.md): understand the integrated authority, runtime topology, dependency order, and devcontainer/shared Engine design.
 - [Container-family parity development cycle](docs/architecture/container-family-development-cycle.md): deliver vertical slices with local-first validation, review-to-clean convergence, MBP runners, clean GitHub state, upstream monitoring, and comparable-or-better performance.

--- a/Tools/release/capture-quality-snapshot.py
+++ b/Tools/release/capture-quality-snapshot.py
@@ -113,7 +113,7 @@ def parse_args() -> argparse.Namespace:
         "--release-kind",
         choices=("current", "stable"),
         default="stable",
-        help="Whether this snapshot belongs to the mutable current build or an immutable stable release",
+        help="Whether this snapshot belongs to an immutable Current build or stable release",
     )
     parser.add_argument("--sonarqube-url", default=SONARQUBE_URL)
     parser.add_argument("--sonarqube-project", default=SONARQUBE_PROJECT)
@@ -979,7 +979,7 @@ def render_snapshot(
     if not asset_url:
         raise ValueError("quality snapshot asset URL must not be empty")
     if release_kind == "current":
-        retention = "These static badges describe this mutable Current build and are replaced when `current` moves."
+        retention = "These static badges describe this immutable, exact-commit Current build and never change."
     else:
         retention = "These static badges are retained as historical evidence; they do not update."
     if sonar_analysis is not None:

--- a/Tools/release/homebrew-preflight.py
+++ b/Tools/release/homebrew-preflight.py
@@ -111,7 +111,9 @@ def validate_container_formula_source(repository: Path) -> None:
     raise ValueError(f"Container Homebrew formula source is missing: {repository}")
 
 
-def validate_tap(tap: Path, require_clean: bool) -> dict[str, Formula]:
+def validate_tap(
+    tap: Path, require_clean: bool, allow_legacy_current_pair: bool = False
+) -> dict[str, Formula]:
     if not (tap / ".git").exists():
         raise ValueError(f"Homebrew tap is not a Git checkout: {tap}")
     origin = run("git", "remote", "get-url", "origin", cwd=tap)
@@ -148,17 +150,38 @@ def validate_tap(tap: Path, require_clean: bool) -> dict[str, Formula]:
                     f"{name}: expected stable asset {expected_asset}, found {formula.asset}"
                 )
         else:
-            if formula.release_tag != "current":
-                raise ValueError(f"{name}: Current formula must use the current release tag")
-            if not formula.version or not re.fullmatch(
-                r"current[.][0-9]+[.][0-9a-f]{12}", formula.version
+            exact_tag = re.fullmatch(r"current-([0-9a-f]{40})", formula.release_tag)
+            if exact_tag is None and not (
+                allow_legacy_current_pair and formula.release_tag == "current"
             ):
+                raise ValueError(
+                    f"{name}: Current formula must use an exact-SHA release tag"
+                )
+            version_match = re.fullmatch(
+                r"current[.]([1-9][0-9]*)[.]([0-9a-f]{12})", formula.version or ""
+            )
+            if version_match is None:
                 raise ValueError(f"{name}: Current formula version is invalid: {formula.version}")
+            tag_short_sha = exact_tag.group(1)[:12] if exact_tag else version_match.group(2)
+            if version_match.group(2) != tag_short_sha:
+                raise ValueError(f"{name}: Current formula version does not match its release tag")
+            expected_current_asset = (
+                f"container-current-{tag_short_sha}-arm64.tar.gz"
+                if name == "container-current"
+                else f"container-compose-plugin-current-{tag_short_sha}-arm64.tar.gz"
+            )
+            if formula.asset != expected_current_asset:
+                raise ValueError(
+                    f"{name}: expected Current asset {expected_current_asset}, "
+                    f"found {formula.asset}"
+                )
 
     if formulae["container"].release_tag != formulae["container-compose"].release_tag:
         raise ValueError("stable Container and Compose formulae do not use the same release tag")
     if formulae["container-current"].version != formulae["container-compose-current"].version:
         raise ValueError("Current Container and Compose formulae do not use the same version")
+    if formulae["container-current"].release_tag != formulae["container-compose-current"].release_tag:
+        raise ValueError("Current Container and Compose formulae do not use the same release tag")
     return formulae
 
 
@@ -168,12 +191,17 @@ def parse_arguments() -> argparse.Namespace:
     parser.add_argument("--compose-repository", type=Path, required=True)
     parser.add_argument("--container-repository", type=Path)
     parser.add_argument("--allow-dirty-tap", action="store_true")
+    parser.add_argument("--allow-legacy-current-pair", action="store_true")
     return parser.parse_args()
 
 
 def main() -> int:
     arguments = parse_arguments()
-    validate_tap(arguments.tap.resolve(), not arguments.allow_dirty_tap)
+    validate_tap(
+        arguments.tap.resolve(),
+        not arguments.allow_dirty_tap,
+        arguments.allow_legacy_current_pair,
+    )
     validate_template(
         arguments.compose_repository.resolve(), "Tools/release/container-compose.rb.in"
     )

--- a/Tools/release/publish-github-release.sh
+++ b/Tools/release/publish-github-release.sh
@@ -59,9 +59,7 @@ if [[ -n "${RELEASE_EXTRA_ASSETS_FILE:-}" && ! -f "${RELEASE_EXTRA_ASSETS_FILE}"
 fi
 
 release_flags=()
-if [[ "${RELEASE_PRERELEASE}" == "true" ]]; then
-  release_flags+=(--prerelease)
-fi
+release_flags+=(--prerelease="${RELEASE_PRERELEASE}")
 if [[ "${RELEASE_LATEST}" == "true" ]]; then
   release_flags+=(--latest)
 else
@@ -113,8 +111,9 @@ case "${PUBLISH_REF_TYPE}:${RELEASE_MUTABLE}" in
     fi
     ;;
   branch:true)
-    if [[ "${RELEASE_TAG}" != "current" ]]; then
-      printf 'mutable branch releases must use the current tag, got: %s\n' "${RELEASE_TAG}" >&2
+    if [[ "${RELEASE_TAG}" != "current-${PUBLISH_SHA}" ]]; then
+      printf 'Current branch releases must use their exact source tag, got: %s\n' \
+        "${RELEASE_TAG}" >&2
       exit 2
     fi
     ;;
@@ -123,7 +122,7 @@ case "${PUBLISH_REF_TYPE}:${RELEASE_MUTABLE}" in
     exit 2
     ;;
   branch:false)
-    printf 'branch releases must explicitly opt into the mutable current tag\n' >&2
+    printf 'branch releases must explicitly select the Current lane\n' >&2
     exit 2
     ;;
   *)
@@ -132,15 +131,13 @@ case "${PUBLISH_REF_TYPE}:${RELEASE_MUTABLE}" in
     ;;
 esac
 
-# A stable release is created once. The mutable current lane is deliberately
-# split into two resumable phases:
+# Every release is created once and becomes immutable. The Current lane uses a
+# content-addressed tag and is split into two resumable phases:
 #
-#   stage    upload immutable, commit-addressed assets while the existing tap
-#            formulae and current tag remain usable;
-#   finalize advance the current tag and edit the existing mutable release
-#            after the matching Homebrew formula pair has been committed. The
-#            release object remains available throughout interruption recovery;
-#            build freshness is carried by explicit metadata, not published_at.
+#   stage    publish the complete exact-SHA prerelease while the existing tap
+#            formulae remain usable;
+#   finalize verify that immutable release after the matching Homebrew formula
+#            pair has been committed.
 #
 # GitHub releases and the Homebrew tap are separate repositories, so this is
 # not a distributed transaction. It does guarantee that an interrupted current
@@ -156,7 +153,7 @@ case "${PUBLISH_REF_TYPE}:${RELEASE_PHASE}" in
   branch:stage|branch:finalize)
     ;;
   branch:publish)
-    printf 'mutable current releases require an explicit stage or finalize phase\n' >&2
+    printf 'Current releases require an explicit stage or finalize phase\n' >&2
     exit 2
     ;;
   *)
@@ -184,47 +181,97 @@ if [[ -n "${RELEASE_EXTRA_ASSETS_FILE:-}" ]]; then
   done < "${RELEASE_EXTRA_ASSETS_FILE}"
 fi
 
-create_args=(
-  "${release_assets[@]}" \
-  --repo "${RELEASE_REPOSITORY}"
-  --title "${RELEASE_TITLE}"
-  --notes-file "${RELEASE_NOTES_FILE}"
-)
-if [[ "${PUBLISH_REF_TYPE}" == "tag" || "${PUBLISH_REF_TYPE}" == "branch" ]]; then
-  create_args+=(--verify-tag)
-else
-  create_args+=(--target "${PUBLISH_SHA}")
-fi
-create_args+=("${release_flags[@]}")
-
-move_current_tag() {
-  # `current` is a lightweight, mutable pointer. Explicitly disable signing so
-  # a developer-level tag.gpgSign setting cannot open an annotation editor.
-  "${GIT}" tag --no-sign --force "${RELEASE_TAG}" "${PUBLISH_SHA}"
-  "${GIT}" push --force origin "refs/tags/${RELEASE_TAG}"
+publish_current_tag() {
+  local local_target remote_target
+  if [[ "${RELEASE_TAG}" != "current-${PUBLISH_SHA}" ]]; then
+    printf 'Current release tag must contain the exact source commit: %s\n' \
+      "${RELEASE_TAG}" >&2
+    return 1
+  fi
+  remote_target="$(
+    "${GIT}" ls-remote --tags --refs origin "refs/tags/${RELEASE_TAG}" |
+      awk '{ print $1 }' | tail -n 1
+  )"
+  if [[ -n "${remote_target}" && "${remote_target}" != "${PUBLISH_SHA}" ]]; then
+    printf 'immutable Current tag %s already targets %s, not %s\n' \
+      "${RELEASE_TAG}" "${remote_target}" "${PUBLISH_SHA}" >&2
+    return 1
+  fi
+  local_target="$(
+    "${GIT}" rev-parse --verify -q "refs/tags/${RELEASE_TAG}^{commit}" || true
+  )"
+  if [[ -n "${local_target}" && "${local_target}" != "${PUBLISH_SHA}" ]]; then
+    printf 'local immutable Current tag %s already targets %s, not %s\n' \
+      "${RELEASE_TAG}" "${local_target}" "${PUBLISH_SHA}" >&2
+    return 1
+  fi
+  if [[ -z "${local_target}" ]]; then
+    # Explicitly disable signing so a developer-level tag.gpgSign setting
+    # cannot open an annotation editor for this generated identity.
+    "${GIT}" tag --no-sign "${RELEASE_TAG}" "${PUBLISH_SHA}"
+  fi
+  if [[ -z "${remote_target}" ]]; then
+    "${GIT}" push origin "refs/tags/${RELEASE_TAG}"
+  fi
 }
 
-create_release() {
-  "${GH}" release create "${RELEASE_TAG}" "${create_args[@]}"
-}
-
-create_stable_draft() {
+create_release_draft() {
   "${GH}" release create "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
     --title "${RELEASE_TITLE}" --notes-file "${RELEASE_NOTES_FILE}" \
     --target "${PUBLISH_SHA}" --verify-tag "${release_flags[@]}" --draft
 }
 
-validate_stable_draft_asset_names() {
+# A private draft is staging state, not immutable release authority. If an
+# interrupted signing attempt left any conflicting or foreign bytes, replace
+# only that draft object after a final exact-state check. Never ask GitHub CLI
+# to clean up the source tag: both Current and stable tags are immutable input.
+recreate_release_draft() {
+  local snapshot remote_tag_sha
+  snapshot="$("${GH}" release view "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" \
+    --json isDraft,tagName,targetCommitish)"
+  if [[ "$(jq -r '.isDraft' <<<"${snapshot}")" != true ||
+        "$(jq -r '.tagName' <<<"${snapshot}")" != "${RELEASE_TAG}" ||
+        "$(jq -r '.targetCommitish' <<<"${snapshot}")" != "${PUBLISH_SHA}" ]]; then
+    printf 'release draft changed before bounded replacement: %s\n' \
+      "${RELEASE_TAG}" >&2
+    return 1
+  fi
+  remote_tag_sha="$(
+    "${GIT}" ls-remote --tags "https://github.com/${RELEASE_REPOSITORY}.git" \
+      "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" |
+      awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+  )"
+  if [[ "${remote_tag_sha}" != "${PUBLISH_SHA}" ]]; then
+    printf 'release draft tag changed before bounded replacement: %s\n' \
+      "${RELEASE_TAG}" >&2
+    return 1
+  fi
+  "${GH}" release delete "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" --yes
+  remote_tag_sha="$(
+    "${GIT}" ls-remote --tags "https://github.com/${RELEASE_REPOSITORY}.git" \
+      "refs/tags/${RELEASE_TAG}" "refs/tags/${RELEASE_TAG}^{}" |
+      awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
+  )"
+  if [[ "${remote_tag_sha}" != "${PUBLISH_SHA}" ]]; then
+    printf 'bounded draft replacement changed immutable tag %s\n' \
+      "${RELEASE_TAG}" >&2
+    return 1
+  fi
+  create_release_draft
+}
+
+validate_release_draft_asset_names() {
   local remote_names="$1" expected_names="$2" require_complete="$3" name count
   while IFS= read -r name; do
     [[ -n "${name}" ]] || continue
     if ! grep -Fqx -- "${name}" <<<"${expected_names}"; then
-      printf 'stable draft contains an unexpected asset: %s\n' "${name}" >&2
+      printf 'release draft contains an unexpected asset: %s\n' "${name}" >&2
       return 1
     fi
     count="$(grep -Fxc -- "${name}" <<<"${remote_names}" || true)"
     if (( count != 1 )); then
-      printf 'stable draft contains a duplicate asset name: %s\n' "${name}" >&2
+      printf 'release draft contains a duplicate asset name: %s\n' "${name}" >&2
       return 1
     fi
   done <<<"${remote_names}"
@@ -232,7 +279,7 @@ validate_stable_draft_asset_names() {
     while IFS= read -r name; do
       [[ -n "${name}" ]] || continue
       if ! grep -Fqx -- "${name}" <<<"${remote_names}"; then
-        printf 'stable draft is missing an uploaded asset: %s\n' "${name}" >&2
+        printf 'release draft is missing an uploaded asset: %s\n' "${name}" >&2
         return 1
       fi
     done <<<"${expected_names}"
@@ -241,21 +288,21 @@ validate_stable_draft_asset_names() {
 
 # Verify GitHub's final asset inventory and server-computed digests immediately
 # before making an immutable stable release public.
-validate_stable_draft_asset_digests() {
+validate_release_draft_asset_digests() {
   local remote_assets="$1" asset name expected_digest remote_digest count
   for asset in "${release_assets[@]}"; do
     name="$(basename "${asset}")"
     count="$(awk -F '\t' -v name="${name}" '$1 == name { count += 1 } END { print count + 0 }' \
       <<<"${remote_assets}")"
     if (( count != 1 )); then
-      printf 'stable draft final inventory changed for asset: %s\n' "${name}" >&2
+      printf 'release draft final inventory changed for asset: %s\n' "${name}" >&2
       return 1
     fi
     remote_digest="$(awk -F '\t' -v name="${name}" '$1 == name { print $2 }' \
       <<<"${remote_assets}")"
     expected_digest="sha256:$(shasum -a 256 "${asset}" | awk '{print $1}')"
     if [[ "${remote_digest}" != "${expected_digest}" ]]; then
-      printf 'stable draft final digest changed for asset: %s\n' "${name}" >&2
+      printf 'release draft final digest changed for asset: %s\n' "${name}" >&2
       return 1
     fi
   done
@@ -266,43 +313,181 @@ validate_stable_draft_asset_digests() {
 # exclusive writer for supported publication and recovery runs. Verify the
 # server's immutable post-publication snapshot so a privileged out-of-band
 # mutation or a lost publish response can never be reported as success.
-verify_published_stable_release() {
-  local expected_names="$1"
-  local snapshot remote_assets remote_names latest_tag remote_tag_sha
+validate_published_release_identity() {
+  local snapshot="$1"
   local field actual expected
-  snapshot="$("${GH}" release view "${RELEASE_TAG}" \
-    --repo "${RELEASE_REPOSITORY}" \
-    --json isDraft,isImmutable,isPrerelease,tagName,targetCommitish,name,body,assets)"
-
   while IFS=$'\t' read -r field actual expected; do
     if [[ "${actual}" != "${expected}" ]]; then
-      printf 'published stable release %s mismatch: expected %s, got %s\n' \
+      printf 'published release %s mismatch: expected %s, got %s\n' \
         "${field}" "${expected}" "${actual}" >&2
       return 1
     fi
   done < <(
     jq -r --arg tag "${RELEASE_TAG}" --arg target "${PUBLISH_SHA}" \
-      --arg name "${RELEASE_TITLE}" --rawfile body "${RELEASE_NOTES_FILE}" \
+      --arg name "${RELEASE_TITLE}" \
       --argjson prerelease "${RELEASE_PRERELEASE}" \
-      '["draft state", .isDraft, false], ["immutability", .isImmutable, true], ["prerelease state", .isPrerelease, $prerelease], ["tag", .tagName, $tag], ["target", .targetCommitish, $target], ["title", .name, $name], ["notes", .body, $body] | @tsv' \
+      '["draft state", .isDraft, false], ["immutability", .isImmutable, true], ["prerelease state", .isPrerelease, $prerelease], ["tag", .tagName, $tag], ["target", .targetCommitish, $target], ["title", .name, $name] | @tsv' \
       <<<"${snapshot}"
   )
+}
+
+validate_published_release_metadata() {
+  local snapshot="$1"
+  local actual_body expected_body
+  validate_published_release_identity "${snapshot}"
+  actual_body="$(jq -er '.body | strings' <<<"${snapshot}")"
+  expected_body="$(<"${RELEASE_NOTES_FILE}")"
+  if [[ "${actual_body}" != "${expected_body}" ]]; then
+    printf 'published release notes mismatch\n' >&2
+    return 1
+  fi
+}
+
+reconstruct_published_release_notes() {
+  local snapshot="$1" remote_assets="$2" destination="$3"
+  local body expected_body asset name digest
+  local -a replacements=()
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    if [[ "${asset}" != "${RELEASE_ASSET_PATH}" &&
+          ! "${name}" =~ ^container-(current-[0-9a-f]{12}|release)-arm64[.]tar[.]gz$ ]]; then
+      continue
+    fi
+    digest="$(awk -F '\t' -v name="${name}" '$1 == name { sub(/^sha256:/, "", $2); print $2 }' \
+      <<<"${remote_assets}")"
+    if [[ ! "${digest}" =~ ^[0-9a-f]{64}$ ]]; then
+      printf 'published release notes asset has no trusted digest: %s\n' \
+        "${name}" >&2
+      return 1
+    fi
+    replacements+=("${name}=${digest}")
+  done
+  python3 - "${RELEASE_NOTES_FILE}" "${destination}" "${replacements[@]}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+destination = Path(sys.argv[2])
+notes = source.read_text(encoding="utf-8")
+for value in sys.argv[3:]:
+    name, digest = value.split("=", 1)
+    pattern = re.compile(
+        rf"(- `{re.escape(name)}` SHA-256:\n  `)[0-9a-f]{{64}}(`\.)"
+    )
+    notes, count = pattern.subn(rf"\g<1>{digest}\g<2>", notes)
+    if count != 1:
+        raise SystemExit(f"release notes do not contain one SHA-256 block for: {name}")
+destination.write_text(notes, encoding="utf-8")
+PY
+  body="$(jq -er '.body | strings' <<<"${snapshot}")"
+  expected_body="$(<"${destination}")"
+  if [[ "${body}" != "${expected_body}" ]]; then
+    printf 'published release notes differ from reconstructed candidate authority\n' >&2
+    return 1
+  fi
+}
+
+# A retry after immutable publication must use the published bytes as its
+# authority. Signed/notarized archives can legitimately differ when rebuilt,
+# even from identical source, so comparing a fresh build to the immutable
+# release would strand a transaction before its Homebrew update. Validate the
+# immutable identity and server digests first, then replace local candidates
+# with authenticated downloads for all downstream verification and rendering.
+restore_published_release_assets() {
+  local expected_names="$1"
+  local snapshot remote_assets remote_names temporary asset name downloaded
+  local remote_digest actual_digest replacement index staged reconstructed_notes
+  local -a staged_replacements=()
+  local -a staged_destinations=()
+  snapshot="$("${GH}" release view "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" \
+    --json isDraft,isImmutable,isPrerelease,tagName,targetCommitish,name,body,assets)"
+  validate_published_release_identity "${snapshot}"
+  remote_assets="$(jq -r '.assets[] | [.name, (.digest // "")] | @tsv' \
+    <<<"${snapshot}")"
+  remote_names="$(cut -f 1 <<<"${remote_assets}")"
+  validate_release_draft_asset_names "${remote_names}" "${expected_names}" true
+
+  temporary="$(mktemp -d \
+    "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/published-release-assets.XXXXXX")"
+  replacement=""
+  trap '
+    find "${temporary}" -depth -delete >/dev/null 2>&1 || true
+    for staged in "${staged_replacements[@]}"; do
+      [[ -n "${staged}" ]] || continue
+      find "${staged}" -depth -delete >/dev/null 2>&1 || true
+    done
+  ' RETURN
+  reconstructed_notes="${temporary}/release-notes.md"
+  reconstruct_published_release_notes \
+    "${snapshot}" "${remote_assets}" "${reconstructed_notes}"
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    remote_digest="$(awk -F '\t' -v name="${name}" '$1 == name { print $2 }' \
+      <<<"${remote_assets}")"
+    if [[ ! "${remote_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]; then
+      printf 'published release asset has no trusted SHA-256 digest: %s\n' \
+        "${name}" >&2
+      return 1
+    fi
+    "${GH}" release download "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
+      --pattern "${name}" --dir "${temporary}"
+    downloaded="${temporary}/${name}"
+    if [[ ! -f "${downloaded}" ]]; then
+      printf 'published release download is missing: %s\n' "${name}" >&2
+      return 1
+    fi
+    actual_digest="sha256:$(shasum -a 256 "${downloaded}" | awk '{print $1}')"
+    if [[ "${actual_digest}" != "${remote_digest}" ]]; then
+      printf 'published release download digest mismatch: %s\n' "${name}" >&2
+      return 1
+    fi
+  done
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    replacement="$(mktemp "$(dirname "${asset}")/.${name}.published.XXXXXX")"
+    cp "${temporary}/${name}" "${replacement}"
+    staged_replacements+=("${replacement}")
+    staged_destinations+=("${asset}")
+  done
+  replacement="$(mktemp \
+    "$(dirname "${RELEASE_NOTES_FILE}")/.release-notes.published.XXXXXX")"
+  cp "${reconstructed_notes}" "${replacement}"
+  staged_replacements+=("${replacement}")
+  staged_destinations+=("${RELEASE_NOTES_FILE}")
+
+  for index in "${!staged_replacements[@]}"; do
+    mv -f "${staged_replacements[${index}]}" "${staged_destinations[${index}]}"
+    staged_replacements[${index}]=""
+  done
+  find "${temporary}" -depth -delete
+  trap - RETURN
+}
+
+verify_published_release() {
+  local expected_names="$1"
+  local snapshot remote_assets remote_names latest_tag remote_tag_sha
+  snapshot="$("${GH}" release view "${RELEASE_TAG}" \
+    --repo "${RELEASE_REPOSITORY}" \
+    --json isDraft,isImmutable,isPrerelease,tagName,targetCommitish,name,body,assets)"
+  validate_published_release_metadata "${snapshot}"
 
   remote_assets="$(jq -r '.assets[] | [.name, (.digest // "")] | @tsv' \
     <<<"${snapshot}")"
   remote_names="$(cut -f 1 <<<"${remote_assets}")"
-  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" true
-  validate_stable_draft_asset_digests "${remote_assets}"
+  validate_release_draft_asset_names "${remote_names}" "${expected_names}" true
+  validate_release_draft_asset_digests "${remote_assets}"
 
   latest_tag="$("${GH}" api "repos/${RELEASE_REPOSITORY}/releases/latest" \
     --jq '.tag_name')"
   if [[ "${RELEASE_LATEST}" == "true" && "${latest_tag}" != "${RELEASE_TAG}" ]]; then
-    printf 'published stable release is not latest: expected %s, got %s\n' \
+    printf 'published release is not latest: expected %s, got %s\n' \
       "${RELEASE_TAG}" "${latest_tag}" >&2
     return 1
   fi
   if [[ "${RELEASE_LATEST}" != "true" && "${latest_tag}" == "${RELEASE_TAG}" ]]; then
-    printf 'published stable release unexpectedly became latest: %s\n' \
+    printf 'published release unexpectedly became latest: %s\n' \
       "${RELEASE_TAG}" >&2
     return 1
   fi
@@ -313,18 +498,19 @@ verify_published_stable_release() {
       awk '$2 ~ /\^\{\}$/ { peeled = $1 } $2 !~ /\^\{\}$/ { direct = $1 } END { print peeled ? peeled : direct }'
   )"
   if [[ "${remote_tag_sha}" != "${PUBLISH_SHA}" ]]; then
-    printf 'published stable tag target mismatch: expected %s, got %s\n' \
+    printf 'published release tag target mismatch: expected %s, got %s\n' \
       "${PUBLISH_SHA}" "${remote_tag_sha:-missing}" >&2
     return 1
   fi
 }
 
-reconcile_stable_draft() {
+reconcile_release_draft() {
   local temporary verification final_snapshot remote_names remote_assets
   local expected_names asset name downloaded
   local missing_assets=()
+  local draft_recreated=false
   if [[ "$("${GIT}" rev-list -n 1 "refs/tags/${RELEASE_TAG}")" != "${PUBLISH_SHA}" ]]; then
-    printf 'stable draft tag no longer resolves to the requested candidate: %s\n' \
+    printf 'release draft tag no longer resolves to the requested candidate: %s\n' \
       "${RELEASE_TAG}" >&2
     return 1
   fi
@@ -334,14 +520,19 @@ reconcile_stable_draft() {
   for asset in "${release_assets[@]}"; do
     name="$(basename "${asset}")"
     if grep -Fqx -- "${name}" <<<"${expected_names}"; then
-      printf 'stable draft candidate contains a duplicate asset name: %s\n' \
+      printf 'release draft candidate contains a duplicate asset name: %s\n' \
         "${name}" >&2
       return 1
     fi
     expected_names+="${name}"$'\n'
   done
-  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" false
-  temporary="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/stable-draft-assets.XXXXXX")"
+  if ! validate_release_draft_asset_names \
+    "${remote_names}" "${expected_names}" false; then
+    recreate_release_draft
+    remote_names=""
+    draft_recreated=true
+  fi
+  temporary="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-draft-assets.XXXXXX")"
   verification=""
   trap 'find "${temporary}" -depth -delete >/dev/null 2>&1 || true; if [[ -n "${verification:-}" ]]; then find "${verification}" -depth -delete >/dev/null 2>&1 || true; fi' RETURN
   for asset in "${release_assets[@]}"; do
@@ -353,9 +544,21 @@ reconcile_stable_draft() {
       if [[ ! -f "${downloaded}" ]] || \
         [[ "$(shasum -a 256 "${downloaded}" | awk '{print $1}')" != \
           "$(shasum -a 256 "${asset}" | awk '{print $1}')" ]]; then
-        printf 'stable draft asset conflicts with retained candidate: %s\n' \
-          "${name}" >&2
-        return 1
+        if [[ "${draft_recreated}" == true ]]; then
+          printf 'replacement release draft asset conflicts with candidate: %s\n' \
+            "${name}" >&2
+          return 1
+        fi
+        find "${temporary}" -depth -delete
+        trap - RETURN
+        recreate_release_draft
+        temporary="$(mktemp -d \
+          "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-draft-assets.XXXXXX")"
+        trap 'find "${temporary}" -depth -delete >/dev/null 2>&1 || true; if [[ -n "${verification:-}" ]]; then find "${verification}" -depth -delete >/dev/null 2>&1 || true; fi' RETURN
+        missing_assets=("${release_assets[@]}")
+        remote_names=""
+        draft_recreated=true
+        break
       fi
     else
       missing_assets+=("${asset}")
@@ -367,9 +570,9 @@ reconcile_stable_draft() {
   done
   remote_names="$("${GH}" release view "${RELEASE_TAG}" \
     --repo "${RELEASE_REPOSITORY}" --json assets --jq '.assets[].name')"
-  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" true
+  validate_release_draft_asset_names "${remote_names}" "${expected_names}" true
   verification="$(mktemp -d \
-    "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/stable-draft-final.XXXXXX")"
+    "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/release-draft-final.XXXXXX")"
   for asset in "${release_assets[@]}"; do
     name="$(basename "${asset}")"
     "${GH}" release download "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
@@ -378,35 +581,31 @@ reconcile_stable_draft() {
     if [[ ! -f "${downloaded}" ]] || \
       [[ "$(shasum -a 256 "${downloaded}" | awk '{print $1}')" != \
         "$(shasum -a 256 "${asset}" | awk '{print $1}')" ]]; then
-      printf 'stable draft asset changed before publication: %s\n' "${name}" >&2
+      printf 'release draft asset changed before publication: %s\n' "${name}" >&2
       return 1
     fi
   done
   final_snapshot="$("${GH}" release view "${RELEASE_TAG}" \
     --repo "${RELEASE_REPOSITORY}" --json isDraft,assets)"
   if [[ "$(jq -r '.isDraft' <<<"${final_snapshot}")" != true ]]; then
-    printf 'stable release is no longer a draft before publication: %s\n' \
+    printf 'release is no longer a draft before publication: %s\n' \
       "${RELEASE_TAG}" >&2
     return 1
   fi
   remote_assets="$(jq -r '.assets[] | [.name, (.digest // "")] | @tsv' \
     <<<"${final_snapshot}")"
   remote_names="$(cut -f 1 <<<"${remote_assets}")"
-  validate_stable_draft_asset_names "${remote_names}" "${expected_names}" true
-  validate_stable_draft_asset_digests "${remote_assets}"
+  validate_release_draft_asset_names "${remote_names}" "${expected_names}" true
+  validate_release_draft_asset_digests "${remote_assets}"
   "${GH}" release edit "${RELEASE_TAG}" --repo "${RELEASE_REPOSITORY}" \
     --target "${PUBLISH_SHA}" --title "${RELEASE_TITLE}" \
     --notes-file "${RELEASE_NOTES_FILE}" \
-    --draft=false --prerelease="${RELEASE_PRERELEASE}" "${release_flags[@]}"
-  verify_published_stable_release "${expected_names}"
+    --draft=false "${release_flags[@]}"
+  verify_published_release "${expected_names}"
 }
 
 if [[ "${published_release_state}" == "draft" ]]; then
-  if [[ "${RELEASE_MUTABLE}" == "true" ]]; then
-    printf 'mutable current release unexpectedly exists as a draft\n' >&2
-    exit 1
-  fi
-  reconcile_stable_draft
+  reconcile_release_draft
   exit 0
 fi
 
@@ -422,46 +621,28 @@ if [[ "${published_release_state}" == "exists" ]]; then
       fi
       expected_names+="${name}"$'\n'
     done
-    verify_published_stable_release "${expected_names}"
+    restore_published_release_assets "${expected_names}"
+    verify_published_release "${expected_names}"
     exit 0
   fi
-
-  if [[ "${RELEASE_PHASE}" == "stage" ]]; then
-    "${GH}" release upload "${RELEASE_TAG}" "${release_assets[@]}" \
-      --repo "${RELEASE_REPOSITORY}" --clobber
-    exit 0
-  fi
-
-  move_current_tag
-  # Re-uploading is idempotent and makes finalization recover from a partially
-  # staged asset set without creating an availability window.
-  "${GH}" release upload "${RELEASE_TAG}" "${release_assets[@]}" \
-    --repo "${RELEASE_REPOSITORY}" --clobber
-  "${GH}" release edit "${RELEASE_TAG}" \
-    --repo "${RELEASE_REPOSITORY}" \
-    --target "${PUBLISH_SHA}" \
-    --title "${RELEASE_TITLE}" \
-    --notes-file "${RELEASE_NOTES_FILE}" \
-    "${release_flags[@]}"
+  expected_names=""
+  for asset in "${release_assets[@]}"; do
+    name="$(basename "${asset}")"
+    if grep -Fqx -- "${name}" <<<"${expected_names}"; then
+      printf 'Current release candidate contains a duplicate asset name: %s\n' \
+        "${name}" >&2
+      exit 1
+    fi
+    expected_names+="${name}"$'\n'
+  done
+  restore_published_release_assets "${expected_names}"
+  verify_published_release "${expected_names}"
   exit 0
 fi
 
 if [[ "${PUBLISH_REF_TYPE}" == "branch" ]]; then
-  # Create the explicit current tag before the first prerelease or a recovered
-  # finalization. This avoids an implicit target and keeps the lane verifiable.
-  move_current_tag
+  publish_current_tag
 fi
 
-if [[ "${PUBLISH_REF_TYPE}" == "tag" ]]; then
-  create_stable_draft
-  reconcile_stable_draft
-else
-  create_release
-fi
-
-if [[ "${PUBLISH_REF_TYPE}" == "branch" && "${RELEASE_PHASE}" == "finalize" ]]; then
-  "${GH}" release edit "${RELEASE_TAG}" \
-    --repo "${RELEASE_REPOSITORY}" \
-    --target "${PUBLISH_SHA}" \
-    --prerelease
-fi
+create_release_draft
+reconcile_release_draft

--- a/Tools/release/release-notes.py
+++ b/Tools/release/release-notes.py
@@ -287,10 +287,9 @@ def release_range(
     if head_commit is None:
         raise ValueError(f"could not resolve release head: {head_ref}")
 
-    # `current` is a mutable prerelease pointer, not a release baseline. Every
-    # Current build must describe the complete delta from the latest stable
-    # release, even after the pointer was advanced by an earlier build.
-    if release_tag != "current":
+    # Content-addressed Current prereleases are not stable release baselines.
+    # Every Current build describes the complete delta from the latest stable.
+    if not release_tag.startswith("current-"):
         tagged_commit = commit_for_ref(repo, f"refs/tags/{release_tag}")
         if tagged_commit is not None:
             if tagged_commit != head_commit:
@@ -828,7 +827,7 @@ def render_release_notes(
     ])
     if not stable_release:
         lines.append(
-            f"- Mutable `current` pointer targets main commit `{selected_range.head_commit}`."
+            f"- Immutable `{release_tag}` prerelease identifies main commit `{selected_range.head_commit}`."
         )
     lines.append("")
 
@@ -922,7 +921,7 @@ def render_release_notes(
         lines.extend(
             [
                 "- The current build atomically updates `stephenlclarke/tap/container-compose-current` and `stephenlclarke/tap/container-current`.",
-                "- Both formulae download the exact matched assets from this one mutable prerelease.",
+                "- Both formulae download the exact matched assets from this content-addressed immutable prerelease.",
                 "- It never changes the stable formula pair.",
             ]
         )
@@ -944,8 +943,8 @@ def render_release_notes(
     else:
         lines.extend(
             [
-                "- The single `Current build` prerelease and its `current` tag move together only after green `main` CI.",
-                "- They do not move semantic source tags or the stable formula pair.",
+                "- Green `main` CI publishes one immutable `current-<sha>` prerelease before atomically updating the Current formula pair.",
+                "- Publication never retargets an existing tag or changes the stable formula pair.",
             ]
         )
 
@@ -955,8 +954,8 @@ def render_release_notes(
             "## Asset Retention",
             "",
             "- Stable release objects, notes, and source tags are retained as history.",
-            "- Only the newest published stable release and the one `current` prerelease retain downloadable assets and tap-backed installation.",
-            "- Superseded generated current-release objects are deleted, while their source tags remain available for reference.",
+            "- Only the newest published stable release and newest `current-<sha>` prerelease are tap-backed installations.",
+            "- Superseded immutable Current releases and source tags remain content-addressed history; mutable legacy prereleases may be retired.",
             "- Superseded stable releases lose binary assets and gain exact source-build instructions on this page.",
             "",
             "## Validation",

--- a/Tools/release/release-workspace.py
+++ b/Tools/release/release-workspace.py
@@ -161,12 +161,21 @@ def mutable_tags(component_name: str) -> frozenset[str]:
     return MUTABLE_TAGS_BY_COMPONENT.get(component_name, frozenset())
 
 
+def checkpoint_ignored_tag(component_name: str, name: str) -> bool:
+    """Return tags that are release pointers/history, not source authority."""
+
+    return name in mutable_tags(component_name) or (
+        component_name == "container-compose"
+        and re.fullmatch(r"current-[0-9a-f]{40}", name) is not None
+    )
+
+
 def remote_immutable_tag_refs(url: str, component_name: str) -> dict[str, str]:
     refs: dict[str, str] = {}
     for line in run_git("ls-remote", "--tags", "--refs", url).splitlines():
         reference_sha, reference = line.split(maxsplit=1)
         name = reference.removeprefix("refs/tags/")
-        if name not in mutable_tags(component_name):
+        if not checkpoint_ignored_tag(component_name, name):
             refs[name] = reference_sha
     return refs
 
@@ -183,7 +192,7 @@ def local_immutable_tag_refs(path: Path, component_name: str) -> dict[str, str]:
         fields = line.split()
         if len(fields) != 2 or not SHA.fullmatch(fields[1]):
             raise WorkspaceError(f"could not inspect tags in {path}")
-        if fields[0] not in mutable_tags(component_name):
+        if not checkpoint_ignored_tag(component_name, fields[0]):
             refs[fields[0]] = fields[1]
     return refs
 
@@ -521,7 +530,7 @@ def verify_workspace(root: Path, build_root: Path) -> dict[str, object]:
             if not isinstance(component_tags, dict) or any(
                 not isinstance(name, str)
                 or not name
-                or name in mutable_tags(component_name)
+                or checkpoint_ignored_tag(component_name, name)
                 or not isinstance(value, str)
                 or not SHA.fullmatch(value)
                 for name, value in component_tags.items()
@@ -655,33 +664,17 @@ def ensure_workspace_is_idle(marker: dict[str, object]) -> None:
     raise WorkspaceError("release transaction lease belongs to another host")
 
 
-def refresh_mutable_current_tag(root: Path) -> None:
-    """Refresh the one mutable release pointer before resuming a checkpoint."""
+def refresh_current_release_tags(root: Path) -> None:
+    """Fetch immutable content-addressed Current tags before checkpoint recovery."""
 
     compose = root / "container-compose"
-    output = run_git(
-        "ls-remote",
-        "--tags",
-        "--refs",
-        "origin",
-        "refs/tags/current",
-        cwd=compose,
-    )
-    if not output.strip():
-        raise WorkspaceError("container-compose current tag is missing from origin")
-    fields = output.split()
-    if len(fields) != 2 or not SHA.fullmatch(fields[0]):
-        raise WorkspaceError("could not resolve container-compose current tag")
     run_git(
         "fetch",
         "--no-write-fetch-head",
         "origin",
-        "+refs/tags/current:refs/tags/current",
+        "refs/tags/current-*:refs/tags/current-*",
         cwd=compose,
     )
-    local_current = run_git("rev-parse", "refs/tags/current", cwd=compose).strip()
-    if local_current != fields[0]:
-        raise WorkspaceError("container-compose current tag changed while refreshing")
 
 
 def workspace_matches_initial_checkpoint(
@@ -1389,7 +1382,7 @@ def _materialize_locked(
             ):
                 stale_retained = retained
             else:
-                refresh_mutable_current_tag(retained)
+                refresh_current_release_tags(retained)
                 if retained_baseline is not None and (
                     workspace_baseline_state(retained) == retained_baseline
                     and workspace_matches_initial_checkpoint(retained, marker)
@@ -1399,7 +1392,7 @@ def _materialize_locked(
                     )
                 return retained
         else:
-            refresh_mutable_current_tag(retained)
+            refresh_current_release_tags(retained)
             return retained
 
     if snapshot is None:
@@ -1439,7 +1432,7 @@ def _materialize_locked(
         ):
             stale_destination = destination
         elif destination != stale_retained:
-            refresh_mutable_current_tag(destination)
+            refresh_current_release_tags(destination)
             destination_tags = workspace_semantic_tag_targets(destination, marker)
             retired: Path | None = None
             if stale_retained is not None:
@@ -1564,7 +1557,7 @@ def _materialize_locked(
         shutil.rmtree(stage, ignore_errors=True)
         raise
     verify_workspace(destination, safe_root)
-    refresh_mutable_current_tag(destination)
+    refresh_current_release_tags(destination)
     return destination
 
 

--- a/Tools/release/render-homebrew-stack-formulae.sh
+++ b/Tools/release/render-homebrew-stack-formulae.sh
@@ -94,17 +94,19 @@ require_release_inputs() {
 
 # Wait for the released GitHub object to be visible and match the selected lane.
 verify_published_release() {
-  local attempt details exit_status actual_tag is_draft is_prerelease
+  local attempt details exit_status actual_tag is_draft is_immutable is_prerelease
   local max_attempts=6
 
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if details="$(gh release view "${RELEASE_TAG}" \
       --repo "${RELEASE_REPOSITORY}" \
-      --json tagName,isDraft,isPrerelease \
-      --jq '[.tagName, .isDraft, .isPrerelease] | @tsv' 2>&1)"; then
-      IFS=$'\t' read -r actual_tag is_draft is_prerelease <<<"${details}"
-      if [[ "${actual_tag}" != "${RELEASE_TAG}" || "${is_draft}" != "false" || "${is_prerelease}" != "${RELEASE_PRERELEASE}" ]]; then
-        error "published release state does not match ${RELEASE_TAG}: tag=${actual_tag:-missing}, draft=${is_draft:-missing}, prerelease=${is_prerelease:-missing}"
+      --json tagName,isDraft,isImmutable,isPrerelease \
+      --jq '[.tagName, .isDraft, .isImmutable, .isPrerelease] | @tsv' 2>&1)"; then
+      IFS=$'\t' read -r actual_tag is_draft is_immutable is_prerelease <<<"${details}"
+      if [[ "${actual_tag}" != "${RELEASE_TAG}" || "${is_draft}" != "false" || \
+        "${is_immutable}" != "true" || \
+        "${is_prerelease}" != "${RELEASE_PRERELEASE}" ]]; then
+        error "published release state does not match ${RELEASE_TAG}: tag=${actual_tag:-missing}, draft=${is_draft:-missing}, immutable=${is_immutable:-missing}, prerelease=${is_prerelease:-missing}"
       fi
       return 0
     else
@@ -208,7 +210,7 @@ main() {
 
   compose_url="https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/${ASSET}"
   runtime_url="https://github.com/${RELEASE_REPOSITORY}/releases/download/${RELEASE_TAG}/${RUNTIME_ASSET}"
-  if [[ "${RELEASE_TAG}" != "current" ]]; then
+  if [[ "${RELEASE_PRERELEASE}" != "true" ]]; then
     version_policy_args+=(--omit-version)
   fi
 

--- a/Tools/release/retain-release-assets.py
+++ b/Tools/release/retain-release-assets.py
@@ -87,7 +87,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--delete-superseded-current-releases",
         action="store_true",
-        help="delete obsolete mutable current release objects while preserving their tags",
+        help="delete obsolete mutable legacy prereleases; immutable releases are retained",
     )
     parser.add_argument(
         "--current-asset",
@@ -95,7 +95,7 @@ def parse_args() -> argparse.Namespace:
         default=[],
         help=(
             "asset name that belongs to the finalized current build; may be repeated. "
-            "All other current-release assets are retired after promotion."
+            "Unexpected assets fail validation because immutable releases cannot be repaired."
         ),
     )
     return parser.parse_args()
@@ -115,12 +115,12 @@ def published_releases(releases: Iterable[dict]) -> list[dict]:
 
 
 def current_release_candidates(releases: Iterable[dict]) -> list[dict]:
-    """Return published prereleases that implement the mutable current lane."""
+    """Return published prereleases that implement the immutable Current lane."""
     return [
         release
         for release in published_releases(releases)
         if release.get("prerelease")
-        and release.get("tag_name") in {"current"}
+        and re.fullmatch(r"current-[0-9a-f]{40}", str(release.get("tag_name") or ""))
     ]
 
 
@@ -128,8 +128,15 @@ def obsolete_current_release(release: dict) -> bool:
     """Return whether a prerelease is an old generated current-build release."""
     tag = str(release.get("tag_name") or "")
     return bool(release.get("prerelease")) and (
-        tag.startswith("current-") or tag.startswith("homebrew-main-")
+        tag == "current" or tag.startswith("current-") or tag.startswith("homebrew-main-")
     )
+
+
+def deletable_legacy_current_release(release: dict) -> bool:
+    """Return legacy mutable prereleases that may be removed as whole objects."""
+
+    tag = str(release.get("tag_name") or "")
+    return bool(release.get("prerelease")) and tag.startswith("homebrew-main-")
 
 
 def latest_stable_release_id(repo: str, releases: Iterable[dict]) -> int | None:
@@ -153,7 +160,7 @@ def latest_stable_release_id(repo: str, releases: Iterable[dict]) -> int | None:
 def retained_release_ids(
     releases: Iterable[dict], *, latest_stable_id: int | None
 ) -> set[int]:
-    """Return GitHub latest stable and the sole mutable current prerelease ids."""
+    """Return GitHub latest stable and the newest immutable Current prerelease ids."""
 
     published = published_releases(releases)
     keep: set[int] = set()
@@ -173,8 +180,10 @@ def retained_release_ids(
         current_candidates = [
             release
             for release in published
-            if release.get("prerelease")
+            if release.get("prerelease") and release.get("tag_name") == "current"
         ]
+    if not current_candidates:
+        current_candidates = [release for release in published if release.get("prerelease")]
     if current_candidates:
         keep.add(max(current_candidates, key=lambda release: release["published_at"])["id"])
     return keep
@@ -285,7 +294,7 @@ def historical_assets_to_retire(release: dict) -> list[dict]:
 
 
 def stale_current_assets(release: dict, retained_names: set[str]) -> list[dict]:
-    """Return superseded assets from the sole mutable current release."""
+    """Return unexpected assets from an exact immutable Current release."""
 
     return [
         asset
@@ -339,6 +348,8 @@ def main() -> None:
     for release in published_releases(releases):
         if release["id"] not in retained:
             continue
+        if release.get("immutable"):
+            continue
         current_body = release.get("body") or ""
         body = replace_retention_note(
             remove_legacy_pin_highlights(current_body),
@@ -360,20 +371,30 @@ def main() -> None:
     retained_current_assets = set(args.current_asset)
     if retained_current_assets:
         for release in published_releases(releases):
-            if release["id"] not in retained or release.get("tag_name") != "current":
+            if release["id"] not in retained or not re.fullmatch(
+                r"current-[0-9a-f]{40}", str(release.get("tag_name") or "")
+            ):
                 continue
             stale_assets = stale_current_assets(release, retained_current_assets)
             if not stale_assets:
                 continue
-            print(
-                "retiring superseded current assets: "
+            raise ValueError(
+                "immutable Current release contains unexpected assets: "
                 + ", ".join(str(asset.get("name")) for asset in stale_assets)
             )
-            if args.apply:
-                delete_named_assets(args.repo, stale_assets)
 
     for release in stale:
-        if args.delete_superseded_current_releases and obsolete_current_release(release):
+        if release.get("tag_name") == "current":
+            print("preserving deprecated legacy Current release without mutation")
+            continue
+        if release.get("immutable"):
+            print(f"preserving immutable historical release: {release['tag_name']}")
+            continue
+        if (
+            args.delete_superseded_current_releases
+            and deletable_legacy_current_release(release)
+            and not release.get("immutable")
+        ):
             print(f"removing superseded current release object: {release['tag_name']}")
             if args.apply:
                 delete_release(args.repo, release)
@@ -395,7 +416,14 @@ def main() -> None:
             continue
         print(f"retiring {release['tag_name']}: {asset_count} asset(s)")
         if args.apply:
-            if asset_count:
+            content_addressed_current = re.fullmatch(
+                r"current-[0-9a-f]{40}", str(release.get("tag_name") or "")
+            )
+            if (
+                asset_count
+                and not release.get("immutable")
+                and content_addressed_current is None
+            ):
                 delete_named_assets(args.repo, retired_assets)
             if body != current_body:
                 update_release_notes(args.repo, release, body)

--- a/Tools/release/test_capture_quality_snapshot.py
+++ b/Tools/release/test_capture_quality_snapshot.py
@@ -511,7 +511,11 @@ class CaptureQualitySnapshotTests(unittest.TestCase):
         self.assertIn("--asset-url", workflow)
         self.assertIn("--badge-snapshot-id", workflow)
         self.assertIn("--verify-static-badges", workflow)
-        self.assertIn("${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}", workflow)
+        self.assertIn('--badge-snapshot-id "${PUBLISH_SHA}"', workflow)
+        self.assertNotIn(
+            '--badge-snapshot-id "${PUBLISH_SHA}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"',
+            workflow,
+        )
         self.assertIn(
             "python3 ../release-tools/Tools/release/capture-quality-snapshot.py",
             workflow,
@@ -741,8 +745,8 @@ class CaptureQualitySnapshotTests(unittest.TestCase):
             release_kind="current",
         )
 
-        self.assertIn("mutable Current build", snapshot)
-        self.assertIn("replaced when `current` moves", snapshot)
+        self.assertIn("immutable, exact-commit Current build", snapshot)
+        self.assertIn("never change", snapshot)
         self.assertIn("CodeQL is reserved for stable releases", snapshot)
         self.assertNotIn("retained as historical evidence", snapshot)
 

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -1885,7 +1885,8 @@ class ContainerStackReleasePolicyTests(unittest.TestCase):
         self.assertIn("update-homebrew-container-formula.py", renderer)
         self.assertNotIn("${CONTAINER_SOURCE_DIR}/scripts/update-homebrew-formula.py", renderer)
         self.assertIn("compose/bin/compose", renderer)
-        self.assertIn('if [[ "${RELEASE_TAG}" != "current" ]]', renderer)
+        self.assertIn('if [[ "${RELEASE_PRERELEASE}" != "true" ]]', renderer)
+        self.assertIn("isImmutable", renderer)
         self.assertEqual(renderer.count('"${version_policy_args[@]}"'), 2)
 
     def test_stable_package_verifier_requires_homebrew_derived_version(self) -> None:
@@ -2699,11 +2700,11 @@ github_cli() {{
             self.assertEqual(resolved.returncode, 0, resolved.stderr)
             self.assertEqual(resolved.stdout.strip(), tagged_ref)
 
-    def test_current_formulae_use_the_matched_runtime_in_the_single_prerelease(self) -> None:
+    def test_current_formulae_use_the_matched_runtime_in_an_immutable_prerelease(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
         self.assertIn('runtime_asset="container-current-${PUBLISH_SHA:0:12}-arm64.tar.gz"', workflow)
         self.assertIn('runtime_repository="${GITHUB_REPOSITORY}"', workflow)
-        self.assertIn('release_tag="current"', workflow)
+        self.assertIn('release_tag="current-${PUBLISH_SHA}"', workflow)
         self.assertIn('release_title="Current build"', workflow)
         self.assertIn('asset="container-compose-plugin-current-${short_sha}-arm64.tar.gz"', workflow)
         self.assertIn('highlights_asset="release-highlights-current-${short_sha}.json"', workflow)
@@ -2726,6 +2727,24 @@ github_cli() {{
         self.assertIn('RELEASE_MUTABLE="${release_mutable}"', workflow)
         self.assertIn("--delete-superseded-current-releases", workflow)
         self.assertIn("release_notes_args=(", workflow)
+
+    def test_active_documentation_has_no_singleton_current_release_pointer(self) -> None:
+        active_documents = (
+            ROOT / "README.md",
+            ROOT / "docs" / "guides" / "INSTALL.md",
+            ROOT / "docs" / "guides" / "BUILD.md",
+            ROOT / "docs" / "architecture" / "runtime-capabilities.md",
+            ROOT / "docs" / "architecture" / "coherent-container-family-parity-design.md",
+            ROOT / "docs" / "project" / "BACKLOG.md",
+            ROOT / "docs" / "project" / "STATUS.md",
+        )
+        for document in active_documents:
+            contents = document.read_text(encoding="utf-8")
+            self.assertNotIn("releases/tag/current", contents, str(document))
+            self.assertNotIn("one mutable `current`", contents, str(document))
+            self.assertNotIn("tag `current`", contents, str(document))
+            self.assertNotIn("0.14.2 candidate", contents, str(document))
+            self.assertNotIn("0.14.2 Current", contents, str(document))
 
     def test_current_publishes_an_exact_attested_vm_init_authority(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
@@ -2767,7 +2786,7 @@ github_cli() {{
         )
         authority_end = self.script.index("# Retain a helper-created candidate")
         authority = self.script[authority_start:authority_end]
-        self.assertIn("github_cli release download current", authority)
+        self.assertIn('github_cli release download "${current_tag}"', authority)
         self.assertIn("github_cli attestation verify", authority)
         self.assertIn('shasum -a 256 -c "${asset}.sha256"', authority)
         self.assertIn('"${OCI_IMAGE_LAYOUT_VALIDATOR}" "${archive}"', authority)
@@ -2873,7 +2892,8 @@ github_cli() {{
             )
             self.git(compose, "add", str(manifest.relative_to(compose)))
             self.git(compose, "commit", "-m", "test: create Current stack")
-            self.git(compose, "tag", "current")
+            compose_head = self.git(compose, "rev-parse", "HEAD")
+            self.git(compose, "tag", f"current-{compose_head}")
 
             dry_run = self.run_release_function(
                 root,
@@ -2999,7 +3019,7 @@ github_cli() {{
                 ),
                 encoding="utf-8",
             )
-            self.run_command("git", "-C", str(compose), "init")
+            self.run_command("git", "-C", str(compose), "init", "-b", "main")
             self.run_command("git", "-C", str(compose), "add", ".")
             self.run_command(
                 "git",
@@ -3140,7 +3160,7 @@ github_cli() {{
                 ROOT / "Tools" / "release" / "write-sha256-sidecar.py",
                 manifest.parent / "write-sha256-sidecar.py",
             )
-            self.run_command("git", "-C", str(compose), "init")
+            self.run_command("git", "-C", str(compose), "init", "-b", "main")
             self.run_command("git", "-C", str(compose), "add", ".")
             self.run_command(
                 "git",
@@ -3155,7 +3175,7 @@ github_cli() {{
                 "current stack",
             )
             current = self.git(compose, "rev-parse", "HEAD")
-            self.git(compose, "tag", "current")
+            self.git(compose, "tag", f"current-{current}")
             self.git(compose, "remote", "add", "origin", str(compose))
 
             cache = root / "authority-cache"
@@ -3253,19 +3273,8 @@ github_cli() {{
         self.assertNotIn("Generate Current build VHS recording", release_critical)
         self.assertNotIn("Validate Current demo init-image authority", release_critical)
         self.assertNotIn("CURRENT_DEMO_INIT_IMAGE_ARCHIVE", release_critical)
-        self.assertIn(
-            'gh release view "${RELEASE_TAG}"', release_critical
-        )
-        self.assertIn(
-            '--pattern "container-compose-demo-current.gif"', release_critical
-        )
-        self.assertIn(
-            'printf \'%s\\n\' "${retained_demo}" >> "${extra_assets}"',
-            release_critical,
-        )
-        self.assertIn(
-            '--current-asset "container-compose-demo-current.gif"', package
-        )
+        self.assertNotIn('container-compose-demo-current.gif', release_critical)
+        self.assertNotIn('--current-asset "container-compose-demo-current.gif"', package)
 
         self.assertNotIn("workflow_run:", workflow)
         self.assertIn("workflow_dispatch:", workflow)
@@ -3318,74 +3327,22 @@ github_cli() {{
         self.assertIn("Tools/release/validate-oci-image-layout.py", workflow)
         self.assertIn("Tools/release/verify-developer-id-archive.sh", workflow)
         self.assertIn("shasum -a 256 -c", workflow)
-        self.assertIn("Verify source and release are still current", workflow)
-        self.assertLess(
-            workflow.index("Verify source and release are still current"),
-            workflow.index("Publish exact Current demo"),
-        )
-        self.assertNotIn('gh release upload current "${DEMO_OUTPUT}"', workflow)
+        self.assertIn('current_tag="current-${source_sha}"', workflow)
+        self.assertIn('gh release download "${CURRENT_RELEASE_TAG}"', workflow)
+        self.assertIn("Retain exact Current demo workflow artifact", workflow)
+        self.assertIn("retention-days: 90", workflow)
+        self.assertIn("contents: read", workflow)
+        self.assertNotIn("contents: write", workflow)
+        self.assertNotIn("Publish exact Current demo", workflow)
+        self.assertNotIn("release_asset_id()", workflow)
+        self.assertNotIn("upload_release_asset()", workflow)
+        self.assertNotIn("replace_release_asset()", workflow)
+        self.assertNotIn("gh release upload", workflow)
+        self.assertNotIn("--method DELETE", workflow)
         self.assertGreaterEqual(
             workflow.count("bash Tools/release/stop-current-demo-runtime.sh"), 2
         )
-        publish_step = workflow[
-            workflow.index("- name: Publish exact Current demo") : workflow.index(
-                "- name: Save bounded demo diagnostics"
-            )
-        ]
-        self.assertIn("DEMO_ASSET: container-compose-demo-current.gif", publish_step)
-        self.assertIn(
-            "PUBLISH_SHA: ${{ needs.resolve-current.outputs.sha }}", publish_step
-        )
-        self.assertIn("current_release_matches()", publish_step)
-        self.assertIn('checkout_sha="$(git rev-parse HEAD)"', publish_step)
-        self.assertIn(
-            'tracked_status="$(git status --porcelain --untracked-files=no)"',
-            publish_step,
-        )
-        self.assertGreaterEqual(
-            publish_step.count("if ! current_release_matches"), 4
-        )
-        self.assertIn("release_asset_id()", publish_step)
-        self.assertIn("download_release_asset()", publish_step)
-        self.assertIn("upload_release_asset()", publish_step)
-        self.assertIn("replace_release_asset()", publish_step)
-        self.assertIn(
-            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/"
-            "${release_id}/assets?name=${DEMO_ASSET}",
-            publish_step,
-        )
-        self.assertIn(
-            'replace_release_asset "${publication_release_id}" "${DEMO_OUTPUT}"',
-            publish_step,
-        )
-        self.assertIn(
-            "Current demo output verified against release %s.",
-            publish_step,
-        )
-        self.assertIn(
-            "Current demo upload returned success without the exact published output.",
-            publish_step,
-        )
-        self.assertIn(
-            'replace_release_asset "${publication_release_id}" "${prior_demo}"',
-            publish_step,
-        )
-        self.assertIn(
-            '"${CURRENT_RELEASE_ID}" != "${publication_release_id}"',
-            publish_step,
-        )
-        self.assertIn(
-            'prior_demo_dir="${RUNNER_TEMP}/container-compose-prior-current-demo"',
-            publish_step,
-        )
-        self.assertIn(
-            "gh api -H 'Accept: application/octet-stream'",
-            publish_step,
-        )
-        self.assertIn("for attempt in 1 2 3; do", publish_step)
-        self.assertNotIn("gh release upload current", publish_step)
-        self.assertIn("restored the prior asset", publish_step)
-        self.assertGreaterEqual(workflow.count('--repo "${GITHUB_REPOSITORY}"'), 4)
+        self.assertGreaterEqual(workflow.count('--repo "${GITHUB_REPOSITORY}"'), 3)
         self.assertIn("if: failure()", workflow)
         self.assertIn("current-demo-diagnostics-", workflow)
 
@@ -3662,11 +3619,200 @@ github_cli() {{
                 msg=f"unexpected runtime classification for {payload}: {result.stderr}",
             )
 
-    def test_current_package_skips_only_when_the_pointer_already_matches_main(self) -> None:
+    def test_current_package_skips_only_when_exact_release_already_matches_main(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
-        self.assertIn("Skipping current package because current already points at", workflow)
-        self.assertIn("refs/tags/current^{}", workflow)
+        self.assertIn("Skipping current package because immutable release", workflow)
+        self.assertIn('current_tag="current-${WORKFLOW_RUN_HEAD_SHA}"', workflow)
+        self.assertIn('"refs/tags/${current_tag}^{}"', workflow)
         self.assertIn('current_tag_sha="$(', workflow)
+
+        self.assertIn('current_release_complete="false"', workflow)
+        self.assertIn(".immutable", workflow)
+        self.assertIn('expected_current_assets="$(', workflow)
+        self.assertIn('current_tap_complete="false"', workflow)
+        self.assertIn('current_success_authority="false"', workflow)
+        self.assertIn("application/vnd.github.raw+json", workflow)
+        self.assertIn('formula_digest="$(', workflow)
+        self.assertIn('formula_url="$(', workflow)
+        self.assertIn('formula_sha256="$(', workflow)
+        self.assertIn('expected_formula_url="https://github.com/', workflow)
+        self.assertIn('"${formula_url}" != "${expected_formula_url}"', workflow)
+        self.assertIn('"${formula_sha256}" != "${formula_digest#sha256:}"', workflow)
+        self.assertIn('current_formula_run_number="${BASH_REMATCH[1]}"', workflow)
+        self.assertIn('^current\\.([1-9][0-9]*)\\.${short_sha}$', workflow)
+        self.assertIn('"${current_formula_run_number}" != "${BASH_REMATCH[1]}"', workflow)
+        self.assertIn('--argjson run_number "${current_formula_run_number}"', workflow)
+        self.assertIn('.run_number == $run_number and', workflow)
+        self.assertIn(
+            "actions/workflows/prebuilt-binaries.yml/runs?head_sha=",
+            workflow,
+        )
+        self.assertIn(
+            '.head_sha == $sha and',
+            workflow,
+        )
+
+    def test_current_skip_authority_is_bound_to_the_formula_run(self) -> None:
+        workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
+        sha = "a" * 40
+        short = sha[:12]
+        script = r'''
+set -euo pipefail
+selected=""
+for body in "${FORMULA_ONE}" "${FORMULA_TWO}"; do
+  version="$(sed -nE 's/^  version "([^"]+)"[[:space:]]*$/\1/p' <<<"${body}")"
+  [[ "${version}" =~ ^current\.([1-9][0-9]*)\.${SHORT_SHA}$ ]] || exit 2
+  if [[ -z "${selected}" ]]; then
+    selected="${BASH_REMATCH[1]}"
+  else
+    [[ "${selected}" == "${BASH_REMATCH[1]}" ]] || exit 3
+  fi
+done
+jq -e --arg sha "${SHA}" --argjson run_number "${selected}" \
+  '[.workflow_runs[] | select(.run_number == $run_number and .head_sha == $sha and .status == "completed" and .conclusion == "success")] | length > 0' \
+  <<<"${RUNS}" >/dev/null
+'''
+
+        def authorized(one: str, two: str, runs: list[dict[str, object]]) -> bool:
+            environment = os.environ.copy()
+            environment.update(
+                FORMULA_ONE=one,
+                FORMULA_TWO=two,
+                SHORT_SHA=short,
+                SHA=sha,
+                RUNS=json.dumps({"workflow_runs": runs}),
+            )
+            return subprocess.run(
+                ["bash", "-c", script], env=environment, check=False
+            ).returncode == 0
+
+        formula_42 = f'  version "current.42.{short}"'
+        success_41 = {
+            "run_number": 41,
+            "head_sha": sha,
+            "status": "completed",
+            "conclusion": "success",
+        }
+        failed_42 = {
+            "run_number": 42,
+            "head_sha": sha,
+            "status": "completed",
+            "conclusion": "failure",
+        }
+        success_42 = {**failed_42, "conclusion": "success"}
+        self.assertFalse(authorized(formula_42, formula_42, [success_41, failed_42]))
+        self.assertTrue(authorized(formula_42, formula_42, [success_41, success_42]))
+        self.assertFalse(
+            authorized(formula_42, f'  version "current.43.{short}"', [success_42])
+        )
+        for malformed in (
+            "  version \"current.0.bad\"",
+            f"{formula_42}\n{formula_42}",
+        ):
+            self.assertFalse(authorized(formula_42, malformed, [success_42]))
+        self.assertIn(
+            '"${current_success_authority}" == "true" ]]; then',
+            workflow,
+        )
+        self.assertIn("no successful exact-commit package run proves", workflow)
+        self.assertIn("Resuming incomplete Current release transaction", workflow)
+        self.assertIn("Resuming Current transaction because the Homebrew pair", workflow)
+
+    def test_current_skip_parses_active_formula_authority(self) -> None:
+        sha = "b" * 40
+        short = sha[:12]
+        asset = f"container-current-{short}-arm64.tar.gz"
+        expected_url = (
+            "https://github.com/stephenlclarke/container-compose/releases/download/"
+            f"current-{sha}/{asset}"
+        )
+        digest = "c" * 64
+        script = r'''
+set -euo pipefail
+formula_url="$(
+  sed -nE 's/^  url "([^"]+)"[[:space:]]*$/\1/p' <<<"${FORMULA_BODY}"
+)"
+formula_sha256="$(
+  sed -nE 's/^  sha256 "([0-9a-f]{64})"[[:space:]]*$/\1/p' <<<"${FORMULA_BODY}"
+)"
+formula_version="$(
+  sed -nE 's/^  version "([^"]+)"[[:space:]]*$/\1/p' <<<"${FORMULA_BODY}"
+)"
+formula_digest="sha256:${DIGEST}"
+[[ "${formula_url}" == "${EXPECTED_URL}" ]] || exit 2
+[[ "${formula_sha256}" == "${formula_digest#sha256:}" ]] || exit 3
+[[ "${formula_version}" =~ ^current\.([1-9][0-9]*)\.${SHORT_SHA}$ ]] || exit 4
+'''
+
+        def complete(body: str) -> bool:
+            environment = os.environ.copy()
+            environment.update(
+                FORMULA_BODY=body,
+                EXPECTED_URL=expected_url,
+                DIGEST=digest,
+                SHORT_SHA=short,
+            )
+            return subprocess.run(
+                ["bash", "-c", script], env=environment, check=False
+            ).returncode == 0
+
+        valid = "\n".join(
+            (
+                "class ContainerCurrent < Formula",
+                f'  url "{expected_url}"',
+                f'  version "current.42.{short}"',
+                f'  sha256 "{digest}"',
+                "end",
+            )
+        )
+        self.assertTrue(complete(valid))
+        self.assertFalse(
+            complete(
+                valid.replace(
+                    f'  url "{expected_url}"',
+                    f'  url "https://example.invalid/{asset}"\n  # {expected_url}',
+                )
+            )
+        )
+        self.assertFalse(
+            complete(
+                valid.replace(
+                    f'  sha256 "{digest}"',
+                    f'  sha256 "{"d" * 64}"\n  # sha256 "{digest}"',
+                )
+            )
+        )
+        self.assertFalse(
+            complete(
+                valid.replace(
+                    f'  url "{expected_url}"',
+                    f'  url "{expected_url}"\n  url "{expected_url}"',
+                )
+            )
+        )
+
+    def test_retention_never_mutates_an_immutable_release(self) -> None:
+        retention = (ROOT / "Tools" / "release" / "retain-release-assets.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertEqual(retention.count('if release.get("immutable"):'), 2)
+        self.assertIn("preserving immutable historical release", retention)
+
+    def test_private_draft_recovery_preserves_the_immutable_source_tag(self) -> None:
+        publisher = (ROOT / "Tools" / "release" / "publish-github-release.sh").read_text(
+            encoding="utf-8"
+        )
+        replacement = publisher[
+            publisher.index("recreate_release_draft() {") : publisher.index(
+                "validate_release_draft_asset_names() {"
+            )
+        ]
+        self.assertIn('--json isDraft,tagName,targetCommitish', replacement)
+        self.assertIn('release delete "${RELEASE_TAG}"', replacement)
+        self.assertIn("create_release_draft", replacement)
+        self.assertNotIn("--cleanup-tag", replacement)
+        published = publisher[publisher.index('if [[ "${published_release_state}" == "exists" ]]') :]
+        self.assertNotIn("release delete", published)
 
     def test_current_package_yields_to_an_exact_stable_candidate(self) -> None:
         workflow = PACKAGE_WORKFLOW.read_text(encoding="utf-8")
@@ -5631,10 +5777,11 @@ github_cli() {{
                 "# Print and optionally execute a command."
             )
         ]
-        self.assertIn('releases/tags/current', readiness)
-        self.assertIn(".prerelease", readiness)
-        self.assertIn("container-compose-plugin-current-[0-9a-f]{12}-arm64", readiness)
-        self.assertIn(".updated_at", readiness)
+        self.assertIn('releases/tags/${current_tag}', readiness)
+        self.assertIn("CURRENT_RELEASE_READINESS_TOOL", readiness)
+        self.assertIn("actions/workflows/prebuilt-binaries.yml/runs?head_sha=", readiness)
+        self.assertIn("container-compose-current.rb?ref=main", readiness)
+        self.assertIn("container-current.rb?ref=main", readiness)
         self.assertNotIn("publishedAt", readiness)
 
     def test_documented_milestone_override_bypasses_only_the_soak_timer(self) -> None:
@@ -5646,7 +5793,7 @@ github_cli() {{
         self.assertIn('"${RELEASE_INTENT}" == "milestone" && -z "${MILESTONE_SOAK_OVERRIDE_REASON}"', readiness)
         self.assertIn('milestone Current soak override accepted:', readiness)
         self.assertLess(readiness.index('current tag targets'), readiness.index('MILESTONE_SOAK_OVERRIDE_REASON'))
-        self.assertLess(readiness.index('current GitHub prerelease or package asset is missing'), readiness.index('MILESTONE_SOAK_OVERRIDE_REASON'))
+        self.assertLess(readiness.index('current GitHub release authority is incomplete'), readiness.index('MILESTONE_SOAK_OVERRIDE_REASON'))
         build_doc = (ROOT / "docs/guides/BUILD.md").read_text(encoding="utf-8")
         self.assertIn("CONTAINER_STACK_MILESTONE_SOAK_OVERRIDE_REASON", build_doc)
         self.assertIn("Current source and package", build_doc)
@@ -5661,9 +5808,11 @@ github_cli() {{
         self.assertIn('  - "--+"', workflow)
         self.assertIn('  - "-+-"', workflow)
         self.assertIn('  - "+--"', workflow)
-        self.assertIn("container-compose-plugin-current-[0-9a-f]{12}-arm64", workflow)
-        self.assertIn(".updated_at", workflow)
-        self.assertIn("current_is_prerelease", workflow)
+        self.assertIn("verify-current-release-readiness.py", workflow)
+        self.assertIn("actions/workflows/prebuilt-binaries.yml/runs?head_sha=", workflow)
+        self.assertIn("container-compose-current.rb?ref=main", workflow)
+        self.assertIn("container-current.rb?ref=main", workflow)
+        self.assertIn("actions: read", workflow)
         self.assertNotIn("--current-published-at", workflow)
         self.assertIn("runs-on: [self-hosted, macOS, ARM64, container-compose-release]", workflow)
         self.assertTrue(os.access(RUNNER_INSTALLER, os.X_OK))
@@ -8116,31 +8265,36 @@ esac
 
     def test_release_helper_fetches_tags_before_resolving_versions(self) -> None:
         self.assertIn("fetch --prune --tags", self.script)
-        self.assertIn("+refs/tags/current:refs/tags/current", self.script)
+        self.assertIn("refs/tags/current-*:refs/tags/current-*", self.script)
+        self.assertNotIn("+refs/tags/current-*:refs/tags/current-*", self.script)
         self.assertIn("^refs/tags/homebrew-main", self.script)
         self.assertNotIn("fetch --prune --tags --force", self.script)
 
     def test_git_fixtures_never_launch_an_editor(self) -> None:
         self.assertEqual(self.non_interactive_environment()["GIT_EDITOR"], ":")
 
-    def test_release_fetch_refreshes_only_mutable_current_tag(self) -> None:
+    def test_release_fetch_adds_immutable_content_addressed_current_tags(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             remote, local = self.create_compose_checkout(root)
-            self.run_command("git", "-C", str(local), "tag", "--no-sign", "current")
-            self.run_command("git", "-C", str(local), "push", "origin", "refs/tags/current")
+            old_sha = self.git(local, "rev-parse", "HEAD")
+            old_tag = f"current-{old_sha}"
+            self.run_command("git", "-C", str(local), "tag", "--no-sign", old_tag)
+            self.run_command(
+                "git", "-C", str(local), "push", "origin", f"refs/tags/{old_tag}"
+            )
 
             updater = root / "updater"
             self.run_command("git", "clone", "--branch", "main", str(remote), str(updater))
             self.configure_repo(updater)
             self.commit_file(updater, "CURRENT.md", "current\n", "chore: advance current")
             self.run_command("git", "-C", str(updater), "push", "origin", "main")
-            # The developer's global tag.gpgSign setting makes an otherwise
-            # lightweight force-update prompt for an annotation. Current is a
-            # mutable pointer, never a signed release identity, so make the
-            # test's intent explicit and keep it non-interactive.
-            self.run_command("git", "-C", str(updater), "tag", "--no-sign", "-f", "current")
-            self.run_command("git", "-C", str(updater), "push", "origin", "+refs/tags/current")
+            new_sha = self.git(updater, "rev-parse", "HEAD")
+            new_tag = f"current-{new_sha}"
+            self.run_command("git", "-C", str(updater), "tag", "--no-sign", new_tag)
+            self.run_command(
+                "git", "-C", str(updater), "push", "origin", f"refs/tags/{new_tag}"
+            )
 
             result = self.run_release_function(
                 root / "github",
@@ -8149,12 +8303,8 @@ esac
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            self.assertIn("refreshing mutable current tag", result.stdout)
-            local_current = self.git(local, "rev-parse", "refs/tags/current")
-            remote_current = self.run_command(
-                "git", "ls-remote", "--tags", "--refs", str(remote), "refs/tags/current"
-            ).stdout.split()[0]
-            self.assertEqual(local_current, remote_current)
+            self.assertEqual(self.git(local, "rev-parse", f"refs/tags/{old_tag}"), old_sha)
+            self.assertEqual(self.git(local, "rev-parse", f"refs/tags/{new_tag}"), new_sha)
 
     def test_release_fetch_excludes_mutable_homebrew_main_tag(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -8226,7 +8376,7 @@ esac
             _remote, local = self.create_compose_checkout(root)
             remote_head = self.git(local, "rev-parse", "origin/main")
             self.run_command(
-                "git", "-C", str(local), "tag", "--no-sign", "current", remote_head
+                "git", "-C", str(local), "tag", "--no-sign", f"current-{remote_head}", remote_head
             )
             self.enable_ssh_signing(root, local)
             self.commit_signed_files(
@@ -8405,7 +8555,7 @@ esac
             published_head = first_remote_head
             self.run_command("git", "-C", str(local), "fetch", "origin", "main")
             self.run_command(
-                "git", "-C", str(local), "tag", "--no-sign", "current", published_head
+                "git", "-C", str(local), "tag", "--no-sign", f"current-{published_head}", published_head
             )
             first = self.run_release_function(
                 root / "github", "recover_unpublished_release_candidate 0.6.71"
@@ -8460,7 +8610,10 @@ esac
 
             earlier_main = self.git(local, "rev-parse", f"{candidate_head}^")
             self.run_command(
-                "git", "-C", str(local), "tag", "--force", "current", earlier_main
+                "git", "-C", str(local), "tag", "-d", f"current-{published_head}"
+            )
+            self.run_command(
+                "git", "-C", str(local), "tag", "--no-sign", f"current-{earlier_main}", earlier_main
             )
             stale = self.run_release_function(
                 root / "github",
@@ -8749,10 +8902,13 @@ esac
             root = Path(directory)
             remote, local = self.create_compose_checkout(root)
             stale_current = self.git(local, "rev-parse", "main")
+            stale_current_tag = f"current-{stale_current}"
             self.run_command(
-                "git", "-C", str(local), "tag", "--no-sign", "current", stale_current
+                "git", "-C", str(local), "tag", "--no-sign", stale_current_tag, stale_current
             )
-            self.run_command("git", "-C", str(local), "push", "origin", "current")
+            self.run_command(
+                "git", "-C", str(local), "push", "origin", stale_current_tag
+            )
             self.enable_ssh_signing(root, local)
             self.commit_signed_files(
                 local,
@@ -8816,11 +8972,12 @@ esac
                 self.create_promotion_merge(root)
             )
             self.run_command("git", "-C", str(local), "fetch", "origin", "main")
+            promoted_tag = f"current-{promoted_head}"
             self.run_command(
-                "git", "-C", str(local), "tag", "--force", "current", promoted_head
+                "git", "-C", str(local), "tag", "--no-sign", promoted_tag, promoted_head
             )
             self.run_command(
-                "git", "-C", str(local), "push", "--force", "origin", "current"
+                "git", "-C", str(local), "push", "origin", promoted_tag
             )
 
             result = self.run_release_function(
@@ -8834,7 +8991,7 @@ esac
             self.assertNotIn("current tag targets published parent", result.stdout)
             self.assertEqual(self.git(local, "rev-parse", "main"), promoted_head)
             self.assertEqual(self.git(local, "rev-parse", "main^{tree}"), candidate_tree)
-            self.assertEqual(self.git(local, "rev-parse", "current"), promoted_head)
+            self.assertEqual(self.git(local, "rev-parse", promoted_tag), promoted_head)
             self.assertEqual(self.git(local, "status", "--short"), "")
             self.assertNotEqual(candidate_head, promoted_head)
 
@@ -8986,8 +9143,9 @@ esac
             _remote, local = self.create_compose_checkout(root)
             remote_head = self.git(local, "rev-parse", "origin/main")
             self.commit_file(local, "STALE", "stale\n", "chore: stale current")
+            stale_head = self.git(local, "rev-parse", "HEAD")
             self.run_command(
-                "git", "-C", str(local), "tag", "--no-sign", "current"
+                "git", "-C", str(local), "tag", "--no-sign", f"current-{stale_head}"
             )
             self.run_command("git", "-C", str(local), "reset", "--hard", remote_head)
             self.enable_ssh_signing(root, local)
@@ -10297,10 +10455,11 @@ exit 64
     ) -> tuple[Path, str, str, str]:
         remote, local = self.create_compose_checkout(root)
         published_head = self.git(local, "rev-parse", "main")
+        published_tag = f"current-{published_head}"
         self.run_command(
-            "git", "-C", str(local), "tag", "--no-sign", "current", published_head
+            "git", "-C", str(local), "tag", "--no-sign", published_tag, published_head
         )
-        self.run_command("git", "-C", str(local), "push", "origin", "current")
+        self.run_command("git", "-C", str(local), "push", "origin", published_tag)
         self.enable_ssh_signing(root, local)
         self.commit_signed_files(
             local,

--- a/Tools/release/test_homebrew_preflight.py
+++ b/Tools/release/test_homebrew_preflight.py
@@ -63,6 +63,7 @@ class HomebrewPreflightTests(unittest.TestCase):
             check=True,
         )
         current_version = "current.42.0123456789ab"
+        current_tag = f"current-{'0123456789ab' * 3}0123"
         fixtures = {
             "container": formula(
                 "Container", "0.14.0", "container-release-arm64.tar.gz"
@@ -74,13 +75,13 @@ class HomebrewPreflightTests(unittest.TestCase):
             ),
             "container-current": formula(
                 "ContainerCurrent",
-                "current",
+                current_tag,
                 "container-current-0123456789ab-arm64.tar.gz",
                 current_version,
             ),
             "container-compose-current": formula(
                 "ContainerComposeCurrent",
-                "current",
+                current_tag,
                 "container-compose-plugin-current-0123456789ab-arm64.tar.gz",
                 current_version,
             ),
@@ -104,6 +105,10 @@ class HomebrewPreflightTests(unittest.TestCase):
             formulae["container-current"].version,
             formulae["container-compose-current"].version,
         )
+        self.assertRegex(
+            formulae["container-current"].release_tag,
+            r"^current-[0-9a-f]{40}$",
+        )
 
     def test_rejects_mismatched_stable_formulae(self) -> None:
         path = self.tap / "Formula" / "container-compose.rb"
@@ -116,7 +121,7 @@ class HomebrewPreflightTests(unittest.TestCase):
             encoding="utf-8",
         )
 
-        with self.assertRaisesRegex(ValueError, "do not use the same release tag"):
+        with self.assertRaises(ValueError):
             PREFLIGHT.validate_tap(self.tap, require_clean=False)
 
     def test_rejects_dirty_tap_before_release(self) -> None:
@@ -124,6 +129,48 @@ class HomebrewPreflightTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "uncommitted changes"):
             PREFLIGHT.validate_tap(self.tap, require_clean=True)
+
+    def test_rejects_current_formulae_with_different_exact_identities(self) -> None:
+        path = self.tap / "Formula" / "container-compose-current.rb"
+        path.write_text(
+            formula(
+                "ContainerComposeCurrent",
+                f"current-{'f' * 40}",
+                "container-compose-plugin-current-ffffffffffff-arm64.tar.gz",
+                "current.42.ffffffffffff",
+            ),
+            encoding="utf-8",
+        )
+
+        with self.assertRaisesRegex(ValueError, "do not use the same version"):
+            PREFLIGHT.validate_tap(self.tap, require_clean=False)
+
+    def test_allows_only_a_matched_legacy_current_pair_when_explicit(self) -> None:
+        for name in ("container-current", "container-compose-current"):
+            path = self.tap / "Formula" / f"{name}.rb"
+            path.write_text(
+                path.read_text(encoding="utf-8").replace(
+                    f"current-{'0123456789ab' * 3}0123", "current"
+                ),
+                encoding="utf-8",
+            )
+        with self.assertRaisesRegex(ValueError, "exact-SHA"):
+            PREFLIGHT.validate_tap(self.tap, require_clean=False)
+        PREFLIGHT.validate_tap(
+            self.tap, require_clean=False, allow_legacy_current_pair=True
+        )
+
+        compose = self.tap / "Formula" / "container-compose-current.rb"
+        compose.write_text(
+            compose.read_text(encoding="utf-8").replace(
+                "/releases/download/current/", f"/releases/download/current-{'f' * 40}/"
+            ),
+            encoding="utf-8",
+        )
+        with self.assertRaises(ValueError):
+            PREFLIGHT.validate_tap(
+                self.tap, require_clean=False, allow_legacy_current_pair=True
+            )
 
     def test_rejects_stable_formula_with_explicit_version(self) -> None:
         path = self.tap / "Formula" / "container.rb"

--- a/Tools/release/test_publish_github_release.py
+++ b/Tools/release/test_publish_github_release.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import subprocess
 import tempfile
@@ -28,27 +29,86 @@ SCRIPT = Path(__file__).with_name("publish-github-release.sh")
 
 
 class PublishGitHubReleaseTests(unittest.TestCase):
-    def test_current_finalize_never_deletes_existing_release(self) -> None:
+    def test_current_published_retry_restores_and_verifies_immutable_release(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             log = root / "commands"
             gh = root / "gh"
             gh.write_text(
-                "#!/bin/bash\nset -euo pipefail\nprintf 'gh:%s\\n' \"$*\" >> \"${TEST_LOG}\"\nif [[ \"${1:-}:${2:-}\" == api:--silent ]]; then printf '{}\\n'; fi\n",
+                """#!/bin/bash
+set -euo pipefail
+printf 'gh:%s\n' "$*" >> "${TEST_LOG}"
+if [[ "${1:-}" == api && "$*" == *releases/latest* ]]; then
+  printf '{"tag_name":"1.2.3"}\n'
+elif [[ "${1:-}" == api ]]; then
+  printf '{}\n'
+elif [[ "${1:-}:${2:-}" == release:view ]]; then
+  jq -n --arg tag "${RELEASE_TAG}" --arg target "${PUBLISH_SHA}" \
+    --arg title "Current build" --rawfile body "${TEST_PUBLISHED_NOTES}" \
+    --arg digest "sha256:${TEST_DIGEST}" \
+    '{isDraft:false,isImmutable:true,isPrerelease:true,tagName:$tag,
+      targetCommitish:$target,name:$title,body:$body,
+      assets:[{name:"current.tar.gz",digest:$digest},
+              {name:"current.tar.gz.sha256",digest:$digest}]}'
+elif [[ "${1:-}:${2:-}" == release:download ]]; then
+  pattern=""
+  directory=""
+  while (( $# > 0 )); do
+    case "$1" in
+      --pattern) pattern="$2"; shift 2 ;;
+      --dir) directory="$2"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+  printf '%s' "${TEST_PUBLISHED_BYTES}" > "${directory}/${pattern}"
+fi
+""",
                 encoding="utf-8",
             )
             gh.chmod(0o755)
             git = root / "git"
             git.write_text(
-                "#!/bin/bash\nset -euo pipefail\nprintf 'git:%s\\n' \"$*\" >> \"${TEST_LOG}\"\n",
+                """#!/bin/bash
+set -euo pipefail
+printf 'git:%s\n' "$*" >> "${TEST_LOG}"
+if [[ "${1:-}" == ls-remote ]]; then
+  printf '%s\trefs/tags/%s\n' "${PUBLISH_SHA}" "${RELEASE_TAG}"
+fi
+""",
                 encoding="utf-8",
             )
             git.chmod(0o755)
             notes = root / "notes.md"
+            published_notes = root / "published-notes.md"
             asset = root / "current.tar.gz"
             checksum = root / "current.tar.gz.sha256"
-            for path in (notes, asset, checksum):
-                path.write_text("data\n", encoding="utf-8")
+            asset.write_text("rebuilt archive\n", encoding="utf-8")
+            checksum.write_text("rebuilt checksum\n", encoding="utf-8")
+            published_bytes = b"published immutable bytes\n"
+            published_digest = hashlib.sha256(published_bytes).hexdigest()
+            rebuilt_digest = hashlib.sha256(asset.read_bytes()).hexdigest()
+            notes.write_text(
+                "\n".join(
+                    (
+                        "deterministic notes",
+                        "- `current.tar.gz` SHA-256:",
+                        f"  `{rebuilt_digest}`.",
+                        "",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            published_notes.write_text(
+                "\n".join(
+                    (
+                        "deterministic notes",
+                        "- `current.tar.gz` SHA-256:",
+                        f"  `{published_digest}`.",
+                        "",
+                    )
+                ),
+                encoding="utf-8",
+            )
             environment = os.environ.copy()
             environment.update(
                 {
@@ -64,9 +124,13 @@ class PublishGitHubReleaseTests(unittest.TestCase):
                     "RELEASE_PHASE": "finalize",
                     "RELEASE_PRERELEASE": "true",
                     "RELEASE_REPOSITORY": "owner/repository",
-                    "RELEASE_TAG": "current",
+                    "RELEASE_TAG": f"current-{'a' * 40}",
                     "RELEASE_TITLE": "Current build",
+                    "TEST_DIGEST": published_digest,
                     "TEST_LOG": str(log),
+                    "TEST_NOTES": str(notes),
+                    "TEST_PUBLISHED_NOTES": str(published_notes),
+                    "TEST_PUBLISHED_BYTES": published_bytes.decode(),
                 }
             )
 
@@ -80,12 +144,17 @@ class PublishGitHubReleaseTests(unittest.TestCase):
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(asset.read_bytes(), published_bytes)
+            self.assertEqual(checksum.read_bytes(), published_bytes)
+            self.assertEqual(notes.read_bytes(), published_notes.read_bytes())
             commands = log.read_text(encoding="utf-8")
-            self.assertIn("gh:release upload current", commands)
-            self.assertIn("gh:release edit current", commands)
+            self.assertIn(f"gh:release view current-{'a' * 40}", commands)
+            self.assertEqual(commands.count("gh:release download"), 2)
+            self.assertNotIn("release upload", commands)
+            self.assertNotIn("release edit", commands)
             self.assertNotIn("release delete", commands)
             self.assertNotIn("release create", commands)
-            self.assertIn("git:push --force origin refs/tags/current", commands)
+            self.assertNotIn("git:push", commands)
 
 
 if __name__ == "__main__":

--- a/Tools/release/test_publish_github_release.sh
+++ b/Tools/release/test_publish_github_release.sh
@@ -71,15 +71,17 @@ if [[ "$1" == "release" && "$2" == "view" ]]; then
     printf '%s\n' "${MOCK_POST_PUBLISH_RACE_ASSET}" >> "${MOCK_REMOTE_STATE}"
   fi
   if [[ " $* " == *"isDraft"* ]]; then
-    digest="$(printf '%s' "${MOCK_DOWNLOAD_CONTENT:-}" | shasum -a 256 | awk '{print $1}')"
-    if [[ "${MOCK_RELEASE_STATE}" == "exists" ]] || (( view_count >= 4 )); then
+    digest="$(shasum -a 256 "${MOCK_DOWNLOAD_CONTENT_FILE}" | awk '{print $1}')"
+    if [[ "${MOCK_RELEASE_STATE}" == "exists" || -f "${MOCK_PUBLISHED_FILE}" ]]; then
       draft=false
     else
       draft="${MOCK_FINAL_DRAFT_STATE:-true}"
     fi
-    printf '{"isDraft":%s,"isImmutable":%s,"isPrerelease":false,"tagName":"1.2.3","targetCommitish":"0123456789012345678901234567890123456789","name":"%s","body":"%s","assets":[' \
+    body_json="$(jq -cn --arg body "${MOCK_PUBLISHED_BODY:-}" '$body')"
+    printf '{"isDraft":%s,"isImmutable":%s,"isPrerelease":%s,"tagName":"%s","targetCommitish":"0123456789012345678901234567890123456789","name":"%s","body":%s,"assets":[' \
       "${draft}" "${MOCK_PUBLISHED_IMMUTABLE:-true}" \
-      "${MOCK_PUBLISHED_NAME:-1.2.3}" "${MOCK_PUBLISHED_BODY:-}"
+      "${MOCK_PUBLISHED_PRERELEASE:-false}" "${MOCK_PUBLISHED_TAG:-1.2.3}" \
+      "${MOCK_PUBLISHED_NAME:-1.2.3}" "${body_json}"
     separator=""
     while IFS= read -r name; do
       [[ -n "${name}" ]] || continue
@@ -117,8 +119,17 @@ if [[ "$1" == "release" && "$2" == "download" ]]; then
         ;;
     esac
   done
-  printf '%s' "${MOCK_DOWNLOAD_CONTENT:-}" > "${directory}/${pattern}"
+  cp "${MOCK_DOWNLOAD_CONTENT_FILE}" "${directory}/${pattern}"
   exit 0
+fi
+
+if [[ "$1" == "release" && "$2" == "delete" ]]; then
+  : > "${MOCK_REMOTE_STATE}"
+  : > "${MOCK_DOWNLOAD_CONTENT_FILE}"
+fi
+
+if [[ "$1" == "release" && "$2" == "edit" && " $* " == *" --draft=false "* ]]; then
+  touch "${MOCK_PUBLISHED_FILE}"
 fi
 
 if [[ "$1" == "release" && "$2" == "upload" ]]; then
@@ -138,8 +149,15 @@ if [[ "$1" == rev-list ]]; then
   printf '0123456789012345678901234567890123456789\n'
 fi
 if [[ "$1" == ls-remote ]]; then
-  printf '%s\trefs/tags/1.2.3\n' \
-    "${MOCK_REMOTE_TAG_SHA:-0123456789012345678901234567890123456789}"
+  if [[ "${MOCK_REF_TYPE}" != branch || "${MOCK_RELEASE_STATE}" != missing || \
+    -f "${MOCK_REMOTE_TAG_FILE}" ]]; then
+    printf '%s\t%s\n' \
+      "${MOCK_REMOTE_TAG_SHA:-0123456789012345678901234567890123456789}" \
+      "${*: -1}"
+  fi
+fi
+if [[ "$1" == push ]]; then
+  touch "${MOCK_REMOTE_TAG_FILE}"
 fi
 EOF
 chmod +x "${temporary_directory}/bin/git"
@@ -154,8 +172,9 @@ touch "${asset}" "${checksum}" "${notes}" "${retained_manifest}"
 run_publisher() {
   local ref_type="$1" release_tag release_title release_latest release_prerelease release_mutable
   local release_phase="${5:-publish}"
+  local published_body="${14:-}" published_digest local_digest
   if [[ "${ref_type}" == "branch" ]]; then
-    release_tag="current"
+    release_tag="current-0123456789012345678901234567890123456789"
     release_title="Current build"
     release_latest="false"
     release_prerelease="true"
@@ -167,7 +186,19 @@ run_publisher() {
     release_prerelease="false"
     release_mutable="false"
   fi
+  if [[ "$2" == exists && -z "${published_body}" ]]; then
+    published_digest="$(printf '%s' "${7:-}" | shasum -a 256 | awk '{print $1}')"
+    printf -v published_body -- '- `%s` SHA-256:\n  `%s`.\n' \
+      "$(basename "${asset}")" "${published_digest}"
+  fi
+  if [[ "$2" == exists ]]; then
+    local_digest="$(shasum -a 256 "${asset}" | awk '{print $1}')"
+    printf -- '- `%s` SHA-256:\n  `%s`.\n' \
+      "$(basename "${asset}")" "${local_digest}" > "${notes}"
+  fi
   printf '%s' "${6:-}" > "${3}.remote"
+  printf '%s' "${7:-}" > "${3}.download"
+  rm -f "${3}.published"
   printf '0\n' > "${3}.views"
 
   GH="${temporary_directory}/bin/gh" \
@@ -187,17 +218,23 @@ run_publisher() {
     RELEASE_RETAINED_COMPLETE_MANIFEST="${retained_manifest}" \
     RELEASE_EXTRA_ASSETS_FILE="${4:-}" \
     MOCK_RELEASE_STATE="$2" \
+    MOCK_REF_TYPE="${ref_type}" \
     MOCK_REMOTE_ASSETS="${6:-}" \
     MOCK_DOWNLOAD_CONTENT="${7:-}" \
+    MOCK_DOWNLOAD_CONTENT_FILE="${3}.download" \
+    MOCK_PUBLISHED_FILE="${3}.published" \
     MOCK_RACE_ASSET="${8:-}" \
     MOCK_FINAL_DIGEST_MISMATCH="${9:-}" \
     MOCK_FINAL_DRAFT_STATE="${10:-true}" \
     MOCK_POST_PUBLISH_RACE_ASSET="${11:-}" \
     MOCK_PUBLISHED_IMMUTABLE="${12:-true}" \
-    MOCK_PUBLISHED_NAME="${13:-1.2.3}" \
-    MOCK_PUBLISHED_BODY="${14:-}" \
+    MOCK_PUBLISHED_NAME="${13:-${release_title}}" \
+    MOCK_PUBLISHED_BODY="${published_body}" \
+    MOCK_PUBLISHED_TAG="${release_tag}" \
+    MOCK_PUBLISHED_PRERELEASE="${release_prerelease}" \
     MOCK_LATEST_TAG="${15:-1.2.3}" \
     MOCK_REMOTE_TAG_SHA="${16:-0123456789012345678901234567890123456789}" \
+    MOCK_REMOTE_TAG_FILE="${3}.remote-tag" \
     MOCK_REMOTE_STATE="${3}.remote" \
     MOCK_VIEW_COUNT_FILE="${3}.views" \
     MOCK_GH_CALLS="$3" \
@@ -224,9 +261,57 @@ if [[ -e "${stable_existing_exact_calls}" ]] && \
   exit 1
 fi
 
+printf 'rebuilt archive bytes' > "${asset}"
+printf 'rebuilt checksum bytes' > "${checksum}"
+stable_restore_calls="${temporary_directory}/stable-restore.calls"
+run_publisher tag exists "${stable_restore_calls}" "" publish \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n' \
+  'published immutable bytes'
+if [[ "$(<"${asset}")" != 'published immutable bytes' || \
+      "$(<"${checksum}")" != 'published immutable bytes' ]]; then
+  printf 'published stable recovery did not restore immutable release bytes\n' >&2
+  exit 1
+fi
+if [[ -e "${stable_restore_calls}" ]] && \
+  grep -Eq 'release (upload|edit|create|delete)' "${stable_restore_calls}"; then
+  printf 'published stable byte recovery mutated immutable release state\n' >&2
+  exit 1
+fi
+
+published_digest="$(printf '%s' 'published immutable bytes' | shasum -a 256 | awk '{print $1}')"
+printf -v tampered_body -- 'tampered prose\n\n- `%s` SHA-256:\n  `%s`.\n' \
+  "$(basename "${asset}")" "${published_digest}"
+stable_tampered_notes_calls="${temporary_directory}/stable-tampered-notes.calls"
+if run_publisher tag exists "${stable_tampered_notes_calls}" "" publish \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n' \
+  'published immutable bytes' "" "" true "" true 1.2.3 "${tampered_body}"; then
+  printf 'published recovery accepted tampered prose with valid asset hashes\n' >&2
+  exit 1
+fi
+: > "${asset}"
+: > "${checksum}"
+
+printf 'locally rebuilt archive' > "${asset}"
+printf 'locally rebuilt checksum' > "${checksum}"
+stable_restore_digest_mismatch_calls="${temporary_directory}/stable-restore-digest-mismatch.calls"
+if run_publisher tag exists "${stable_restore_digest_mismatch_calls}" "" publish \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n' \
+  'published immutable bytes' "" "$(basename "${asset}")"; then
+  printf 'published recovery accepted a download that disagreed with the server digest\n' >&2
+  exit 1
+fi
+if [[ "$(<"${asset}")" != 'locally rebuilt archive' || \
+      "$(<"${checksum}")" != 'locally rebuilt checksum' ]]; then
+  printf 'failed published recovery partially replaced local candidate bytes\n' >&2
+  exit 1
+fi
+: > "${asset}"
+: > "${checksum}"
+: > "${notes}"
+
 stable_create_calls="${temporary_directory}/stable-create.calls"
 run_publisher tag missing "${stable_create_calls}"
-grep -Fqx "release create 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --target 0123456789012345678901234567890123456789 --verify-tag --latest --draft" "${stable_create_calls}"
+grep -Fqx "release create 1.2.3 --repo stephenlclarke/container-compose --title 1.2.3 --notes-file ${notes} --target 0123456789012345678901234567890123456789 --verify-tag --prerelease=false --latest --draft" "${stable_create_calls}"
 grep -Fqx "release upload 1.2.3 ${asset} --repo stephenlclarke/container-compose" "${stable_create_calls}"
 grep -Fqx "release upload 1.2.3 ${checksum} --repo stephenlclarke/container-compose" "${stable_create_calls}"
 grep -Fqx "release edit 1.2.3 --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --title 1.2.3 --notes-file ${notes} --draft=false --prerelease=false --latest" "${stable_create_calls}"
@@ -246,38 +331,43 @@ if grep -Eq 'release create|clobber|release delete' "${stable_draft_calls}"; the
 fi
 
 stable_draft_unexpected_calls="${temporary_directory}/stable-draft-unexpected.calls"
-if run_publisher tag draft "${stable_draft_unexpected_calls}" "" publish \
-  $'container-vminit-arm64.oci.tar\ncontainer-vminit-arm64.oci.tar.sha256\n'; then
-  printf 'stable draft recovery accepted an unexpected asset\n' >&2
-  exit 1
-fi
-if [[ -e "${stable_draft_unexpected_calls}" ]] && \
-  grep -Eq 'release (upload|edit|create|delete)' "${stable_draft_unexpected_calls}"; then
-  printf 'stable draft recovery mutated a draft with an unexpected asset\n' >&2
+run_publisher tag draft "${stable_draft_unexpected_calls}" "" publish \
+  $'container-vminit-arm64.oci.tar\ncontainer-vminit-arm64.oci.tar.sha256\n'
+if ! grep -Fq 'release delete 1.2.3' "${stable_draft_unexpected_calls}" || \
+  ! grep -Fq 'release create 1.2.3' "${stable_draft_unexpected_calls}" || \
+  ! grep -Fq 'release edit 1.2.3' "${stable_draft_unexpected_calls}"; then
+  printf 'stable draft recovery did not replace an incoherent private draft\n' >&2
   exit 1
 fi
 
 stable_draft_mismatch_calls="${temporary_directory}/stable-draft-mismatch.calls"
-if run_publisher tag draft "${stable_draft_mismatch_calls}" "" publish \
-  "$(basename "${asset}")" 'conflicting bytes'; then
-  printf 'stable draft recovery accepted a mismatched asset\n' >&2
-  exit 1
-fi
-if [[ -e "${stable_draft_mismatch_calls}" ]] && \
-  grep -Eq 'release (upload|edit|create|delete)' "${stable_draft_mismatch_calls}"; then
-  printf 'stable draft recovery mutated a draft with a mismatched asset\n' >&2
+run_publisher tag draft "${stable_draft_mismatch_calls}" "" publish \
+  "$(basename "${asset}")" 'conflicting bytes'
+if ! grep -Fq 'release delete 1.2.3' "${stable_draft_mismatch_calls}" || \
+  ! grep -Fq 'release create 1.2.3' "${stable_draft_mismatch_calls}" || \
+  grep -Fq -- '--cleanup-tag' "${stable_draft_mismatch_calls}"; then
+  printf 'stable draft recovery did not preserve the immutable source tag\n' >&2
   exit 1
 fi
 
 stable_draft_late_mismatch_calls="${temporary_directory}/stable-draft-late-mismatch.calls"
-if run_publisher tag draft "${stable_draft_late_mismatch_calls}" "" publish \
-  "$(basename "${checksum}")" 'conflicting bytes'; then
-  printf 'stable draft recovery accepted a later mismatched asset\n' >&2
+run_publisher tag draft "${stable_draft_late_mismatch_calls}" "" publish \
+  "$(basename "${checksum}")" 'conflicting bytes'
+if ! grep -Fq 'release delete 1.2.3' "${stable_draft_late_mismatch_calls}" || \
+  ! grep -Fq 'release edit 1.2.3' "${stable_draft_late_mismatch_calls}"; then
+  printf 'stable draft recovery did not replace a late conflicting asset\n' >&2
   exit 1
 fi
-if [[ -e "${stable_draft_late_mismatch_calls}" ]] && \
-  grep -Eq 'release (upload|edit|create|delete)' "${stable_draft_late_mismatch_calls}"; then
-  printf 'stable draft recovery mutated before validating every existing asset\n' >&2
+
+stable_draft_published_before_replace_calls="${temporary_directory}/stable-draft-published-before-replace.calls"
+if run_publisher tag draft "${stable_draft_published_before_replace_calls}" "" publish \
+  "$(basename "${asset}")" 'conflicting bytes' "" "" false; then
+  printf 'draft recovery deleted a release that became published\n' >&2
+  exit 1
+fi
+if [[ -e "${stable_draft_published_before_replace_calls}" ]] && \
+  grep -Fq 'release delete' "${stable_draft_published_before_replace_calls}"; then
+  printf 'draft recovery mutated a concurrently published release\n' >&2
   exit 1
 fi
 
@@ -381,36 +471,62 @@ if run_publisher branch exists "${main_implicit_calls}"; then
 fi
 
 main_stage_calls="${temporary_directory}/main-stage.calls"
-run_publisher branch exists "${main_stage_calls}" "" stage
-grep -Fqx "release upload current ${asset} ${checksum} --repo stephenlclarke/container-compose --clobber" "${main_stage_calls}"
-if [[ -e "${main_stage_calls}.git" ]] || grep -Eq 'release (create|edit|delete)' "${main_stage_calls}"; then
-  printf 'current staging changed a release identity instead of only uploading assets\n' >&2
+run_publisher branch exists "${main_stage_calls}" "" stage \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n'
+if [[ -e "${main_stage_calls}" ]] && \
+  grep -Eq 'release (upload|create|edit|delete)' "${main_stage_calls}"; then
+  printf 'published Current stage retry mutated immutable release state\n' >&2
   exit 1
 fi
 
 main_finalize_calls="${temporary_directory}/main-finalize.calls"
-run_publisher branch exists "${main_finalize_calls}" "" finalize
-grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_finalize_calls}.git"
-grep -Fqx "push --force origin refs/tags/current" "${main_finalize_calls}.git"
-grep -Fqx "release upload current ${asset} ${checksum} --repo stephenlclarke/container-compose --clobber" "${main_finalize_calls}"
-grep -Fqx "release edit current --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --title Current build --notes-file ${notes} --prerelease --latest=false" "${main_finalize_calls}"
-if grep -Eq 'release (create|delete)' "${main_finalize_calls}" || grep -Fq -- '--cleanup-tag' "${main_finalize_calls}"; then
-  printf 'current finalization replaced the release object or removed the current tag\n' >&2
+run_publisher branch exists "${main_finalize_calls}" "" finalize \
+  $'container-compose-plugin-release-arm64.tar.gz\ncontainer-compose-plugin-release-arm64.tar.gz.sha256\n'
+if [[ -e "${main_finalize_calls}" ]] && \
+  grep -Eq 'release (upload|create|edit|delete)' "${main_finalize_calls}"; then
+  printf 'Current finalization mutated immutable release state\n' >&2
   exit 1
 fi
 
+: > "${notes}"
+main_draft_mismatch_calls="${temporary_directory}/main-draft-mismatch.calls"
+run_publisher branch draft "${main_draft_mismatch_calls}" "" stage \
+  "$(basename "${asset}")" 'conflicting Current bytes'
+if ! grep -Fq "release delete current-0123456789012345678901234567890123456789" \
+    "${main_draft_mismatch_calls}" || \
+  ! grep -Fq "release create current-0123456789012345678901234567890123456789" \
+    "${main_draft_mismatch_calls}" || \
+  grep -Eq -- '--cleanup-tag|--force|--clobber' \
+    "${main_draft_mismatch_calls}" "${main_draft_mismatch_calls}.git"; then
+  printf 'Current draft recovery did not replace only the private draft object\n' >&2
+  exit 1
+fi
+: > "${notes}"
+
 main_create_calls="${temporary_directory}/main-create.calls"
 run_publisher branch missing "${main_create_calls}" "" stage
-grep -Fqx "release create current ${asset} ${checksum} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --verify-tag --prerelease --latest=false" "${main_create_calls}"
-grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_create_calls}.git"
-grep -Fqx "push --force origin refs/tags/current" "${main_create_calls}.git"
+current_tag="current-0123456789012345678901234567890123456789"
+grep -Fqx "release create ${current_tag} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --target 0123456789012345678901234567890123456789 --verify-tag --prerelease=true --latest=false --draft" "${main_create_calls}"
+grep -Fqx "release upload ${current_tag} ${asset} --repo stephenlclarke/container-compose" "${main_create_calls}"
+grep -Fqx "release upload ${current_tag} ${checksum} --repo stephenlclarke/container-compose" "${main_create_calls}"
+grep -Fqx "release edit ${current_tag} --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --title Current build --notes-file ${notes} --draft=false --prerelease=true --latest=false" "${main_create_calls}"
+grep -Fqx "tag --no-sign ${current_tag} 0123456789012345678901234567890123456789" "${main_create_calls}.git"
+grep -Fqx "push origin refs/tags/${current_tag}" "${main_create_calls}.git"
+if grep -Eq -- '--force|--clobber|release delete' "${main_create_calls}" "${main_create_calls}.git"; then
+  printf 'Current creation attempted to replace immutable state\n' >&2
+  exit 1
+fi
 
 main_missing_finalize_calls="${temporary_directory}/main-missing-finalize.calls"
 run_publisher branch missing "${main_missing_finalize_calls}" "" finalize
-grep -Fqx "release create current ${asset} ${checksum} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --verify-tag --prerelease --latest=false" "${main_missing_finalize_calls}"
-grep -Fqx "release edit current --repo stephenlclarke/container-compose --target 0123456789012345678901234567890123456789 --prerelease" "${main_missing_finalize_calls}"
-grep -Fqx "tag --no-sign --force current 0123456789012345678901234567890123456789" "${main_missing_finalize_calls}.git"
-grep -Fqx "push --force origin refs/tags/current" "${main_missing_finalize_calls}.git"
+grep -Fqx "release create ${current_tag} --repo stephenlclarke/container-compose --title Current build --notes-file ${notes} --target 0123456789012345678901234567890123456789 --verify-tag --prerelease=true --latest=false --draft" "${main_missing_finalize_calls}"
+if grep -Fq "release edit ${current_tag}" "${main_missing_finalize_calls}" && \
+  grep -Fq -- '--draft=false' "${main_missing_finalize_calls}"; then
+  :
+else
+  printf 'Current finalize recovery did not publish its complete draft\n' >&2
+  exit 1
+fi
 
 runtime_asset="${temporary_directory}/container-release-arm64.tar.gz"
 runtime_checksum="${runtime_asset}.sha256"
@@ -423,5 +539,6 @@ grep -Fqx "release upload 1.2.3 ${runtime_asset} --repo stephenlclarke/container
 grep -Fqx "release upload 1.2.3 ${runtime_checksum} --repo stephenlclarke/container-compose" "${stable_extra_calls}"
 
 current_extra_calls="${temporary_directory}/current-extra.calls"
-run_publisher branch exists "${current_extra_calls}" "${extra_assets}" stage
-grep -Fqx "release upload current ${asset} ${checksum} ${runtime_asset} ${runtime_checksum} --repo stephenlclarke/container-compose --clobber" "${current_extra_calls}"
+run_publisher branch missing "${current_extra_calls}" "${extra_assets}" stage
+grep -Fqx "release upload ${current_tag} ${runtime_asset} --repo stephenlclarke/container-compose" "${current_extra_calls}"
+grep -Fqx "release upload ${current_tag} ${runtime_checksum} --repo stephenlclarke/container-compose" "${current_extra_calls}"

--- a/Tools/release/test_release_notes.py
+++ b/Tools/release/test_release_notes.py
@@ -49,10 +49,11 @@ class ReleaseNotesTests(unittest.TestCase):
             self.git(repo, "tag", "--no-sign", "0.6.0")
             self.commit(repo, "feat(mounts): support bind propagation")
             self.commit(repo, "docs: refresh compose guidance")
+            head = self.git(repo, "rev-parse", "HEAD")
 
             notes = module.render_release_notes(
                 repo=repo,
-                release_tag="current",
+                release_tag=f"current-{head}",
                 release_label="current build",
                 compose_version="0.6.1",
                 asset="container-compose-plugin-current-arm64.tar.gz",
@@ -66,9 +67,9 @@ class ReleaseNotesTests(unittest.TestCase):
             self.assertIn("## Promotion", notes)
             self.assertIn("## Asset Retention", notes)
             self.assertIn("It never changes the stable formula pair.", notes)
-            self.assertIn("They do not move semantic source tags or the stable formula pair.", notes)
-            self.assertIn("Mutable `current` pointer targets main commit", notes)
-            self.assertIn("single `Current build` prerelease", notes)
+            self.assertIn("Publication never retargets an existing tag", notes)
+            self.assertIn(f"Immutable `current-{head}` prerelease", notes)
+            self.assertIn("one immutable `current-<sha>` prerelease", notes)
             self.assertIn("## Highlights", notes)
             self.assertIn("Support bind propagation.", notes)
             self.assertNotIn("feat(mounts): support bind propagation", notes)
@@ -82,12 +83,14 @@ class ReleaseNotesTests(unittest.TestCase):
             self.init_repo(repo)
             self.git(repo, "tag", "--no-sign", "0.6.0")
             self.commit(repo, "feat(runtime): add the first current change")
-            self.git(repo, "tag", "--no-sign", "current")
+            previous_head = self.git(repo, "rev-parse", "HEAD")
+            self.git(repo, "tag", "--no-sign", f"current-{previous_head}")
             self.commit(repo, "fix(runtime): add the next current change")
+            head = self.git(repo, "rev-parse", "HEAD")
 
             notes = module.render_release_notes(
                 repo=repo,
-                release_tag="current",
+                release_tag=f"current-{head}",
                 release_label="current build",
                 compose_version="0.6.1",
                 asset="container-compose-plugin-current-arm64.tar.gz",
@@ -98,7 +101,7 @@ class ReleaseNotesTests(unittest.TestCase):
             self.assertIn("Source history: `0.6.0..", notes)
             self.assertNotIn("feat(runtime): add the first current change", notes)
             self.assertNotIn("fix(runtime): add the next current change", notes)
-            self.assertNotIn("Source history: `current..", notes)
+            self.assertNotIn(f"Source history: `current-{previous_head}..", notes)
 
     def test_current_notes_record_the_matched_runtime_checksum(self) -> None:
         module = load_module()
@@ -109,7 +112,7 @@ class ReleaseNotesTests(unittest.TestCase):
 
             notes = module.render_release_notes(
                 repo=repo,
-                release_tag="current",
+                release_tag=f"current-{head}",
                 release_label="current build",
                 compose_version="0.6.1",
                 asset="container-compose-plugin-current-arm64.tar.gz",
@@ -119,7 +122,10 @@ class ReleaseNotesTests(unittest.TestCase):
                 head_ref="HEAD",
             )
 
-            self.assertIn(f"Mutable `current` pointer targets main commit `{head}`", notes)
+            self.assertIn(
+                f"Immutable `current-{head}` prerelease identifies main commit `{head}`",
+                notes,
+            )
             self.assertIn("`container-current-arm64.tar.gz` SHA-256:", notes)
             self.assertIn("`runtime-sha`.", notes)
             self.assertIn(
@@ -268,10 +274,11 @@ class ReleaseNotesTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             repo = Path(directory)
             self.init_repo(repo)
+            head = self.git(repo, "rev-parse", "HEAD")
 
             notes = module.render_release_notes(
                 repo=repo,
-                release_tag="current",
+                release_tag=f"current-{head}",
                 release_label="current build",
                 compose_version="0.6.1",
                 asset="container-compose-plugin-current-arm64.tar.gz",

--- a/Tools/release/test_release_workspace.py
+++ b/Tools/release/test_release_workspace.py
@@ -748,7 +748,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         ):
             checkpoint.pop(field)
         WORKSPACE.atomic_json(release_root / WORKSPACE.WORKSPACE_MARKER, checkpoint)
-        refresh = WORKSPACE.refresh_mutable_current_tag
+        refresh = WORKSPACE.refresh_current_release_tags
 
         def add_operator_tag(root: Path) -> None:
             refresh(root)
@@ -756,7 +756,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
 
         with mock.patch.object(
             WORKSPACE,
-            "refresh_mutable_current_tag",
+            "refresh_current_release_tags",
             side_effect=add_operator_tag,
         ):
             resumed = WORKSPACE.materialize(
@@ -2039,7 +2039,7 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         self.assertEqual(retired_marker["state"], "retired")
         self.assertNotIn("replacement", retired_marker)
 
-    def test_resume_refreshes_the_mutable_current_tag(self) -> None:
+    def test_resume_fetches_a_new_content_addressed_current_tag(self) -> None:
         release_root = WORKSPACE.materialize(
             self.build_root, "-+-", self.remote_root
         )
@@ -2048,11 +2048,11 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         self.git("add", "README.md", cwd=source)
         self.git("commit", "-m", "promote current", cwd=source)
         promoted = self.git("rev-parse", "HEAD", cwd=source).strip()
+        current_tag = f"current-{promoted}"
         self.git(
             "push",
-            "--force",
             str(self.remote_root / "container-compose.git"),
-            "HEAD:refs/tags/current",
+            f"HEAD:refs/tags/{current_tag}",
             cwd=source,
         )
 
@@ -2062,14 +2062,14 @@ class ReleaseWorkspaceTests(unittest.TestCase):
         self.assertEqual(
             self.git(
                 "rev-parse",
-                "refs/tags/current",
+                f"refs/tags/{current_tag}",
                 cwd=resumed / "container-compose",
             ).strip(),
             promoted,
         )
 
-    def test_resume_rejects_a_missing_remote_current_tag(self) -> None:
-        WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+    def test_resume_does_not_require_the_legacy_current_tag(self) -> None:
+        release_root = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
         source = self.root / "sources" / "container-compose"
         self.git(
             "push",
@@ -2078,10 +2078,9 @@ class ReleaseWorkspaceTests(unittest.TestCase):
             cwd=source,
         )
 
-        with self.assertRaisesRegex(
-            WORKSPACE.WorkspaceError, "current tag is missing"
-        ):
-            WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+        resumed = WORKSPACE.materialize(self.build_root, "-+-", self.remote_root)
+
+        self.assertEqual(resumed, release_root)
 
     def test_missing_baseline_object_is_fetched_into_retained_workspace(self) -> None:
         release_root = WORKSPACE.materialize(

--- a/Tools/release/test_retain_release_assets.py
+++ b/Tools/release/test_retain_release_assets.py
@@ -22,6 +22,7 @@ import json
 import sys
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 
@@ -52,9 +53,21 @@ class ReleaseAssetRetentionTests(unittest.TestCase):
             module.retained_release_ids(releases, latest_stable_id=2), {2, 4}
         )
 
-    def test_current_pointer_beats_newer_noncurrent_prerelease(self) -> None:
+    def test_newest_content_addressed_current_beats_other_prereleases(self) -> None:
         module = load_module()
+        old_sha = "a" * 40
+        new_sha = "b" * 40
         releases = [
+            {
+                "id": 0,
+                "tag_name": "current",
+                "published_at": "2026-06-30T00:00:00Z",
+                "prerelease": True,
+                "draft": False,
+                "immutable": True,
+                "body": "legacy body",
+                "assets": [{"id": 1, "name": "legacy.tar.gz"}],
+            },
             {
                 "id": 1,
                 "tag_name": "0.6.69",
@@ -62,6 +75,35 @@ class ReleaseAssetRetentionTests(unittest.TestCase):
                 "prerelease": False,
                 "draft": False,
             },
+            {
+                "id": 2,
+                "tag_name": f"current-{old_sha}",
+                "published_at": "2026-07-02T00:00:00Z",
+                "prerelease": True,
+                "draft": False,
+            },
+            {
+                "id": 3,
+                "tag_name": "0.6.70-rc.1",
+                "published_at": "2026-07-03T00:00:00Z",
+                "prerelease": True,
+                "draft": False,
+            },
+            {
+                "id": 4,
+                "tag_name": f"current-{new_sha}",
+                "published_at": "2026-07-04T00:00:00Z",
+                "prerelease": True,
+                "draft": False,
+            },
+        ]
+        self.assertEqual(
+            module.retained_release_ids(releases, latest_stable_id=1), {1, 4}
+        )
+
+    def test_legacy_current_beats_newer_noncurrent_prerelease_during_migration(self) -> None:
+        module = load_module()
+        releases = [
             {
                 "id": 2,
                 "tag_name": "current",
@@ -78,7 +120,76 @@ class ReleaseAssetRetentionTests(unittest.TestCase):
             },
         ]
         self.assertEqual(
-            module.retained_release_ids(releases, latest_stable_id=1), {1, 2}
+            module.retained_release_ids(releases, latest_stable_id=None), {2}
+        )
+
+    def test_immutable_historical_current_release_is_never_deleted(self) -> None:
+        module = load_module()
+        old_sha = "a" * 40
+        new_sha = "b" * 40
+        releases = [
+            {
+                "id": 0,
+                "tag_name": "current",
+                "published_at": "2026-06-30T00:00:00Z",
+                "prerelease": True,
+                "draft": False,
+                "immutable": True,
+                "body": "legacy body",
+                "assets": [{"id": 1, "name": "legacy.tar.gz"}],
+            },
+            {
+                "id": 1,
+                "tag_name": f"current-{old_sha}",
+                "published_at": "2026-07-01T00:00:00Z",
+                "prerelease": True,
+                "draft": False,
+                "immutable": False,
+                "body": "",
+                "assets": [{"id": 11, "name": "old.tar.gz"}],
+            },
+            {
+                "id": 2,
+                "tag_name": f"current-{new_sha}",
+                "published_at": "2026-07-02T00:00:00Z",
+                "prerelease": True,
+                "draft": False,
+                "immutable": True,
+                "body": "",
+                "assets": [{"id": 22, "name": "new.tar.gz"}],
+            },
+        ]
+        arguments = SimpleNamespace(
+            repo="owner/repository",
+            current_asset=[],
+            delete_superseded_current_releases=True,
+            apply=True,
+            bootstrap_command="brew install go",
+            build_command="make package",
+            source_guidance="BUILD.md",
+            install_command=None,
+            current_install_command="brew install current",
+            stable_install_command="brew install stable",
+        )
+        with (
+            mock.patch.object(module, "parse_args", return_value=arguments),
+            mock.patch.object(module, "list_releases", return_value=releases),
+            mock.patch.object(module, "latest_stable_release_id", return_value=None),
+            mock.patch.object(module, "delete_release") as delete_release,
+            mock.patch.object(module, "delete_named_assets") as delete_assets,
+            mock.patch.object(module, "update_release_notes") as update_notes,
+        ):
+            module.main()
+
+        delete_release.assert_not_called()
+        delete_assets.assert_not_called()
+        self.assertNotIn(
+            0,
+            [call.args[1]["id"] for call in update_notes.call_args_list],
+        )
+        self.assertNotIn(
+            2,
+            [call.args[1]["id"] for call in update_notes.call_args_list],
         )
 
     def test_github_latest_beats_a_newer_published_maintenance_backfill(self) -> None:
@@ -120,6 +231,17 @@ class ReleaseAssetRetentionTests(unittest.TestCase):
 
     def test_only_generated_current_releases_are_removed(self) -> None:
         module = load_module()
+        self.assertTrue(module.obsolete_current_release({"prerelease": True, "tag_name": "current"}))
+        self.assertFalse(
+            module.deletable_legacy_current_release(
+                {"prerelease": True, "tag_name": f"current-{'a' * 40}"}
+            )
+        )
+        self.assertTrue(
+            module.deletable_legacy_current_release(
+                {"prerelease": True, "tag_name": "homebrew-main-old"}
+            )
+        )
         self.assertTrue(module.obsolete_current_release({"prerelease": True, "tag_name": "current-12-abc"}))
         self.assertTrue(
             module.obsolete_current_release(

--- a/Tools/release/test_verify_current_release_readiness.py
+++ b/Tools/release/test_verify_current_release_readiness.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+TOOL = Path(__file__).with_name("verify-current-release-readiness.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("current_release_readiness", TOOL)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class VerifyCurrentReleaseReadinessTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.module = load_module()
+        cls.sha = "a" * 40
+        cls.tag = f"current-{cls.sha}"
+        cls.repository = "owner/repository"
+
+    def payload(self):
+        digest = "b" * 64
+        assets = [
+            {"name": name, "digest": f"sha256:{digest}", "updated_at": "2026-09-11T20:00:00Z"}
+            for name in self.module.expected_assets(self.sha)
+        ]
+        short = self.sha[:12]
+        compose = f"container-compose-plugin-current-{short}-arm64.tar.gz"
+        runtime = f"container-current-{short}-arm64.tar.gz"
+        base = f"https://github.com/{self.repository}/releases/download/{self.tag}"
+        return {
+            "release": {
+                "draft": False,
+                "immutable": True,
+                "prerelease": True,
+                "tag_name": self.tag,
+                "target_commitish": self.sha,
+                "published_at": "2026-09-11T20:05:00Z",
+                "assets": assets,
+            },
+            "runs": {
+                "workflow_runs": [
+                    {
+                        "head_sha": self.sha,
+                        "run_number": 42,
+                        "status": "completed",
+                        "conclusion": "success",
+                        "updated_at": "2026-09-11T20:10:00Z",
+                    }
+                ]
+            },
+            "compose_formula": (
+                f'  url "{base}/{compose}"\n  sha256 "{digest}"\n'
+                f'  version "current.42.{self.sha[:12]}"\n'
+            ),
+            "container_formula": (
+                f'  url "{base}/{runtime}"\n  sha256 "{digest}"\n'
+                f'  version "current.42.{self.sha[:12]}"\n'
+            ),
+        }
+
+    def verify(self, payload):
+        return self.module.verify(
+            payload,
+            repository=self.repository,
+            tag=self.tag,
+            sha=self.sha,
+        )
+
+    def test_accepts_the_complete_exact_authority(self) -> None:
+        self.assertEqual(self.verify(self.payload()), "2026-09-11T20:10:00Z")
+
+    def test_soak_uses_selected_package_run_not_old_draft_asset_or_later_noop(self) -> None:
+        payload = self.payload()
+        for asset in payload["release"]["assets"]:
+            asset["updated_at"] = "2026-09-01T00:00:00Z"
+        payload["runs"]["workflow_runs"].append(
+            {
+                "head_sha": self.sha,
+                "run_number": 43,
+                "status": "completed",
+                "conclusion": "success",
+                "updated_at": "2026-09-11T20:15:00Z",
+            }
+        )
+        self.assertEqual(self.verify(payload), "2026-09-11T20:10:00Z")
+
+    def test_rejects_draft_mutable_and_wrong_target_releases(self) -> None:
+        for field, value in (("draft", True), ("immutable", False), ("target_commitish", "c" * 40)):
+            with self.subTest(field=field):
+                payload = self.payload()
+                payload["release"][field] = value
+                with self.assertRaises(self.module.ReadinessError):
+                    self.verify(payload)
+
+    def test_rejects_incomplete_or_digestless_asset_closure(self) -> None:
+        incomplete = self.payload()
+        incomplete["release"]["assets"].pop()
+        with self.assertRaises(self.module.ReadinessError):
+            self.verify(incomplete)
+        digestless = self.payload()
+        digestless["release"]["assets"][0]["digest"] = None
+        with self.assertRaises(self.module.ReadinessError):
+            self.verify(digestless)
+
+    def test_rejects_untapped_or_wrong_digest_formulae(self) -> None:
+        for field in ("compose_formula", "container_formula"):
+            with self.subTest(field=field):
+                payload = self.payload()
+                payload[field] = payload[field].replace("b" * 64, "c" * 64)
+                with self.assertRaises(self.module.ReadinessError):
+                    self.verify(payload)
+
+    def test_rejects_expected_authority_only_in_comments_or_caveats(self) -> None:
+        payload = self.payload()
+        expected_url = payload["compose_formula"].splitlines()[0]
+        payload["compose_formula"] = payload["compose_formula"].replace(
+            expected_url,
+            '  url "https://example.invalid/foreign.tar.gz"\n'
+            f"  # {expected_url.strip()}\n"
+            "\n  def caveats\n"
+            "    <<~EOS\n"
+            f"      {expected_url.strip()}\n"
+            "    EOS\n"
+            "  end",
+        )
+        with self.assertRaises(self.module.ReadinessError):
+            self.verify(payload)
+
+        payload = self.payload()
+        expected_digest = f'  sha256 "{"b" * 64}"'
+        payload["container_formula"] = payload["container_formula"].replace(
+            expected_digest,
+            f'  sha256 "{"c" * 64}"\n'
+            f"  # {expected_digest.strip()}\n"
+            "\n  def caveats\n"
+            "    <<~EOS\n"
+            f"      {expected_digest.strip()}\n"
+            "    EOS\n"
+            "  end",
+        )
+        with self.assertRaises(self.module.ReadinessError):
+            self.verify(payload)
+
+    def test_rejects_duplicate_active_formula_declarations(self) -> None:
+        for declaration in ("url", "sha256", "version"):
+            with self.subTest(declaration=declaration):
+                payload = self.payload()
+                lines = payload["compose_formula"].splitlines()
+                line = next(item for item in lines if item.strip().startswith(declaration))
+                payload["compose_formula"] += f"{line}\n"
+                with self.assertRaises(self.module.ReadinessError):
+                    self.verify(payload)
+
+    def test_rejects_mismatched_or_wrong_current_formula_run_versions(self) -> None:
+        replacements = (
+            ("container_formula", "current.42.", "current.43."),
+            ("compose_formula", f"current.42.{self.sha[:12]}", "current.42.cccccccccccc"),
+            ("compose_formula", 'version "current.42.', 'version "current.042.'),
+        )
+        for field, old, new in replacements:
+            with self.subTest(field=field, new=new):
+                payload = self.payload()
+                payload[field] = payload[field].replace(old, new)
+                with self.assertRaises(self.module.ReadinessError):
+                    self.verify(payload)
+
+    def test_rejects_missing_exact_head_package_authority(self) -> None:
+        payload = self.payload()
+        payload["runs"]["workflow_runs"][0]["conclusion"] = "failure"
+        with self.assertRaises(self.module.ReadinessError):
+            self.verify(payload)
+
+    def test_rejects_missing_or_malformed_authority_timestamps(self) -> None:
+        for owner, field in (("release", "published_at"), ("run", "updated_at")):
+            for value in (None, "", "2026-09-11 20:10:00", "2026-13-11T20:10:00Z"):
+                with self.subTest(owner=owner, value=value):
+                    payload = self.payload()
+                    target = (
+                        payload["release"]
+                        if owner == "release"
+                        else payload["runs"]["workflow_runs"][0]
+                    )
+                    target[field] = value
+                    with self.assertRaises(self.module.ReadinessError):
+                        self.verify(payload)
+
+    def test_rejects_a_package_run_completed_before_publication(self) -> None:
+        payload = self.payload()
+        payload["runs"]["workflow_runs"][0]["updated_at"] = "2026-09-11T20:04:59Z"
+        with self.assertRaises(self.module.ReadinessError):
+            self.verify(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/verify-current-release-readiness.py
+++ b/Tools/release/verify-current-release-readiness.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Verify the complete immutable Current authority used by stable promotion."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import json
+import re
+import sys
+from typing import Any
+
+
+SHA256 = re.compile(r"sha256:([0-9a-f]{64})")
+GITHUB_TIMESTAMP = re.compile(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z")
+FORMULA_URL = re.compile(r'^  url\s+"([^"]+)"\s*$', re.MULTILINE)
+FORMULA_SHA256 = re.compile(r'^  sha256\s+"([0-9a-f]{64})"\s*$', re.MULTILINE)
+FORMULA_VERSION = re.compile(r'^  version\s+"([^"]+)"\s*$', re.MULTILINE)
+
+
+class ReadinessError(ValueError):
+    """The Current release is not a complete promotion authority."""
+
+
+def expected_assets(sha: str) -> tuple[str, ...]:
+    short = sha[:12]
+    return tuple(
+        sorted(
+            (
+                f"container-compose-plugin-current-{short}-arm64.tar.gz",
+                f"container-compose-plugin-current-{short}-arm64.tar.gz.sha256",
+                f"container-current-{short}-arm64.tar.gz",
+                f"container-current-{short}-arm64.tar.gz.sha256",
+                f"container-vminit-current-{short}-arm64.oci.tar",
+                f"container-vminit-current-{short}-arm64.oci.tar.sha256",
+                f"release-highlights-current-{short}.json",
+                "quality-snapshot-current.svg",
+            )
+        )
+    )
+
+
+def require_mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ReadinessError(f"{label} is not an object")
+    return value
+
+
+def parse_github_timestamp(value: Any, label: str) -> tuple[str, datetime]:
+    if not isinstance(value, str) or GITHUB_TIMESTAMP.fullmatch(value) is None:
+        raise ReadinessError(f"{label} is not a GitHub UTC timestamp")
+    try:
+        parsed = datetime.fromisoformat(value.removesuffix("Z") + "+00:00")
+    except ValueError as error:
+        raise ReadinessError(f"{label} is not a valid timestamp") from error
+    return value, parsed
+
+
+def formula_declaration(formula: Any, pattern: re.Pattern[str], label: str) -> str:
+    if not isinstance(formula, str):
+        raise ReadinessError(f"formula for {label} is unavailable")
+    values = pattern.findall(formula)
+    if len(values) != 1:
+        raise ReadinessError(f"Homebrew formula does not have one active {label} declaration")
+    return values[0]
+
+
+def verify_formula(formula: Any, *, repository: str, tag: str, asset: str, digest: str) -> None:
+    expected_url = f"https://github.com/{repository}/releases/download/{tag}/{asset}"
+    active_url = formula_declaration(formula, FORMULA_URL, "URL")
+    active_digest = formula_declaration(formula, FORMULA_SHA256, "SHA-256")
+    if active_url != expected_url or active_digest != digest:
+        raise ReadinessError(f"Homebrew formula does not authenticate {asset}")
+
+
+def formula_run_number(formula: Any, *, sha: str, label: str) -> int:
+    version = formula_declaration(formula, FORMULA_VERSION, f"{label} version")
+    match = re.fullmatch(rf"current\.([1-9][0-9]*)\.{re.escape(sha[:12])}", version)
+    if match is None:
+        raise ReadinessError(f"{label} formula version does not identify the Current package run")
+    return int(match.group(1))
+
+
+def verify(payload: dict[str, Any], *, repository: str, tag: str, sha: str) -> str:
+    if re.fullmatch(r"[0-9a-f]{40}", sha) is None or tag != f"current-{sha}":
+        raise ReadinessError("Current tag is not the exact source identity")
+    release = require_mapping(payload.get("release"), "release")
+    fields = {
+        "draft": False,
+        "immutable": True,
+        "prerelease": True,
+        "tag_name": tag,
+        "target_commitish": sha,
+    }
+    for field, expected in fields.items():
+        if release.get(field) != expected:
+            raise ReadinessError(f"Current release {field} is not {expected!r}")
+
+    raw_assets = release.get("assets")
+    if not isinstance(raw_assets, list):
+        raise ReadinessError("Current release assets are unavailable")
+    assets: dict[str, dict[str, Any]] = {}
+    for raw in raw_assets:
+        asset = require_mapping(raw, "release asset")
+        name = asset.get("name")
+        if not isinstance(name, str) or name in assets:
+            raise ReadinessError("Current release has an invalid or duplicate asset")
+        assets[name] = asset
+    expected = expected_assets(sha)
+    if tuple(sorted(assets)) != expected:
+        raise ReadinessError("Current release does not have the exact asset closure")
+    digests: dict[str, str] = {}
+    for name, asset in assets.items():
+        match = SHA256.fullmatch(str(asset.get("digest", "")))
+        if match is None:
+            raise ReadinessError(f"Current release asset has no SHA-256 digest: {name}")
+        digests[name] = match.group(1)
+
+    short = sha[:12]
+    compose_asset = f"container-compose-plugin-current-{short}-arm64.tar.gz"
+    runtime_asset = f"container-current-{short}-arm64.tar.gz"
+    compose_formula = payload.get("compose_formula")
+    container_formula = payload.get("container_formula")
+    verify_formula(
+        compose_formula,
+        repository=repository,
+        tag=tag,
+        asset=compose_asset,
+        digest=digests[compose_asset],
+    )
+    verify_formula(
+        container_formula,
+        repository=repository,
+        tag=tag,
+        asset=runtime_asset,
+        digest=digests[runtime_asset],
+    )
+    compose_run_number = formula_run_number(
+        compose_formula, sha=sha, label="container-compose-current"
+    )
+    container_run_number = formula_run_number(
+        container_formula, sha=sha, label="container-current"
+    )
+    if compose_run_number != container_run_number:
+        raise ReadinessError("Current Homebrew formulae do not identify the same package run")
+
+    _, publication_time = parse_github_timestamp(
+        release.get("published_at"), "Current release publication timestamp"
+    )
+    runs = require_mapping(payload.get("runs"), "package runs").get("workflow_runs")
+    if not isinstance(runs, list):
+        raise ReadinessError("package runs are unavailable")
+    successful_run_times: list[tuple[str, datetime]] = []
+    for raw_run in runs:
+        run = require_mapping(raw_run, "package run")
+        if (
+            run.get("run_number") == compose_run_number
+            and run.get("head_sha") == sha
+            and run.get("status") == "completed"
+            and run.get("conclusion") == "success"
+        ):
+            successful_run_times.append(
+                parse_github_timestamp(
+                    run.get("updated_at"), "successful package run completion timestamp"
+                )
+            )
+    if not successful_run_times:
+        raise ReadinessError("no successful exact-head Prebuilt Binaries authority exists")
+    soak_started_at, soak_start_time = max(successful_run_times, key=lambda item: item[1])
+    if soak_start_time < publication_time:
+        raise ReadinessError("successful package run completed before Current was published")
+    return soak_started_at
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--tag", required=True)
+    parser.add_argument("--sha", required=True)
+    options = parser.parse_args()
+    try:
+        payload = require_mapping(json.load(sys.stdin), "input")
+        print(
+            verify(
+                payload,
+                repository=options.repository,
+                tag=options.tag,
+                sha=options.sha,
+            )
+        )
+    except (ReadinessError, json.JSONDecodeError) as error:
+        print(f"current-release-readiness: {error}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/architecture/coherent-container-family-parity-design.md
+++ b/docs/architecture/coherent-container-family-parity-design.md
@@ -2,15 +2,15 @@
 
 | Item | Value |
 | --- | --- |
-| Status | Integrated design complete; implementation underway. The current 0.14.2 candidate includes the neutral Engine API/gateway, selected enhanced provider, versioned capabilities, durable logging/provider work, explicit dedicated/shared VM isolation, live memory targeting, adaptive reclamation, and several network/image/lifecycle subsets. Docker-compatible namespace joins, singular-authority devcontainer cutover, remaining resource planes, migration, security, and comparable-performance gates are incomplete. |
+| Status | Integrated design complete; implementation underway. The current candidate includes the neutral Engine API/gateway, selected enhanced provider, versioned capabilities, durable logging/provider work, explicit dedicated/shared VM isolation, live memory targeting, adaptive reclamation, and several network/image/lifecycle subsets. Docker-compatible namespace joins, singular-authority devcontainer cutover, remaining resource planes, migration, security, and comparable-performance gates are incomplete. |
 | Family | `container-engine-api`, `container-engine`, `container`, `containerization`, `container-compose`, `container-builder-shim`, `devcontainer`, and supporting matched-stack projects |
 | Compatibility target | Docker Compose 5.4.0 with Docker Engine 29.2.1 API 1.53 on macOS. Retained 5.3.1 citations below identify original source or evidence checkpoints. |
-| 0.14.2 candidate Container revision | `a252482bbacbd15742845764893585131e2c4825` |
-| 0.14.2 candidate Containerization revision | `b404e03bb914904107a6a9305ba1f0e44c79a59c` |
+| Reviewed 0.14.2 evidence: Container revision | `a252482bbacbd15742845764893585131e2c4825` |
+| Reviewed 0.14.2 evidence: Containerization revision | `b404e03bb914904107a6a9305ba1f0e44c79a59c` |
 | Original devcontainer design evidence | `b31e80b2b9c09ecc73bb3badf9cd5cf16550a538` on `origin/main`; extraction head must be reselected from a clean reviewed revision |
 | Socktainer comparison | 1.1.1 at `6cc7a32cc37d4ad0c07e9c88a7bbf2abdaceeea0`; conformance input only |
 | Design date | 31 July 2026 |
-| Last documentation review | 5 September 2026 against the 0.14.2 Current candidate and programme STATUS |
+| Last documentation review | 5 September 2026 against the retained 0.14.2 evidence and programme STATUS |
 
 ## Outcome
 
@@ -2095,7 +2095,7 @@ Performance does not compensate for behavioural divergence, and parity does not 
 - Follow the [Container-family parity development cycle](container-family-development-cycle.md) for slice scope, proportionate local testing, full review convergence, self-hosted MBP execution, main checkpoints, quality scanning, and upstream handoffs.
 - Add `container-engine-api` and accepted devcontainer revision to the common stack manifest/fingerprint and compatibility documentation.
 - Pin Container, Containerization, guest image, builder components, Container Compose, Engine gateway/API package, devcontainer provider, logging/model dependencies, and API schemas as one tested release set.
-- Use semantic immutable releases for the neutral package and one mutable `current` only where the existing family release contract permits it.
+- Use immutable semantic releases for the neutral package and content-addressed `current-<full-sha>` prereleases for the rolling lane; formulae select the active exact identity.
 - Generate compatibility matrices from provider capability manifests and oracle results; do not hand-maintain unsupported claims separately in each project.
 - Changes to a shared DTO/route/lease/event require provider and cross-client contract tests before merge.
 - Status rows close only after the exact final published heads and GitHub-recorded gates/authorities pass; local design or unit evidence alone is insufficient. Those jobs may execute on the trusted self-hosted MBP lane.

--- a/docs/architecture/release-workflow-resilience-followup-design-2026-09-10.md
+++ b/docs/architecture/release-workflow-resilience-followup-design-2026-09-10.md
@@ -2,13 +2,13 @@
 
 Date: 2026-09-10. Status: implemented on `release-workflow-resilience`; quiet-machine performance measurements remain deliberately deferred.
 
-Reviewed checkout: `/Volumes/SSD/github/container-compose-release-0.14.3`, branch `release-workflow-resilience`, HEAD `acb46f59ac958136f4dae391e7fade5ff72129a7`. Review covers the changes in `8861c73b` and `acb46f59`, their callers, build/cleanup paths, release publication, DocC, checkpointing, and recovery inspection. Product version remains **0.14.3**.
+Reviewed checkout: `/Volumes/SSD/github/container-compose-release-0.14.3`, branch `release-workflow-resilience`, HEAD `acb46f59ac958136f4dae391e7fade5ff72129a7`. Review covers the changes in `8861c73b` and `acb46f59`, their callers, build/cleanup paths, release publication, DocC, checkpointing, and recovery inspection. The product version at that reviewed head was **0.14.3**; the implemented integration and release target is exactly **0.15.0**.
 
 ## Decision
 
 Do not yet treat the previous resilience implementation as fully recoverable, cleanup-safe, or sufficient to eliminate redundant work. The content-addressed store, atomic records, exact-byte checks, shared formula validator, and non-deleting Current finalization are useful foundations. Several guarantees, however, stop at a helper API rather than holding across the complete workflow.
 
-This review identifies twelve findings: eight P1 correctness/recovery issues and four P2 recovery/efficiency issues. Eight isolated probe scenarios produced direct evidence; other findings are traced through callers and consumers. No native build, runtime/parity test, benchmark, production dispatch, release mutation, tap update, or Pages deployment was performed.
+This review identifies twenty-two findings: sixteen P1 correctness/recovery issues and six P2 recovery/efficiency issues. Eight isolated probe scenarios produced direct evidence; other findings are traced through callers and consumers. No native build, runtime/parity test, benchmark, production dispatch, release mutation, tap update, or Pages deployment was performed during the design review.
 
 The previous document's implementation-status assertions about symlink-safe cleanup, complete checkout relocation, dispatch reconciliation, independent DocC retention, and universal storage separation were stronger than the implementation supported. This review supersedes those assertions, not the historical record of what was changed.
 
@@ -27,6 +27,64 @@ the active Pages deployment to a successful exact-version Documentation run;
 superseded versions are classified explicitly. Normal validation fingerprints
 no longer execute Docker applications; Docker remains confined to explicit
 oracle lanes.
+
+The production rollout exposed R13: GitHub immutable releases make the former
+singleton `current` tag and delete/upload replacement transaction impossible.
+Current now uses one lightweight `current-<full-sha>` tag and one immutable
+prerelease per exact source commit. Publication creates a draft, reconciles and
+verifies the complete digest closure, publishes once, atomically updates the
+Homebrew pair, and then verifies without editing the release. Published retries
+are read-only. The demo is a bounded exact-commit workflow artifact and never a
+late mutation of release assets. Retention preserves immutable historical
+Current releases and treats the old singleton release as deprecated history.
+
+R14 and R15 close the remaining immutable-retry and promotion-authority gaps.
+Published retries reconstruct deterministic expected notes by substituting only
+server-authenticated published archive digests, reject every other metadata
+change, restore all authenticated published assets as a staged local set, and
+then perform full verification without mutating the release. Stable promotion
+uses one shared verifier for both scheduled and controller paths; it requires a
+published immutable exact-tag release with the complete digest closure, the
+matching Homebrew URL and digest pair, and a successful exact-head package run.
+
+R16 closes partial-draft recovery without weakening published immutability. A
+conflicting private draft is re-read immediately before mutation and replaced
+only when it is still a draft for the exact tag and target. The release object
+is deleted without deleting or retargeting its source tag, one complete fresh
+asset set is uploaded and verified, and the operation is bounded to a single
+replacement. Any race to published state stops without deletion.
+
+R17 prevents private-draft age from being credited as public soak time. The
+shared promotion verifier now requires strict GitHub publication and successful
+exact-head package-run timestamps, binds both installed Current formula versions
+to one exact run number, and rejects a completion before publication. Because
+that selected workflow completes only after release publication and Homebrew
+pair selection, neither a recovered old draft nor a later no-op run can distort
+stable-promotion eligibility.
+
+R18 and R19 close rollout and immutable stable-finalization gaps. The initial
+Current fail-fast preflight has one explicit branch-lane migration allowance for
+a coherent legacy `current` formula pair; exact-SHA validation remains mandatory
+for the resulting publication authority. Draft finalization now always sends an
+explicit prerelease boolean, so a stale stable draft cannot become an immutable
+prerelease before the verifier detects the mismatch.
+
+R20 binds Current's early skip to the same package-run identity encoded by both
+installed formula versions. An older successful exact-head no-op run can no
+longer mask failure of the selected publication run; malformed or mismatched
+formula run identities force recovery rather than false completion.
+
+R21 makes the installed Homebrew declarations, rather than arbitrary formula
+text, the promotion authority. The shared verifier requires exactly one active
+top-level URL, SHA-256, and version declaration in each Current formula and
+compares their parsed values with the immutable release. Expected values in
+comments, caveats, or duplicate declarations cannot authorize stable promotion.
+
+R22 applies the same declaration authority to Current's early recovery skip.
+The resolver parses exactly one active top-level URL, SHA-256, and version from
+each formula, compares the URL and digest with the exact immutable release, and
+binds both formula versions to the same successful package run. Stale active
+declarations cannot be hidden by expected values in comments or caveats.
 
 The 0.15.0 integration extends the retained Compose product closure with both
 Docker-free Linux volume-initializer executables. Their build outputs,
@@ -84,6 +142,16 @@ P1 means fix before relying on the claimed recovery/cleanup guarantee. P2 means 
 | R10 | P2 | Broad/repeated fingerprints invalidate unrelated work and probe Docker | Make and validation fingerprint paths traced |
 | R11 | P2 | Single mutable pin slots and separate producer builds limit reuse | Receipt identity, pin paths, and build graph traced |
 | R12 | P2 | Recovery plans omit important remote state and have unbounded reads | Incomplete/malformed remote fixtures plus code trace |
+| R13 | P1 | A singleton mutable Current release cannot operate when repository releases are immutable | Production HTTP 422 on asset deletion; mixed legacy closure retained as evidence |
+| R14 | P1 | Published immutable retries compare fresh signed bytes and hash-bearing notes before recovery | Exact retry path trace; secure timestamps and notarization make rebuilt archives non-authoritative |
+| R15 | P1 | Stable promotion accepts an incomplete, draft, mutable, or untapped Current shape | Scheduled and controller readiness paths traced |
+| R16 | P1 | Partial private drafts retain timestamp-signed bytes that conflict with a fresh retry | Draft reconciliation path and signing inputs traced |
+| R17 | P2 | Private-draft asset age can be mistaken for public Current soak time after recovery | Exact-head review of shared promotion verifier and interrupted-draft timeline |
+| R18 | P1 | Exact-SHA-only preflight prevents the first automatic migration from the coherent legacy Current formula pair | Production tap state and fail-fast job ordering traced |
+| R19 | P1 | Stable draft publication can preserve stale prerelease metadata into an immutable release | Draft edit flags and post-publication verification ordering traced |
+| R20 | P1 | Any older successful exact-head package run can mask failure of the run selected by the Current formula pair | Early-skip and stable-readiness authority paths compared |
+| R21 | P1 | Formula comments or caveats can impersonate the URL and digest used as stable-promotion authority | Exact-head review of the shared readiness verifier and adversarial formula fixtures |
+| R22 | P2 | Current's early recovery skip searches raw formula text instead of parsing active URL and digest declarations | Exact-head review of the publish-context resolver and adversarial formula fixtures |
 
 ### R01: cleanup safety does not survive path replacement
 
@@ -374,6 +442,8 @@ Tests must assert work counts and terminal state, not merely exit success or the
 | Response lost after accepted dispatch | Reconcile same operation/run; zero blind second POSTs |
 | Controller dies after gate, signing, or upload | Resume from authenticated retained closure; zero repeated valid builds/tests/signing |
 | Matching partial draft | Upload only missing exact members; published stable bytes never replaced |
+| Current publication with repository immutability enabled | Publish one complete `current-<full-sha>` draft exactly once; formulae select that tag; retries never edit, delete, clobber, or retarget published state |
+| Current formula contains stale active declarations plus expected values in comments | Early skip rejects the formula pair and resumes bounded recovery; comments and caveats never establish authority |
 | Hosted gate or site artifact expires | Use valid retained authority/site; otherwise explicit missing-node plan or authority blocker |
 | One of four DocC sites fails | Retain three successes; retry only the failed site; deploy without regenerating valid sites |
 | Self-consistent site from wrong source/base path | Reject despite valid file hashes |

--- a/docs/architecture/runtime-capabilities.md
+++ b/docs/architecture/runtime-capabilities.md
@@ -70,14 +70,11 @@ logging create request, authority-owned protected options, native and remote
 provider lifecycle, canonical reads, dual cache, and exact-process foreground
 attachment in the
 [Docker logging-driver design](docker-logging-driver-semantics-design.md).
-It is present in the coordinated 0.14.2 candidate manifest on the
-[`current` prerelease](https://github.com/stephenlclarke/container-compose/releases/tag/current).
-The candidate manifest uses Container
-`a252482bbacbd15742845764893585131e2c4825`, Engine API
-`386a40c726ecd25d67a3e5933582aebbfbe4fa2f`, Containerization
-`b404e03bb914904107a6a9305ba1f0e44c79a59c`, and SwiftNIO SSL
-`3e13ce5f6dd5b7e89fff9ab55ab7caed39fe7285`. This graph must pass the hosted
-Stable Release Gate before it can be published as 0.14.2. Compose preflight still negotiates the identifier before
+It is present in the coordinated candidate manifest on the formula-selected
+[`current-<full-sha>` prerelease](https://github.com/stephenlclarke/container-compose/releases).
+That release records the exact Container, Engine API, Containerization, and
+SwiftNIO SSL revisions for its tested graph. The graph must pass the hosted
+Stable Release Gate before semantic publication. Compose preflight still negotiates the identifier before
 using advanced logging; advertising the requirement does not make every remote
 provider universally available or close the remaining external-client,
 failure, migration, security, and comparable-performance evidence.
@@ -146,6 +143,6 @@ recovers after restart without provider lifecycle effects. Later signed heads
 complete reference-aware quiescence, durable configuration/history migration,
 terminal proof before alias cutover, final N reclamation, and distributable
 plugin certification. Release trust and coordinated dependency publication
-originally shipped in 0.11.0 and remain part of the 0.14.2 candidate; complete paired Docker
+originally shipped in 0.11.0 and remain part of the current candidate; complete paired Docker
 provider certification and programme-level failure, migration, security, and
 performance evidence remain.

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -427,11 +427,11 @@ their live engines. The release helper no longer accepts
 
 There are two package lanes, with no manual asset copying:
 
-- Every successful runtime-affecting CI run that originates from a push to `main` refreshes the explicit `current` tag and a newly published mutable GitHub prerelease named **Current build**, plus the opt-in `container-current` / `container-compose-current` Homebrew pair. Documentation, workflow-control, and other changes classified outside runtime validation do not rebuild or republish the unchanged product. A commit superseded before promotion is skipped so the subsequent successful runtime run publishes the newest eligible `main` head.
+- Every successful runtime-affecting CI run that originates from a push to `main` publishes one immutable, content-addressed `current-<full-sha>` GitHub prerelease named **Current build**, then atomically updates the opt-in `container-current` / `container-compose-current` Homebrew pair to select it. Documentation, workflow-control, and other changes classified outside runtime validation do not rebuild or republish the unchanged product. A commit superseded before promotion is skipped so the subsequent successful runtime run publishes the newest eligible `main` head.
 - A semantic release is an immutable `x.y.z` tag and becomes Homebrew's default `container` / `container-compose` pair.
 
-`current` is deliberately an unsigned, movable pointer; signing it would make
-its verification describe a prior commit as soon as it advances. Stable semantic
+Each generated `current-<full-sha>` tag is an unsigned lightweight identity
+whose name and target must agree and which is never retargeted. Stable semantic
 tags are SSH-signed and GitHub-verified before their release gate starts.
 
 Current is the normal delivery lane. Create a stable release after the current
@@ -439,19 +439,24 @@ build has soaked for seven days for a milestone, as a documented `--+`
 maintenance promotion, or for a documented security incident. A maintenance
 promotion is manual, must record its operational reason, and is limited to a
 patch bump; it is suitable for an explicit baseline promotion or a release
-mechanism fix. The soak starts when the commit-identified current plugin asset
-(`container-compose-plugin-current-<12-character-sha>-arm64.tar.gz`) is
-published, not when the long-lived Current prerelease was first created. The
-release helper enforces these rules.
+mechanism fix. The soak starts when the successful exact-head package run named
+by both installed Current formula versions completes, after the
+commit-identified release is public and the matching Homebrew pair has been
+selected. An old upload timestamp from a recovered private draft cannot satisfy
+the soak, and a later no-op workflow cannot reset it. The release helper parses
+the single active URL, SHA-256, and version declarations from each formula;
+matching text in comments, caveats, or duplicate declarations is not authority.
+The Current early-recovery check uses the same parsing rules before it can skip
+a transaction. A malformed, duplicate, or stale active declaration resumes the
+bounded publication transaction instead of hiding behind expected comment text.
+The release helper enforces these rules.
 
 Current publication is recoverable across GitHub and Homebrew: it stages
-immutable commit-identified archives on the existing Current prerelease, updates
-the matching Homebrew formula pair, then moves the mutable `current` tag and
-recreates the release object from those staged assets. Recreating the object
-makes GitHub's published time represent this Current build rather than the
-first build that used the `current` tag. If that final replacement is
-interrupted, rerunning the same publication recreates the release from the same
-candidate assets. The Current Homebrew pair uses the monotonically increasing
+the complete commit-identified closure on a draft `current-<full-sha>` release,
+verifies every uploaded digest, and publishes that release exactly once before
+updating the matching Homebrew formula pair. A retry reconciles an incomplete
+draft or verifies the already-published immutable closure; it never deletes,
+clobbers, or retargets published state. The Current Homebrew pair uses the monotonically increasing
 package-workflow run number before the source SHA in its shared formula
 version. Both `container-current` and `container-compose-current` receive that
 same version, so `brew upgrade container-current container-compose-current`
@@ -468,7 +473,7 @@ is no release-producing commit or the soak is incomplete, so an unready week is
 not a failed release. Manual dispatch can use the same automatic decision or an
 explicit patch, minor, or major override.
 
-The scheduled stable-release workflow and the Current package workflow run only from `main` on the dedicated `container-compose-release` Apple-silicon self-hosted runner. It creates clean, disposable stack checkouts, reconstructs the read-only Apple remotes and Stephen-owned push remotes, and invokes the existing helper unchanged. That preserves the required local runtime and Docker Compose parity gate, signed semantic tag, source-promotion pull request, hosted stable gate, immutable package assets, and paired Homebrew update. The separate Current Demo workflow consumes the already-published exact-SHA signed packages on the same hardware-virtualization-capable runner, uses a stable internal-volume runtime path, and applies a process-group deadline. Its mutable visual asset is recoverable and deliberately outside the package, attestation, release, and Homebrew critical path. GitHub-hosted macOS workers cannot provide the nested virtualization needed to record Container guest startup, so they must never publish that recording.
+The scheduled stable-release workflow and the Current package workflow run only from `main` on the dedicated `container-compose-release` Apple-silicon self-hosted runner. It creates clean, disposable stack checkouts, reconstructs the read-only Apple remotes and Stephen-owned push remotes, and invokes the existing helper unchanged. That preserves the required local runtime and Docker Compose parity gate, signed semantic tag, source-promotion pull request, hosted stable gate, immutable package assets, and paired Homebrew update. The separate Current Demo workflow consumes the already-published exact-SHA signed packages on the same hardware-virtualization-capable runner, uses a stable internal-volume runtime path, and applies a process-group deadline. Its exact-commit visual output is retained as a bounded workflow artifact and remains deliberately outside the package, attestation, release, and Homebrew critical path. It never modifies an immutable release. GitHub-hosted macOS workers cannot provide the nested virtualization needed to record Container guest startup, so they must never publish that recording.
 
 Bootstrap that runner once on the release Mac after its normal build prerequisites and GitHub CLI login are in place:
 
@@ -486,21 +491,20 @@ From clean `~/github/container-compose`, `~/github/container-builder-shim`,
 make release-plan
 make release-version
 make release-plan VERSION_SELECTOR=--+ # reviewed maintenance plan
-make release-status VERSION=0.14.3
-make release-recovery-plan VERSION=0.14.3
+make release-status VERSION=0.15.0
+make release-recovery-plan VERSION=0.15.0
 ```
 
 ### Promote The Current Build
 
-Do not copy, rename, or edit the mutable GitHub **Current build** prerelease.
+Do not copy, rename, or edit a published GitHub **Current build** prerelease.
 It is an installable view of green `main`, not a stable release candidate asset.
 Promotion always rebuilds the exact tagged source into immutable stable assets,
 which is what keeps the semantic version, runtime pin, checksums, Homebrew
-formulae, and release notes deterministic. Current finalization preserves the
-existing GitHub release object, uploads the complete replacement closure, then
-edits its metadata after the matching Homebrew formulae update. A failed refresh
-therefore leaves the prior Current release available; freshness is carried by
-explicit build metadata rather than destructive recreation for `published_at`.
+formulae, and release notes deterministic. Current finalization only verifies
+the already-published exact-SHA closure after the matching Homebrew formulae
+update. A failed publication leaves the prior formula-selected Current release
+available and the candidate draft or immutable release recoverable by identity.
 
 `make release-version` reports the latest reachable semantic tag, selected
 bump, and next version. `make release-plan` includes that decision. After the
@@ -528,8 +532,9 @@ the decision. Explicit selectors remain available for reviewed maintenance
 promotions, security releases, and exact recovery retries; they are not a way
 to bypass release evidence.
 
-Before source promotion, the helper requires the mutable `current` tag to point
-at the validated `main` head. Milestones also require that Current build's
+Before source promotion, the helper requires the nearest content-addressed
+Current release tag to identify the validated `main` head (or the published
+parent of an exact retained release candidate). Milestones also require that Current build's
 seven-day soak. An exceptional milestone promotion may bypass only that timer
 with a non-empty `CONTAINER_STACK_MILESTONE_SOAK_OVERRIDE_REASON` recording the
 explicit maintainer authorization and rationale; it still requires the exact
@@ -573,18 +578,18 @@ If a hosted gate fails before the semantic GitHub release is created, correct th
 
 Stable gate, package, and documentation concurrency groups retain a full pending queue rather than replacing an earlier pending release. Candidate-bound gate receipts verify the immutable Homebrew snapshot recorded by the gate; later tap movement is handled only by the serial, conflict-checked formula publication transaction and does not invalidate compiled release evidence.
 
-After the tag is published, the one mutable `current` prerelease continues to
-follow later green `main` commits. Homebrew users without `-current` always use
-the newly promoted stable formula pair; opted-in users continue to use the
-current pair.
+After the stable tag is published, later green `main` commits receive new
+content-addressed Current prereleases. Homebrew users without `-current` always
+use the newly promoted stable formula pair; opted-in users continue to use the
+Current pair selected atomically by its two formulae.
 
-Each package note begins with a quality snapshot for its exact commit. Stable releases contain the eleven SonarQube quality metrics shown in the README plus CodeQL analysis, result, and rule counts. Mutable Current builds contain the eleven exact-commit SonarQube metrics and do not query or display release-only CodeQL evidence. The controller emits the applicable metrics as individual static Shields-compatible badges and uploads the same set as one self-contained SVG evidence asset.
+Each package note begins with a quality snapshot for its exact commit. Stable releases contain the eleven SonarQube quality metrics shown in the README plus CodeQL analysis, result, and rule counts. Current builds contain the eleven exact-commit SonarQube metrics and do not query or display release-only CodeQL evidence. The controller emits the applicable metrics as individual static Shields-compatible badges and uploads the same set as one self-contained SVG evidence asset.
 
 Every publication uses a unique static delivery key and Shields' maximum supported five-day cache lifetime, so a successfully verified static badge is not needlessly re-fetched through GitHub's image proxy while the release remains current. The controller asks GitHub to render the exact release Markdown, fetches every resulting GitHub-proxied image, and parses every payload as SVG before publication can continue. A badge-host, GitHub image-proxy, SonarCloud, or GitHub Actions authority-query failure blocks either lane rather than producing an unverified or broken note; a CodeQL failure additionally blocks stable publication. Both publish-context resolution and quality-snapshot capture retry transient GitHub `429` and `5xx` responses twelve times; exhaustion fails the package workflow visibly instead of reporting a successful skip and leaving Current stale. The workflow-run gate also retries the short GitHub jobs-API window in which a completed CI run can still expose a null aggregate `Validate` conclusion, and it publishes only after every relevant conclusion is populated and the normal success-or-intentional-skip policy passes.
 
 A Current package accepts only an exact-main successful CI run with a passed SonarQube scan and retained per-metric history, whether that CI was triggered by a push or by an explicit full-validation dispatch. It waits within the configured quality-evidence window for the exact analysis and all required metrics to finish indexing. A docs-only run simply leaves the existing Current release in place.
 
-SonarCloud can discard an older analysis and its metric history after a later `main` scan, even while GitHub retains the immutable semantic tag, the exact SonarCloud check run, and the exact CI job. Stable publication alone therefore has a retention-aware path: when the exact metric history is absent, it requires both a successful `SonarCloud Code Analysis` check attached to the promoted commit and a successful `SonarQube scan` step in a successful exact-commit `main` CI run. It uses that evidence immediately only when SonarCloud already exposes a different analysis completed after the exact scan; otherwise it honors the configured polling window so normal analysis and measure-history indexing can produce the full snapshot before classifying the history as expired. The same wait applies when the analysis record is visible but some required metrics are not yet indexed. The resulting fallback snapshot labels the SonarQube quality gate as passed and the historical metrics as expired, links both retained authorities, keeps the exact CodeQL counts, and states that no later metrics were substituted. A missing, failed, mismatched, or unreadable authority still blocks publication. This path is not available to mutable Current builds and never converts a transient metric API error into retention evidence. The SVG stays a downloadable evidence artifact and is not embedded inline, because GitHub release pages serve release assets as attachment data rather than reliable inline SVG images. Current-build snapshots refresh whenever the mutable `current` pointer moves; stable snapshots are immutable historical evidence.
+SonarCloud can discard an older analysis and its metric history after a later `main` scan, even while GitHub retains the immutable semantic tag, the exact SonarCloud check run, and the exact CI job. Stable publication alone therefore has a retention-aware path: when the exact metric history is absent, it requires both a successful `SonarCloud Code Analysis` check attached to the promoted commit and a successful `SonarQube scan` step in a successful exact-commit `main` CI run. It uses that evidence immediately only when SonarCloud already exposes a different analysis completed after the exact scan; otherwise it honors the configured polling window so normal analysis and measure-history indexing can produce the full snapshot before classifying the history as expired. The same wait applies when the analysis record is visible but some required metrics are not yet indexed. The resulting fallback snapshot labels the SonarQube quality gate as passed and the historical metrics as expired, links both retained authorities, keeps the exact CodeQL counts, and states that no later metrics were substituted. A missing, failed, mismatched, or unreadable authority still blocks publication. This path is not available to Current builds and never converts a transient metric API error into retention evidence. The SVG stays a downloadable evidence artifact and is not embedded inline, because GitHub release pages serve release assets as attachment data rather than reliable inline SVG images. Each Current-build snapshot belongs to its immutable `current-<sha>` prerelease; stable snapshots are immutable historical evidence.
 
 ## Docker Compose Parity
 

--- a/docs/guides/INSTALL.md
+++ b/docs/guides/INSTALL.md
@@ -11,19 +11,18 @@ time: both runtime formulae provide the `container` executable.
 | --- | --- | --- |
 | `container-compose` | stable release build | Default install. It depends on the matched `stephenlclarke/container` runtime. |
 | `container` | runtime build | Installed automatically as the runtime dependency for the plugin formula. |
-| `container-compose-current` | one mutable `current` prerelease | Opt in when you want the latest green-`main` app. It depends on `container-current`. |
+| `container-compose-current` | exact-SHA Current prerelease | Opt in when you want the latest green-`main` app. It depends on `container-current`. |
 | `container-current` | current runtime build | Installed automatically with the current plugin formula. |
 
 The formulae install prebuilt GitHub release assets. They do not build Swift or Go source on the user's machine and do not require Go or Xcode for normal installation. Maintainer-only release and branch rules live in [BUILD.md](BUILD.md).
 
-This guide describes the [`0.14.1` stable lane](https://github.com/stephenlclarke/container-compose/releases/tag/0.14.1) and the rolling `current` lane, which carries the reviewed 0.14.2 candidate until it passes the stable gate and is published. A later immutable semantic release supersedes 0.14.1 automatically in the stable formulae; `container compose version` and `container system version` report the exact installed pair.
+This guide describes the [latest stable lane](https://github.com/stephenlclarke/container-compose/releases/latest) and the rolling Current lane, whose paired formulae select one immutable `current-<full-sha>` prerelease. A later immutable semantic release updates the stable formulae automatically; `container compose version` and `container system version` report the exact installed pair.
 
 Homebrew without a `-current` formula always uses the latest immutable semantic
-release. The opt-in lane follows the single mutable GitHub prerelease named
-**Current build** (tag `current`), which advances only after green `main` CI.
-The release page retains downloadable assets only for the newest stable release
-and that one current prerelease; older release notes contain source-build
-instructions instead.
+release. The opt-in lane advances only after green `main` CI by atomically
+selecting a new immutable **Current build** tagged `current-<full-sha>`.
+Content-addressed Current releases remain historical identities; the formulae
+identify which exact release is active.
 
 ## Requirements
 
@@ -115,9 +114,9 @@ If the machine has a mixed Homebrew/Apple install, use the [reset flow](#trouble
 ## Install The Current Matched Stack
 
 Use this lane when you want the latest installable `main` build rather than the
-latest semantic stable release. It follows the one mutable **Current build**
-prerelease (tag `current`), generated only after green `main` CI, and is always
-paired with the exact runtime package in its Compose stack manifest. It
+latest semantic stable release. It follows the formula-selected immutable
+**Current build** prerelease (`current-<full-sha>`), generated only after green
+`main` CI, and is always paired with the exact runtime package in its Compose stack manifest. It
 deliberately does not modify the stable formulae.
 
 Switch from stable (or reset a mixed installation) first:
@@ -289,7 +288,7 @@ brew postinstall stephenlclarke/tap/container
 brew services restart stephenlclarke/tap/container
 ```
 
-To opt in to the one mutable **Current build** prerelease instead, replace the
+To opt in to the formula-selected **Current build** prerelease instead, replace the
 last three commands with:
 
 ```sh

--- a/docs/project/BACKLOG.md
+++ b/docs/project/BACKLOG.md
@@ -135,7 +135,7 @@ grant, security, recovery, and external-client contracts are proved.
 Tracking issue: [[Parity] Complete Docker logging-provider and history
 semantics](https://github.com/stephenlclarke/container-compose/issues/271).
 
-The current 0.14.2 candidate retains durable `json-file` and `local`
+The current candidate retains durable `json-file` and `local`
 histories, `none`, Syslog, Journald, Fluentd, GELF, Splunk HEC, AWS Logs,
 Google Cloud Logs, installed Docker logging plugins, dual cache, bounded live
 readers, recovery, rotation, compression, and exact-process foreground

--- a/docs/project/STATUS.md
+++ b/docs/project/STATUS.md
@@ -11,31 +11,17 @@ guidance remains in [INSTALL.md](../guides/INSTALL.md).
 
 ## Current Stable Release
 
-[`0.14.1`](https://github.com/stephenlclarke/container-compose/releases/tag/0.14.1)
-was published for macOS arm64 on 3 September 2026.
+[`0.14.3`](https://github.com/stephenlclarke/container-compose/releases/tag/0.14.3)
+was published for macOS arm64 on 10 September 2026. The release notes and
+attached manifests record its exact matched Container, Containerization,
+builder-shim, builder-image, and SwiftNIO SSL authorities.
 
-The immutable release manifest selects:
-
-- Container `2647090a8af74cf18fae2472342cdb55bab60e45`.
-- Containerization `818f5917819a32dac1bc233605c253b4a105e0e0`.
-- Container builder shim `4aff0ea2e7ff293544a4efac28b508da53aac3d6`.
-- Builder image digest
-  `sha256:d81d12e1dca1133ede535483a809803e6b256555a73d17f207003279539454a4`.
-- SwiftNIO SSL `09c5c9adcdd2a459187e45fe0143eb01063f244a`.
-
-The hosted stable-release gate passed for that immutable package. Current and
-Homebrew release artifacts are Developer ID signed, checksummed, attested, and
-bound to the matched runtime stack.
-
-The 0.14.2 Current candidate selects Container
-`a252482bbacbd15742845764893585131e2c4825`, Containerization
-`b404e03bb914904107a6a9305ba1f0e44c79a59c`, Container builder shim
-`287f2ea3276eca73cd3781ff59b4c9c82d5f3d32`, builder image digest
-`sha256:7398845b67e6d5c5e610e9f1c6bf4ce84e4c7242a8f8002ff2e5e917437cfdf7`,
-and SwiftNIO SSL `3e13ce5f6dd5b7e89fff9ab55ab7caed39fe7285`.
-These candidate revisions do not
-describe immutable 0.14.2 artifacts until the stable release gate succeeds and
-publishes that version.
+Stable and Current Homebrew artifacts are Developer ID signed, checksummed,
+attested, and bound to their matched runtime stacks. Current candidates use an
+immutable content-addressed `current-<full-sha>` prerelease; the formula pair
+must select the same exact release before automation treats that transaction as
+complete. Candidate revisions do not describe stable artifacts until the
+stable release gate succeeds and publishes a semantic version.
 
 The candidate additionally carries reviewed runtime corrections for changing
 Kubernetes control-plane addresses, unreadable image entries and build
@@ -384,11 +370,11 @@ Normal repository validation uses `make ci`, targeted tests while iterating,
 the complete Docker Compose parity target when Compose or runtime behavior
 changes, and `make release-gate` before stable publication.
 
-The 0.14.2 candidate has passed the local matched-stack, Compose CI, live
-runtime, and complete Docker Compose parity checkpoints. Its exact-head hosted
-review and Stable Release Gate remain pending, so it is not yet an immutable
-release. CodeQL, stable packaging, and final documentation publication remain
-release-gate work rather than evidence already earned by this candidate.
+The current candidate must pass the local matched-stack, Compose CI, live
+runtime, complete Docker Compose parity, exact-head hosted review, and Stable
+Release Gate checkpoints before publication. CodeQL, stable packaging, and
+final documentation publication remain release-gate work rather than evidence
+earned by an unpublished candidate.
 
 The maintained local parity suite covers project loading, Compose and
 Dockerfile models, lifecycle, logging, terminal sessions, networking, IPAM,

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -27,6 +27,7 @@ readonly RELEASE_COMMAND_DEADLINE_RUNNER="${SELF_DIRECTORY}/../Tools/ci/run-comm
 readonly RELEASE_HOST_STATE_TOOL="${SELF_DIRECTORY}/../Tools/release/release-host-state.py"
 readonly RELEASE_DISPATCH_JOURNAL_TOOL="${SELF_DIRECTORY}/../Tools/release/release-dispatch-journal.py"
 readonly RELEASE_ASSET_RETENTION_TOOL="${SELF_DIRECTORY}/../Tools/release/retain-local-release-assets.py"
+readonly CURRENT_RELEASE_READINESS_TOOL="${SELF_DIRECTORY}/../Tools/release/verify-current-release-readiness.py"
 readonly FORMULA_PAIR_VALIDATOR="${CONTAINER_STACK_FORMULA_PAIR_VALIDATOR:-${SELF_DIRECTORY}/../Tools/release/verify-homebrew-formula-pair.py}"
 readonly STABLE_AUTHORITY_BUNDLE_VERIFIER="${SELF_DIRECTORY}/../Tools/release/verify-stable-authority-bundle.py"
 readonly DOC_SITE_MANIFEST_TOOL="${SELF_DIRECTORY}/../Tools/ci/doc-site-manifest.py"
@@ -59,7 +60,7 @@ Modes:
       Deterministically promote the prepared stack and Homebrew tap to the next
       stable release. A stable release requires an explicit milestone,
       maintenance, or security intent. The version selector is resolved from the
-      latest local semantic container-compose tag, not from mutable
+      latest local semantic container-compose tag, not from transient
       working-tree state. The helper bumps container-compose on main when
       needed, commits that bump, promotes the stephenlclarke source main
       branches, creates and pushes the stable container-compose source tag,
@@ -582,6 +583,49 @@ ensure_release_intent() {
   fi
 }
 
+# Return the immutable Current tag for one exact source commit.
+current_release_tag_for_commit() {
+  local commit="$1"
+  if [[ ! "${commit}" =~ ^[0-9a-f]{40}$ ]]; then
+    printf 'invalid Current source commit: %s\n' "${commit:-missing}" >&2
+    return 2
+  fi
+  printf 'current-%s\n' "${commit}"
+}
+
+# Return the nearest content-addressed Current commit in the candidate graph.
+# A retained release candidate may merge a newer remote main as its second
+# parent, so first-parent traversal alone can miss the active published build.
+current_release_commit_for_main() {
+  local path="$1" main_commit="$2" tag commit resolved distance
+  local best_commit="" best_distance=""
+  while IFS= read -r tag; do
+    commit="${tag#current-}"
+    if [[ ! "${commit}" =~ ^[0-9a-f]{40}$ ]]; then
+      continue
+    fi
+    resolved="$(git -C "${path}" rev-parse --verify -q "refs/tags/${tag}^{commit}" || true)"
+    if [[ "${resolved}" != "${commit}" ]] || \
+      ! git -C "${path}" merge-base --is-ancestor "${commit}" "${main_commit}"; then
+      continue
+    fi
+    distance="$(git -C "${path}" rev-list --count "${commit}..${main_commit}")"
+    if [[ -z "${best_distance}" || "${distance}" -lt "${best_distance}" ]]; then
+      best_commit="${commit}"
+      best_distance="${distance}"
+    elif [[ "${distance}" == "${best_distance}" && "${commit}" != "${best_commit}" ]]; then
+      printf 'ambiguous nearest Current tags for %s: %s and %s\n' \
+        "${main_commit}" "${best_commit}" "${commit}" >&2
+      return 2
+    fi
+  done < <(git -C "${path}" tag --list 'current-*')
+  if [[ -n "${best_commit}" ]]; then
+    printf '%s\n' "${best_commit}"
+    return 0
+  fi
+  return 1
+}
+
 # Require Current to identify local main, or the published parent of the exact
 # helper-created candidate retained for this retry. The candidate itself is not
 # published until its release PR passes, so requiring Current to name it makes
@@ -590,7 +634,7 @@ ensure_current_release_source_identity() {
   local path main_commit current_commit
   path="$(repo_path "${COMPOSE_REPO}")"
   main_commit="$(git -C "${path}" rev-parse main)"
-  current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
+  current_commit="$(current_release_commit_for_main "${path}" "${main_commit}" || true)"
   if [[ "${current_commit}" == "${main_commit}" ]]; then
     return 0
   fi
@@ -607,12 +651,13 @@ ensure_current_release_source_identity() {
   exit 1
 }
 
-# Require the mutable Current build to identify the same source as local main.
+# Require the nearest immutable Current build to identify the same source as local main.
 # Milestone releases additionally require a seven-day soak unless an explicit,
 # documented milestone-only override is supplied. Maintenance and security
 # releases retain the source-identity check but may bypass that waiting period.
 ensure_current_build_release_readiness() {
-  local path current_is_prerelease current_built_at
+  local path repository current_commit current_tag current_release current_runs
+  local container_formula compose_formula current_built_at
   path="$(repo_path "${COMPOSE_REPO}")"
 
   if [[ "${EXECUTE}" != "1" ]]; then
@@ -622,15 +667,32 @@ ensure_current_build_release_readiness() {
 
   need_command gh
   ensure_current_release_source_identity
-
-  current_is_prerelease="$(github_cli api \
-    "repos/$(github_repo "${COMPOSE_REPO}")/releases/tags/current" \
-    --jq '.prerelease')"
-  current_built_at="$(github_cli api \
-    "repos/$(github_repo "${COMPOSE_REPO}")/releases/tags/current" \
-    --jq '[.assets[] | select(.name | test("^container-compose-plugin-current-[0-9a-f]{12}-arm64[.]tar[.]gz$")) | .updated_at] | max // empty')"
-  if [[ "${current_is_prerelease}" != "true" || -z "${current_built_at}" ]]; then
-    printf 'current GitHub prerelease or package asset is missing; wait for green main package publication\n' >&2
+  current_commit="$(current_release_commit_for_main "${path}" "$(git -C "${path}" rev-parse main)")"
+  current_tag="$(current_release_tag_for_commit "${current_commit}")"
+  repository="$(github_repo "${COMPOSE_REPO}")"
+  current_release="$(github_cli api \
+    "repos/${repository}/releases/tags/${current_tag}")"
+  current_runs="$(github_cli api \
+    "repos/${repository}/actions/workflows/prebuilt-binaries.yml/runs?head_sha=${current_commit}&status=success&per_page=100")"
+  container_formula="$(github_cli api \
+    -H 'Accept: application/vnd.github.raw+json' \
+    'repos/stephenlclarke/homebrew-tap/contents/Formula/container-current.rb?ref=main')"
+  compose_formula="$(github_cli api \
+    -H 'Accept: application/vnd.github.raw+json' \
+    'repos/stephenlclarke/homebrew-tap/contents/Formula/container-compose-current.rb?ref=main')"
+  current_built_at="$(jq -n \
+      --argjson release "${current_release}" \
+      --argjson runs "${current_runs}" \
+      --arg container_formula "${container_formula}" \
+      --arg compose_formula "${compose_formula}" \
+      '{release: $release, runs: $runs, container_formula: $container_formula, compose_formula: $compose_formula}' \
+      | python3 "${CURRENT_RELEASE_READINESS_TOOL}" \
+          --repository "${repository}" \
+          --tag "${current_tag}" \
+          --sha "${current_commit}"
+  )"
+  if [[ -z "${current_built_at}" ]]; then
+    printf 'current GitHub release authority is incomplete; wait for green main package publication\n' >&2
     exit 1
   fi
 
@@ -699,7 +761,7 @@ refresh_release_sibling_main() {
 require_current_stack_matches_sibling_mains() {
   local path current_commit component published_ref local_ref
   path="$(repo_path "${COMPOSE_REPO}")"
-  current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
+  current_commit="$(current_release_commit_for_main "${path}" "$(git -C "${path}" rev-parse main)")"
   for component in container-builder-shim containerization container; do
     if [[ "${EXECUTE}" == "1" ]]; then
       refresh_release_sibling_main "${component}"
@@ -723,7 +785,7 @@ require_current_stack_matches_sibling_mains() {
 
 # Remove only the marker-protected authority after stable publication succeeds.
 # A failed or interrupted release intentionally retains the content-addressed
-# input so an unpublished tag can resume even after mutable Current advances.
+# input so an unpublished tag can resume after a newer Current release appears.
 cleanup_current_init_image_authority() {
   local root="${CURRENT_INIT_IMAGE_AUTHORITY_ROOT:-}" parent expected_parent
   if [[ -z "${root}" || "${CURRENT_INIT_IMAGE_AUTHORITY_RELEASED}" != "1" ]]; then
@@ -754,7 +816,7 @@ cleanup_current_init_image_authority() {
 # normal path downloads a checksum-paired, attested asset whose name and
 # Current tag are bound to the validated source.
 prepare_stable_init_image_authority() {
-  local path repo current_commit remote_current_before remote_current_after
+  local path repo current_commit current_tag remote_current_before remote_current_after
   local source_ref="${1:-}" containerization_reference archive asset root
   local cache_root cache_asset cache_sidecar stage downloaded_asset digest
   path="$(repo_path "${COMPOSE_REPO}")"
@@ -824,9 +886,11 @@ PY
       github_cli attestation verify "${cache_root}/${cache_asset}" --repo "${repo}"
     else
       local staged_attempts staged_attempt_count staged_digest staged_name staged_extra staged_line_count
-      current_commit="$(git -C "${path}" rev-parse 'refs/tags/current^{}')"
+      current_commit="$(current_release_commit_for_main \
+        "${path}" "$(git -C "${path}" rev-parse main)")"
+      current_tag="$(current_release_tag_for_commit "${current_commit}")"
       remote_current_before="$(git -C "${path}" ls-remote --tags origin \
-        'refs/tags/current' 'refs/tags/current^{}' | awk '{print $1}' | tail -n 1)"
+        "refs/tags/${current_tag}" "refs/tags/${current_tag}^{}" | awk '{print $1}' | tail -n 1)"
       if [[ "${remote_current_before}" != "${current_commit}" ]]; then
         printf 'remote Current moved before VM-init authority download: local %s, remote %s\n' \
           "${current_commit}" "${remote_current_before:-missing}" >&2
@@ -870,7 +934,7 @@ PY
       else
         stage="$(mktemp -d \
           "${RELEASE_INIT_AUTHORITY_CACHE_ROOT}/.${containerization_reference}.XXXXXX")"
-        github_cli release download current \
+        github_cli release download "${current_tag}" \
           --repo "${repo}" \
           --dir "${stage}" \
           --pattern "${asset}" \
@@ -882,7 +946,7 @@ PY
       )
       github_cli attestation verify "${stage}/${asset}" --repo "${repo}"
       remote_current_after="$(git -C "${path}" ls-remote --tags origin \
-        'refs/tags/current' 'refs/tags/current^{}' | awk '{print $1}' | tail -n 1)"
+        "refs/tags/${current_tag}" "refs/tags/${current_tag}^{}" | awk '{print $1}' | tail -n 1)"
       if [[ "${remote_current_after}" != "${current_commit}" ]]; then
         printf 'remote Current moved during VM-init authority download: expected %s, got %s\n' \
           "${current_commit}" "${remote_current_after:-missing}" >&2
@@ -1252,7 +1316,7 @@ published_base_for_retained_candidate() {
   local path="$1" version="$2" remote_head="$3" commits="$4"
   local current_head commit subject main_parent
 
-  current_head="$(git -C "${path}" rev-parse --verify -q 'refs/tags/current^{}' || true)"
+  current_head="$(current_release_commit_for_main "${path}" "${remote_head}" || true)"
   if [[ ! "${current_head}" =~ ^[0-9a-f]{40}$ ]] ||
     ! git -C "${path}" merge-base --is-ancestor "${current_head}" "${remote_head}"; then
     printf '%s\n' "${remote_head}"
@@ -1327,7 +1391,7 @@ recover_unpublished_release_candidate() {
         printf 'promoted container-compose candidate is not the reviewed direct merge parent\n' >&2
         exit 1
       fi
-      current_head="$(git -C "${path}" rev-parse --verify -q 'refs/tags/current^{}' || true)"
+      current_head="$(current_release_commit_for_main "${path}" "${remote_head}" || true)"
       if [[ "${current_head}" != "${promotion_parent}" &&
         "${current_head}" != "${remote_head}" ]]; then
         printf 'current does not identify the exact pre-promotion container-compose main\n' >&2
@@ -1424,26 +1488,14 @@ stephen_https_url() {
   esac
 }
 
-# Refresh the one intentionally mutable release pointer without forcing semantic tags.
-refresh_mutable_current_tag() {
-  local repo="$1" path="$2" remote="$3" local_current remote_current
+# Fetch immutable content-addressed Current tags without allowing retargeting.
+refresh_current_release_tags() {
+  local repo="$1" path="$2" remote="$3"
   if [[ "${repo}" != "${COMPOSE_REPO}" ]]; then
     return 0
   fi
-
-  remote_current="$(git -C "${path}" ls-remote --tags --refs "${remote}" refs/tags/current 2>/dev/null || true)"
-  remote_current="$(awk '{ print $1 }' <<<"${remote_current}" | tail -n 1)"
-  if [[ -z "${remote_current}" ]]; then
-    return 0
-  fi
-
-  local_current="$(git -C "${path}" rev-parse --verify -q refs/tags/current 2>/dev/null || true)"
-  if [[ "${local_current}" == "${remote_current}" ]]; then
-    return 0
-  fi
-
-  printf 'refreshing mutable current tag for %s\n' "${repo}"
-  git -C "${path}" fetch "${remote}" '+refs/tags/current:refs/tags/current'
+  git -C "${path}" fetch --no-write-fetch-head "${remote}" \
+    'refs/tags/current-*:refs/tags/current-*'
 }
 
 fetch_release_remote() {
@@ -1478,7 +1530,7 @@ fetch_release_remote() {
     url="${fallback_url}"
   fi
 
-  refresh_mutable_current_tag "${repo}" "${path}" "${remote}"
+  refresh_current_release_tags "${repo}" "${path}" "${remote}"
   printf '+'
   printf ' %s' "${fetch_args[@]}"
   printf '\n'


### PR DESCRIPTION
## Summary

- replace the mutable singleton Current release with exact-SHA immutable prereleases
- make draft publication, Homebrew selection, retention, demo recording, and stable recovery use content-addressed Current identities
- preserve the deprecated mixed legacy Current release without mutation and keep demo output outside release assets

## Validation

- `make source-checks CONTAINER_STACK_REPO=/Volumes/SSD/github/container-compose-release-transactions/0.15.0/container`
- 327 focused release-controller/workspace/publisher/retention/notes/Homebrew tests
- `bash Tools/release/test_publish_github_release.sh`
- `git diff --check`

No benchmark timings were collected.