### PR TITLE
fix: preserve offline runtime capabilities

### DIFF
--- a/Sources/ComposePlugin/ComposePlugin.swift
+++ b/Sources/ComposePlugin/ComposePlugin.swift
@@ -39,7 +39,12 @@ private func selectedRuntimeDependencies(
 }
 
 private func selectedRuntimeCapabilities() -> ComposeRuntimeCapabilities {
-    var identifiers = installedRuntimeCapabilities.snapshot().identifiers
+    let compiledCapabilities = ComposeRuntimeCapabilities(
+        identifiers: ComposeBuildInfo.defaultRuntimeCapabilityManifest.identifiers,
+    )
+    var identifiers = installedRuntimeCapabilities.snapshot(
+        fallback: compiledCapabilities,
+    ).identifiers
     #if !CONTAINER_COMPOSE_ENHANCED_RUNTIME
         identifiers.insert(ComposeRuntimeCapabilities.containerLaunchV1Identifier)
     #endif

--- a/Sources/ComposePlugin/InstalledRuntimeCapabilities.swift
+++ b/Sources/ComposePlugin/InstalledRuntimeCapabilities.swift
@@ -28,15 +28,21 @@ enum ComposeOptionalRuntimeCapability: String, Codable, Sendable {
 final class InstalledRuntimeCapabilities: @unchecked Sendable {
     private let lock = NSLock()
     private var capabilities = ComposeRuntimeCapabilities()
+    private var hasSelection = false
 
     func replace(with capabilities: ComposeRuntimeCapabilities) {
         lock.withLock {
             self.capabilities = capabilities
+            self.hasSelection = true
         }
     }
 
-    func snapshot() -> ComposeRuntimeCapabilities {
-        lock.withLock { capabilities }
+    /// Returns the negotiated selection, or a compile-time fallback when this
+    /// invocation intentionally did not contact the installed runtime.
+    func snapshot(
+        fallback: ComposeRuntimeCapabilities = ComposeRuntimeCapabilities(),
+    ) -> ComposeRuntimeCapabilities {
+        lock.withLock { hasSelection ? capabilities : fallback }
     }
 }
 

--- a/Tests/ComposePluginTests/ContainerPackageCompatibilityTests.swift
+++ b/Tests/ComposePluginTests/ContainerPackageCompatibilityTests.swift
@@ -375,6 +375,28 @@ struct ContainerPackageCompatibilityTests {
     #expect(selection.snapshot().identifiers.isEmpty)
   }
 
+  @Test("unresolved runtime selection uses compile-time capabilities")
+  func unresolvedRuntimeSelectionUsesCompileTimeCapabilities() {
+    let selection = InstalledRuntimeCapabilities()
+    let fallback = ComposeRuntimeCapabilities(identifiers: [
+      ComposeRuntimeCapabilities.networkScopedAliasesV1Identifier,
+    ])
+
+    #expect(selection.snapshot(fallback: fallback) == fallback)
+  }
+
+  @Test("explicit runtime selection overrides compile-time capabilities")
+  func explicitRuntimeSelectionOverridesCompileTimeCapabilities() {
+    let selection = InstalledRuntimeCapabilities()
+    let fallback = ComposeRuntimeCapabilities(identifiers: [
+      ComposeRuntimeCapabilities.networkScopedAliasesV1Identifier,
+    ])
+
+    selection.replace(with: ComposeRuntimeCapabilities())
+
+    #expect(selection.snapshot(fallback: fallback).identifiers.isEmpty)
+  }
+
   @Test("mismatched package pins report install guidance")
   func mismatchedPackagePinsReportInstallGuidance() throws {
     let components = [


### PR DESCRIPTION
## Summary

- retain the enhanced binary compile-time capability manifest when an offline command intentionally skips installed-runtime preflight
- keep an explicit negotiated selection, including an empty stock selection, authoritative over that fallback
- add regression coverage for fallback and explicit-selection precedence

## Release-gate failure fixed

The retained 0.15.0 stable gate reached strict network service-discovery parity and found that `up --dry-run` normalized aliases correctly but omitted them from the rendered Apple Container create command. The cause was that dry-run correctly avoids starting/contacting a runtime, while capability projection incorrectly depended only on the process-local preflight result.

After this change the previously failing command renders:

`--network model-dns_backend,alias=api,alias=api.internal,alias=shared.internal`

## Validation

- `swift test --disable-automatic-resolution --filter ContainerPackageCompatibilityTests` — 35 tests / 5 suites passed
- `make --no-print-directory lint-static` — passed
- direct enhanced `up --dry-run` reproduction — implicit service name and both explicit aliases rendered
- retained stable release transaction remains unpublished and will be refreshed onto this reviewed head before resuming

Fixes #649