### PR TITLE
fix(release): create authority receipt parent

### DIFF
--- a/.github/workflows/stable-release-gate.yml
+++ b/.github/workflows/stable-release-gate.yml
@@ -524,6 +524,7 @@ jobs:
             printf 'stable release authority bundle already exists: %s\n' "${bundle}" >&2
             exit 2
           fi
+          mkdir -p "$(dirname "${bundle}")"
           mkdir "${bundle}"
           checkpoint="${evidence}/hosted-sibling-stack.success.json"
           output_name="$(python3 - "${checkpoint}" <<'PY'

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -4327,6 +4327,18 @@ formula_digest="sha256:${DIGEST}"
         )
         self.assertIn("Create candidate-bound authority receipt", workflow)
         self.assertIn("Upload candidate-bound authority receipt", workflow)
+        receipt_start = workflow.index(
+            "      - name: Create candidate-bound authority receipt"
+        )
+        receipt_end = workflow.index(
+            "      - name: Upload candidate-bound authority receipt"
+        )
+        receipt = workflow[receipt_start:receipt_end]
+        self.assertIn('mkdir -p "$(dirname "${bundle}")"', receipt)
+        self.assertLess(
+            receipt.index('mkdir -p "$(dirname "${bundle}")"'),
+            receipt.index('mkdir "${bundle}"'),
+        )
         self.assertIn(
             'summary+=" Authority receipt SHA-256: ${AUTHORITY_RECEIPT_SHA256}."',
             workflow,


### PR DESCRIPTION
## Summary

- create the stable authority parent before the run-attempt receipt leaf
- preserve the existing fail-closed leaf collision guard
- assert parent-before-leaf ordering in the release workflow contract

## Evidence

- focused authority workflow test: passed
- workflow syntax validation: passed
- release-tool Python suite: 601 passed
- publication shell harness: passed
- `git diff --check`: passed

Failed release run retained for exact recovery: https://github.com/stephenlclarke/container-compose/actions/runs/34730975538

Closes #652