### PR TITLE
fix(release): suppress authority AppleDouble metadata

### DIFF
--- a/.github/workflows/prebuilt-binaries.yml
+++ b/.github/workflows/prebuilt-binaries.yml
@@ -1410,7 +1410,7 @@ jobs:
             --homebrew-tap-ref "${homebrew_tap_ref}" \
             --init-image-sha256 "${init_image_sha256}" >/dev/null
           authority_asset="stable-release-authority.tar.gz"
-          /usr/bin/tar -C "${authority_root}/bundle" -czf \
+          COPYFILE_DISABLE=1 /usr/bin/tar -C "${authority_root}/bundle" -czf \
             "${RUNNER_TEMP}/${authority_asset}" .
           python3 container-compose/Tools/release/write-sha256-sidecar.py \
             "${RUNNER_TEMP}/${authority_asset}"

--- a/Tools/release/test_container_stack_release.py
+++ b/Tools/release/test_container_stack_release.py
@@ -4563,6 +4563,14 @@ formula_digest="sha256:${DIGEST}"
         )
         self.assertIn('"stable-release-authority.tar.gz"', retention)
         self.assertIn('"stable-release-authority.tar.gz.sha256"', retention)
+        self.assertIn(
+            'COPYFILE_DISABLE=1 /usr/bin/tar -C "${authority_root}/bundle"',
+            workflow,
+        )
+        self.assertIn(
+            'COPYFILE_DISABLE=1 /usr/bin/tar -C "${bundle}"',
+            self.script,
+        )
 
     def test_package_authority_requires_a_successful_candidate_bound_gate(self) -> None:
         accepted = self.run_package_authority_step("tag", "0.6.70", "29288195238", "success")

--- a/scripts/CONTAINER_STACK_RELEASE.sh
+++ b/scripts/CONTAINER_STACK_RELEASE.sh
@@ -6361,7 +6361,7 @@ retain_stable_gate_authority() {
     if (( retained == 0 )); then
       archive="${tmp}/stable-release-authority.tar.gz"
       sidecar="${archive}.sha256"
-      /usr/bin/tar -C "${bundle}" -czf "${archive}" .
+      COPYFILE_DISABLE=1 /usr/bin/tar -C "${bundle}" -czf "${archive}" .
     fi
     receipt_sha="$(shasum -a 256 "${receipt}" | awk '{print $1}')"
     tag_sha="$(git -C "$(repo_path "${COMPOSE_REPO}")" rev-list -n 1 "refs/tags/${version}")"


### PR DESCRIPTION
Closes #654.

## Summary

- disable macOS AppleDouble metadata when reconstructing the stable authority archive locally
- apply the same deterministic tar rule to the hosted package workflow
- retain the strict three-file authority closure and add regression assertions for both archive paths

## Evidence

- reproduced the failure from stable gate run 34735195551: BSD tar added `._*` members for GitHub-downloaded files carrying `com.apple.provenance`
- reconstructed that real authority artifact with `COPYFILE_DISABLE=1`; the strict verifier accepted its candidate, component, init-image, receipt, checkpoint, output, and Homebrew identities
- focused release tests pass
- Actions workflow validation passes
- `git diff --check` passes

The 0.15.0 release remains unpublished; the retained release transaction will be resumed only after this exact head is reviewed, checked, and merged.