### PR TITLE
fix(release): verify runner is remotely online

### DIFF
--- a/Tools/release/test_install_scheduled_release_runner.py
+++ b/Tools/release/test_install_scheduled_release_runner.py
@@ -22,6 +22,7 @@ import os
 import shlex
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -75,14 +76,22 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
             "printf 'gh:%s\\n' \"$*\" >> \"${RUNNER_TEST_LOG}\"\n"
             "if [[ \"$1\" == api ]]; then\n"
             "  if [[ \"${2:-}\" == */actions/runners\\?per_page=100 ]]; then\n"
+            "    if [[ -n \"${RUNNER_TEST_API_SLEEP_SECONDS:-}\" ]]; then\n"
+            "      sleep \"${RUNNER_TEST_API_SLEEP_SECONDS}\"\n"
+            "    fi\n"
             "    if [[ \"${RUNNER_TEST_PAGINATED:-0}\" == 1 ]]; then\n"
             "      printf '%s\\n' "
             "'{\"runners\":[{\"name\":\"other-runner\",\"status\":\"online\"}]}' "
             "'{\"runners\":[{\"name\":\"fixture-runner\",\"status\":\"online\"}]}'\n"
             "      exit 0\n"
             "    fi\n"
+            "    runner_state=\"${RUNNER_TEST_STATE:-online}\"\n"
+            "    if [[ \"${RUNNER_TEST_EXPECT_RESTART:-0}\" == 1 ]] && "
+            "! grep -q '^service:start$' \"${RUNNER_TEST_LOG}\"; then\n"
+            "      runner_state=offline\n"
+            "    fi\n"
             "    printf '{\"runners\":[{\"name\":\"fixture-runner\",\"status\":\"%s\"}]}\\n' "
-            '"${RUNNER_TEST_STATE:-online}"\n'
+            '"${runner_state}"\n'
             "    exit 0\n"
             "  fi\n"
             f"  printf '%s\\n' {shlex.quote(release_json)}\n"
@@ -143,6 +152,12 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
             environment["RUNNER_TEST_LOG"] = str(log_path)
             environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS"] = "1"
             environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS"] = "0"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_API_TIMEOUT_SECONDS"] = "1"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_API_DEADLINE_TOOL"] = str(
+                ROOT / "Tools" / "ci" / "run-command-with-deadline.py"
+            )
+            if runner_version != LATEST_VERSION:
+                environment["RUNNER_TEST_EXPECT_RESTART"] = "1"
             if paginated_runner:
                 environment["RUNNER_TEST_PAGINATED"] = "1"
             environment.pop("BASH_ENV", None)
@@ -195,6 +210,28 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
         self.assertIn("remotely online", result.stdout)
         self.assertIn("--paginate", result.stdout)
 
+    def test_runner_update_proves_offline_before_accepting_online(self) -> None:
+        """A replacement listener must establish a fresh remote session."""
+        result = self.run_install("2.335.1")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        offline = result.stdout.index("remotely offline")
+        online = result.stdout.index("remotely online")
+        self.assertLess(offline, online)
+        logged = result.stdout.splitlines()
+        stop = logged.index("service:stop")
+        first_api = logged.index(
+            "gh:api repos/stephenlclarke/container-compose/actions/runners?per_page=100 --paginate"
+        )
+        start = logged.index("service:start")
+        second_api = logged.index(
+            "gh:api repos/stephenlclarke/container-compose/actions/runners?per_page=100 --paginate",
+            first_api + 1,
+        )
+        self.assertLess(stop, first_api)
+        self.assertLess(first_api, start)
+        self.assertLess(start, second_api)
+
     def test_digest_mismatch_keeps_the_existing_runner_in_service(self) -> None:
         """The service is untouched until the downloaded archive matches its digest."""
         result = self.run_install("2.335.1", advertised_digest="0" * 64)
@@ -245,6 +282,10 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
             environment["RUNNER_TEST_STATE"] = "offline"
             environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS"] = "1"
             environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS"] = "0"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_API_TIMEOUT_SECONDS"] = "1"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_API_DEADLINE_TOOL"] = str(
+                ROOT / "Tools" / "ci" / "run-command-with-deadline.py"
+            )
             environment.pop("BASH_ENV", None)
             command = (
                 f"source {shlex.quote(str(library))}\n"
@@ -266,6 +307,55 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
         self.assertIn("did not become remotely online", result.stderr)
         self.assertIn("Removable Volumes", result.stderr)
         self.assertIn("Runner.Listener", result.stderr)
+
+    def test_runner_status_request_has_a_wall_clock_deadline(self) -> None:
+        """One stalled API request cannot make the installer wait forever."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            runner_dir = temporary_root / "runner"
+            bin_dir = temporary_root / "bin"
+            log_path = temporary_root / "runner.log"
+            bin_dir.mkdir()
+            self.write_runner(runner_dir, LATEST_VERSION)
+            self.write_fake_tools(bin_dir)
+            library = temporary_root / "installer-library.sh"
+            source = INSTALLER.read_text(encoding="utf-8")
+            library.write_text(
+                source.rsplit('\nmain "$@"', 1)[0] + "\n", encoding="utf-8"
+            )
+            environment = os.environ.copy()
+            environment["PATH"] = f"{bin_dir}:{environment['PATH']}"
+            environment["RUNNER_TEST_LOG"] = str(log_path)
+            environment["RUNNER_TEST_API_SLEEP_SECONDS"] = "10"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS"] = "1"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS"] = "0"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_API_TIMEOUT_SECONDS"] = "1"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_API_DEADLINE_TOOL"] = str(
+                ROOT / "Tools" / "ci" / "run-command-with-deadline.py"
+            )
+            environment.pop("BASH_ENV", None)
+            command = (
+                f"source {shlex.quote(str(library))}\n"
+                f"RUNNER_DIR={shlex.quote(str(runner_dir))}\n"
+                "RUNNER_NAME=fixture-runner\n"
+                "install_runner\n"
+            )
+
+            started = time.monotonic()
+            result = subprocess.run(
+                ["bash", "-c", command],
+                capture_output=True,
+                check=False,
+                cwd=temporary_root,
+                env=environment,
+                text=True,
+                timeout=5,
+            )
+            elapsed = time.monotonic() - started
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertLess(elapsed, 4)
+        self.assertIn("query failed", result.stderr)
 
 
 if __name__ == "__main__":

--- a/Tools/release/test_install_scheduled_release_runner.py
+++ b/Tools/release/test_install_scheduled_release_runner.py
@@ -74,6 +74,11 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
             "set -euo pipefail\n"
             "printf 'gh:%s\\n' \"$*\" >> \"${RUNNER_TEST_LOG}\"\n"
             "if [[ \"$1\" == api ]]; then\n"
+            "  if [[ \"${2:-}\" == */actions/runners\\?per_page=100 ]]; then\n"
+            "    printf '{\"runners\":[{\"name\":\"fixture-runner\",\"status\":\"%s\"}]}\\n' "
+            '"${RUNNER_TEST_STATE:-online}"\n'
+            "    exit 0\n"
+            "  fi\n"
             f"  printf '%s\\n' {shlex.quote(release_json)}\n"
             "  exit 0\n"
             "fi\n"
@@ -129,6 +134,8 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
             environment = os.environ.copy()
             environment["PATH"] = f"{bin_dir}:{environment['PATH']}"
             environment["RUNNER_TEST_LOG"] = str(log_path)
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS"] = "1"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS"] = "0"
             environment.pop("BASH_ENV", None)
             command = (
                 f"source {shlex.quote(str(library))}\n"
@@ -200,6 +207,48 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("updates an existing runner", result.stdout)
+        self.assertIn("Removable Volumes access", result.stdout)
+
+    def test_launchd_status_does_not_substitute_for_remote_runner_health(self) -> None:
+        """A running wrapper cannot mask an offline updated listener."""
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            runner_dir = temporary_root / "runner"
+            bin_dir = temporary_root / "bin"
+            log_path = temporary_root / "runner.log"
+            bin_dir.mkdir()
+            self.write_runner(runner_dir, LATEST_VERSION)
+            self.write_fake_tools(bin_dir)
+            library = temporary_root / "installer-library.sh"
+            source = INSTALLER.read_text(encoding="utf-8")
+            library.write_text(source.rsplit('\nmain "$@"', 1)[0] + "\n", encoding="utf-8")
+            environment = os.environ.copy()
+            environment["PATH"] = f"{bin_dir}:{environment['PATH']}"
+            environment["RUNNER_TEST_LOG"] = str(log_path)
+            environment["RUNNER_TEST_STATE"] = "offline"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS"] = "1"
+            environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS"] = "0"
+            environment.pop("BASH_ENV", None)
+            command = (
+                f"source {shlex.quote(str(library))}\n"
+                f"RUNNER_DIR={shlex.quote(str(runner_dir))}\n"
+                "RUNNER_NAME=fixture-runner\n"
+                "install_runner\n"
+            )
+
+            result = subprocess.run(
+                ["bash", "-c", command],
+                capture_output=True,
+                check=False,
+                cwd=temporary_root,
+                env=environment,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("did not become remotely online", result.stderr)
+        self.assertIn("Removable Volumes", result.stderr)
+        self.assertIn("Runner.Listener", result.stderr)
 
 
 if __name__ == "__main__":

--- a/Tools/release/test_install_scheduled_release_runner.py
+++ b/Tools/release/test_install_scheduled_release_runner.py
@@ -75,6 +75,12 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
             "printf 'gh:%s\\n' \"$*\" >> \"${RUNNER_TEST_LOG}\"\n"
             "if [[ \"$1\" == api ]]; then\n"
             "  if [[ \"${2:-}\" == */actions/runners\\?per_page=100 ]]; then\n"
+            "    if [[ \"${RUNNER_TEST_PAGINATED:-0}\" == 1 ]]; then\n"
+            "      printf '%s\\n' "
+            "'{\"runners\":[{\"name\":\"other-runner\",\"status\":\"online\"}]}' "
+            "'{\"runners\":[{\"name\":\"fixture-runner\",\"status\":\"online\"}]}'\n"
+            "      exit 0\n"
+            "    fi\n"
             "    printf '{\"runners\":[{\"name\":\"fixture-runner\",\"status\":\"%s\"}]}\\n' "
             '"${RUNNER_TEST_STATE:-online}"\n'
             "    exit 0\n"
@@ -117,6 +123,7 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
         runner_version: str,
         advertised_digest: str = ARCHIVE_DIGEST,
         extracted_version: str = LATEST_VERSION,
+        paginated_runner: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         """Run the installer function with a configured fixture runner."""
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -136,6 +143,8 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
             environment["RUNNER_TEST_LOG"] = str(log_path)
             environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS"] = "1"
             environment["CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS"] = "0"
+            if paginated_runner:
+                environment["RUNNER_TEST_PAGINATED"] = "1"
             environment.pop("BASH_ENV", None)
             command = (
                 f"source {shlex.quote(str(library))}\n"
@@ -177,6 +186,14 @@ class ScheduledReleaseRunnerInstallerTests(unittest.TestCase):
         self.assertNotIn("gh:release download", result.stdout)
         self.assertNotIn("service:stop", result.stdout)
         self.assertIn("service:status", result.stdout)
+
+    def test_runner_registration_is_found_on_a_later_api_page(self) -> None:
+        """The exact runner remains discoverable beyond the first API page."""
+        result = self.run_install(LATEST_VERSION, paginated_runner=True)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("remotely online", result.stdout)
+        self.assertIn("--paginate", result.stdout)
 
     def test_digest_mismatch_keeps_the_existing_runner_in_service(self) -> None:
         """The service is untouched until the downloaded archive matches its digest."""

--- a/docs/guides/BUILD.md
+++ b/docs/guides/BUILD.md
@@ -186,6 +186,13 @@ cannot silently consume internal retained storage. On the release Mac it points
 to `/Volumes/SSD/cf/github-actions/container-compose-release-runner-work`.
 Verify both the resolved path and filesystem device after runner maintenance;
 the workflows' retained roots must continue to resolve to the internal volume.
+After every Actions runner update, macOS may treat the new `Runner.Listener`
+binary as a new privacy client. Enable **Privacy & Security > Files & Folders >
+Removable Volumes** (or Full Disk Access) for the exact installed binary when
+prompted. Rerun `scripts/install-scheduled-release-runner.sh`; it now waits for
+the repository registration to become remotely online and fails with the exact
+binary path if launchd is running but access to the external work directory is
+blocked.
 
 Published and historical benchmark attempts follow the same lifetime split:
 downloads, reconstructed distributions, fixtures, worktrees and compiler

--- a/scripts/install-scheduled-release-runner.sh
+++ b/scripts/install-scheduled-release-runner.sh
@@ -265,9 +265,9 @@ wait_for_runner_online() {
 
   for ((attempt = 1; attempt <= attempts; attempt++)); do
     runner_state="$(gh api \
-      "repos/${REPOSITORY}/actions/runners?per_page=100" 2>/dev/null \
-      | jq -r --arg name "${RUNNER_NAME}" \
-        '[.runners[] | select(.name == $name)] | if length == 1 then .[0].status elif length == 0 then "missing" else "ambiguous" end' \
+      "repos/${REPOSITORY}/actions/runners?per_page=100" --paginate 2>/dev/null \
+      | jq -sr --arg name "${RUNNER_NAME}" \
+        '[.[].runners[] | select(.name == $name)] | if length == 1 then .[0].status elif length == 0 then "missing" else "ambiguous" end' \
         2>/dev/null || true)"
     if [[ "${runner_state}" == "online" ]]; then
       printf 'scheduled release runner %s is remotely online for %s\n' \

--- a/scripts/install-scheduled-release-runner.sh
+++ b/scripts/install-scheduled-release-runner.sh
@@ -19,6 +19,8 @@ set -Eeuo pipefail
 
 SELF_PATH="${BASH_SOURCE[0]:-$0}"
 readonly SELF_PATH
+SELF_DIRECTORY="$(cd "$(dirname "${SELF_PATH}")" && pwd -P)"
+readonly SELF_DIRECTORY
 SCRIPT_NAME="$(basename "${SELF_PATH}")"
 readonly SCRIPT_NAME
 readonly SCRIPT_USAGE="scripts/${SCRIPT_NAME}"
@@ -28,6 +30,7 @@ readonly RUNNER_LABEL="container-compose-release"
 REPOSITORY="${CONTAINER_COMPOSE_RELEASE_REPOSITORY:-${DEFAULT_REPOSITORY}}"
 RUNNER_DIR="${CONTAINER_COMPOSE_RELEASE_RUNNER_DIR:-${HOME}/.local/share/container-compose-release-runner}"
 RUNNER_NAME="${CONTAINER_COMPOSE_RELEASE_RUNNER_NAME:-}"
+RUNNER_API_DEADLINE_TOOL="${CONTAINER_COMPOSE_RELEASE_RUNNER_API_DEADLINE_TOOL:-${SELF_DIRECTORY}/../Tools/ci/run-command-with-deadline.py}"
 TEMPORARY_DIRECTORY=""
 RUNNER_ARCHIVE=""
 
@@ -243,15 +246,49 @@ runner_service() {
   )
 }
 
-# Require the exact repository runner registration to become remotely online.
+# Print the exact repository runner's state across every API page. Each request
+# is process-group supervised so an unavailable GitHub endpoint cannot turn the
+# configured attempt count into an unbounded maintenance hang.
+runner_remote_state() {
+  local request_timeout="${CONTAINER_COMPOSE_RELEASE_RUNNER_API_TIMEOUT_SECONDS:-10}"
+
+  if ! [[ "${request_timeout}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'runner API timeout seconds must be a positive integer: %s\n' \
+      "${request_timeout}" >&2
+    return 2
+  fi
+  if [[ ! -f "${RUNNER_API_DEADLINE_TOOL}" || \
+    ! -r "${RUNNER_API_DEADLINE_TOOL}" ]]; then
+    printf 'runner API deadline tool is unavailable: %s\n' \
+      "${RUNNER_API_DEADLINE_TOOL}" >&2
+    return 2
+  fi
+
+  python3 "${RUNNER_API_DEADLINE_TOOL}" \
+    --seconds "${request_timeout}" --grace-seconds 1 -- \
+    gh api "repos/${REPOSITORY}/actions/runners?per_page=100" --paginate \
+    2>/dev/null \
+    | jq -sr --arg name "${RUNNER_NAME}" \
+      '[.[].runners[] | select(.name == $name)] | if length == 1 then .[0].status elif length == 0 then "missing" else "ambiguous" end'
+}
+
+# Require the exact repository runner registration to reach one remote state.
 # launchctl can report a healthy wrapper while macOS privacy control blocks the
 # updated Runner.Listener at its external work directory, so service status is
-# not sufficient release-host evidence.
-wait_for_runner_online() {
+# not sufficient release-host evidence. Update callers first prove that the old
+# session went offline, preventing a delayed disconnect from masquerading as a
+# successful replacement connection.
+wait_for_runner_state() {
+  local expected_state="$1"
   local attempt=0
   local attempts="${CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS:-30}"
   local poll_seconds="${CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS:-2}"
   local runner_state=""
+
+  if [[ "${expected_state}" != "offline" && "${expected_state}" != "online" ]]; then
+    printf 'unsupported runner state target: %s\n' "${expected_state}" >&2
+    return 2
+  fi
 
   if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
     printf 'runner online attempts must be a positive integer: %s\n' "${attempts}" >&2
@@ -264,14 +301,12 @@ wait_for_runner_online() {
   fi
 
   for ((attempt = 1; attempt <= attempts; attempt++)); do
-    runner_state="$(gh api \
-      "repos/${REPOSITORY}/actions/runners?per_page=100" --paginate 2>/dev/null \
-      | jq -sr --arg name "${RUNNER_NAME}" \
-        '[.[].runners[] | select(.name == $name)] | if length == 1 then .[0].status elif length == 0 then "missing" else "ambiguous" end' \
-        2>/dev/null || true)"
-    if [[ "${runner_state}" == "online" ]]; then
-      printf 'scheduled release runner %s is remotely online for %s\n' \
-        "${RUNNER_NAME}" "${REPOSITORY}"
+    if ! runner_state="$(runner_remote_state 2>/dev/null)"; then
+      runner_state=""
+    fi
+    if [[ "${runner_state}" == "${expected_state}" ]]; then
+      printf 'scheduled release runner %s is remotely %s for %s\n' \
+        "${RUNNER_NAME}" "${expected_state}" "${REPOSITORY}"
       return 0
     fi
     if ((attempt < attempts)); then
@@ -279,11 +314,18 @@ wait_for_runner_online() {
     fi
   done
 
-  printf 'scheduled release runner %s did not become remotely online for %s (state: %s)\n' \
-    "${RUNNER_NAME}" "${REPOSITORY}" "${runner_state:-query failed}" >&2
-  printf 'On macOS, enable Privacy & Security > Files & Folders > Removable Volumes (or Full Disk Access) for %s, then rerun this installer.\n' \
-    "${RUNNER_DIR}/bin/Runner.Listener" >&2
+  printf 'scheduled release runner %s did not become remotely %s for %s (state: %s)\n' \
+    "${RUNNER_NAME}" "${expected_state}" "${REPOSITORY}" \
+    "${runner_state:-query failed}" >&2
+  if [[ "${expected_state}" == "online" ]]; then
+    printf 'On macOS, enable Privacy & Security > Files & Folders > Removable Volumes (or Full Disk Access) for %s, then rerun this installer.\n' \
+      "${RUNNER_DIR}/bin/Runner.Listener" >&2
+  fi
   return 1
+}
+
+wait_for_runner_online() {
+  wait_for_runner_state online
 }
 
 # Download and verify the exact upstream runner archive before touching a service.
@@ -306,6 +348,11 @@ update_runner() {
   local installed_version="$1" expected_version="$2" updated_version
   if ! runner_service stop; then
     printf 'could not stop scheduled release runner for update\n' >&2
+    return 1
+  fi
+  if ! wait_for_runner_state offline; then
+    printf 'could not prove the previous scheduled release runner session stopped\n' >&2
+    runner_service start || true
     return 1
   fi
   if ! tar -xzf "${RUNNER_ARCHIVE}" -C "${RUNNER_DIR}"; then

--- a/scripts/install-scheduled-release-runner.sh
+++ b/scripts/install-scheduled-release-runner.sh
@@ -61,6 +61,8 @@ Requirements:
   - gh authenticated as the owner of the target repository
   - git configured with user.name, user.email, gpg.format=ssh, commit.gpgsign=true, and user.signingkey
   - swift, go, node, npm, python3, docker compose, jq, GNU tar, and shasum
+  - Removable Volumes access for the installed Runner.Listener when _work is
+    placed on /Volumes/SSD; macOS treats each updated runner binary separately
 
 Options:
   --repository OWNER/REPOSITORY  Target repository (default: ${DEFAULT_REPOSITORY})
@@ -241,6 +243,49 @@ runner_service() {
   )
 }
 
+# Require the exact repository runner registration to become remotely online.
+# launchctl can report a healthy wrapper while macOS privacy control blocks the
+# updated Runner.Listener at its external work directory, so service status is
+# not sufficient release-host evidence.
+wait_for_runner_online() {
+  local attempt=0
+  local attempts="${CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_ATTEMPTS:-30}"
+  local poll_seconds="${CONTAINER_COMPOSE_RELEASE_RUNNER_ONLINE_POLL_SECONDS:-2}"
+  local runner_state=""
+
+  if ! [[ "${attempts}" =~ ^[1-9][0-9]*$ ]]; then
+    printf 'runner online attempts must be a positive integer: %s\n' "${attempts}" >&2
+    return 2
+  fi
+  if ! [[ "${poll_seconds}" =~ ^[0-9]+$ ]]; then
+    printf 'runner online poll seconds must be a non-negative integer: %s\n' \
+      "${poll_seconds}" >&2
+    return 2
+  fi
+
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    runner_state="$(gh api \
+      "repos/${REPOSITORY}/actions/runners?per_page=100" 2>/dev/null \
+      | jq -r --arg name "${RUNNER_NAME}" \
+        '[.runners[] | select(.name == $name)] | if length == 1 then .[0].status elif length == 0 then "missing" else "ambiguous" end' \
+        2>/dev/null || true)"
+    if [[ "${runner_state}" == "online" ]]; then
+      printf 'scheduled release runner %s is remotely online for %s\n' \
+        "${RUNNER_NAME}" "${REPOSITORY}"
+      return 0
+    fi
+    if ((attempt < attempts)); then
+      sleep "${poll_seconds}"
+    fi
+  done
+
+  printf 'scheduled release runner %s did not become remotely online for %s (state: %s)\n' \
+    "${RUNNER_NAME}" "${REPOSITORY}" "${runner_state:-query failed}" >&2
+  printf 'On macOS, enable Privacy & Security > Files & Folders > Removable Volumes (or Full Disk Access) for %s, then rerun this installer.\n' \
+    "${RUNNER_DIR}/bin/Runner.Listener" >&2
+  return 1
+}
+
 # Download and verify the exact upstream runner archive before touching a service.
 download_verified_runner() {
   local asset="$1" digest="$2" actual_digest release_tag
@@ -277,6 +322,7 @@ update_runner() {
   fi
   runner_service start
   runner_service status
+  wait_for_runner_online || return
   printf 'updated scheduled release runner from %s to %s\n' \
     "${installed_version}" "${updated_version}"
 }
@@ -296,6 +342,7 @@ install_runner() {
     if [[ "${installed_version}" == "${release_version}" ]]; then
       printf 'scheduled release runner is already current at %s\n' "${installed_version}"
       runner_service status
+      wait_for_runner_online || return
       return 0
     fi
     if ! download_verified_runner "${asset}" "${digest}"; then
@@ -332,8 +379,7 @@ install_runner() {
     ./svc.sh start
     ./svc.sh status
   )
-  printf 'scheduled stable-release runner %s is online for %s\n' \
-    "${RUNNER_NAME}" "${REPOSITORY}"
+  wait_for_runner_online || return
 }
 
 # Install the runner after validating its requested configuration.


### PR DESCRIPTION
## Summary\n\n- require the exact self-hosted runner registration to become remotely online after install, update, or service verification\n- query every runner-registration page and match the exact runner name\n- bound every runner-status request with process-group cleanup\n- prove an updated listener transitions offline before accepting its fresh online session\n- fail closed for offline, missing, ambiguous, timed-out, or failed GitHub state\n- report the exact macOS Removable Volumes / Full Disk Access remedy for the installed Runner.Listener\n- document the per-binary privacy boundary for an external release workspace\n\n## Verification\n\n- exact-head Codex review found no major issues at 50106061bc3ae3084cf611cc67fb16672a0ccb80\n- 601 release-tool tests passed in 771.284 seconds\n- focused installer tests: 9 passed\n- make lint-static, Bash syntax, ShellCheck, Markdown lint, and diff whitespace checks passed\n- hosted Source Checks, Tool Tests (ci), Tool Tests (release), stock Apple runtime validation, and workflow validation passed\n\nCloses #647