### PR TITLE
fix(release): support macOS system Python

### DIFF
--- a/Tools/build/stack-artifact.py
+++ b/Tools/build/stack-artifact.py
@@ -152,7 +152,7 @@ def promote(source: Path, root: Path, name: str) -> Path:
         if destination.exists():
             if destination.is_symlink() or digest_file(destination) != digest:
                 raise ArtifactError(f"retained artifact conflicts with {destination}")
-            if stat.S_IMODE(destination.stat(follow_symlinks=False).st_mode) != retained_mode:
+            if stat.S_IMODE(destination.lstat().st_mode) != retained_mode:
                 raise ArtifactError(f"retained artifact mode conflicts with {destination}")
         else:
             try:
@@ -165,7 +165,7 @@ def promote(source: Path, root: Path, name: str) -> Path:
                         f"retained artifact conflicts with {destination}"
                     )
                 if (
-                    stat.S_IMODE(destination.stat(follow_symlinks=False).st_mode)
+                    stat.S_IMODE(destination.lstat().st_mode)
                     != retained_mode
                 ):
                     raise ArtifactError(

--- a/Tools/build/stack-pin.py
+++ b/Tools/build/stack-pin.py
@@ -566,7 +566,7 @@ def verify_artifacts(receipt: dict[str, Any]) -> None:
             raise PinError(f"artifact {path} has an invalid size")
         try:
             actual = sha256_file(path)
-            actual_mode = stat.S_IMODE(path.stat(follow_symlinks=False).st_mode)
+            actual_mode = stat.S_IMODE(path.lstat().st_mode)
         except (OSError, PinError) as error:
             raise PinError(f"build artifact is unavailable: {path}: {error}") from error
         if actual != expected:
@@ -578,7 +578,7 @@ def verify_artifacts(receipt: dict[str, Any]) -> None:
                 f"build artifact mode changed: {path} "
                 f"(expected {expected_mode:#o}, got {actual_mode:#o})"
             )
-        if expected_size is not None and path.stat(follow_symlinks=False).st_size != expected_size:
+        if expected_size is not None and path.lstat().st_size != expected_size:
             raise PinError(f"build artifact size changed: {path}")
     if recorded_names != sorted(set(recorded_names)):
         raise PinError("build receipt artifact names are duplicated or not canonical")
@@ -780,13 +780,13 @@ def artifact_record(path: Path, logical_path: str | None = None) -> dict[str, st
     if path.is_symlink():
         raise PinError(f"artifact path must not be a symbolic link: {path}")
     resolved = path.resolve(strict=True)
-    mode = stat.S_IMODE(resolved.stat(follow_symlinks=False).st_mode)
+    mode = stat.S_IMODE(resolved.lstat().st_mode)
     return {
         "mode": mode,
         "name": validate_logical_path(logical_path or resolved.name),
         "path": str(resolved),
         "sha256": sha256_file(resolved),
-        "size": resolved.stat(follow_symlinks=False).st_size,
+        "size": resolved.lstat().st_size,
     }
 
 

--- a/Tools/ci/doc-site-manifest.py
+++ b/Tools/ci/doc-site-manifest.py
@@ -67,7 +67,7 @@ def files(root: Path) -> list[dict[str, object]]:
         if path.is_dir():
             continue
         relative = path.relative_to(root).as_posix()
-        status = path.stat(follow_symlinks=False)
+        status = path.lstat()
         if not stat.S_ISREG(status.st_mode):
             raise ManifestError(f"DocC site contains a special file: {path}")
         entries.append(

--- a/Tools/ci/run-release-checkpoint.py
+++ b/Tools/ci/run-release-checkpoint.py
@@ -161,7 +161,7 @@ def required_output_path(value: str) -> Path:
 def required_output_record(path: Path) -> dict[str, object]:
     if path.is_symlink():
         raise OSError(f"release checkpoint required output is indirect: {path}")
-    status = path.stat(follow_symlinks=False)
+    status = path.lstat()
     if not stat.S_ISREG(status.st_mode):
         raise OSError(f"release checkpoint required output is not regular: {path}")
     return {

--- a/Tools/ci/test_python39_compatibility.py
+++ b/Tools/ci/test_python39_compatibility.py
@@ -1,0 +1,56 @@
+##===----------------------------------------------------------------------===##
+## Copyright © 2026 container-compose project authors.
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##   https://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##===----------------------------------------------------------------------===##
+
+"""Protect release tooling that runs with macOS's system Python 3.9."""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+class Python39CompatibilityTests(unittest.TestCase):
+    def test_tools_do_not_use_path_stat_follow_symlinks(self) -> None:
+        offenders = []
+        for script in sorted((ROOT / "Tools").rglob("*.py")):
+            if script.name.startswith("test_"):
+                continue
+            tree = ast.parse(script.read_text(encoding="utf-8"), filename=str(script))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                function = node.func
+                if not isinstance(function, ast.Attribute) or function.attr != "stat":
+                    continue
+                if isinstance(function.value, ast.Name) and function.value.id == "os":
+                    continue
+                if any(keyword.arg == "follow_symlinks" for keyword in node.keywords):
+                    offenders.append(
+                        f"{script.relative_to(ROOT)}:{node.lineno}"
+                    )
+
+        self.assertEqual(
+            offenders,
+            [],
+            "Path.stat(follow_symlinks=...) requires Python 3.10; use "
+            "Path.lstat() for the macOS system Python 3.9 release path",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Tools/release/retain-local-release-assets.py
+++ b/Tools/release/retain-local-release-assets.py
@@ -138,7 +138,7 @@ def retain(root: Path, version: str, candidates: list[Path]) -> None:
                     f"retained stable asset changed while repairing {version}: {name}"
                 )
             record = {
-                "mode": stat.S_IMODE(retained.stat(follow_symlinks=False).st_mode),
+                "mode": stat.S_IMODE(retained.lstat().st_mode),
                 "path": str(retained),
                 "sha256": digest,
                 "size": retained.stat().st_size,
@@ -184,7 +184,7 @@ def retained_path(root: Path, version: str, name: str) -> Path:
         or not path.is_file()
         or sha256(path) != record.get("sha256")
         or path.stat().st_size != record.get("size")
-        or stat.S_IMODE(path.stat(follow_symlinks=False).st_mode) != record.get("mode")
+        or stat.S_IMODE(path.lstat().st_mode) != record.get("mode")
     ):
         raise RetentionError(f"retained stable asset is invalid: {version}/{name}")
     return path


### PR DESCRIPTION
## Summary

- replace the Python 3.10-only `Path.stat(follow_symlinks=False)` calls in release-critical tooling with `Path.lstat()`
- preserve no-symlink metadata validation on macOS's bundled Python 3.9
- add a repository-wide regression test for this unsupported `pathlib` API

## Evidence

- reproduced the retained 0.15.0 release failure under `/usr/bin/python3` 3.9.6
- focused checkpoint, stack pin, artifact, retained-asset, and DocC manifest tests pass under `/usr/bin/python3`
- `make coverage-tools-test`: 597 release tests, publication harness, 323 CI tests, and 46 stack self-tests pass
- `make lint-static`
- `git diff --check`

The 0.15.0 release transaction stopped safely after completing its upstream stack checkpoint and is retained for exact recovery after this PR merges.
