### PR TITLE
fix(release): isolate tool test temporary storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,12 @@ CODESIGN_OPTS ?= --force --sign - --timestamp=none
 # unattended and must not block behind a GUI approval dialog.
 CONTAINER_RUNTIME_CODESIGN_IDENTITY ?=
 PYTHON ?= python3
+# Tool tests intentionally create incomplete synthetic runtime and release
+# layouts. Keep those fixtures on the host's ordinary local temporary volume so
+# a release controller's retained/external-volume TMPDIR cannot make production
+# privacy-boundary detection reinterpret them as real packaged runtimes.
+override TOOL_TEST_TEMP_ROOT := $(shell if [[ -d /private/tmp && -w /private/tmp ]]; then printf '%s' /private/tmp; else printf '%s' /tmp; fi)
+override TOOL_TEST_TEMP_ENV := TMPDIR="$(TOOL_TEST_TEMP_ROOT)" TMP="$(TOOL_TEST_TEMP_ROOT)" TEMP="$(TOOL_TEST_TEMP_ROOT)"
 MARKDOWNLINT ?= markdownlint
 HAWKEYE ?= .local/bin/hawkeye
 CODEQL_CACHE_ROOT ?= .local/share/codeql
@@ -503,7 +509,7 @@ stack-status:
 	exit "$$exit_status"
 
 stack-self-test:
-	"$(PYTHON)" -m unittest discover Tools/build
+	$(TOOL_TEST_TEMP_ENV) "$(PYTHON)" -m unittest discover Tools/build
 
 stack-transient-clean-plan:
 	@if [[ -d "$(STACK_TRANSIENT_ROOT)" ]]; then \
@@ -2544,14 +2550,14 @@ actions-lint:
 		.github/workflows/*.yml
 
 coverage-python-tools-test: coverage-tools-syntax
-	$(PYTHON) -m unittest discover Tools/coverage
+	$(TOOL_TEST_TEMP_ENV) $(PYTHON) -m unittest discover Tools/coverage
 
 release-tools-test: coverage-tools-syntax
-	$(PYTHON) -m unittest discover Tools/release
-	Tools/release/test_publish_github_release.sh
+	$(TOOL_TEST_TEMP_ENV) $(PYTHON) -m unittest discover Tools/release
+	$(TOOL_TEST_TEMP_ENV) Tools/release/test_publish_github_release.sh
 
 ci-tools-test: coverage-tools-syntax
-	$(PYTHON) -m unittest discover Tools/ci
+	$(TOOL_TEST_TEMP_ENV) $(PYTHON) -m unittest discover Tools/ci
 	$(MAKE) --no-print-directory stack-self-test
 
 coverage-tools-test: coverage-python-tools-test release-tools-test ci-tools-test

--- a/Tools/ci/test_release_stage_git_history.py
+++ b/Tools/ci/test_release_stage_git_history.py
@@ -185,6 +185,28 @@ class RecoverableStackBuildPolicyTests(unittest.TestCase):
         )
         self.assertEqual(MAKEFILE.count("stack-self-test\n"), 1)
 
+    def test_tool_tests_ignore_a_release_controllers_temporary_root(self) -> None:
+        self.assertIn("override TOOL_TEST_TEMP_ROOT :=", MAKEFILE)
+        self.assertIn("-d /private/tmp && -w /private/tmp", MAKEFILE)
+        self.assertIn("printf '%s' /tmp", MAKEFILE)
+        expected_environment = (
+            'TMPDIR="$(TOOL_TEST_TEMP_ROOT)" TMP="$(TOOL_TEST_TEMP_ROOT)" '
+            'TEMP="$(TOOL_TEST_TEMP_ROOT)"'
+        )
+        self.assertIn(
+            f"override TOOL_TEST_TEMP_ENV := {expected_environment}",
+            MAKEFILE,
+        )
+        for target, end in (
+            ("stack-self-test", "stack-transient-clean-plan"),
+            ("coverage-python-tools-test", "release-tools-test"),
+            ("release-tools-test", "ci-tools-test"),
+            ("ci-tools-test", "coverage-tools-test"),
+        ):
+            with self.subTest(target=target):
+                recipe = make_target(target, end)
+                self.assertIn("$(TOOL_TEST_TEMP_ENV)", recipe)
+
     def test_runtime_validation_uses_pinned_managed_macos_toolchain(self) -> None:
         runtime_validation = CI_WORKFLOW.split("  validate_runtime:", 1)[1].split(
             "  prebuilt_binaries:", 1


### PR DESCRIPTION
## Summary

- keep synthetic tool-test fixtures on the host local temporary volume
- prevent retained release-controller `TMPDIR` from triggering production privacy-boundary staging
- cover every Python, shell, and nested stack tool-test entry point with a regression policy test

## Validation

- hostile inherited release `TMPDIR`: 597 release tests pass
- release publication shell harness passes
- hostile inherited release `TMPDIR`: 322 CI tests pass
- nested stack self-tests: 46 pass
- `make lint-static`
- `git diff --check`