### PR TITLE
test(release): bound staging recovery timeout

### DIFF
--- a/Tools/ci/test_run_with_container_runtime.py
+++ b/Tools/ci/test_run_with_container_runtime.py
@@ -1265,6 +1265,7 @@ exit 113
                 {
                     "CONTAINER_RUNTIME_APP_ROOT": str(temporary_root / "app-root"),
                     "CONTAINER_RUNTIME_STAGE_CANDIDATE": "always",
+                    "CONTAINER_RUNTIME_START_DEADLINE_SECONDS": "45",
                     "CONTAINER_RUNTIME_LOCK_FILE": str(
                         temporary_root / "runtime.lock"
                     ),
@@ -1305,7 +1306,7 @@ exit 113
                     env=environment,
                     capture_output=True,
                     text=True,
-                    timeout=20,
+                    timeout=60,
                 )
                 self.assertEqual(
                     second.returncode, 0, second.stdout + second.stderr


### PR DESCRIPTION
## Summary

- bound the interrupted staging recovery fixture with a 45-second runtime startup deadline
- allow a 60-second outer subprocess guard so full release-suite load cannot cause the previous 20-second false timeout
- retain hard failure for runtime hangs and preserve every recovery assertion

## Evidence

- focused recovery test passed three consecutive runs after the change
- complete runtime-wrapper module: 74 tests passed in 452.574 seconds before the change
- exact release-contract suite: 597 tests passed in 816.590 seconds after the change
- signed commit verified locally

This unblocks the retained 0.15.0 release transaction.