### PR TITLE
chore(release): refresh 0.15.0 upstream authority

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4e4975b0b53e0a5e3b131d4e28ec872d93bff348bb19be947135d18289627e84",
+  "originHash" : "f61a22aeec981a617248f011e52b28e03c30bb2925ec63c6601e1146991e7e23",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -15,7 +15,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/container.git",
       "state" : {
-        "revision" : "46bc879296fe78debe51133e81eecfa64455be86"
+        "revision" : "780a86b995ac4cb0985db97f38875fdc6e33d16b"
       }
     },
     {
@@ -31,7 +31,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/stephenlclarke/containerization.git",
       "state" : {
-        "revision" : "333c5a9986fb8fd6bc17328b4b355fe97764f794"
+        "revision" : "7e066a3101bc84fa0f7231daf6a03aa9ef62a567"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let containerDependency: Package.Dependency = {
     return enhancedRuntime
         ? .package(
             url: "https://github.com/stephenlclarke/container.git",
-            revision: "46bc879296fe78debe51133e81eecfa64455be86",
+            revision: "780a86b995ac4cb0985db97f38875fdc6e33d16b",
         )
         : .package(url: "https://github.com/apple/container.git", exact: "1.4.1")
 }()
@@ -54,7 +54,7 @@ let containerizationDependency: Package.Dependency = {
     return enhancedRuntime
         ? .package(
             url: "https://github.com/stephenlclarke/containerization.git",
-            revision: "333c5a9986fb8fd6bc17328b4b355fe97764f794",
+            revision: "7e066a3101bc84fa0f7231daf6a03aa9ef62a567",
         )
         : .package(url: "https://github.com/apple/containerization.git", exact: "0.45.0")
 }()

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ in the stable baseline and current candidate. Planned compatibility work is kept
 > 🤬 **This project is a maintenance nightmare.** 🤬
 >
 > <!-- upstream-metrics:start -->
-> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 10 September 2026 snapshot, the three support forks are **1202 commits ahead of Apple upstream**:
+> What started as a 'fun' implementation due to a real need for Compose functionality on `apple/container` has turned into a beast. `container-compose` cannot be maintained in isolation: it depends on runtime and build capabilities not yet available in Apple releases, plus local fixes for upstream defects. Keeping it working means carrying and continuously refreshing a matched four-repository stack. At the 12 September 2026 snapshot, the three support forks are **1224 commits ahead of Apple upstream**:
 >
-> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 317 ahead** at [`bd8130fea851`](https://github.com/stephenlclarke/containerization/commit/bd8130fea851f6ee264f00fc684e2543a7d2faa3).
-> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 826 ahead** at [`e653616e62ab`](https://github.com/stephenlclarke/container/commit/e653616e62ab7763c3a7d10e88c365d6dca7e0c4).
+> - [`containerization`](https://github.com/stephenlclarke/containerization): **0 behind, 321 ahead** at [`7e066a3101bc`](https://github.com/stephenlclarke/containerization/commit/7e066a3101bc84fa0f7231daf6a03aa9ef62a567).
+> - [`container`](https://github.com/stephenlclarke/container): **0 behind, 844 ahead** at [`780a86b995ac`](https://github.com/stephenlclarke/container/commit/780a86b995ac4cb0985db97f38875fdc6e33d16b).
 > - [`container-builder-shim`](https://github.com/stephenlclarke/container-builder-shim): **0 behind, 59 ahead** at [`5373d9b4363c`](https://github.com/stephenlclarke/container-builder-shim/commit/5373d9b4363c6e536dc6401199da269c7045abf9).
 > - [`container-compose`](https://github.com/stephenlclarke/container-compose): the integration repository's current `main` branch, with no Apple repository to compare against.
 >

--- a/Tools/release/stack-refs.json
+++ b/Tools/release/stack-refs.json
@@ -1,7 +1,7 @@
 {
   "components": {
     "container": {
-      "ref": "46bc879296fe78debe51133e81eecfa64455be86",
+      "ref": "780a86b995ac4cb0985db97f38875fdc6e33d16b",
       "repository": "stephenlclarke/container"
     },
     "container-builder-shim": {
@@ -14,7 +14,7 @@
       "repository": "stephenlclarke/container-builder-shim"
     },
     "containerization": {
-      "ref": "333c5a9986fb8fd6bc17328b4b355fe97764f794",
+      "ref": "7e066a3101bc84fa0f7231daf6a03aa9ef62a567",
       "repository": "stephenlclarke/containerization"
     }
   },

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.json
@@ -1,10 +1,10 @@
 {
   "schemaVersion": 1,
-  "reviewedAt": "2026-09-10",
+  "reviewedAt": "2026-09-12",
   "repositories": {
     "container": {
-      "upstreamHead": "8ca5c80c380cdd925d87b497fb23eddb6b58843f",
-      "forkHead": "e653616e62ab7763c3a7d10e88c365d6dca7e0c4",
+      "upstreamHead": "55437109add247406b07644f9662f03ded52a5e7",
+      "forkHead": "780a86b995ac4cb0985db97f38875fdc6e33d16b",
       "slices": [
         {
           "id": "container-support-maintenance",
@@ -517,7 +517,19 @@
             "8dc1d66f4f5c4e02588f8233b32cbe6cb03dfec7",
             "60072d92ed96c1a7b88b5710cfda5bf072ee7606",
             "99924d767d10ad733ff89838564be0fd51e51ee2",
-            "e891c12796f101162ba95b76db3af7cf2cfd363d"
+            "e891c12796f101162ba95b76db3af7cf2cfd363d",
+            "424d11d80da62609a3591ca4d6653ccde384836c",
+            "f2986139a4cd5d2fcbbaa7bc516ed43673b5ceb2",
+            "1755997e3f02c40825231366cffba1a2aa360efb",
+            "5e8f6eb9e19c631947e1378f4ea72896b932dc82",
+            "ccf99d73b75626ed49a0d638c640bd3b9851e2de",
+            "84bb1cf1ab506ee68534e39ac12d8fbe50302415",
+            "cf908bb6548891fbc033dbe885fbe96e4be00059",
+            "b9123d8e5ab6275ffead6f5884dcae1bae408e19",
+            "a6daa392e83ad0f96a5b56980dee8daa851bef84",
+            "e3bd2efe20171ff7a27193d92b80550489a2c14c",
+            "69318c93dec01ba73402f1912ff82702cc06d4bf",
+            "9ed11e69dab7a27c68822e51444e922f4bdf78ef"
           ]
         },
         {
@@ -763,8 +775,8 @@
       ]
     },
     "containerization": {
-      "upstreamHead": "a7221ab17f3f2f84c5d0112e050cb467009ce3fa",
-      "forkHead": "bd8130fea851f6ee264f00fc684e2543a7d2faa3",
+      "upstreamHead": "b44e17e1a4c135bc0168e615bf6a8e3798d070c0",
+      "forkHead": "7e066a3101bc84fa0f7231daf6a03aa9ef62a567",
       "slices": [
         {
           "id": "containerization-support-maintenance",
@@ -947,7 +959,8 @@
             "5b07660964d4e713f17356d6e508b6c42a886e4e",
             "920183b992ea02fb8a096420f6bef7fc6098e750",
             "c54205ecd77ee443af9994f5edc5a1f5d3bd2e92",
-            "79d5eb1ec231dc571c9c05875940e72b942fb32e"
+            "79d5eb1ec231dc571c9c05875940e72b942fb32e",
+            "e22a06bad6e223533d48a3320ec26ea3dd6e45f3"
           ]
         },
         {

--- a/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
+++ b/docs/upstream/FORK-COMMIT-CLASSIFICATIONS.md
@@ -1,6 +1,6 @@
 # Fork Commit Classifications
 
-Updated: 10 September 2026
+Updated: 12 September 2026
 
 This review classifies every patch-unique non-merge commit in the three
 Stephen-supported Apple forks. The machine-readable source is
@@ -20,10 +20,10 @@ git log --cherry-pick --right-only --no-merges \
 
 | Repository | Apple `main` | Stephen `main` | Apple-only | Fork-only | Classified non-merge commits |
 | --- | --- | --- | ---: | ---: | ---: |
-| `container` | `8ca5c80c380cdd925d87b497fb23eddb6b58843f` | `e653616e62ab7763c3a7d10e88c365d6dca7e0c4` | 0 | 826 | 682 |
-| `containerization` | `a7221ab17f3f2f84c5d0112e050cb467009ce3fa` | `bd8130fea851f6ee264f00fc684e2543a7d2faa3` | 0 | 317 | 244 |
+| `container` | `55437109add247406b07644f9662f03ded52a5e7` | `780a86b995ac4cb0985db97f38875fdc6e33d16b` | 0 | 844 | 694 |
+| `containerization` | `b44e17e1a4c135bc0168e615bf6a8e3798d070c0` | `7e066a3101bc84fa0f7231daf6a03aa9ef62a567` | 0 | 321 | 245 |
 | `container-builder-shim` | `5dc4286e5adbeb7dac189b22b7d5aab336942fe2` | `5373d9b4363c6e536dc6401199da269c7045abf9` | 0 | 59 | 46 |
-| **Total** | | | **0** | **1202** | **972** |
+| **Total** | | | **0** | **1224** | **985** |
 
 The graph-ahead count includes merge commits. The classification count excludes
 merges and patch-equivalent commits so the registry covers semantic fork work.
@@ -32,7 +32,7 @@ merges and patch-equivalent commits so the registry covers semantic fork work.
 
 | Classification | Commits | Disposition |
 | --- | ---: | --- |
-| `support-maintenance` | 704 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
+| `support-maintenance` | 729 | Retain independent bug fixes, tests, CI, release engineering, dependency pins, documentation, and review corrections. Split generally useful fixes during FORK-105. |
 | `generic-runtime-primitive` | 231 | Retain typed VM, guest, archive, network, process, storage, resource, logging, Engine API, and BuildKit capabilities below Compose. Keep Apple-shaped handoffs and independently reviewable upstream slices. |
 | `temporary-upstream-port` | 21 | Retain only until the named Apple PR lands or an equivalent change is verified. Published duplicate history is not rewritten. Remove remaining source duplication through normal follow-up commits. |
 | `rejected-compose-policy` | 4 | Remove runtime config, secret, and Keychain storage added solely for Compose. Their supported behaviour now belongs to the Compose provider. |
@@ -358,3 +358,17 @@ the merge resolution keeps the fork's typed registry-token cache and accepts
 both fractional and whole-second RFC 3339 issue times. Container commit
 `e891c12796f1` advances the exact dependency pin and is classified as support
 maintenance; the Containerization merge adds no patch-unique non-merge commit.
+
+The 12 September 2026 release refresh advances Apple Container through
+`55437109add2`, Apple Containerization through `b44e17e1a4c1`, the reviewed
+Container merge through `780a86b995ac`, and Containerization through
+`7e066a3101bc`. Apple fixes localhost-DNS egress, closes an abandoned forwarding
+backend, removes a warning, and corrects Kubernetes documentation; its
+Containerization change is documentation-only. The 13 newly classified
+fork-only commits cover dependency identity and exact pins, OCI platform-aware
+image inspection, bounded log-record responses, and the reviewed Packet Filter
+corrections. The PF design preserves Apple's egress-safe child-anchor reload,
+normalizes legacy directives, rejects ambiguous configuration, and independently
+verifies an active redirect attachment point before changing either file. All 13
+commits are support maintenance; no generic runtime primitive, temporary port,
+or rejected Compose-policy disposition changed.


### PR DESCRIPTION
## Summary

- pin the reviewed Container merge at 780a86b995ac and Containerization merge at 7e066a3101bc
- classify all 985 current fork-only non-merge commits and refresh the 12 September divergence snapshot
- preserve Apple upstream currentness while keeping the enhanced Compose stack release-authoritative

This unblocks the retained Docker-free 0.15.0 release transaction. It adds no Compose-owned policy to the lower runtime repositories.

## Validation

- exact-head strict upstream-current report passed for all three support forks
- fork classification gate passed: Container 694/694, Containerization 245/245, builder 46/46
- stack consistency, runtime neutrality, handoff registry, README metrics, license, static lint, and diff checks passed
- linked enhanced stack resolved and compiled successfully
- 31 Compose Container runtime adapter tests passed
- 33 Container package compatibility and preflight tests passed
- 597 release-tool tests passed

Closes #640
